### PR TITLE
Improving Browser Upgrade settings

### DIFF
--- a/test/unit/displays/controllers/ctr-display-details.tests.js
+++ b/test/unit/displays/controllers/ctr-display-details.tests.js
@@ -212,4 +212,25 @@ describe('controller: display details', function() {
     });
   });
 
+  describe('browserUpgradeMode:',function(){
+    it('should watch display.browserUpgradeMode',function(){
+      expect($scope.$$watchers[0].exp).to.equal('display.browserUpgradeMode');
+    });
+
+    it('should change to User Managed (1) any value different than Auto Upgrade (0)',function(){
+      $scope.display = {id:123, browserUpgradeMode: 2};
+      $scope.$digest();
+      expect($scope.display.browserUpgradeMode).to.equal(1);
+      $scope.display = {id:123, browserUpgradeMode: 1};
+      $scope.$digest();
+      expect($scope.display.browserUpgradeMode).to.equal(1);
+    });
+
+    it('should not change Auto Upgrade (0)',function(){
+      $scope.display = {id:123, browserUpgradeMode: 0};
+      $scope.$digest();
+      expect($scope.display.browserUpgradeMode).to.equal(0);
+    });
+  })
+
 });

--- a/web/partials/displays/display-fields.html
+++ b/web/partials/displays/display-fields.html
@@ -129,22 +129,14 @@
     <div class="form-control-static">{{display.viewerVersion}}</div>
   </div>
   
-  <div class="form-group form-inline" ng-show="display.recommendedBrowserVersion">
+  <div class="form-group form-inline" ng-show="showBrowserUpgradeMode">
     <label class="control-label" translate>displays-app.fields.player.browser.upgrade.name</label>
     <select class="form-control" ng-model="display.browserUpgradeMode" integer-parser ng-disabled="!display.playerName && !display.playerVersion">
       <option value="0" translate>displays-app.fields.player.browser.upgrade.autoUpgrade</option>
-      <option value="2" translate>displays-app.fields.player.browser.upgrade.current</option>
-      <option value="3" translate>displays-app.fields.player.browser.upgrade.previous</option>
       <option value="1" translate>displays-app.fields.player.browser.upgrade.userManaged</option>
     </select>
   </div>
   
-  <div class="panel panel-info animated fadeIn" ng-show="display.browserUpgradeMode !== 0">
-    <div class="panel-body">
-      <p class="add-right text-danger" translate>displays-app.fields.player.browser.upgrade.warning</p>
-    </div>
-  </div>
-
   <div class="form-group form-inline" ng-show="display.browserUpgradeMode !== 0">
     <label class="control-label" translate>displays-app.fields.player.browser.recommended</label>
     <div class="form-control-static">{{display.recommendedBrowserVersion}}</div>

--- a/web/scripts/displays/controllers/ctr-display-details.js
+++ b/web/scripts/displays/controllers/ctr-display-details.js
@@ -32,6 +32,9 @@ angular.module('risevision.displays.controllers')
         display.get($scope.displayId)
           .then(function (result) {
             $scope.display = result.item;
+            if ($scope.display) {
+              $scope.showBrowserUpgradeMode = $scope.display.browserUpgradeMode !== 0;  
+            }            
           })
           .then(null, function (e) {
             $scope.submitError = e.message ? e.message : e.toString();
@@ -161,5 +164,10 @@ angular.module('risevision.displays.controllers')
         return deferred.promise;
       };
 
+      $scope.$watch('display.browserUpgradeMode',function(){
+        if ($scope.display && $scope.display.browserUpgradeMode != 0) {
+          $scope.display.browserUpgradeMode = 1;
+        }
+      });
     }
   ]);


### PR DESCRIPTION
- Only show Browser Upgrade field for Displays that are not 'Auto Upgrade'
- 'Current' and 'Previous' options are changed to 'User Managed'
- Changed field labels

@alex-deaconu Please review. Thanks