### PR TITLE
Add htmleditor specific path

### DIFF
--- a/test/e2e/editor/cases/html-editor.js
+++ b/test/e2e/editor/cases/html-editor.js
@@ -56,11 +56,16 @@ var HtmlEditorScenarios = function() {
           expect(workspacePage.getCodemirrorHtmlEditor().isDisplayed()).to.eventually.be.true;
           expect(workspacePage.getCodemirrorHtmlEditor().getText()).to.eventually.contain('var presentationData =');
         });
+        
+        it('should update the path to htmleditor', function() {
+          expect(browser.getCurrentUrl()).to.eventually.contain.string('/htmleditor');
+        });
 
         it('should parse and update presentation', function () {
           browser.executeScript("var editor = $('.CodeMirror')[0].CodeMirror;" +
             "editor.replaceRange(\"ph1\",{line:8,ch: 11},{line:8,ch: 14});" +
             "editor.replaceRange(\"ph1\",{line:18,ch: 11},{line:18,ch: 14})");
+            
           workspacePage.getDesignButton().click();
 
           // wait for transitions
@@ -68,10 +73,13 @@ var HtmlEditorScenarios = function() {
 
           expect(placeholdersListPage.getPlaceholders().get(0).getText()).to.eventually.contain('ph1');
         });
+        
+        it('path should not contain htmleditor', function() {
+          expect(browser.getCurrentUrl()).to.eventually.not.contain.string('/htmleditor');
+        });
 
       });
     });
   });
 };
 module.exports = HtmlEditorScenarios;
-

--- a/test/unit/editor/controllers/ctr-html-editor.tests.js
+++ b/test/unit/editor/controllers/ctr-html-editor.tests.js
@@ -56,8 +56,10 @@ describe('controller: HtmlEditor', function() {
 	});
 
 	it('should parse presentation and distribution when scope $destroyed', function () {
+		var scopeApplySpy = sinon.spy($scope, '$apply');
 		$scope.$destroy();  
 		parsePresentationSpy.should.have.been.calledWith(presentation);
 		parseDistributionSpy.should.have.been.calledWith(presentation);
+		scopeApplySpy.should.have.been.called.once;
 	});
 });

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -352,7 +352,7 @@ angular.module('risevision.apps', [
       })
 
       .state('apps.editor.workspace.htmleditor', {
-        url: '',
+        url: '/htmleditor',
         templateProvider: ['$templateCache', function ($templateCache) {
           return $templateCache.get(
             'partials/editor/html-editor.html');

--- a/web/scripts/editor/controllers/ctr-html-editor.js
+++ b/web/scripts/editor/controllers/ctr-html-editor.js
@@ -18,6 +18,8 @@ angular.module('risevision.editor.controllers')
       $scope.$on('$destroy', function () {
         presentationParser.parsePresentation(editorFactory.presentation);
         distributionParser.parseDistribution(editorFactory.presentation);
+        
+        $scope.$apply();
       });
     }
   ]); //ctr


### PR DESCRIPTION
Routing issue caused by updated Angular/ui-router versions

Fix by adding `/htmleditor` path
Update controller to force digest cycle on `$destroy`

[stage-2]