### PR TITLE
Temporarily hide Schedule Item PUD field

### DIFF
--- a/web/partials/schedules/playlist-item.html
+++ b/web/partials/schedules/playlist-item.html
@@ -35,7 +35,7 @@
       <div class="form-group half-top">
 
         <label class="control-label add-right" translate>editor-app.playlistItem.duration</label>
-        <label class="control-label control-label-secondary add-left" ng-if="playlistItem.type === 'presentation'">
+        <label class="control-label control-label-secondary add-left" ng-if="playlistItem.type === 'presentation' && playlistItem.playUntilDone">
           <input type="checkbox" ng-model="playlistItem.playUntilDone" />
           <span translate>editor-app.playlistItem.playUntilDone</span>
         </label>


### PR DESCRIPTION
The field will only show if the option is checked; which it is not since this was never deployed. However, this keeps backwards compatibility for stage where the field may have been checked at one point.

[stage-2]