### PR TITLE
Refactored event tracking

### DIFF
--- a/test/unit/displays/controllers/ctr-display-add.tests.js
+++ b/test/unit/displays/controllers/ctr-display-add.tests.js
@@ -116,7 +116,6 @@ describe('controller: display add', function() {
     $scope.displayDetails.$valid = true;
     $scope.display = {id:123};
     $scope.save();
-    expect(trackerCalled).to.equal('Save Display');
     expect($scope.savingDisplay).to.be.true;
     $scope.$digest();
     $loadingStartSpy.should.have.been.calledWith('displays-loader');
@@ -137,7 +136,6 @@ describe('controller: display add', function() {
     $scope.displayDetails = {};
     $scope.displayDetails.$valid = true;
     $scope.save();
-    expect(trackerCalled).to.equal('Save Display');
     setTimeout(function(){
       expect($state._state).to.be.empty;
       expect(trackerCalled).to.not.equal('Display Created');

--- a/test/unit/displays/controllers/ctr-display-details.tests.js
+++ b/test/unit/displays/controllers/ctr-display-details.tests.js
@@ -142,7 +142,6 @@ describe('controller: display details', function() {
       $scope.displayDetails.$valid = true;
       $scope.display = {id:123};
       $scope.save();
-      expect(trackerCalled).to.equal('Save Display');
       expect($scope.savingDisplay).to.be.true;
       setTimeout(function(){
         expect(trackerCalled).to.equal('Display Updated');
@@ -159,7 +158,6 @@ describe('controller: display details', function() {
       $scope.displayDetails = {};
       $scope.displayDetails.$valid = true;
       $scope.save();
-      expect(trackerCalled).to.equal('Save Display');
       setTimeout(function(){
         expect($state._state).to.be.empty;
         expect(trackerCalled).to.not.equal('Display Updated');

--- a/test/unit/editor/controllers/ctr-presentation-list.tests.js
+++ b/test/unit/editor/controllers/ctr-presentation-list.tests.js
@@ -60,7 +60,6 @@ describe('controller: Presentation List', function() {
     expect($scope.factory.loadingItems).to.be.false;
     expect($scope.search).to.be.ok;
     expect($scope.filterConfig).to.be.ok;
-    expect($scope.presentationTracker).to.be.ok;
     
   });
   

--- a/test/unit/editor/controllers/ctr-store-products-modal.tests.js
+++ b/test/unit/editor/controllers/ctr-store-products-modal.tests.js
@@ -109,7 +109,6 @@ describe('controller: Store Products Modal', function() {
     expect($scope.search).to.be.ok;
     expect($scope.filterConfig).to.be.ok;
     expect($scope.selectProductTag).to.be.ok;
-    expect($scope.presentationTracker).to.be.ok;
 
     expect($scope.select).to.be.a('function');
     expect($scope.dismiss).to.be.a('function');

--- a/test/unit/editor/services/svc-editor-factory.tests.js
+++ b/test/unit/editor/services/svc-editor-factory.tests.js
@@ -170,12 +170,23 @@ describe('service: editorFactory:', function() {
     expect(editorFactory.deletePresentation).to.be.a('function');
     expect(editorFactory.isRevised).to.be.a('function');
     expect(editorFactory.copyPresentation).to.be.a('function');
-    expect(editorFactory.addFromTemplate).to.be.a('function');
+    expect(editorFactory.addPresentationModal).to.be.a('function');
     expect(editorFactory.saveAndPreview).to.be.a('function');
   });
+
+  it('should initialize',function(){
+    expect(editorFactory.presentation.layout).to.be.ok;
+    expect(editorFactory.presentation.parsed).to.be.true;
+    expect(editorFactory.presentationId).to.not.be.ok;
+  });
+
   
   it('newPresentation: should reset the presentation',function(){
+    editorFactory.presentation.id = 'presentationId';
+    
     editorFactory.newPresentation();
+    
+    expect(trackerCalled).to.equal('New Presentation');
     
     expect(editorFactory.presentation.layout).to.be.ok;
     expect(editorFactory.presentation.parsed).to.be.true;
@@ -463,26 +474,47 @@ describe('service: editorFactory:', function() {
     });
   });
   
-  it('copyPresentation: should copy the presentation',function(){
-    editorFactory.presentation = {
-      id: 'someId',
-      name: 'New Presentation',
-      revisionStatusname: 'revised'
-    };
-    
-    editorFactory.copyPresentation();
-    
-    expect(editorFactory.presentation.id).to.not.be.ok;
-    expect(editorFactory.presentation.name).to.equal('Copy of New Presentation');
-    
-    expect(trackerCalled).to.equal('Presentation Copied');
-    expect(currentState).to.equal('apps.editor.workspace.artboard');
-    expect(stateParams).to.deep.equal({presentationId: undefined, copyPresentation:true});
+  describe('copyPresentation: ', function() {
+    it('should copy the presentation',function(){
+      editorFactory.presentation = {
+        id: 'someId',
+        name: 'New Presentation',
+        revisionStatusname: 'revised'
+      };
+      
+      editorFactory.copyPresentation();
+      
+      expect(editorFactory.presentation.id).to.not.be.ok;
+      expect(editorFactory.presentation.name).to.equal('Copy of New Presentation');
+      
+      expect(trackerCalled).to.equal('Presentation Copied');
+      expect(currentState).to.equal('apps.editor.workspace.artboard');
+      expect(stateParams).to.deep.equal({presentationId: undefined, copyPresentation:true});
+    });
+  
+    it('should copy a template',function(){
+      editorFactory.presentation = {
+        id: 'someId',
+        name: 'New Presentation',
+        revisionStatusname: 'revised',
+        isTemplate: true
+      };
+      
+      editorFactory.copyPresentation();
+      
+      expect(editorFactory.presentation.id).to.not.be.ok;
+      expect(editorFactory.presentation.name).to.equal('Copy of New Presentation');
+      expect(editorFactory.presentation.isTemplate).to.be.false;
+      
+      expect(trackerCalled).to.equal('Template Copied');
+      expect(currentState).to.equal('apps.editor.workspace.artboard');
+      expect(stateParams).to.deep.equal({presentationId: undefined, copyPresentation:true});
+    });
   });
   
-  it('addFromTemplate: ', function(done) {
-    editorFactory.addFromTemplate();
-    expect(trackerCalled).to.equal("Add Presentation From Template");
+  it('addPresentationModal: ', function(done) {
+    editorFactory.addPresentationModal();
+    expect(trackerCalled).to.equal("Add Presentation");
     
     setTimeout(function() {
       expect(editorFactory.loadingPresentation).to.be.false;
@@ -591,10 +623,27 @@ describe('service: editorFactory:', function() {
     });
   });
 
-  describe('save:',function(){
-    it('should track event',function(){
+  describe('save: ',function(){
+    it('should add presentation', function(done){
       editorFactory.save();
-      expect(trackerCalled).to.equal("Save Presentation");
+      
+      setTimeout(function(){
+        expect(trackerCalled).to.equal("Presentation Created");
+        
+        done();
+      }, 10);
+    });
+    
+    it('should update presentation', function(done){
+      editorFactory.presentation.id = "presentationId";
+      
+      editorFactory.save();
+      
+      setTimeout(function(){
+        expect(trackerCalled).to.equal("Presentation Updated");
+        
+        done();
+      }, 10);
     });
   });
 

--- a/test/unit/schedules/controllers/ctr-schedule-add.tests.js
+++ b/test/unit/schedules/controllers/ctr-schedule-add.tests.js
@@ -25,17 +25,10 @@ describe('controller: schedule add', function() {
       }
     });
 
-    $provide.service('scheduleTracker',function(){
-      return function(eventName,scheduleId, scheduleName) {
-        trackedEvent = eventName;
-      };
-    });
-
   }));
-  var $scope, scheduleFactory, $loading,$loadingStartSpy, $loadingStopSpy, scheduleAdded, trackedEvent;
+  var $scope, scheduleFactory, $loading,$loadingStartSpy, $loadingStopSpy, scheduleAdded;
   beforeEach(function(){
     scheduleAdded = false;
-    trackedEvent = undefined;
     
     inject(function($injector,$rootScope, $controller){
       $scope = $rootScope.$new();
@@ -76,7 +69,6 @@ describe('controller: schedule add', function() {
     $scope.schedule = {id:123};
     $scope.save();
 
-    expect(trackedEvent).to.equal('Save Schedule');
     expect(scheduleAdded).to.be.true;
 
   });

--- a/test/unit/schedules/controllers/ctr-schedule-details.tests.js
+++ b/test/unit/schedules/controllers/ctr-schedule-details.tests.js
@@ -46,18 +46,11 @@ describe('controller: schedule details', function() {
         }
       }
     });
-
-    $provide.service('scheduleTracker',function(){
-      return function(eventName,scheduleId, scheduleName) {
-        trackedEvent = eventName;
-      };
-    });
   }));
-  var $scope, $state, updateCalled, deleteCalled, confirmDelete, trackedEvent;
+  var $scope, $state, updateCalled, deleteCalled, confirmDelete;
   beforeEach(function(){
     updateCalled = false;
     deleteCalled = false;
-    trackedEvent = undefined;
     
     inject(function($injector,$rootScope, $controller){
       $scope = $rootScope.$new();
@@ -96,7 +89,6 @@ describe('controller: schedule details', function() {
       $scope.schedule = {id:123};
       $scope.save();
 
-      expect(trackedEvent).to.equal('Save Schedule');
       expect(updateCalled).to.be.true;
     });
   });

--- a/test/unit/schedules/controllers/ctr-schedules-list.tests.js
+++ b/test/unit/schedules/controllers/ctr-schedules-list.tests.js
@@ -101,7 +101,6 @@ describe('controller: schedules list', function() {
 
   it('should exist',function(){
     expect($scope).to.be.truely;
-    expect($scope.scheduleTracker).to.be.ok;
 
     expect($scope.sortBy).to.be.a('function');
     expect($scope.doSearch).to.be.a('function');

--- a/test/unit/schedules/services/svc-schedule-factory.tests.js
+++ b/test/unit/schedules/services/svc-schedule-factory.tests.js
@@ -93,8 +93,18 @@ describe('service: scheduleFactory:', function() {
     expect(scheduleFactory.getPreviewUrl).to.be.a('function');
   });
   
+  it('should initialize',function(){
+    expect(scheduleFactory.schedule).to.deep.equal({content: [], distributeToAll: false, distribution: []});
+    expect(scheduleFactory.scheduleId).to.not.be.truely;
+  });
+  
   it('newSchedule: should reset the schedule',function(){
+    scheduleFactory.schedule.id = 'scheduleId';
+    scheduleFactory.scheduleId = 'scheduleId';
+    
     scheduleFactory.newSchedule();
+    
+    expect(trackerCalled).to.equal('Add Schedule');
     
     expect(scheduleFactory.schedule).to.deep.equal({content: [], distributeToAll: false, distribution: []});
     expect(scheduleFactory.scheduleId).to.not.be.truely;

--- a/web/partials/displays/download-player.html
+++ b/web/partials/displays/download-player.html
@@ -7,7 +7,7 @@
   </div>
 
   <div class="col-md-5 col-xs-6">
-    <a class="btn btn-primary btn-block ng-scope" ng-click="displayTracker('Player Download', display.id, display.name, 'Ubuntu 32bit')" href="http://install-versions.risevision.com/installer-lnx-32.sh">
+    <a class="btn btn-primary btn-block ng-scope" ng-click="displayTracker('Player Download', display.id, display.name, 'Ubuntu 32bit')" href="http://install-versions.risevision.com/installer-lnx-32.sh" target="_blank">
       {{'displays-app.download.linux32' |  translate }}
       <img src="https://s3.amazonaws.com/Rise-Images/Icons/ubuntu.png">
     </a>
@@ -23,7 +23,7 @@
   </div>
 
   <div class="col-md-5 col-xs-6">
-    <a class="btn btn-primary btn-block ng-scope" ng-click="displayTracker('Player Download', display.id, display.name, 'Ubuntu 64bit')" href="http://install-versions.risevision.com/installer-lnx-64.sh">
+    <a class="btn btn-primary btn-block ng-scope" ng-click="displayTracker('Player Download', display.id, display.name, 'Ubuntu 64bit')" href="http://install-versions.risevision.com/installer-lnx-64.sh" target="_blank">
       {{'displays-app.download.linux64' |  translate }}
       <img src="https://s3.amazonaws.com/Rise-Images/Icons/ubuntu.png">
     </a>

--- a/web/partials/editor/presentation-list.html
+++ b/web/partials/editor/presentation-list.html
@@ -6,7 +6,7 @@
     </div>
 
     <div class="global-actions">
-        <button id="presentationAddButton" ng-click="presentationTracker('Add Presentation'); editorFactory.addFromTemplate()" class="btn btn-primary btn-lg">
+        <button id="presentationAddButton" ng-click="editorFactory.addPresentationModal()" class="btn btn-primary btn-lg">
           {{'editor-app.list.actions.add' |translate}} <i class="fa fa-plus icon-right"></i>
         </button>
     </div>

--- a/web/partials/editor/store-products-modal.html
+++ b/web/partials/editor/store-products-modal.html
@@ -24,7 +24,7 @@
           rv-spinner-start-active="1">
 
       <li class="blank-template" ng-if="factory.search.category == 'Templates' && !factory.loadingItems">
-        <a class="clickable" id="newPresentationButton" ui-sref="apps.editor.workspace.artboard" ng-click="dismiss(); presentationTracker('New Presentation')">
+        <a class="clickable" id="newPresentationButton" ui-sref="apps.editor.workspace.artboard" ng-click="dismiss();">
           <p><span><i class="fa fa-plus fa-2x"></i></span> {{'editor-app.storeProduct.templates.blank' | translate}}</p>
         </a>
       </li>

--- a/web/partials/launcher/app-launcher.html
+++ b/web/partials/launcher/app-launcher.html
@@ -15,7 +15,7 @@
             <div class="padding-large-horizontal padding-small-vertical">  
               <h4>1. Create</h4>
               <p class="text-muted add-left add-right">Create your first Presentation with our easy to use Editor.</p><br>
-              <button id="presentationAddButton" class="btn btn-hg btn-primary add-bottom btn-block" ng-click="launcherTracker('Add Presentation'); editorFactory.addFromTemplate()">Add Presentation</button>
+              <button id="presentationAddButton" class="btn btn-hg btn-primary add-bottom btn-block" ng-click="editorFactory.addPresentationModal()">Add Presentation</button>
             </div>
           </div><!--content-box-->
         </div><!--col-->
@@ -39,7 +39,7 @@
             <div class="padding-large-horizontal padding-small-vertical">  
               <h4>3. Manage</h4>
               <p class="text-muted add-left add-right">Create a Schedule to choose when and where you’d like your content to show.</p>
-              <a ui-sref="apps.schedules.add" class="btn btn-hg btn-primary add-bottom btn-block" ng-click="launcherTracker('Add Schedule')">Add Schedule</a>
+              <a ui-sref="apps.schedules.add" class="btn btn-hg btn-primary add-bottom btn-block">Add Schedule</a>
             </div>
           </div><!--content-box-->
         </div>           

--- a/web/partials/schedules/schedules-list.html
+++ b/web/partials/schedules/schedules-list.html
@@ -5,7 +5,7 @@
   </div>
 
   <div class="global-actions" require-role="cp">
-    <a id="scheduleAddButton" ui-sref="apps.schedules.add" class="btn btn-lg btn-primary" ng-click="scheduleTracker('Add Schedule')">
+    <a id="scheduleAddButton" ui-sref="apps.schedules.add" class="btn btn-lg btn-primary">
       {{ 'schedules-app.actions.new' | translate }}
       <i class="fa fa-plus icon-right"></i> 
     </a>

--- a/web/scripts/displays/controllers/ctr-display-add.js
+++ b/web/scripts/displays/controllers/ctr-display-add.js
@@ -25,8 +25,6 @@ angular.module('risevision.displays.controllers')
       });
 
       $scope.save = function (id, comment, toggleStatus) {
-        displayTracker('Save Display', null, $scope.display ? $scope.display
-          .name : undefined);
         if (!$scope.displayDetails.$valid) {
           $log.error('form not valid: ', $scope.displayDetails.errors);
           return;

--- a/web/scripts/displays/controllers/ctr-display-details.js
+++ b/web/scripts/displays/controllers/ctr-display-details.js
@@ -135,8 +135,6 @@ angular.module('risevision.displays.controllers')
       };
 
       $scope.save = function () {
-        displayTracker('Save Display', $scope.displayId, $scope.display ?
-          $scope.display.name : undefined);
         var deferred = $q.defer();
 
         if (!$scope.displayDetails.$valid) {

--- a/web/scripts/editor/controllers/ctr-presentation-list.js
+++ b/web/scripts/editor/controllers/ctr-presentation-list.js
@@ -2,9 +2,9 @@
 angular.module('risevision.editor.controllers')
   .controller('PresentationListController', ['$scope',
     'ScrollingListService', 'presentation', 'editorFactory', '$loading',
-    '$filter', 'presentationTracker',
+    '$filter',
     function ($scope, ScrollingListService, presentation, editorFactory,
-      $loading, $filter, presentationTracker) {
+      $loading, $filter) {
       $scope.search = {
         sortBy: 'changeDate',
         reverse: true
@@ -13,7 +13,6 @@ angular.module('risevision.editor.controllers')
       $scope.factory = new ScrollingListService(presentation.list,
         $scope.search);
       $scope.editorFactory = editorFactory;
-      $scope.presentationTracker = presentationTracker;
 
       $scope.filterConfig = {
         placeholder: $filter('translate')(

--- a/web/scripts/editor/controllers/ctr-store-products-modal.js
+++ b/web/scripts/editor/controllers/ctr-store-products-modal.js
@@ -15,13 +15,11 @@ angular.module('risevision.editor.controllers')
   .controller('storeProductsModal', ['$scope', 'ScrollingListService',
     'store', '$modalInstance', '$loading', '$filter', 'STORE_URL', 'category',
     '$modal', 'storeAuthorization', 'playlistItemFactory',
-    'TEMPLATE_PRODUCT_TAGS', 'TEMPLATES_CATEGORY', 'presentationTracker',
+    'TEMPLATE_PRODUCT_TAGS', 'TEMPLATES_CATEGORY',
     function ($scope, ScrollingListService, store, $modalInstance, $loading,
       $filter, STORE_URL, category, $modal, storeAuthorization,
-      playlistItemFactory, TEMPLATE_PRODUCT_TAGS, TEMPLATES_CATEGORY,
-      presentationTracker) {
+      playlistItemFactory, TEMPLATE_PRODUCT_TAGS, TEMPLATES_CATEGORY) {
       var defaultCount = 1000;
-      $scope.presentationTracker = presentationTracker;
 
       $scope.productTags = TEMPLATE_PRODUCT_TAGS;
 

--- a/web/scripts/editor/controllers/ctr-workspace.js
+++ b/web/scripts/editor/controllers/ctr-workspace.js
@@ -3,12 +3,10 @@
 angular.module('risevision.editor.controllers')
   .controller('WorkspaceController', ['$scope', 'editorFactory',
     'placeholderFactory', 'userState', '$modal', '$templateCache',
-    '$location', '$stateParams', '$window', 'RVA_URL', 'presentationTracker',
+    '$location', '$stateParams', '$window', 'RVA_URL',
     function ($scope, editorFactory, placeholderFactory, userState, $modal,
-      $templateCache, $location, $stateParams, $window, RVA_URL,
-      presentationTracker) {
+      $templateCache, $location, $stateParams, $window, RVA_URL) {
       $scope.factory = editorFactory;
-      $scope.presentationTracker = presentationTracker;
       $scope.placeholderFactory = placeholderFactory;
       $scope.isSubcompanySelected = userState.isSubcompanySelected;
       $scope.isTestCompanySelected = userState.isTestCompanySelected;

--- a/web/scripts/editor/services/svc-editor-factory.js
+++ b/web/scripts/editor/services/svc-editor-factory.js
@@ -43,7 +43,7 @@ angular.module('risevision.editor.services')
         factory.apiError = '';
       };
 
-      factory.newPresentation = function () {
+      var _init = function () {
         factory.presentation = {
           layout: DEFAULT_LAYOUT
         };
@@ -53,8 +53,14 @@ angular.module('risevision.editor.services')
         _clearMessages();
       };
 
-      factory.newPresentation();
+      _init();
+      
+      factory.newPresentation = function() {
+        presentationTracker('New Presentation');
 
+        _init();
+      };
+      
       var _updatePresentation = function (presentation) {
         factory.presentation = presentation;
 
@@ -201,8 +207,6 @@ angular.module('risevision.editor.services')
       };
 
       factory.save = function () {
-        presentationTracker('Save Presentation', factory.presentation.id,
-          factory.presentation.name);
         if (factory.presentation.id) {
           return factory.updatePresentation();
         } else {
@@ -302,12 +306,14 @@ angular.module('risevision.editor.services')
       };
 
       factory.copyPresentation = function () {
-        presentationTracker('Presentation Copied', factory.presentation.id,
+        presentationTracker((factory.presentation.isTemplate ? 
+          'Template' : 'Presentation') + ' Copied', factory.presentation.id,
           factory.presentation.name);
 
         factory.presentation.id = undefined;
         factory.presentation.name = 'Copy of ' + factory.presentation.name;
         factory.presentation.revisionStatusName = undefined;
+        factory.presentation.isTemplate = false;
 
         $state.go('apps.editor.workspace.artboard', {
           presentationId: undefined,
@@ -320,8 +326,9 @@ angular.module('risevision.editor.services')
           .then(factory.copyPresentation);
       };
 
-      factory.addFromTemplate = function () {
-        presentationTracker('Add Presentation From Template');
+      factory.addPresentationModal = function () {
+        presentationTracker('Add Presentation');
+        
         var modalInstance = $modal.open({
           templateUrl: 'partials/editor/store-products-modal.html',
           size: 'lg',
@@ -334,10 +341,10 @@ angular.module('risevision.editor.services')
         });
 
         modalInstance.result.then(function (productDetails) {
-          presentationTracker('Template Selected');
           if (!productDetails || !productDetails.rvaEntityId) {
             return;
           }
+
           factory.newCopyOf(productDetails.rvaEntityId);
         });
       };

--- a/web/scripts/schedules/controllers/ctr-schedule-add.js
+++ b/web/scripts/schedules/controllers/ctr-schedule-add.js
@@ -2,8 +2,7 @@
 
 angular.module('risevision.schedules.controllers')
   .controller('scheduleAdd', ['$scope', 'scheduleFactory', '$loading', '$log',
-    'scheduleTracker',
-    function ($scope, scheduleFactory, $loading, $log, scheduleTracker) {
+    function ($scope, scheduleFactory, $loading, $log) {
       $scope.factory = scheduleFactory;
       $scope.schedule = scheduleFactory.schedule;
 
@@ -16,8 +15,6 @@ angular.module('risevision.schedules.controllers')
       });
 
       $scope.save = function () {
-        scheduleTracker('Save Schedule', scheduleFactory.schedule.id,
-          scheduleFactory.schedule.name);
         if (!$scope.scheduleDetails.$valid) {
           $log.error('form not valid: ', $scope.scheduleDetails.errors);
           return;

--- a/web/scripts/schedules/controllers/ctr-schedule-details.js
+++ b/web/scripts/schedules/controllers/ctr-schedule-details.js
@@ -3,9 +3,8 @@
 angular.module('risevision.schedules.controllers')
   .controller('scheduleDetails', ['$scope', '$q', '$state',
     'scheduleFactory', '$loading', '$log', '$modal', '$templateCache',
-    'scheduleTracker',
     function ($scope, $q, $state, scheduleFactory, $loading, $log, $modal,
-      $templateCache, scheduleTracker) {
+      $templateCache) {
       $scope.factory = scheduleFactory;
       $scope.schedule = scheduleFactory.schedule;
 
@@ -81,8 +80,6 @@ angular.module('risevision.schedules.controllers')
       };
 
       $scope.save = function () {
-        scheduleTracker('Save Schedule', scheduleFactory.schedule.id,
-          scheduleFactory.schedule.name);
         if (!$scope.scheduleDetails.$valid) {
           $log.info('form not valid: ', $scope.scheduleDetails.$error);
 

--- a/web/scripts/schedules/controllers/ctr-schedules-list.js
+++ b/web/scripts/schedules/controllers/ctr-schedules-list.js
@@ -2,13 +2,12 @@
 
 angular.module('risevision.schedules.controllers')
   .controller('schedulesList', ['$scope', 'userState', 'schedule', 'BaseList',
-    '$location', '$loading', '$filter', 'scheduleTracker',
+    '$location', '$loading', '$filter',
     function ($scope, userState, schedule, BaseList, $location, $loading,
-      $filter, scheduleTracker) {
+      $filter) {
       var DB_MAX_COUNT = 40; //number of records to load at a time
 
       $scope.schedules = new BaseList(DB_MAX_COUNT);
-      $scope.scheduleTracker = scheduleTracker;
 
       $scope.search = angular.extend({
         sortBy: 'changeDate',

--- a/web/scripts/schedules/services/svc-schedule-factory.js
+++ b/web/scripts/schedules/services/svc-schedule-factory.js
@@ -15,7 +15,7 @@ angular.module('risevision.schedules.services')
         factory.apiError = '';
       };
 
-      factory.newSchedule = function () {
+      var _init = function() {
         _scheduleId = undefined;
 
         factory.schedule = {
@@ -26,8 +26,14 @@ angular.module('risevision.schedules.services')
 
         _clearMessages();
       };
+      
+      _init();
 
-      factory.newSchedule();
+      factory.newSchedule = function() {
+        scheduleTracker('Add Schedule');
+        
+        _init();
+      };
 
       factory.getSchedule = function (scheduleId) {
         var deferred = $q.defer();


### PR DESCRIPTION
Editor:
Removed tracking from partials; added to factory
Single tracked event for all actions
Renamed addFromTemplate to addPresentationModal
Refactored editorFactory initialization to distinguish from newPresentation

Remove isTemplate flag when a Template is copied

Open player download links in new tab

Schedules:
Removed duplicate event from controllers
Add Schedule event in factory (refactor init)

Removed duplicate Display tracking events

[stage-4]