### PR TITLE
Fix Gadgets 'reloading' page.

### DIFF
--- a/test/unit/editor/controllers/ctr-playlist-item-modal.tests.js
+++ b/test/unit/editor/controllers/ctr-playlist-item-modal.tests.js
@@ -155,6 +155,39 @@ describe('controller: playlist item modal', function() {
     });
   });
 
+  describe('Gadget checks', function () {
+    beforeEach(function(){
+      presentation = {
+        id : ''
+      };
+
+      inject(function($injector,$rootScope, $controller){
+        itemUpdated = null;
+        itemProperties.type = 'gadget';
+        updateSubscriptionStatusCalled = false;
+        $scope = $rootScope.$new();
+
+        $controller('PlaylistItemModalController', {
+          $scope: $scope,
+          $modalInstance : $modalInstance,
+          item: itemProperties,
+          showWidgetModal: false,
+          editorFactory: $injector.get('editorFactory')
+        });
+        $scope.$digest();
+      });
+    });
+
+    it('should not load widget name for Gadget', function(done) {
+      setTimeout(function() {
+        expect($scope.widgetName).to.not.equal('Widget');
+
+        done();
+      }, 10);
+    });
+
+  });
+
   describe('Check presentation id on the previous editor url', function () {
     beforeEach(function(){
       presentation.id = 852;
@@ -238,6 +271,12 @@ describe('controller: playlist item modal', function() {
     });
 
     it('should not open widget modal if not requested', function() {
+      _createController(false);
+      showWidgetModalSpy.should.not.have.been.called;
+    });
+
+    it('should not open widget modal for gadgets', function() {
+      itemProperties.type = 'gadget';
       _createController(false);
       showWidgetModalSpy.should.not.have.been.called;
     });

--- a/web/scripts/editor/controllers/ctr-playlist-item-modal.js
+++ b/web/scripts/editor/controllers/ctr-playlist-item-modal.js
@@ -17,15 +17,14 @@ angular.module('risevision.editor.controllers')
       if (!item.objectReference && item.settingsUrl) {
         $scope.widgetName = item.name;
       } else {
-        if (item.objectReference && (item.type === 'widget' || item.type ===
-            'gadget')) {
+        if (item.objectReference && item.type === 'widget') {
           gadgetFactory.getGadget(item.objectReference).then(function (gadget) {
             $scope.widgetName = gadget.name;
           });
         }
       }
 
-      if (showWidgetModal) {
+      if (showWidgetModal && item.type === 'widget' ) {
         widgetModalFactory.showWidgetModal($scope.item);
       }
 


### PR DESCRIPTION
They were actually opening a full page iframe for their settings, but as they don't have settings page, it was showing a new Editor page in the frame.

To fix, we should not show Gadget settings.

@alex-deaconu Please review. Thanks!