### PR TITLE
Fix add presentation e2e test

### DIFF
--- a/test/e2e/editor/cases/presentation-add.js
+++ b/test/e2e/editor/cases/presentation-add.js
@@ -62,6 +62,7 @@ var PresentationAddScenarios = function() {
       var presentationName = 'TEST_E2E_PRESENTATION';
 
       helper.wait(presentationPropertiesModalPage.getNameInput(), 'Waiting for Name Input');
+      presentationPropertiesModalPage.getNameInput().sendKeys("workaround"); // clear() fails sometimes
       presentationPropertiesModalPage.getNameInput().clear();
       presentationPropertiesModalPage.getNameInput().sendKeys(presentationName);
       helper.clickWhenClickable(presentationPropertiesModalPage.getApplyButton(), 'Apply Button');

--- a/test/e2e/editor/cases/shared-templates.js
+++ b/test/e2e/editor/cases/shared-templates.js
@@ -75,6 +75,7 @@ var SharedTemplatesScenarios = function() {
     it("should preview template in a new tab", function (done) {
       var newWindowHandle, oldWindowHandle;
       sharedTemplatesModalPage.getPreviewLinks().get(0).click();
+      browser.sleep(1000);
       browser.ignoreSynchronization = true;
       browser.getAllWindowHandles().then(function (handles) {
         oldWindowHandle = handles[0];


### PR DESCRIPTION
@alex-deaconu Another attempt to fix E2E tests. I run 4 builds without failures.  
For Add Presentation test, the workaround is to interact with the input before calling `clear()`.

I got one failure when previewing template in a new tab, so I am adding a sleep to give a time for processing. 

Please review. Thanks