### PR TITLE
Fixing folder selection right after upload

### DIFF
--- a/test/unit/storage/services/svc-files-factory.tests.js
+++ b/test/unit/storage/services/svc-files-factory.tests.js
@@ -138,6 +138,7 @@ describe('service: filesFactory:', function() {
         filesFactory.addFile({ name: 'folder/subFolder/file2.txt' });
 
         expect(filesFactory.filesDetails.files.length).to.equal(5);
+        expect(filesFactory.filesDetails.files[4]).to.deep.equal({name: 'folder/', kind: 'folder'});
       });
     });
 

--- a/web/scripts/storage/services/svc-files-factory.js
+++ b/web/scripts/storage/services/svc-files-factory.js
@@ -33,7 +33,8 @@ angular.module('risevision.storage.services')
         if (idx >= 0) {
           if (!existingFileNameIndex) {
             svc.filesDetails.files.push({
-              name: fileName
+              name: fileName,
+              kind: 'folder'
             });
           }
         } else if (existingFileNameIndex) {


### PR DESCRIPTION
Fixes issue brought up here: https://trello.com/c/OpMms5DC/1093-dev-in-app-storage-file-selection-2.

When a new folder is added, set the `kind` property. Otherwise, when the URL is formed the new folder will be interpreted as a file: https://github.com/Rise-Vision/rise-vision-apps/blob/master/web/scripts/storage/services/svc-file-selector-factory.js#L90.

@ezequielc please review. Thanks!