### PR TITLE
Fix #185 - escaping apostrophe in background filename

### DIFF
--- a/test/unit/editor/services/svc-background-parser.tests.js
+++ b/test/unit/editor/services/svc-background-parser.tests.js
@@ -73,6 +73,18 @@ describe('service: backgroundParser:', function() {
       expect(backgroundParser.getScaleToFit(background)).to.be.true;
 
     });
+
+    it('should escape apostrophe in image filename', function() {
+      var background = {'useImage':true,'image':{'url':'/images/b\'g\'.jpg','position':'top-left', repeat: 'no-repeat','scale':true}};
+
+      expect(backgroundParser.getStyle(background)).to.equal('url(\'/images/b\\\'g\\\'.jpg\') no-repeat left top');
+    });
+
+    it('should unescape apostrophe in filename', function() {
+      var background = {'useImage':true,'image':{'url':'/images/b\'g\'.jpg', repeat: 'no-repeat','position':'top-left','scale':true}};
+
+      expect(backgroundParser.parseBackground('url(\'/images/b\\\'g\\\'.jpg\') no-repeat left top', true)).to.deep.equal(background);
+    });
     
     it('should get image & clor background', function() {
       var backgroundString = 'rgb(170, 170, 170) url(\'https://storage.googleapis.com/risemedialibrary-b428b4e8-c8b9-41d5-8a10-b4193c789443/image-1.png\') no-repeat center center';

--- a/web/scripts/editor/services/svc-background-parser.js
+++ b/web/scripts/editor/services/svc-background-parser.js
@@ -58,7 +58,7 @@ angular.module('risevision.editor.services')
               '\')', urlTokenPosition);
             background.image.url = backgroundStyle.substring(
               openingParenthesesPosition + 2,
-              closingParenthesesPosition);
+              closingParenthesesPosition).replace(/\\'/g,'\'');
 
             for (var i = 0; i < POSITION_OPTIONS.length; i++) {
               if (backgroundStyle.indexOf(POSITION_OPTIONS[i][0]) !== -1) {
@@ -90,7 +90,7 @@ angular.module('risevision.editor.services')
 
         if (background && background.useImage) {
           backgroundStyle += backgroundStyle ? ' ' : '';
-          backgroundStyle += 'url(\'' + background.image.url +
+          backgroundStyle += 'url(\'' + background.image.url.replace(/'/g,'\\\'') +
             '\')';
 
           if (background.image.repeat && !background.image.scale) {


### PR DESCRIPTION
Background images with apostrophe in filename were not rendering in Editor.

Sample image: https://storage.googleapis.com/risemedialibrary-960b72df-9af7-476b-8a47-b67ded4c779d/JULY-NewWhat's-Happening-Template-sm.jpg

@alex-deaconu Please review. Thanks
