### PR TITLE
Update Storage to allow multiple File/Folder selection

### DIFF
--- a/test/unit/storage/directives/dtv-storage-selector.tests.js
+++ b/test/unit/storage/directives/dtv-storage-selector.tests.js
@@ -1,31 +1,25 @@
 'use strict';
 describe('directive: storage-selector', function() {
-  var $rootScope, element, storageFactory, $modal;
+  var $rootScope, element, fileSelectorFactory;
   var testitem = {name: 'image.jpg'};
 
   beforeEach(module('risevision.storage.directives'));
   beforeEach(module(function ($provide) {
-    $provide.service('$modal', function() {
-      return $modal = {
-        open: function() {
-          return {
-            result:{
-              then:function(func){
-                  expect(func).to.be.a('function');
-                  func(testitem);
-              }
-            }
-          };
-        }
-      };
-    });
     $provide.service('storageFactory', function() {
-        return storageFactory = {};
+      return {selectorType: 'single-file'};
     });
-    $provide.value('SELECTOR_TYPES', {SINGLE_FILE: 'single-file'});
+    $provide.service('fileSelectorFactory', function() {
+      return fileSelectorFactory;
+    });
   }));
 
   beforeEach(inject(function(_$compile_, _$rootScope_, $templateCache){
+    fileSelectorFactory = {
+      openSelector: function() {
+        return Q.resolve(testitem);
+      }
+    };
+
     $templateCache.put('partials/storage/storage-selector.html', '<p>mock</p>');
     var $compile = _$compile_;
     $rootScope = _$rootScope_;
@@ -37,36 +31,30 @@ describe('directive: storage-selector', function() {
   it('should replace the element with the appropriate content', function() {
     expect(element.html()).to.equal('<p>mock</p>');
   });
-  
-  it('should initialize constants', function() {
-    expect(storageFactory.selectorType).to.equal('single-file');
-    expect(storageFactory.storageFull).to.be.false;
-  });
-  
+
   describe('open:', function(){
     it('should have open function in scope', function() {
       expect(element.isolateScope().open).to.be.a('function');
     });
     
-    it('should open modal', function() {
-      var $modalSpy = sinon.spy($modal, 'open');
-      
-      element.isolateScope().open();      
-      
-      $modalSpy.should.have.been.calledWith({
-        templateUrl: 'partials/storage/storage-modal.html',
-        controller: 'StorageSelectorModalController',
-        size: 'lg'
-      });
+    it('should have open function in scope', function() {
+      var openSelectorSpy = sinon.spy(fileSelectorFactory, 'openSelector');
+
+      element.isolateScope().open();
+
+      openSelectorSpy.should.have.been.called;
     });
 
-    it('should open modal and emit "picked"', function() {
+    it('should open modal and emit "picked"', function(done) {
       var isolateScope = element.isolateScope();
       var $emitSpy = sinon.spy(isolateScope, '$emit');
 
-      isolateScope.open();
+      isolateScope.open();    
+      setTimeout(function() {
+        $emitSpy.should.have.been.calledWith('picked', testitem, 'single-file');
 
-      $emitSpy.should.have.been.calledWith('picked', testitem, 'single-file');
+        done();        
+      }, 10);
     });
   });
   

--- a/test/unit/storage/services/svc-file-selector-factory.tests.js
+++ b/test/unit/storage/services/svc-file-selector-factory.tests.js
@@ -3,6 +3,7 @@
 describe('service: fileSelectorFactory:', function() {
   beforeEach(module('risevision.storage.services'));
   beforeEach(module(function ($provide) {
+    $provide.service('$q', function() {return Q;});
     $provide.service('filesFactory', function() {
       return filesFactory;
     });
@@ -22,8 +23,28 @@ describe('service: fileSelectorFactory:', function() {
         _restoreState: function() {}
       };
     });
+    $provide.service('$modal', function() {
+      return {
+        open: function(func){
+          return {
+            result:{
+              then:function(func, failure){
+                expect(func).to.be.a('function');
+                if(modalSuccess) {
+                  func('success');  
+                }
+                else {
+                  failure();
+                }  
+              }
+            }
+          }
+        }
+      };
+    });
   }));
   var filesResponse, fileSelectorFactory, returnFiles, filesFactory, storageFactory, gadgetsApi, $rootScope, $broadcastSpy, $window;
+  var $modal, modalSuccess;
   beforeEach(function(){
     returnFiles = true;
     filesFactory = {
@@ -40,10 +61,12 @@ describe('service: fileSelectorFactory:', function() {
       refreshFilesList: function() {
       }
     };
+    modalSuccess = true;
     
     inject(function($injector){  
       $rootScope = $injector.get('$rootScope');
       $window = $injector.get('$window');
+      $modal = $injector.get('$modal');
       storageFactory = $injector.get('storageFactory');
       fileSelectorFactory = $injector.get('fileSelectorFactory');
     });
@@ -61,12 +84,11 @@ describe('service: fileSelectorFactory:', function() {
     expect(fileSelectorFactory).to.be.ok;
 
     expect(fileSelectorFactory.resetSelections).to.be.a('function');
-    expect(fileSelectorFactory.folderSelect).to.be.a('function');    
-    expect(fileSelectorFactory.fileCheckToggled).to.be.a('function');    
     expect(fileSelectorFactory.selectAllCheckboxes).to.be.a('function');
     expect(fileSelectorFactory.getSelectedFiles).to.be.a('function');
     expect(fileSelectorFactory.sendFiles).to.be.a('function');
     expect(fileSelectorFactory.onFileSelect).to.be.a('function');
+    expect(fileSelectorFactory.changeFolder).to.be.a('function');    
     expect(fileSelectorFactory.cancel).to.be.a('function');
   });
   
@@ -88,8 +110,8 @@ describe('service: fileSelectorFactory:', function() {
   });
 
   it('resetSelections: ', function() {
-    fileSelectorFactory.fileCheckToggled(filesFactory.filesDetails.files[1]);
-    fileSelectorFactory.fileCheckToggled(filesFactory.filesDetails.files[3]);
+    fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[1]);
+    fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[3]);
     
     fileSelectorFactory.resetSelections();
     
@@ -98,77 +120,6 @@ describe('service: fileSelectorFactory:', function() {
     expect(filesFactory.filesDetails.checkedCount).to.be.equal(0);
     expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(0);
     expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(0);
-  });
-
-  describe('folderSelect: ', function() {
-    it('should not do anything if a file is selected', function() {
-      fileSelectorFactory.folderSelect(filesFactory.filesDetails.files[1]);
-      
-      expect(filesFactory.filesDetails.files[1].isChecked).to.be.false;
-      expect(filesFactory.filesDetails.checkedCount).to.be.equal(0);
-      expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(0);
-      expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(0);
-    });
-
-    it('should not select folder if selector type is single-file/multiple-file', function() {
-      fileSelectorFactory.folderSelect(filesFactory.filesDetails.files[3]);
-      
-      expect(filesFactory.filesDetails.files[3].isChecked).to.be.false;
-      expect(filesFactory.filesDetails.checkedCount).to.be.equal(0);
-      expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(0);
-      expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(0);
-    });
-    
-    it('should select folder', function() {
-      storageFactory.selectorType = '';
-
-      fileSelectorFactory.folderSelect(filesFactory.filesDetails.files[3]);
-      
-      expect(filesFactory.filesDetails.files[3].isChecked).to.be.true;
-      expect(filesFactory.filesDetails.checkedCount).to.be.equal(0);
-      expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(1);
-      expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(1);
-    });
-
-    it('should send folder via broadcast', function() {
-      storageFactory.selectorType = 'single-folder';
-
-      fileSelectorFactory.folderSelect(filesFactory.filesDetails.files[3]);
-
-      $broadcastSpy.should.have.been.calledWith('FileSelectAction',
-        ['https://storage.googleapis.com/risemedialibrary-companyId/test%2F']);
-    });
-
-  });
-
-  describe('fileCheckToggled: ', function() {
-    it('should select a file', function() {
-      fileSelectorFactory.fileCheckToggled(filesFactory.filesDetails.files[1]);
-      
-      expect(filesFactory.filesDetails.files[1].isChecked).to.be.true;
-      expect(filesFactory.filesDetails.checkedCount).to.be.equal(1);
-      expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(0);
-      expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(1);
-    });
-    
-    it('should select a folder', function() {
-      fileSelectorFactory.fileCheckToggled(filesFactory.filesDetails.files[3]);
-      
-      expect(filesFactory.filesDetails.files[3].isChecked).to.be.true;
-      expect(filesFactory.filesDetails.checkedCount).to.be.equal(0);
-      expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(1);
-      expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(1);
-    });
-    
-    it('should toggle selection', function() {
-      fileSelectorFactory.fileCheckToggled(filesFactory.filesDetails.files[1]);
-      fileSelectorFactory.fileCheckToggled(filesFactory.filesDetails.files[1]);
-      
-      expect(filesFactory.filesDetails.files[1].isChecked).to.be.false;
-      expect(filesFactory.filesDetails.checkedCount).to.be.equal(0);
-      expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(0);
-      expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(0);
-    });
   });
 
   describe('selectAllCheckboxes: ', function() {
@@ -215,8 +166,8 @@ describe('service: fileSelectorFactory:', function() {
   });
   
   it('getSelectedFiles: ', function() {
-    fileSelectorFactory.fileCheckToggled(filesFactory.filesDetails.files[1]);
-    fileSelectorFactory.fileCheckToggled(filesFactory.filesDetails.files[2]);
+    fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[1]);
+    fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[2]);
 
     expect(fileSelectorFactory.getSelectedFiles()).to.deep.equal([
       filesFactory.filesDetails.files[1], 
@@ -227,9 +178,10 @@ describe('service: fileSelectorFactory:', function() {
   it('sendFiles: ', function() {
     storageFactory.selectorType = 'multiple-file';
     
-    fileSelectorFactory.fileCheckToggled(filesFactory.filesDetails.files[1]);
-    fileSelectorFactory.fileCheckToggled(filesFactory.filesDetails.files[2]);
+    fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[1]);
+    fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[2]);
 
+      expect(filesFactory.filesDetails.checkedCount).to.be.equal(2);
     fileSelectorFactory.sendFiles();
 
     $broadcastSpy.should.have.been.calledWith('FileSelectAction', [
@@ -238,38 +190,109 @@ describe('service: fileSelectorFactory:', function() {
     ]);
   });
   
+  describe('changeFolder: ', function() {
+    it('should not do anything if a file is selected', function() {
+      fileSelectorFactory.changeFolder(filesFactory.filesDetails.files[1]);
+      
+      expect(filesFactory.filesDetails.files[1].isChecked).to.be.false;
+      expect(filesFactory.filesDetails.checkedCount).to.be.equal(0);
+      expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(0);
+      expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(0);
+    });
+
+    it('should reset selections and refreshFilesList', function() {
+      var refreshFilesListSpy = sinon.spy(filesFactory, 'refreshFilesList');
+
+      fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[1]);
+
+      fileSelectorFactory.changeFolder(filesFactory.filesDetails.files[3]);
+
+      expect(filesFactory.filesDetails.checkedCount).to.be.equal(0);
+      expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(0);
+      expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(0);
+      
+      refreshFilesListSpy.should.have.been.calledOnce;
+    });
+
+    it('should update folderPath', function() {
+      fileSelectorFactory.changeFolder(filesFactory.filesDetails.files[3]);
+
+      expect(storageFactory.folderPath).to.be.equal(filesFactory.filesDetails.files[3].name);
+    });
+    
+    it('should navigate to parent folder', function() {
+      storageFactory.folderPath = filesFactory.filesDetails.files[3].name;
+      fileSelectorFactory.changeFolder(filesFactory.filesDetails.files[3]);
+
+      expect(storageFactory.folderPath).to.be.equal('');
+    });
+  });
+
   describe('onFileSelect: ', function() {
-    describe('navigating to a folder (double click): ', function() {
-      it('should reset selections and refreshFilesList', function() {
-        var refreshFilesListSpy = sinon.spy(filesFactory, 'refreshFilesList');
-
-        fileSelectorFactory.fileCheckToggled(filesFactory.filesDetails.files[1]);
-
+    describe('storageFull: ', function() {
+      it('should select a file', function() {
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[1]);
+        
+        expect(filesFactory.filesDetails.files[1].isChecked).to.be.true;
+        expect(filesFactory.filesDetails.checkedCount).to.be.equal(1);
+        expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(0);
+        expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(1);
+      });
+      
+      it('should select a folder', function() {
         fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[3]);
-
+        
+        expect(filesFactory.filesDetails.files[3].isChecked).to.be.true;
+        expect(filesFactory.filesDetails.checkedCount).to.be.equal(0);
+        expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(1);
+        expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(1);
+      });
+      
+      it('should select multiple files/folders', function() {
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[1]);
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[3]);
+        
+        expect(filesFactory.filesDetails.files[1].isChecked).to.be.true;
+        expect(filesFactory.filesDetails.files[3].isChecked).to.be.true;
+        expect(filesFactory.filesDetails.checkedCount).to.be.equal(1);
+        expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(1);
+        expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(2);
+      });
+      
+      it('should toggle selection', function() {
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[1]);
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[1]);
+        
+        expect(filesFactory.filesDetails.files[1].isChecked).to.be.false;
         expect(filesFactory.filesDetails.checkedCount).to.be.equal(0);
         expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(0);
         expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(0);
-        
-        refreshFilesListSpy.should.have.been.calledOnce;
+      });
+    });
+
+    describe('single-file: ', function() {
+      beforeEach(function() {
+        storageFactory.storageFull = false;
       });
 
-      it('should update folderPath', function() {
-        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[3]);
+      it('should select a file', function() {
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[1]);
+        
+        expect(filesFactory.filesDetails.files[1].isChecked).to.be.true;
+        expect(filesFactory.filesDetails.checkedCount).to.be.equal(1);
+        expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(0);
+        expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(1);
+      });
 
-        expect(storageFactory.folderPath).to.be.equal(filesFactory.filesDetails.files[3].name);
+      it('should not select folder', function() {
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[3]);
+        
+        expect(filesFactory.filesDetails.files[3].isChecked).to.be.false;
+        expect(filesFactory.filesDetails.checkedCount).to.be.equal(0);
+        expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(0);
+        expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(0);
       });
       
-      it('should navigate to parent folder', function() {
-        storageFactory.folderPath = filesFactory.filesDetails.files[3].name;
-        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[3]);
-
-        expect(storageFactory.folderPath).to.be.equal('');
-      });
-
-    });
-    
-    describe('selecting a single file: ', function() {
       it('should select file', function() {
         fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[1]);
 
@@ -282,7 +305,6 @@ describe('service: fileSelectorFactory:', function() {
         var rpcCallSpy = sinon.spy(gadgetsApi.rpc, 'call');
         var postMessageSpy = sinon.spy($window.parent, "postMessage");
 
-
         fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[1]);
 
         rpcCallSpy.should.have.been.calledWith('', 'rscmd_saveSettings', null,
@@ -291,6 +313,125 @@ describe('service: fileSelectorFactory:', function() {
         // postMessage receives an array of file paths and a '*' as second parameter
         postMessageSpy.should.have.been.calledWith(['https://storage.googleapis.com/risemedialibrary-companyId/test%2Ffile2'], '*');
         postMessageSpy.restore();
+      });
+    });
+
+    describe('single-folder: ', function() {
+      beforeEach(function() {
+        storageFactory.storageFull = false;
+        storageFactory.selectorType = 'single-folder';
+      });
+
+      it('should select a folder', function() {
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[3]);
+        
+        expect(filesFactory.filesDetails.files[3].isChecked).to.be.true;
+        expect(filesFactory.filesDetails.checkedCount).to.be.equal(0);
+        expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(1);
+        expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(1);
+      });
+
+      it('should not select a file', function() {
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[1]);
+
+        expect(filesFactory.filesDetails.files[1].isChecked).to.be.false;
+        expect(filesFactory.filesDetails.checkedCount).to.be.equal(0);
+        expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(0);
+        expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(0);
+      });
+      
+      it('should select folder', function() {
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[3]);
+
+        $broadcastSpy.should.have.been.calledWith('FileSelectAction',
+          ['https://storage.googleapis.com/risemedialibrary-companyId/test%2F']);
+      });
+      
+      it('should select folder and postMessage/send rpc', function() {
+        storageFactory.storageIFrame = true;
+        var rpcCallSpy = sinon.spy(gadgetsApi.rpc, 'call');
+        var postMessageSpy = sinon.spy($window.parent, "postMessage");
+
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[3]);
+
+        rpcCallSpy.should.have.been.calledWith('', 'rscmd_saveSettings', null,
+          {params: 'https://storage.googleapis.com/risemedialibrary-companyId/test%2F'});
+          
+        // postMessage receives an array of file paths and a '*' as second parameter
+        postMessageSpy.should.have.been.calledWith(['https://storage.googleapis.com/risemedialibrary-companyId/test%2F'], '*');
+        postMessageSpy.restore();
+      });
+    });
+
+    describe('multiple-file: ', function() {
+      beforeEach(function() {
+        storageFactory.storageFull = false;
+        storageFactory.selectorType = 'multiple-file';
+      });
+
+      it('should select a file', function() {
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[1]);
+        
+        expect(filesFactory.filesDetails.files[1].isChecked).to.be.true;
+        expect(filesFactory.filesDetails.checkedCount).to.be.equal(1);
+        expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(0);
+        expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(1);
+      });
+
+      it('should not select a folder', function() {
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[3]);
+        
+        expect(filesFactory.filesDetails.files[3].isChecked).to.be.false;
+        expect(filesFactory.filesDetails.checkedCount).to.be.equal(0);
+        expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(0);
+        expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(0);
+      });
+      
+      it('should select multiple files', function() {
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[1]);
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[2]);
+        
+        expect(filesFactory.filesDetails.files[1].isChecked).to.be.true;
+        expect(filesFactory.filesDetails.files[2].isChecked).to.be.true;
+        expect(filesFactory.filesDetails.checkedCount).to.be.equal(2);
+        expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(0);
+        expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(2);
+      });
+    });
+
+    describe('multiple-files-folders: ', function() {
+      beforeEach(function() {
+        storageFactory.storageFull = false;
+        storageFactory.selectorType = 'multiple-files-folders';
+      });
+
+      it('should select a file', function() {
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[1]);
+        
+        expect(filesFactory.filesDetails.files[1].isChecked).to.be.true;
+        expect(filesFactory.filesDetails.checkedCount).to.be.equal(1);
+        expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(0);
+        expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(1);
+      });
+      
+      it('should select a folder', function() {
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[3]);
+        
+        expect(filesFactory.filesDetails.files[3].isChecked).to.be.true;
+        expect(filesFactory.filesDetails.checkedCount).to.be.equal(0);
+        expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(1);
+        expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(1);
+      });
+      
+      it('should select multiple files/folders', function() {
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[1]);
+        fileSelectorFactory.onFileSelect(filesFactory.filesDetails.files[3]);
+        
+        expect(filesFactory.filesDetails.files[1].isChecked).to.be.true;
+        expect(filesFactory.filesDetails.files[3].isChecked).to.be.true;
+        expect(filesFactory.filesDetails.checkedCount).to.be.equal(1);
+        expect(filesFactory.filesDetails.folderCheckedCount).to.be.equal(1);
+        expect(filesFactory.filesDetails.checkedItemsCount).to.be.equal(2);
       });
     });
 
@@ -313,6 +454,53 @@ describe('service: fileSelectorFactory:', function() {
         postMessageSpy.should.have.been.calledWith("close", "*");
         postMessageSpy.restore();
       });
+    });
+
+  });  
+
+  describe('openSelector:', function(){
+    it('should return a promise', function() {
+      expect(fileSelectorFactory.openSelector().then).to.be.a('function');
+    });
+    
+    it('should initialize default selection', function() {
+      fileSelectorFactory.openSelector();
+
+      expect(storageFactory.selectorType).to.equal('single-file');
+    });
+
+    it('should open modal', function() {
+      var $modalSpy = sinon.spy($modal, 'open');
+      
+      fileSelectorFactory.openSelector();      
+      
+      $modalSpy.should.have.been.calledWith({
+        templateUrl: 'partials/storage/storage-modal.html',
+        controller: 'StorageSelectorModalController',
+        size: 'lg'
+      });
+    });
+
+    it('should resolve promise', function(done) {
+      fileSelectorFactory.openSelector()
+      .then(function(result){
+        expect(result).to.equal('success');
+
+        done();
+      })
+      .then(null,done);
+    });
+    
+    it('should reject promise on cancel', function(done) {
+      modalSuccess = false;
+      fileSelectorFactory.openSelector()
+      .then(function(result) {
+        done('failed');
+      })
+      .then(null, function() {
+        done();
+      })
+      .then(null,done);
     });
 
   });

--- a/test/unit/storage/services/svc-storage-factory.tests.js
+++ b/test/unit/storage/services/svc-storage-factory.tests.js
@@ -6,7 +6,8 @@ describe('service: storageFactory:', function() {
   beforeEach(module(function ($provide) {
     $provide.service('$modal', function() {
       return {
-        open: function(){}
+        open: function(){
+        }      
       };
     });
     $provide.service('userState', function() {
@@ -20,7 +21,6 @@ describe('service: storageFactory:', function() {
   }));
 
   beforeEach(function(){
-    
     inject(function($injector){  
       storageFactory = $injector.get('storageFactory');
       $modal = $injector.get('$modal');
@@ -32,21 +32,67 @@ describe('service: storageFactory:', function() {
 
   it('should exist',function(){
     expect(storageFactory).to.be.ok;
-    
-    // Hardcoded
-    expect(storageFactory.storageFull).to.be.true;
-    expect(storageFactory.isSingleFileSelector()).to.be.true;
-    expect(storageFactory.isMultipleFileSelector()).to.be.false;
-    expect(storageFactory.isSingleFolderSelector()).to.be.false;
-    
+        
     expect(storageFactory.getBucketName).to.be.a('function');
     expect(storageFactory.getFolderSelfLinkUrl).to.be.a('function');
-    
+    expect(storageFactory.isMultipleSelector).to.be.a('function');
+    expect(storageFactory.isFileSelector).to.be.a('function');
+    expect(storageFactory.isFolderSelector).to.be.a('function');
+    expect(storageFactory.canSelect).to.be.a('function');
     expect(storageFactory.fileIsCurrentFolder).to.be.a('function');
     expect(storageFactory.fileIsFolder).to.be.a('function');
     expect(storageFactory.fileIsTrash).to.be.a('function');
-    
     expect(storageFactory.isTrashFolder).to.be.a('function');
+    
+    expect(storageFactory.addFolder).to.be.a('function');
+  });
+  
+  it('should initialize values', function() {
+    // Hardcoded
+    expect(storageFactory.storageFull).to.be.true;
+    expect(storageFactory.isMultipleSelector()).to.be.true;
+    expect(storageFactory.isFileSelector()).to.be.true;
+    expect(storageFactory.isFolderSelector()).to.be.true;
+  });
+  
+  describe('canSelect: ', function() {
+    beforeEach(function() {
+      storageFactory.storageFull = false;
+    });
+
+    it('false for file is currentFolder', function() {
+      expect(storageFactory.canSelect({name: 'folder/', currentFolder: true})).to.be.false;
+    });
+
+    it('false for file is trash', function() {
+      expect(storageFactory.canSelect({name: '--TRASH--/'})).to.be.false;
+    });
+
+    it('false for files in singleFolderSelector', function() {
+      storageFactory.selectorType = 'single-folder';
+
+      expect(storageFactory.canSelect({name: 'file.jpg'})).to.be.false;
+    });
+    
+    it('true for files in singleFileSelector', function() {
+      expect(storageFactory.canSelect({name: 'file.jpg'})).to.be.true;
+    });
+    
+    it('true for folders in singleFolderSelector', function() {
+      storageFactory.selectorType = 'single-folder';
+
+      expect(storageFactory.canSelect({name: 'folder/'})).to.be.true;
+    });
+    
+    it('false for folders in non singleFolderSelector', function() {
+      expect(storageFactory.canSelect({name: 'folder/'})).to.be.false;
+    });
+    
+    it('true for folders in fullScreen', function() {
+      storageFactory.storageFull = true;
+
+      expect(storageFactory.canSelect({name: 'folder/'})).to.be.true;
+    });
   });
   
   it('getBucketName: ', function() {

--- a/web/partials/storage/files-list.html
+++ b/web/partials/storage/files-list.html
@@ -2,12 +2,12 @@
   <div class="scrollable-list" 
   rv-spinner rv-spinner-key="storage-selector-loader"
   rv-spinner-start-active="1" >
-    <table id="storageFileList" class="table-2 table-hover table-selector" ng-class="storageFactory.storageFull || storageFactory.isMultipleFileSelector() ? 'multiple-selector' : 'single-selector'" ng-show="statusDetails.code!==202 && statusDetails.code!==404 && isFileListVisible()">
+    <table id="storageFileList" class="table-2 table-hover table-selector" ng-class="storageFactory.isMultipleSelector() ? 'multiple-selector' : 'single-selector'" ng-show="statusDetails.code!==202 && statusDetails.code!==404 && isFileListVisible()">
       <thead>
         <tr>
           <th class="col-sm-6">
             <input type="checkbox" class="add-right" ng-model="selectAll">
-            <label ng-click="fileSelectorFactory.selectAllCheckboxes(query)" ng-show="storageFactory.storageFull || storageFactory.isMultipleFileSelector()"></label>
+            <label ng-click="fileSelectorFactory.selectAllCheckboxes(query)" ng-show="storageFactory.isMultipleSelector()"></label>
             <a id="tableHeaderName" href="" ng-click="orderByAttribute = fileNameOrderFunction; reverseSort = !reverseSort">
               <span translate="common.file-name" ></span>
               <span ng-show="orderByAttribute==fileNameOrderFunction">
@@ -61,7 +61,7 @@
       <tbody>
         <tr class="clickable-row"
         ng-click="fileClick(file);"
-        ng-class="{'active': file.isChecked, 'blocked-file': file.isThrottled, 'back-btn': file.currentFolder, 'no-select-row': isNoSelectRow(file), 'disabled-row': !storageFactory.fileIsFolder(file) && storageFactory.isSingleFolderSelector() }"
+        ng-class="{'active': file.isChecked, 'blocked-file': file.isThrottled, 'back-btn': file.currentFolder, 'no-select-row': !storageFactory.canSelect(file), 'disabled-row': !storageFactory.fileIsFolder(file) && !storageFactory.isFileSelector() }"
         ng-repeat="file in filesDetails.files | filter:search.query | orderBy:orderByAttribute:reverseSort track by $index" ng-if="!storageFactory.fileIsTrash(file) || storageFactory.storageFull">
           <td ng-if="storageFactory.fileIsFolder(file)">
             <span class="folder">{{file.name | fileNameFilter:storageFactory.folderPath}}</span>

--- a/web/partials/storage/storage-modal.html
+++ b/web/partials/storage/storage-modal.html
@@ -51,7 +51,7 @@
     	
       <ng-include src="'partials/storage/start-trial.html'" ng-show="trialAvailable"></ng-include>
 
-      <div ng-show="storageFactory.isMultipleFileSelector() && !trialAvailable">
+      <div ng-show="storageFactory.isMultipleSelector() && !trialAvailable">
         <button type="button" title="select" class="btn btn-primary" ng-click="fileSelectorFactory.sendFiles()" ng-disabled="filesDetails.checkedCount < 1 && filesDetails.folderCheckedCount < 1">
           <span translate="common.select"></span> <span class="fa fa-check icon-right"></span>
         </button>

--- a/web/scripts/storage/controllers/ctr-files-list.js
+++ b/web/scripts/storage/controllers/ctr-files-list.js
@@ -59,9 +59,7 @@ angular.module('risevision.storage.controllers')
           if (currentTime - lastClickTime < dblClickDelay) {
             lastClickTime = 0;
 
-            if (storageFactory.fileIsFolder(file)) {
-              fileSelectorFactory.onFileSelect(file);
-            }
+            fileSelectorFactory.changeFolder(file);
           } else {
             lastClickTime = currentTime;
 
@@ -70,9 +68,8 @@ angular.module('risevision.storage.controllers')
               var currentTime = (new Date()).getTime();
 
               if (lastClickTime !== 0 && currentTime - lastClickTime >=
-                dblClickDelay && !file.currentFolder &&
-                !storageFactory.fileIsTrash(file)) {
-                fileSelectorFactory.folderSelect(file);
+                dblClickDelay) {
+                fileSelectorFactory.onFileSelect(file);
               }
             }, dblClickDelay);
           }
@@ -83,11 +80,7 @@ angular.module('risevision.storage.controllers')
             return;
           }
 
-          if (storageFactory.isSingleFileSelector()) {
-            fileSelectorFactory.onFileSelect(file);
-          } else if (!storageFactory.isSingleFolderSelector()) {
-            fileSelectorFactory.fileCheckToggled(file);
-          }
+          fileSelectorFactory.onFileSelect(file);
         }
       };
 
@@ -128,17 +121,6 @@ angular.module('risevision.storage.controllers')
         } else {
           return true;
         }
-      };
-
-      $scope.isNoSelectRow = function (file) {
-        var isFileCases = !storageFactory.fileIsFolder(file) &&
-          storageFactory.isSingleFolderSelector();
-        var isFolderCases = storageFactory.fileIsFolder(file) &&
-          !storageFactory.isSingleFolderSelector() &&
-          !storageFactory.storageFull;
-
-        return file.currentFolder || storageFactory.fileIsTrash(file) ||
-          (isFileCases) || (isFolderCases);
       };
 
     }

--- a/web/scripts/storage/directives/dtv-storage-selector.js
+++ b/web/scripts/storage/directives/dtv-storage-selector.js
@@ -5,9 +5,8 @@
   // Declare legacy selector [error without it]
   angular.module('risevision.widget.common.storage-selector', []);
   angular.module('risevision.storage.directives')
-    .directive('storageSelector', ['$modal', '$log', 'SELECTOR_TYPES',
-      'storageFactory',
-      function ($modal, $log, SELECTOR_TYPES, storageFactory) {
+    .directive('storageSelector', ['fileSelectorFactory', 'storageFactory',
+      function (fileSelectorFactory, storageFactory) {
         return {
           restrict: 'EA',
           scope: {
@@ -17,28 +16,14 @@
           },
           templateUrl: 'partials/storage/storage-selector.html',
           link: function ($scope) {
-            storageFactory.storageFull = false;
-            storageFactory.selectorType = $scope.type ?
-              $scope.type : SELECTOR_TYPES.SINGLE_FILE;
-
             $scope.open = function () {
-              $scope.modalInstance = $modal.open({
-                templateUrl: 'partials/storage/storage-modal.html',
-                controller: 'StorageSelectorModalController',
-                size: 'lg'
-              });
-
-              $scope.modalInstance.result.then(function (files) {
-                $log.info('Files selected: ' + files);
-
-                // emit an event with name 'files', passing the array of files selected from storage and the selector type
-                $scope.$emit('picked', files, storageFactory.selectorType);
-
-              }, function () {
-
-              });
-
+              fileSelectorFactory.openSelector($scope.type)
+                .then(function (files) {
+                  // emit an event with name 'files', passing the array of files selected from storage and the selector type
+                  $scope.$emit('picked', files, storageFactory.selectorType);
+                });
             };
+
           }
         };
       }

--- a/web/scripts/storage/services/svc-file-selector-factory.js
+++ b/web/scripts/storage/services/svc-file-selector-factory.js
@@ -1,10 +1,12 @@
 'use strict';
 angular.module('risevision.storage.services')
   .value('STORAGE_FILE_URL', 'https://storage.googleapis.com/')
-  .factory('fileSelectorFactory', ['$rootScope', '$window', 'storageFactory',
-    'filesFactory', 'gadgetsApi', 'filterFilter', 'STORAGE_FILE_URL',
-    function ($rootScope, $window, storageFactory, filesFactory,
-      gadgetsApi, filterFilter, STORAGE_FILE_URL) {
+  .factory('fileSelectorFactory', ['$rootScope', '$window', '$log', '$q',
+    '$modal', 'storageFactory', 'filesFactory', 'gadgetsApi', 'filterFilter',
+    'STORAGE_FILE_URL', 'SELECTOR_TYPES',
+    function ($rootScope, $window, $log, $q, $modal, storageFactory,
+      filesFactory, gadgetsApi, filterFilter, STORAGE_FILE_URL,
+      SELECTOR_TYPES) {
       var factory = {};
 
       //on all state Changes do not hold onto checkedFiles list
@@ -24,33 +26,6 @@ angular.module('risevision.storage.services')
 
       factory.resetSelections();
 
-      factory.folderSelect = function (folder) {
-        if (storageFactory.fileIsFolder(folder)) {
-          if (storageFactory.isSingleFolderSelector()) {
-            _postFileToParent(folder);
-          } else if (!storageFactory.isSingleFileSelector() && !
-            storageFactory.isMultipleFileSelector()) {
-            factory.fileCheckToggled(folder);
-          }
-        }
-      };
-
-      factory.fileCheckToggled = function (file) {
-        // ng-click is processed before btn-checkbox updates the model
-        var checkValue = !file.isChecked;
-
-        file.isChecked = checkValue;
-
-        if (file.name.substr(-1) !== '/') {
-          filesFactory.filesDetails.checkedCount += checkValue ? 1 : -1;
-        } else {
-          filesFactory.filesDetails.folderCheckedCount += checkValue ? 1 :
-            -1;
-        }
-
-        filesFactory.filesDetails.checkedItemsCount += checkValue ? 1 : -1;
-      };
-
       factory.selectAllCheckboxes = function (query) {
         var filteredFiles = filterFilter(filesFactory.filesDetails.files,
           query);
@@ -65,8 +40,8 @@ angular.module('risevision.storage.services')
 
           if (storageFactory.fileIsCurrentFolder(file) ||
             storageFactory.fileIsTrash(file) ||
-            (storageFactory.fileIsFolder(file) && !(storageFactory.storageFull ||
-              storageFactory.isSingleFolderSelector()))) {
+            (storageFactory.fileIsFolder(file) &&
+              !storageFactory.isFolderSelector())) {
             continue;
           }
 
@@ -136,31 +111,72 @@ angular.module('risevision.storage.services')
         _sendMessage(fileUrls);
       };
 
-      var _postFileToParent = function (file) {
-        var fileUrl = _getFileUrl(file);
-
-        _sendMessage([fileUrl]);
-      };
-
-      factory.onFileSelect = function (file) {
-        if (storageFactory.fileIsFolder(file)) {
+      factory.changeFolder = function (folder) {
+        if (storageFactory.fileIsFolder(folder)) {
           factory.resetSelections();
 
-          if (storageFactory.fileIsCurrentFolder(file)) {
+          if (storageFactory.fileIsCurrentFolder(folder)) {
             var folderPath = storageFactory.folderPath.split('/');
             folderPath = folderPath.length > 2 ?
               folderPath.slice(0, -2).join('/') + '/' : '';
 
             storageFactory.folderPath = folderPath;
           } else {
-            storageFactory.folderPath = file.name;
+            storageFactory.folderPath = folder.name;
           }
 
           filesFactory.refreshFilesList();
 
-        } else {
-          _postFileToParent(file);
         }
+      };
+
+      var _fileCheckToggled = function (file) {
+        // ng-click is processed before btn-checkbox updates the model
+        var checkValue = !file.isChecked;
+
+        file.isChecked = checkValue;
+
+        if (file.name.substr(-1) !== '/') {
+          filesFactory.filesDetails.checkedCount += checkValue ? 1 : -1;
+        } else {
+          filesFactory.filesDetails.folderCheckedCount += checkValue ? 1 :
+            -1;
+        }
+
+        filesFactory.filesDetails.checkedItemsCount += checkValue ? 1 : -1;
+      };
+
+      factory.onFileSelect = function (file) {
+        if (storageFactory.canSelect(file)) {
+          _fileCheckToggled(file);
+
+          if (!storageFactory.isMultipleSelector()) {
+            factory.sendFiles();
+          }
+        }
+      };
+
+      factory.openSelector = function (type) {
+        storageFactory.storageFull = false;
+        storageFactory.selectorType = type || SELECTOR_TYPES.SINGLE_FILE;
+
+        var deferred = $q.defer();
+
+        var modalInstance = $modal.open({
+          templateUrl: 'partials/storage/storage-modal.html',
+          controller: 'StorageSelectorModalController',
+          size: 'lg'
+        });
+
+        modalInstance.result.then(function (files) {
+          $log.info('Files selected: ' + files);
+
+          deferred.resolve(files);
+        }, function () {
+          deferred.reject();
+        });
+
+        return deferred.promise;
       };
 
       return factory;

--- a/web/scripts/storage/services/svc-storage-factory.js
+++ b/web/scripts/storage/services/svc-storage-factory.js
@@ -3,7 +3,8 @@ angular.module('risevision.storage.services')
   .value('SELECTOR_TYPES', {
     SINGLE_FILE: 'single-file',
     MULTIPLE_FILE: 'multiple-file',
-    SINGLE_FOLDER: 'single-folder'
+    SINGLE_FOLDER: 'single-folder',
+    MULTIPLE_FILES_FOLDERS: 'multiple-files-folders'
   })
   .value('STORAGE_CLIENT_API', 'https://www.googleapis.com/storage/v1/b/')
   .factory('storageFactory', ['userState', '$modal', 'SELECTOR_TYPES',
@@ -24,16 +25,29 @@ angular.module('risevision.storage.services')
         return STORAGE_CLIENT_API + factory.getBucketName() + '/o?prefix=';
       };
 
-      factory.isSingleFileSelector = function () {
-        return factory.selectorType === SELECTOR_TYPES.SINGLE_FILE;
+      factory.isMultipleSelector = function () {
+        return factory.storageFull ||
+          factory.selectorType === SELECTOR_TYPES.MULTIPLE_FILE ||
+          factory.selectorType === SELECTOR_TYPES.MULTIPLE_FILES_FOLDERS;
       };
 
-      factory.isMultipleFileSelector = function () {
-        return factory.selectorType === SELECTOR_TYPES.MULTIPLE_FILE;
+      factory.isFileSelector = function () {
+        return factory.storageFull ||
+          factory.selectorType === SELECTOR_TYPES.SINGLE_FILE ||
+          factory.selectorType === SELECTOR_TYPES.MULTIPLE_FILE ||
+          factory.selectorType === SELECTOR_TYPES.MULTIPLE_FILES_FOLDERS;
       };
 
-      factory.isSingleFolderSelector = function () {
-        return factory.selectorType === SELECTOR_TYPES.SINGLE_FOLDER;
+      factory.isFolderSelector = function () {
+        return factory.storageFull ||
+          factory.selectorType === SELECTOR_TYPES.SINGLE_FOLDER ||
+          factory.selectorType === SELECTOR_TYPES.MULTIPLE_FILES_FOLDERS;
+      };
+
+      factory.canSelect = function (file) {
+        return !file.currentFolder && !factory.fileIsTrash(file) &&
+          (factory.fileIsFolder(file) && factory.isFolderSelector() ||
+            !factory.fileIsFolder(file) && factory.isFileSelector());
       };
 
       factory.fileIsCurrentFolder = function (file) {


### PR DESCRIPTION
Created separate `openSelector` function that opens the Storage modal
Moved selection code out of the `filesListController` into the `fileSelectorFactory`
Split out `changeFolder` function that deals solely with changing folders
Refactored & simplified `storageFactory` helper functions

Unit test coverage improvements

[stage-4]