### PR TITLE
Show Help for new users

### DIFF
--- a/test/e2e/launcher/cases/homepage.js
+++ b/test/e2e/launcher/cases/homepage.js
@@ -92,12 +92,12 @@ var HomepageScenarios = function() {
       });
 
       it("should show animation when clicking help text",function(){
-        homepage.getHelpToggleButton().click();
+        homepage.getShowHelpButton().click();
         expect(homepage.getHelpContainer().isDisplayed()).to.eventually.be.true;
       });
 
-      it("should hide animation when clicking help text again",function(){
-        homepage.getHelpToggleButton().click();
+      it("should hide animation when clicking Hide Animation",function(){
+        homepage.getHideHelpButton().click();
         expect(homepage.getHelpContainer().isDisplayed()).to.eventually.be.false;
       });
     });

--- a/test/e2e/launcher/pages/homepage.js
+++ b/test/e2e/launcher/pages/homepage.js
@@ -10,7 +10,8 @@ var HomePage = function() {
 
   var appLauncherContainer = element(by.id('appLauncherContainer'));
   var helpContainer = element(by.id('helpContainer'));
-  var helpToggleButton = element(by.id('helpToggleButton'));
+  var showHelpButton = element(by.id('showHelpButton'));
+  var hideHelpButton = element(by.id('hideHelpButton'));
 
   var prioritySupportBanner = element(by.id('prioritySupportBanner'));
   var presentationCTA = element(by.id('presentationCTA'));
@@ -82,8 +83,12 @@ var HomePage = function() {
     return helpContainer;
   };
 
-  this.getHelpToggleButton = function() {
-    return helpToggleButton;
+  this.getShowHelpButton = function() {
+    return showHelpButton;
+  };
+
+  this.getHideHelpButton = function() {
+    return hideHelpButton;
   };
 
   this.getPrioritySupportBanner = function() {

--- a/test/unit/launcher/controllers/ctr-home.tests.js
+++ b/test/unit/launcher/controllers/ctr-home.tests.js
@@ -1,7 +1,7 @@
 'use strict';
 describe('controller: Home', function() {
   beforeEach(module('risevision.apps.launcher.controllers'));
-  var $scope, localStorageService, localStorageGetSpy, startGlobalSpy, stopGlobalSpy;
+  var $scope, localStorageService, localStorageGetSpy, startGlobalSpy, stopGlobalSpy, lsGetReturn;
   beforeEach(function(){
     module(function ($provide) {
       $provide.service('$loading', function() {
@@ -12,13 +12,13 @@ describe('controller: Home', function() {
       });    
       $provide.service('localStorageService', function() {
         return localStorageService = {
-          get: function() { return false; },
+          get: function() { return lsGetReturn; },
           set: function(){}
         };
       }); 
       $provide.service('editorFactory', function() {
         return {
-          presentations: { loadingItems: true }
+          presentations: { loadingItems: true , items: { list: [ ] } }
         };
       });      
       $provide.service('displayFactory', function() {
@@ -26,6 +26,7 @@ describe('controller: Home', function() {
       });
     })
     inject(function($injector,$rootScope, $controller, localStorageService, $loading) {
+      lsGetReturn = false;
       localStorageGetSpy = sinon.spy(localStorageService,'get');
       startGlobalSpy = sinon.spy($loading,'startGlobal');
       stopGlobalSpy = sinon.spy($loading,'stopGlobal');
@@ -65,6 +66,31 @@ describe('controller: Home', function() {
       $scope.$apply();
       stopGlobalSpy.should.have.been.calledWith("launcher.loading");
     });
+
+    it("should not flag help if user has presentations",function(){
+      var spy = sinon.spy(localStorageService,'set');
+
+      $scope.editorFactory.presentations.loadingItems = false;
+      $scope.editorFactory.presentations.items.list = [{id:'id'}];
+
+      $scope.$apply();
+
+      spy.should.not.have.been.called;
+    });
+
+    it("should flag help if user has 0 presentations and has not set visbility of Help",function(){
+      var spy = sinon.spy(localStorageService,'set');
+
+      $scope.editorFactory.presentations.loadingItems = false;
+      $scope.editorFactory.presentations.items.list = [];
+      lsGetReturn = null
+
+      $scope.$apply();
+      
+      spy.should.have.been.calledWith("launcher.showHelp",true);
+    });
+
+    
   });
 
   describe("toggleHelp:",function(){

--- a/web/partials/displays/display-fields.html
+++ b/web/partials/displays/display-fields.html
@@ -18,7 +18,8 @@
 <div ng-show="display.id && !display.lastActivityDate">
 
   <div class="text-right add-top add-bottom">
-    <button class="btn btn-link" ng-click="showHelp = !showHelp">{{ 'displays-app.fields.controls.howtoInstall' | translate }}</button>
+    <button class="btn btn-link" ng-click="showHelp = !showHelp" ng-hide="showHelp">{{ 'displays-app.fields.controls.howtoInstall' | translate }}</button>
+    <button class="btn btn-link" ng-click="showHelp = !showHelp" ng-show="showHelp">{{ 'launcher.hideAnimation' | translate }}</button>
   </div>
 
   <div class="video-box add-bottom text-center" ng-show="showHelp">

--- a/web/partials/launcher/app-launcher.html
+++ b/web/partials/launcher/app-launcher.html
@@ -5,7 +5,8 @@
   
   <div ng-show="editorFactory.presentations.items.list.length > 0">
     <div class="text-right add-top add-bottom">
-      <button id="helpToggleButton" class="btn btn-link" ng-click="toggleHelp()">{{'launcher.howToShow'|translate}}</button>
+      <button id="showHelpButton" class="btn btn-link" ng-click="toggleHelp()" ng-hide="showHelp">{{'launcher.howToShow'|translate}}</button>
+      <button id="hideHelpButton" class="btn btn-link" ng-click="toggleHelp()" ng-show="showHelp">{{'launcher.hideAnimation'|translate}}</button>
     </div>
 
     <div id="helpContainer" class="video-box add-bottom" ng-show="showHelp">

--- a/web/scripts/launcher/controllers/ctr-home.js
+++ b/web/scripts/launcher/controllers/ctr-home.js
@@ -16,6 +16,10 @@ angular.module('risevision.apps.launcher.controllers')
         loadingItems) {
         if (loadingItems === false) {
           $loading.stopGlobal('launcher.loading');
+          if (editorFactory.presentations.items.list.length === 0 &&
+            localStorageService.get('launcher.showHelp') == null) {
+            localStorageService.set('launcher.showHelp', true);
+          }
         }
       });
 


### PR DESCRIPTION
Show help in launcher for users that don't have presentations and that haven't dismissed the help yet.

So, new users will see it opened by default. Existing users with Presentations will not see it opened.

@alex-deaconu Please review. Thanks