### PR TITLE
Show Storage spinner when loading list

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "common-header": "https://github.com/Rise-Vision/common-header.git#v1.10.11",
     "component-storage-selector": "https://github.com/Rise-Vision/component-storage-selector.git",
     "rv-common-i18n": "https://github.com/Rise-Vision/common-i18n.git",
-    "rv-common-style": "https://github.com/Rise-Vision/common-style.git#v1.3.73",
+    "rv-common-style": "https://github.com/Rise-Vision/common-style.git#v1.3.74",
     "rv-common-app-components": "https://github.com/Rise-Vision/common-app-components.git",
     "rv-loading": "https://github.com/Rise-Vision/rv-loading.git",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#1.0.4",
@@ -43,6 +43,6 @@
     "angular-touch": "^1.4.1",
     "angular-mocks": "~1.3.0",
     "angular-sanitize": "~1.3.0",
-    "rv-common-style": "v1.3.73"
+    "rv-common-style": "v1.3.74"
   }
 }

--- a/test/unit/storage/controllers/ctr-empty-state.tests.js
+++ b/test/unit/storage/controllers/ctr-empty-state.tests.js
@@ -1,23 +1,22 @@
 'use strict';
-describe('controller: Storage', function() {
+describe('controller: Empty State', function() {
   beforeEach(module('risevision.storage.controllers'));
   beforeEach(module(function ($provide) {
     $provide.service('storageFactory',function(){
       return storageFactory = {
-          storageFull: false,
-          setSelectorType: function() {
-            selectorTypeSet = true;
-          }
+        selectorType: 'multiple-files-folders'
         }
     });
+    $provide.value('SELECTOR_TYPES', {
+      MULTIPLE_FILES_FOLDERS: 'multiple-files-folders'
+    });
   }));
-  var $scope, storageFactory, selectorTypeSet;
+  var $scope, storageFactory;
   beforeEach(function(){
-    selectorTypeSet = false;
     inject(function($injector,$rootScope, $controller){
 
       $scope = $rootScope.$new();
-      $controller('StorageController', {
+      $controller('EmptyStateController', {
         $scope : $scope
       });
       $scope.$digest();
@@ -28,9 +27,8 @@ describe('controller: Storage', function() {
     expect($scope).to.be.ok;
   });
 
-  it('should set storageFull',function(){
-    expect(storageFactory.storageFull).to.be.true;
-    expect(selectorTypeSet).to.be.true;
+  it('should not default to MULTIPLE_FILES_FOLDERS',function(){
+    expect($scope.isMultipleFilesFoldersSelector).to.be.true;
   });
 
 });

--- a/test/unit/storage/controllers/ctr-files-list.tests.js
+++ b/test/unit/storage/controllers/ctr-files-list.tests.js
@@ -53,8 +53,7 @@ describe('controller: Files List', function() {
         },
         filesDetails: {
           files: []
-        },
-        statusDetails: {}
+        }
       }
     });
     $provide.service('FileUploader',function(){
@@ -88,7 +87,6 @@ describe('controller: Files List', function() {
     expect($scope.fileUploader).to.be.ok;    
 
     expect($scope.filesDetails).to.be.ok;
-    expect($scope.statusDetails).to.be.ok;
     expect($scope.bucketCreationStatus).to.be.ok;
 
     expect($scope.fileClick).to.be.a('function');
@@ -217,27 +215,26 @@ describe('controller: Files List', function() {
   describe('isFileListVisible: ', function() {
     beforeEach(function() {
       $scope.storageFactory.folderPath = '';
-      $scope.storageFactory.storageFull = false;
+      $scope.trialAvailable = false;
+      $scope.fileUploader.queue = [];
     });
 
-    it('hidden for no files', function() {
-      expect($scope.isFileListVisible()).to.be.false;
-    });
-    
-    it('hidden if Trash is the only file', function() {
-      $scope.filesDetails.files.push({name: '--TRASH--/'});
+    it('should be hidden for no files', function() {
       expect($scope.isFileListVisible()).to.be.false;
     });
 
-    it('always visible for full screen storage', function() {
-      $scope.storageFactory.storageFull = true;
-
-      expect($scope.isFileListVisible()).to.be.true;
+    it('should be hidden if loading', function() {
+      $scope.storageFactory.loadingItems = true;
+      expect($scope.isFileListVisible()).to.be.false;
     });
 
-    it('show for subfolders', function() {
-      $scope.storageFactory.folderPath = 'someFolder/';
+    it('should be hidden if trial is available',function(){
+      $scope.trialAvailable = true;
+      expect($scope.isFileListVisible()).to.be.false;
+    });
 
+    it('should show if file list is not empty',function(){
+      $scope.filesDetails.files.push({name: 'aa'});
       expect($scope.isFileListVisible()).to.be.true;
     });
 
@@ -247,8 +244,6 @@ describe('controller: Files List', function() {
 
     beforeEach(function() {
       $scope.storageFactory.folderPath = '';
-      $scope.storageFactory.storageFull = false;
-      $scope.trialAvailable = false;
       $scope.fileUploader.queue = [];
     });
 
@@ -260,9 +255,9 @@ describe('controller: Files List', function() {
       $scope.fileUploader.queue = [{}];
       expect($scope.isEmptyState()).to.be.false;
     });
-
-    it('should be false if trial is available',function(){
-      $scope.trialAvailable = true;
+    
+    it('show be false for subfolders', function() {
+      $scope.storageFactory.folderPath = 'someFolder/';
       expect($scope.isEmptyState()).to.be.false;
     });
 
@@ -271,6 +266,10 @@ describe('controller: Files List', function() {
       expect($scope.isEmptyState()).to.be.false;
     });
 
+    it('should be true if Trash is the only file', function() {
+      $scope.filesDetails.files.push({name: '--TRASH--/'});
+      expect($scope.isEmptyState()).to.be.true;
+    });
 
   });
 

--- a/web/index.html
+++ b/web/index.html
@@ -223,6 +223,7 @@
   <script src="scripts/storage/directives/dtv-storage-breadcrumb.js"></script>
   
   <script src="scripts/storage/controllers/ctr-files-list.js"></script>
+  <script src="scripts/storage/controllers/ctr-empty-state.js"></script>
   <script src="scripts/storage/controllers/ctr-storage-selector-modal.js"></script>
   <script src="scripts/storage/controllers/ctr-new-folder-modal.js"></script>
   <script src="scripts/storage/controllers/ctr-storage.js"></script>

--- a/web/partials/displays/displays-list.html
+++ b/web/partials/displays/displays-list.html
@@ -58,11 +58,11 @@
           <td class="col-sm-1 hidden-xs nowrap text-right"><a ui-sref="apps.displays.change({displayId: display.id, companyId: display.companyId})"><span class="text-muted">{{display.lastActivityDate | date:'d-MMM-yyyy h:mm a'}}</span></a></td>
         </tr>
         <!-- If no displays available -->
-        <tr ng-show="displays.list.length === 0 && !search.query">
+        <tr ng-show="displays.items.list.length === 0 && !search.query">
           <td colspan="4" class="text-center"><span translate>displays-app.list.empty</span></td>
         </tr>
         <!-- If no search results -->
-        <tr ng-show="displays.list.length === 0 && search.query">
+        <tr ng-show="displays.items.list.length === 0 && search.query">
           <td colspan="4" class="text-center"><span translate>displays-app.list.no-results</span></td>
         </tr>
         

--- a/web/partials/storage/empty-state.html
+++ b/web/partials/storage/empty-state.html
@@ -1,8 +1,15 @@
-<div class="file-empty-state content-box add-top">   
-    <p class="add-top" translate>storage-client.empty-state.no-uploads</p>
-    <span> {{ 'storage-client.empty-state.select' | translate}} <b translate>storage-client.upload-files</b>, <b translate>storage-client.upload-folder</b>, {{ 'storage-client.empty-state.or' | translate}} <b translate>storage-client.new-folder</b>.</span><br/><br/>
-    <div><svg-icon p="riseWidgetFolder"></svg-icon>
-    <span translate>storage-client.empty-state.select-folder</span></div>
-    <div><svg-icon p="riseWidgetImageMulti"></svg-icon>
-    <span translate>storage-client.empty-state.select-file</span></div>
+<div class="file-empty-state add-top" ng-controller="EmptyStateController">   
+  <p class="add-top" translate>storage-client.empty-state.no-uploads</p>
+  <span> {{ 'storage-client.empty-state.select' | translate}} <b translate>storage-client.upload-files</b>, <b translate>storage-client.upload-folder</b>, {{ 'storage-client.empty-state.or' | translate}} <b translate>storage-client.new-folder</b>.</span>
+  <br/><br/>
+  <div ng-if="isMultipleFilesFoldersSelector">
+    <div>
+      <svg-icon p="riseWidgetFolder"></svg-icon>
+      <span translate>storage-client.empty-state.select-folder</span>
+    </div>
+    <div>
+      <svg-icon p="riseWidgetImageMulti"></svg-icon>
+      <span translate>storage-client.empty-state.select-file</span>
+    </div>
+  </div>
 </div>

--- a/web/partials/storage/files-list.html
+++ b/web/partials/storage/files-list.html
@@ -2,7 +2,7 @@
   <div class="scrollable-list" 
   rv-spinner rv-spinner-key="storage-selector-loader"
   rv-spinner-start-active="1" >
-    <table id="storageFileList" class="table-2 table-hover table-selector" ng-class="storageFactory.isMultipleSelector() ? 'multiple-selector' : 'single-selector'" ng-show="statusDetails.code!==202 && statusDetails.code!==404 && isFileListVisible()">
+    <table id="storageFileList" class="table-2 table-hover table-selector" ng-class="storageFactory.isMultipleSelector() ? 'multiple-selector' : 'single-selector'" ng-show="filesDetails.code!==202 && filesDetails.code!==404 && isFileListVisible()">
       <thead>
         <tr>
           <th class="col-sm-6">
@@ -92,5 +92,7 @@
         </tr>
       </tbody>
     </table>
+    
+    <ng-include src="'partials/storage/empty-state.html'" ng-show="!filesFactory.loadingItems && isEmptyState()"></ng-include>
   </div>	
 </div>

--- a/web/partials/storage/home.html
+++ b/web/partials/storage/home.html
@@ -21,11 +21,11 @@
 
 	<ng-include src="'partials/storage/upload-panel.html'"></ng-include>
 	
-	<search-filter filter-config="filterConfig" search="search" do-search="search.doSearch" ng-show="!trialAvailable && isFileListVisible()"></search-filter>
+	<search-filter filter-config="filterConfig" search="search" do-search="search.doSearch" ng-show="isFileListVisible()"></search-filter>
 
 
 	<div ng-controller="FileActionsController">
-		<div class="row add-top" ng-show="!trialAvailable && isFileListVisible()">
+		<div class="row add-top" ng-show="isFileListVisible()">
 			<div class="col-sm-8">
 			  <!-- <ng-include src="'partials/storage/list-grid-toggle.html'"></ng-include> -->
           	  <storage-breadcrumb></storage-breadcrumb>
@@ -44,9 +44,7 @@
 	</div>
 
 
-	<ng-include src="'partials/storage/files-list.html'" ng-show="isFileListVisible()"></ng-include>
-
-	<ng-include src="'partials/storage/empty-state.html'" ng-show="isEmptyState()"></ng-include>
+	<ng-include src="'partials/storage/files-list.html'"></ng-include>
 
 	<ng-include src="'partials/storage/start-trial.html'" ng-show="trialAvailable"></ng-include>
 

--- a/web/partials/storage/storage-modal.html
+++ b/web/partials/storage/storage-modal.html
@@ -9,7 +9,7 @@
   <div class="modal-body storage-full" stop-event="touchend">
     <div class="padding-large-horizontal padding-large-bottom">
 
-      <ng-include src="'partials/storage/global-actions.html'" class="pull-right" ng-show="!trialAvailable" ></ng-include>
+      <ng-include src="'partials/storage/global-actions.html'" class="pull-right" ng-show="!trialAvailable"></ng-include>
 
       <div class="clearfix"></div>
 
@@ -22,7 +22,7 @@
 
       <ng-include src="'partials/storage/upload-panel.html'"></ng-include>
       
-      <div class="row add-top" ng-show="!trialAvailable && isFileListVisible()">
+      <div class="row add-top" ng-show="isFileListVisible()">
         <div class="col-xs-12 col-md-8">
           <!-- <ng-include src="'partials/storage/list-grid-toggle.html'"></ng-include> -->
           <storage-breadcrumb></storage-breadcrumb>
@@ -32,10 +32,8 @@
         </div>
       </div>
 
-      <ng-include src="'partials/storage/files-list.html'" ng-show="isFileListVisible()"></ng-include>
-
-      <ng-include src="'partials/storage/empty-state.html'" ng-show="isEmptyState()"></ng-include>
-    	
+      <ng-include src="'partials/storage/files-list.html'"></ng-include>
+      
       <ng-include src="'partials/storage/start-trial.html'" ng-show="trialAvailable"></ng-include>
   	</div><!--padding-->
   </div><!--modal-body-->

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -515,4 +515,4 @@ angular.module('risevision.storage.directives', [
   'ui.bootstrap'
 ]);
 angular.module('risevision.storage.controllers', []);
-angular.module('risevision.storage.filters', []);
+angular.module('risevision.storage.filters', ['risevision.common.i18n']);

--- a/web/scripts/storage-selector-app.js
+++ b/web/scripts/storage-selector-app.js
@@ -120,4 +120,4 @@ angular.module('risevision.storage.directives', [
   'ui.bootstrap'
 ]);
 angular.module('risevision.storage.controllers', []);
-angular.module('risevision.storage.filters', []);
+angular.module('risevision.storage.filters', ['risevision.common.i18n']);

--- a/web/scripts/storage/controllers/ctr-empty-state.js
+++ b/web/scripts/storage/controllers/ctr-empty-state.js
@@ -1,0 +1,9 @@
+'use strict';
+angular.module('risevision.storage.controllers')
+  .controller('EmptyStateController', ['$scope', 'storageFactory',
+    'SELECTOR_TYPES',
+    function ($scope, storageFactory, SELECTOR_TYPES) {
+      $scope.isMultipleFilesFoldersSelector =
+        storageFactory.selectorType === SELECTOR_TYPES.MULTIPLE_FILES_FOLDERS;
+    }
+  ]);

--- a/web/scripts/storage/controllers/ctr-files-list.js
+++ b/web/scripts/storage/controllers/ctr-files-list.js
@@ -38,7 +38,6 @@ angular.module('risevision.storage.controllers')
       var lastClickTime = 0;
 
       $scope.filesDetails = filesFactory.filesDetails;
-      $scope.statusDetails = filesFactory.statusDetails;
       $scope.bucketCreationStatus = {
         code: 202
       };
@@ -110,21 +109,19 @@ angular.module('risevision.storage.controllers')
         return file.size ? Number(file.size) : 0;
       };
 
-      // Hide file list for in app selector when no files and folders exist in root
       $scope.isFileListVisible = function () {
-        if (!storageFactory.storageFull && (!$scope.currentDecodedFolder() ||
-            $scope.currentDecodedFolder() === '/')) {
-          return $scope.filesDetails.files.filter(function (f) {
-            return !storageFactory.fileIsTrash(f);
-          }).length > 0;
-        } else {
-          return true;
-        }
+        return !(filesFactory.loadingItems ||
+          $scope.filesDetails.code === 202 || $scope.trialAvailable ||
+          $scope.isEmptyState());
       };
 
       $scope.isEmptyState = function () {
-        return $scope.statusDetails.code !== 202 && !$scope.isFileListVisible() &&
-          !$scope.trialAvailable && $scope.fileUploader.queue.length === 0;
+        return !$scope.currentDecodedFolder() &&
+          $scope.currentDecodedFolder() !== '/' &&
+          $scope.fileUploader.queue.length === 0 &&
+          $scope.filesDetails.files.filter(function (f) {
+            return !storageFactory.fileIsTrash(f);
+          }).length === 0;
       };
 
     }

--- a/web/scripts/storage/controllers/ctr-storage.js
+++ b/web/scripts/storage/controllers/ctr-storage.js
@@ -3,5 +3,6 @@ angular.module('risevision.storage.controllers')
   .controller('StorageController', ['$scope', 'storageFactory',
     function ($scope, storageFactory) {
       storageFactory.storageFull = true;
+      storageFactory.setSelectorType();
     }
   ]);

--- a/web/scripts/storage/directives/dtv-storage-breadcrumb.js
+++ b/web/scripts/storage/directives/dtv-storage-breadcrumb.js
@@ -27,8 +27,8 @@
                 var width = element[0].parentNode.clientWidth;
                 var steps = Math.min(_originalTree.length - 1, Math.floor(
                   width / spacePerFolder));
-                var tree = []
-                tree.push(_originalTree[0])
+                var tree = [];
+                tree.push(_originalTree[0]);
                 if (steps < _originalTree.length - 1) {
                   tree.push({
                     name: '...'
@@ -41,19 +41,19 @@
               } else {
                 $scope.tree = _originalTree;
               }
-            }
+            };
 
             $scope.$watch('storageFactory.folderPath', function () {
               _originalTree = [{
-                path: "",
+                path: '',
                 name: 'My Storage'
               }];
               var folders = storageFactory.folderPath.split('/');
-              var path = ""
+              var path = '';
               for (var i = 0; i < folders.length; i++) {
                 var folder = folders[i];
                 if (folder !== '') {
-                  path += folder + "/";
+                  path += folder + '/';
                   var name = folder === '--TRASH--' ? $filter(
                     'translate')('storage-client.trash') : folder;
                   name = name.length > 20 ? name.substr(0, 20) +

--- a/web/scripts/storage/filters/ftr-filters.js
+++ b/web/scripts/storage/filters/ftr-filters.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* Filters */
-angular.module('risevision.storage.filters', ['risevision.common.i18n'])
+angular.module('risevision.storage.filters')
   .filter('fileTypeFilter', ['$translate', function ($translate) {
     var folderLabel = '';
 

--- a/web/scripts/storage/services/svc-files-factory.js
+++ b/web/scripts/storage/services/svc-files-factory.js
@@ -5,9 +5,7 @@ angular.module('risevision.storage.services')
       var svc = {
         startTrial: storage.startTrial,
         filesDetails: {
-          files: []
-        },
-        statusDetails: {
+          files: [],
           code: 202
         }
       };
@@ -86,7 +84,7 @@ angular.module('risevision.storage.services')
 
           svc.filesDetails.bucketExists = resp.bucketExists;
           svc.filesDetails.files = resp.files || [];
-          svc.statusDetails.code = resp.code;
+          svc.filesDetails.code = resp.code;
 
           if (!storageFactory.folderPath || !parentFolder || parentFolder ===
             '/') {
@@ -105,14 +103,11 @@ angular.module('risevision.storage.services')
         var params = {};
         if (storageFactory.folderPath) {
           params.folderPath = decodeURIComponent(storageFactory.folderPath);
-          svc.statusDetails.folder = params.folderPath;
         } else {
           params.folderPath = undefined;
-          svc.statusDetails.folder = '/';
         }
 
-        svc.statusDetails.code = 202;
-
+        svc.filesDetails.code = 202;
         svc.loadingItems = true;
 
         return storage.files.get(params)

--- a/web/storage-selector.html
+++ b/web/storage-selector.html
@@ -87,6 +87,7 @@
 
   <script src="scripts/storage/controllers/ctr-storage-login.js"></script>  
   <script src="scripts/storage/controllers/ctr-files-list.js"></script>
+  <script src="scripts/storage/controllers/ctr-empty-state.js"></script>
   <script src="scripts/storage/controllers/ctr-storage-selector-modal.js"></script>
   <script src="scripts/storage/controllers/ctr-new-folder-modal.js"></script>
   <script src="scripts/storage/controllers/ctr-storage.js"></script>


### PR DESCRIPTION
Reworked show/hide logic
Moved empty state partial to list

Misc fixes:
Spinner fix from common-style

Removed un-used variable
Fixed filter initialization

Only show select files/folders CTA for specific selector type

Fix Displays list empty state

JSHint fixes

[stage-4]