### PR TITLE
Fix file/folder names with % chars

### DIFF
--- a/test/unit/storage/controllers/ctr-files-list.tests.js
+++ b/test/unit/storage/controllers/ctr-files-list.tests.js
@@ -91,7 +91,6 @@ describe('controller: Files List', function() {
     expect($scope.bucketCreationStatus).to.be.ok;
 
     expect($scope.fileClick).to.be.a('function');
-    expect($scope.currentDecodedFolder).to.be.a('function');
     expect($scope.dateModifiedOrderFunction).to.be.a('function');
     expect($scope.fileNameOrderFunction).to.be.a('function');
     expect($scope.orderByAttribute).to.be.a('function');
@@ -172,17 +171,6 @@ describe('controller: Files List', function() {
     });
   });
   
-  it('currentDecodedFolder: ', function() {
-    $scope.storageFactory.folderPath = '';
-    expect($scope.currentDecodedFolder()).to.be.undefined;
-    
-    $scope.storageFactory.folderPath = 'someFolder/';
-    expect($scope.currentDecodedFolder()).to.equal('someFolder/');
-
-    $scope.storageFactory.folderPath = 'my%20test/';
-    expect($scope.currentDecodedFolder()).to.equal('my test/');
-  });
-  
   it('dateModifiedOrderFunction: ', function() {
     expect($scope.dateModifiedOrderFunction({})).to.equal('');
     expect($scope.dateModifiedOrderFunction({updated: {value: undefined}})).to.be.undefined;
@@ -250,7 +238,6 @@ describe('controller: Files List', function() {
   });
 
   describe('isEmptyState:', function(){
-
     beforeEach(function() {
       $scope.storageFactory.folderPath = '';
       $scope.fileUploader.queue = [];

--- a/test/unit/storage/controllers/ctr-new-folder-modal.tests.js
+++ b/test/unit/storage/controllers/ctr-new-folder-modal.tests.js
@@ -27,7 +27,7 @@ describe('controller: NewFolderModalCtrl', function() {
       });
 
       $provide.service('storageFactory', function() {
-        return {
+        return storageFactory = {
           folderPath: ''
         };
       });
@@ -57,7 +57,7 @@ describe('controller: NewFolderModalCtrl', function() {
   });
 
   var $scope, storage, $modalInstance, $modalInstanceCloseSpy, createFolderSpy, 
-    duplicatedName, filesFactory, refreshFilesListSpy, emitSpy, result;
+    duplicatedName, storageFactory, filesFactory, refreshFilesListSpy, emitSpy, result;
   beforeEach(function(){
     duplicatedName = false;
     result = { code: 200 };
@@ -116,6 +116,25 @@ describe('controller: NewFolderModalCtrl', function() {
     createFolderSpy.should.not.have.been.called;
     expect($scope.duplicateFolderSpecified).to.be.true;
     expect($scope.waitingForResponse).to.be.false;
+  });
+  
+  it('should correctly create sub-folder of folder with % in name',function(done){
+    storageFactory.folderPath = 'some % folder/';
+
+    $scope.folderName = 'newFolder';
+    $scope.ok();
+
+    expect($scope.waitingForResponse).to.be.true;
+    createFolderSpy.should.have.been.calledWith('some % folder/newFolder');
+
+    setTimeout(function() {
+      expect($scope.waitingForResponse).to.be.false;
+      refreshFilesListSpy.should.have.been.called;      
+      $modalInstanceCloseSpy.should.have.been.calledWith('newFolder');
+      emitSpy.should.have.been.calledWith('refreshSubscriptionStatus', 'trial-available');
+      
+      done();
+    }, 10);
   });
 
   it('should not proceed if foder name is empty',function(){

--- a/test/unit/storage/services/svc-files-factory.tests.js
+++ b/test/unit/storage/services/svc-files-factory.tests.js
@@ -108,6 +108,21 @@ describe('service: filesFactory:', function() {
         done();
       })
     });
+    
+    it('should handle % in folderPath', function(done) {
+      storageFactory.folderPath = 'folder % name/';
+      filesResponse.files = [{ name: 'folder % name/file1.txt' }];
+
+      filesFactory.refreshFilesList();
+
+      setTimeout(function() {
+        expect(filesFactory.filesDetails.files.length).to.equal(1);
+        expect(filesFactory.filesDetails.files[0].name).to.equal('folder % name/file1.txt');
+        expect(filesFactory.filesDetails.files[0].currentFolder).to.be.undefined;
+        
+        done();
+      })
+    });
 
   });
   

--- a/test/unit/storage/services/svc-storage.tests.js
+++ b/test/unit/storage/services/svc-storage.tests.js
@@ -21,6 +21,7 @@ describe('service: storage:', function() {
             get: function(obj){
               expect(obj).to.be.ok;
               folderPath = obj.folder;
+              filePath = obj.file;
               
               var def = Q.defer();
               if (obj.companyId && returnResult) {
@@ -170,10 +171,11 @@ describe('service: storage:', function() {
     });
 
   }));
-  var storage, returnResult, folderPath, folderName, $rootScope, storageApiRequestObj;
+  var storage, returnResult, folderPath, filePath, folderName, $rootScope, storageApiRequestObj;
   beforeEach(function(){
     returnResult = true;
     folderPath = '';
+    filePath = '';
     
     inject(function($injector){
       $rootScope = $injector.get('$rootScope');
@@ -209,6 +211,36 @@ describe('service: storage:', function() {
       storage.files.get({folderPath: 'someFolder/'})
       .then(function(result){
         expect(folderPath).to.equal('someFolder/');
+
+        done();
+      })
+      .then(null,done);
+    });
+
+    it('should handle % in folder name',function(done){
+      storage.files.get({folderPath: 'some % Folder/'})
+      .then(function(result){
+        expect(folderPath).to.equal('some % Folder/');
+
+        done();
+      })
+      .then(null,done);
+    });
+
+    it('should get single file',function(done){
+      storage.files.get({file: 'someFile.jpg'})
+      .then(function(result){
+        expect(filePath).to.equal('someFile.jpg');
+
+        done();
+      })
+      .then(null,done);
+    });
+
+    it('should handle % in file name',function(done){
+      storage.files.get({file: 'some % File.jpg'})
+      .then(function(result){
+        expect(filePath).to.equal('some % File.jpg');
 
         done();
       })

--- a/web/partials/storage/list-view.html
+++ b/web/partials/storage/list-view.html
@@ -65,7 +65,7 @@
       </td>
       <td ng-if="!storageFactory.fileIsFolder(file)" class="col-sm-6">
         <span class="file" ng-class='{"throttled-type": file.isThrottled && !storageFactory.fileIsFolder(file)}'>
-          <a style="white-space: nowrap;overflow: hidden;text-overflow: ellipsis;" href="" data-toggle="tooltip" title="{{file.name | fileNameFilter:currentDecodedFolder}}">
+          <a style="white-space: nowrap;overflow: hidden;text-overflow: ellipsis;" href="" data-toggle="tooltip" title="{{file.name | fileNameFilter:storageFactory.folderPath}}">
             <i class="fa" ng-class='{"fa-exclamation": file.isThrottled && !storageFactory.fileIsFolder(file), "icon-red": file.isThrottled && !storageFactory.fileIsFolder(file)}'></i>
             {{file.name | fileNameFilter:storageFactory.folderPath}}
           </a>

--- a/web/scripts/storage/controllers/ctr-files-list.js
+++ b/web/scripts/storage/controllers/ctr-files-list.js
@@ -88,11 +88,6 @@ angular.module('risevision.storage.controllers')
         }
       };
 
-      $scope.currentDecodedFolder = function () {
-        return storageFactory.folderPath ?
-          decodeURIComponent(storageFactory.folderPath) : undefined;
-      };
-
       $scope.dateModifiedOrderFunction = function (file) {
         return file.updated ? file.updated.value : '';
       };
@@ -121,8 +116,8 @@ angular.module('risevision.storage.controllers')
       };
 
       $scope.isEmptyState = function () {
-        return !$scope.currentDecodedFolder() &&
-          $scope.currentDecodedFolder() !== '/' &&
+        return !storageFactory.folderPath &&
+          storageFactory.folderPath !== '/' &&
           $scope.fileUploader.queue.length === 0 &&
           $scope.filesDetails.files.filter(function (f) {
             return !storageFactory.fileIsTrash(f);

--- a/web/scripts/storage/controllers/ctr-new-folder-modal.js
+++ b/web/scripts/storage/controllers/ctr-new-folder-modal.js
@@ -24,8 +24,8 @@ angular.module('risevision.storage.controllers')
         if ($scope.folderName !== '') {
           $scope.waitingForResponse = true;
 
-          storage.createFolder(decodeURIComponent(storageFactory.folderPath ||
-            '') + $scope.folderName).then(function (resp) {
+          storage.createFolder(storageFactory.folderPath + $scope.folderName)
+            .then(function (resp) {
 
             if (resp.code === 200) {
               $rootScope.$emit('refreshSubscriptionStatus',

--- a/web/scripts/storage/services/svc-files-factory.js
+++ b/web/scripts/storage/services/svc-files-factory.js
@@ -65,7 +65,7 @@ angular.module('risevision.storage.services')
       svc.refreshFilesList = function () {
         function processFilesResponse(resp) {
           var TRASH = '--TRASH--/';
-          var parentFolder = decodeURIComponent(storageFactory.folderPath);
+          var parentFolder = storageFactory.folderPath;
           var parentFolderIndex = null;
 
           resp.files = resp.files || [];
@@ -102,7 +102,7 @@ angular.module('risevision.storage.services')
 
         var params = {};
         if (storageFactory.folderPath) {
-          params.folderPath = decodeURIComponent(storageFactory.folderPath);
+          params.folderPath = storageFactory.folderPath;
         } else {
           params.folderPath = undefined;
         }

--- a/web/scripts/storage/services/svc-storage.js
+++ b/web/scripts/storage/services/svc-storage.js
@@ -16,10 +16,10 @@ angular.module('risevision.storage.services')
             };
 
             if (search.folderPath) {
-              obj.folder = decodeURIComponent(search.folderPath);
+              obj.folder = search.folderPath;
             }
             if (search.file) {
-              obj.file = decodeURIComponent(search.file);
+              obj.file = search.file;
             }
 
             $log.debug('Storage files get called with', obj);


### PR DESCRIPTION
Remove decodeURICompnent calls across the board
Functionality directly copied from Storage where folder name was stored in querystring; not needed anymore

[stage-4]