### PR TITLE
Fix #248 : Unsaved changes dialog should appear 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tmp
 web/tmp
 web/scripts/config/config.js
 test/e2e/config/config.json
+.DS_Store

--- a/test/unit/app.tests.js
+++ b/test/unit/app.tests.js
@@ -91,6 +91,27 @@ describe('app:', function() {
     });
   });
 
+  describe('state apps.editor.workspace.artboard:',function(){
+    it('should register state',function(){
+      var state = $state.get('apps.editor.workspace.artboard')
+      expect(state).to.be.ok;
+      expect(state.url).to.equal('');
+      expect(state.controller).to.be.ok;
+      expect(state.reloadOnSearch).to.be.false;      
+    });
+  });
+  
+
+  describe('state apps.editor.workspace.htmleditor:',function(){
+    it('should register state',function(){
+      var state = $state.get('apps.editor.workspace.htmleditor')
+      expect(state).to.be.ok;
+      expect(state.url).to.equal('/htmleditor');
+      expect(state.controller).to.be.ok;
+      expect(state.reloadOnSearch).to.be.false;      
+    });
+  });
+
 
   it('should open add display modal when addDisplay event is sent',function(){
     var spy = sinon.spy(displayFactory,'addDisplayModal');

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -384,6 +384,7 @@ angular.module('risevision.apps', [
         templateProvider: ['$templateCache', function ($templateCache) {
           return $templateCache.get('partials/editor/artboard.html');
         }],
+        reloadOnSearch: false,
         controller: 'ArtboardController',
         resolve: {
           canAccess: ['canAccessApps',
@@ -400,6 +401,7 @@ angular.module('risevision.apps', [
           return $templateCache.get(
             'partials/editor/html-editor.html');
         }],
+        reloadOnSearch: false,
         controller: 'HtmlEditorController',
         resolve: {
           canAccess: ['canAccessApps',


### PR DESCRIPTION
and Presentation list should remain in sub company

When changing to a subcompany, CID is changed in search string. When calling event.presentDefault on stateChange to show Unsaved Changes dialog, a new state change was triggered as the cid has changed since last state change. Adding the flag `reloadOnSearch` prevents the reload and the subsequent trigger of stateChange. 
I could not think of a scenario where this could cause issues as this change is restricted to the workspace states (artboard and htmleditor). 

@alex-deaconu  Please review. Thanks