### PR TITLE
Fix #261 - Mi'cros'fot was being handled as a ChromeOs

### DIFF
--- a/test/unit/displays/directives/dtv-display-fields.tests.js
+++ b/test/unit/displays/directives/dtv-display-fields.tests.js
@@ -1,37 +1,42 @@
 'use strict';
-
-xdescribe("filter: Display fields", function() {
-
-  var $scope, scope, element, compiledElem;
-
-  beforeEach(module('risevision.displays.filters'));
-  beforeEach(module('templates'));
-
+describe('directive: display fields', function() {
+  var COUNTRIES = ["country1","country2"]
+  beforeEach(module('risevision.displays.directives'));
   beforeEach(module(function ($provide) {
-    $provide.value("COUNTRIES", [""]);
+     $provide.value("COUNTRIES", COUNTRIES);
+     $provide.value("REGIONS_CA", [""]);
+     $provide.value("REGIONS_US", [""]);
+     $provide.value("TIMEZONES", [""]);
+     
   }));
   
-  beforeEach(function() {
-    inject(function(_$rootScope_, _$compile_) {
-      $scope = _$rootScope_.$new();
-      //$scope.display = {};
+  var elm, $scope, $compile;
 
-      element = _$compile_('<display-fields></display-fields>')($scope);
+  beforeEach(inject(function($rootScope, _$compile_, $templateCache) {
+    $templateCache.put('partials/displays/display-fields.html', '<p>Fields</p>');
+    $scope = $rootScope.$new();
+    $compile = _$compile_;
+    compileDirective();
+  }));
 
+  function compileDirective() {
+    var tpl = '<display-fields></display-fields>';
+    inject(function($compile) {
+      elm = $compile(tpl)($scope);
     });
+    $scope.$digest();
+  }
+
+  it('should compile html', function() {
+    expect(elm.html()).to.equal('<p>Fields</p>');
+    expect($scope.countries).to.equal(COUNTRIES);
+    expect($scope.isChromeOs).to.be.a('function');
+  });
+
+  it("isChromeOs: ", function() {
+    expect($scope.isChromeOs({os: "cros/x86-64"})).to.be.true;
+    expect($scope.isChromeOs({os: "64-bit Microsoft Windows Embedded Standard"})).to.be.false;
   });
   
-  xit("should exist", function() {
-    $scope.$digest()
-    //expect(scope).to.be.exist;
-    console.log(element.isolateScope());
-    expect(element.isolateScope()).to.eventually.be.ok;
-
-  });
-
-  xit("isChromeOs: ", function() {
-    expect(scope.isChromeOs()).to.be.true;
-    expect(scope.isChromeOs({os: "cros/x86-64"})).to.be.false;
-  });
-
 });
+

--- a/web/scripts/displays/directives/dtv-display-fields.js
+++ b/web/scripts/displays/directives/dtv-display-fields.js
@@ -14,8 +14,8 @@ angular.module('risevision.displays.directives')
             $scope.timezones = TIMEZONES;
 
             $scope.isChromeOs = function (display) {
-              return display && display.os && display.os.indexOf('cros') !==
-                -1;
+              return display && display.os && (display.os.indexOf('cros') !==
+                -1 && display.os.indexOf('icrosoft') === -1);
             };
 
             $scope.canReboot = function (display) {


### PR DESCRIPTION
Our condition to check for chrome os was interpreting Mi**cros**oft label as Chrome OS a device.

@alex-deaconu @settinghead Please review. Thanks