### PR TITLE
Fix #264 - First file in the list was being duplicated on re-upload

### DIFF
--- a/test/unit/storage/services/svc-files-factory.tests.js
+++ b/test/unit/storage/services/svc-files-factory.tests.js
@@ -145,6 +145,14 @@ describe('service: filesFactory:', function() {
         expect(filesFactory.filesDetails.files.length).to.equal(6);
       });
     });
+
+    it('should not duplicate first item - fix issue', function () {
+      return filesFactory.refreshFilesList().then(function() {
+        filesFactory.addFile({ name: 'test1' });
+
+        expect(filesFactory.filesDetails.files.length).to.equal(4);
+      });
+    });
   
     it('should add one folder', function () {
       return filesFactory.refreshFilesList().then(function() {

--- a/web/scripts/storage/services/svc-files-factory.js
+++ b/web/scripts/storage/services/svc-files-factory.js
@@ -17,7 +17,7 @@ angular.module('risevision.storage.services')
         // Handles the case where a file inside a folder was added (since files are not visible, only adds the folder)
         var fileName = idx >= 0 ? newFile.name.substring(0, idx + 1) :
           newFile.name;
-        var existingFileNameIndex;
+        var existingFileNameIndex = -1;
 
         for (var i = 0, j = svc.filesDetails.files.length; i < j; i += 1) {
           if (svc.filesDetails.files[i].name === fileName) {
@@ -27,13 +27,13 @@ angular.module('risevision.storage.services')
         }
 
         if (idx >= 0) {
-          if (!existingFileNameIndex) {
+          if (existingFileNameIndex === -1) {
             svc.filesDetails.files.push({
               name: fileName,
               kind: 'folder'
             });
           }
-        } else if (existingFileNameIndex) {
+        } else if (existingFileNameIndex !== -1) {
           svc.filesDetails.files.splice(existingFileNameIndex, 1, newFile);
         } else {
           svc.filesDetails.files.push(newFile);


### PR DESCRIPTION
When `existingFileNameIndex` was 0, it was not being handled as an existing file.
Change to default and check for -1.

@settinghead @alex-deaconu Please review. Thanks!