### PR TITLE
Attempt to avoid deleting E2E test company

### DIFF
--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -82,8 +82,11 @@ var FirstSigninScenarios = function() {
         autoScheduleModalPage.getCloseButton().click();
       });
 
+      it('removes current SubCompany',function(){
+        commonHeaderPage.deleteCurrentCompany();
+      });
+
       after(function(){
-        commonHeaderPage.deleteCurrentCompany(); //deleting the SubCompany
         commonHeaderPage.deleteAllSubCompanies();
       });
       


### PR DESCRIPTION
@settinghead  I checked the logs and the Test Company was deleted at the time this build was running: https://circleci.com/gh/Rise-Vision/rise-vision-apps/2498
In fact, I can see some tests passing and then they start failing at some point. The screenshot in artifacts/ shows the dialog for a new sign up. One of the tests that fail is deleting sub-companies. I checked the test and it has a after() method that deletes current company, which should be a sub-company. 

My assumption is that the sub-company was not created and the parent company got deleted.

To fix, I am moving the deleteCurrentCompany() to an individual step, which will not run if the creation of sub-company fails.

Please review. Thanks