### PR TITLE
Fix #276 - Duplicate Playlist item after saving widget settings

### DIFF
--- a/test/unit/editor/services/svc-widget-modal-factory.tests.js
+++ b/test/unit/editor/services/svc-widget-modal-factory.tests.js
@@ -162,6 +162,18 @@ describe('service: widgetModalFactory:', function() {
       done();
     }, 10);
   });
+
+  it('should update item but nort Playlist if soft update',function(done){
+    widgetModalFactory.showWidgetModal(item,true);
+    
+    setTimeout(function() {
+      expect(item.additionalParams).to.equal('updatedParams');
+      
+      expect(placeholderPlaylistFactory.items).to.have.length(0);
+      
+      done();
+    }, 10);
+  });
   
   it('should cancel',function(done){
     updateParams = false;

--- a/web/partials/editor/playlist-item-modal.html
+++ b/web/partials/editor/playlist-item-modal.html
@@ -19,7 +19,7 @@
     <gadget-subscription-status item="item"></gadget-subscription-status>
 
     <p ng-show="widgetName"><strong>{{'editor-app.playlistItem.content' | translate}}:</strong>
-      <a id="widgetName" class="link add-left" href="" ng-click="widgetModalFactory.showWidgetModal(item)">
+      <a id="widgetName" class="link add-left" href="" ng-click="widgetModalFactory.showWidgetModal(item,true)">
         {{widgetName}} <i class="fa fa-cog icon-right"></i>
       </a>
     </p>

--- a/web/scripts/editor/services/svc-widget-modal-factory.js
+++ b/web/scripts/editor/services/svc-widget-modal-factory.js
@@ -82,7 +82,7 @@ angular.module('risevision.editor.services')
         }
       };
 
-      factory.showWidgetModal = function (item) {
+      factory.showWidgetModal = function (item, softUpdate) {
         if (!item || !item.objectReference && !item.settingsUrl) {
           return;
         }
@@ -127,7 +127,9 @@ angular.module('risevision.editor.services')
             _updateItemObjectData(item, widgetData.params);
             item.additionalParams = widgetData.additionalParams;
 
-            placeholderPlaylistFactory.updateItem(item);
+            if (!softUpdate) {
+              placeholderPlaylistFactory.updateItem(item);
+            }
           }
 
           $log.info('Widget saved:', widgetData);


### PR DESCRIPTION
As we work on a copy of the Item in the Item Modal, when saving the Widget it was adding a new one because it did not recognize that the Item already existed in the Playlist.
Added a softUpdate flag to update only the copy item, not the playlist.

@Rise-Vision/apps Please review. Thanks!