### PR TITLE
If the display is online, consider it as installed and don't prompt to download it

### DIFF
--- a/web/partials/displays/display-fields.html
+++ b/web/partials/displays/display-fields.html
@@ -15,7 +15,7 @@
 </div>
 
 <!--      INSTALL PLAYER      -->
-<div ng-show="display.id && !display.playerVersion">
+<div ng-show="display.id && !display.playerVersion && display.onlineStatus !== 'online'">
 
   <div class="text-right add-top add-bottom">
     <button class="btn btn-link" ng-click="showHelp = !showHelp" ng-hide="showHelp">{{ 'displays-app.fields.controls.howtoInstall' | translate }}</button>
@@ -51,7 +51,7 @@
 
 </div>
 
-<div class="form-group" ng-show="display.playerVersion" ng-controller="displayControls">
+<div class="form-group" ng-show="display.playerVersion || display.onlineStatus === 'online'" ng-controller="displayControls">
   <hr />
 
   <div class="form-group form-inline">


### PR DESCRIPTION
This change hides the download buttons if the display is online but its basic information has not yet been updated (mainly, playerVersion). I'm wondering if we should display something else to the user, since having a bunch of empty fields does not make a lot of sense. The change for running the Core task every 5 minutes was handled in a Core PR.

@Rise-Vision/apps please review