### PR TITLE
Use pretty rather than oneline

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ deployment:
       # To deploy to one of these environments a tag must be added to the commit message. For instance, [stage-0] for apps-stage-0.risevision.com.
       # If tag is missing, the [stage-0] is used.
       - >
-        STAGE_ENV="$(git log master.. --oneline | grep -m 1 '\[.*\]' | sed -e 's/.*\[\(.*\)\].*/\1/g')";
+        STAGE_ENV="$(git log master.. --pretty=%B | grep -m 1 '\[.*\]' | sed -e 's/.*\[\(.*\)\].*/\1/g')";
         if [ "$STAGE_ENV" != '' ]; then
           echo "Deploying to $STAGE_ENV";
         fi;


### PR DESCRIPTION
`--oneline` only selects the first line of the commit message. So, something like

```
Random commit message

[stage-4]
```

would only select the first line and be staged at stage-0.

Updating to use `--pretty=%B` which keeps all the lines in the commit, but removes whitespace, name, date, etc. This is what we had originally.

The latest commit will always have precedence as the 1st occurrence of the `[.*]` string is selected. However, if the string pattern appears more than once in the commit message, the first instance will be selected. This is achieved by `-m 1` which was already included.