### PR TITLE
Fix a couple of issues when navigating to a trash subfolder

### DIFF
--- a/test/unit/storage/services/svc-storage-factory.tests.js
+++ b/test/unit/storage/services/svc-storage-factory.tests.js
@@ -203,6 +203,9 @@ describe('service: storageFactory:', function() {
 
     storageFactory.folderPath = '--TRASH--/';
     expect(storageFactory.isTrashFolder()).to.be.true;
+
+    storageFactory.folderPath = '--TRASH--/subfolder/';
+    expect(storageFactory.isTrashFolder()).to.be.true;
   });
 
   it('fileIsImage:',function(){

--- a/web/scripts/storage/services/svc-storage-factory.js
+++ b/web/scripts/storage/services/svc-storage-factory.js
@@ -134,7 +134,7 @@ angular.module('risevision.storage.services')
 
 
       factory.isTrashFolder = function () {
-        return factory.folderPath === '--TRASH--/';
+        return factory.folderPath.lastIndexOf('--TRASH--/', 0) === 0;
       };
 
       factory.addFolder = function () {


### PR DESCRIPTION
Trash subfolders were not being handled as being inside trash, therefore restore and delete forever actions were not available. Also, upload buttons were enabled when they shouldn't be.

@Rise-Vision/apps Please review. Thanks
[stage-4]