### PR TITLE
CH Update: fix script that automatically hides extra zendesk widget fields

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "angular-ui-codemirror": "~0.3.0",
     "angular-vertilize": "~1.0.1",
     "angular-mocks": "1.5.0",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v1.13.14",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v1.13.15",
     "component-storage-selector": "https://github.com/Rise-Vision/component-storage-selector.git",
     "rv-common-i18n": "https://github.com/Rise-Vision/common-i18n.git",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#v1.4.26",


### PR DESCRIPTION
- Rename common-header to rise-vision-common-header for easier bower link ops