### PR TITLE
Revert "Handle nooverride param to prevent new session in Analytics [stage-3]"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v2.0.3"
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v2.0.2"
   },
   "devDependencies": {
     "q": "1.0.1",


### PR DESCRIPTION
Reverts Rise-Vision/rise-vision-apps#509

Page paths are not being tracked. I will revert until I fix it. @Rise-Vision/apps Please review. Thanks