### PR TITLE
Add script to check which environments were used by the latest commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ gulp
 
 * If browser hasn't opened, you can open it on http://localhost:8000
 
+### Staging summary
+
+When pushing changes to chore/fix/feature branches, an optional staging environment can be indicated at the end of the commit message. The format is [stage-x], with x ranging from 0 to 4 (defaulting to 0, in case it's not provided). In order to check which staging environment is not currently being used, ```./currently-staged.sh``` can be ran in the root directory of the repository. The command's output is:
+
+```
+This command will show which branch has the latest commit referencing a given staging environment.
+If a staging environment is not listed, it means it is not currently in use by any active branch.
+Warning: this command will not show information about stage-0, unless it appears in the commit message
+If you have not ran git pull/git fetch in a while, you may want to run: git fetch --prune
+
+[stage-3] - 2017-12-13 15:31:54 -0300 - Commit user 1           - chore/branch-name
+[stage-2] - 2017-12-12 17:22:15 -0300 - Commit user 2           - release/branch-name
+
+```
+
+Because of the way git works (mainly, references to remote repositories), it's important to have an up to date copy of the repository. The proposed command, ```git fetch --prune```, will retrieve the latest branches from GitHub and remove no longer existing references to branches. It will NOT remove local branches and it will not merge into working copies, which means unless you are doing something really specific with your repository, it's safe to run.
+
 ## Submitting Issues
 If you encounter problems or find defects we really want to hear about them. If you could take the time to add them as issues to this Repository it would be most appreciated. When reporting issues please use the following format where applicable:
 

--- a/currently-staged.sh
+++ b/currently-staged.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 git branch -r \
 | sed '1d' \
 | xargs -n1 git --no-pager log --format="%ct %H %D" --max-count=1 --grep=stage- \
@@ -9,4 +10,5 @@ git branch -r \
 | grep stage- \
 | sed '$!N;s/\n/ - /' \
 | sed 's/- stage-//g' \
-| sed 's/origin\///g'
+| sed 's/origin\///g' \
+| awk '!seen[$1]++'

--- a/currently-staged.sh
+++ b/currently-staged.sh
@@ -1,11 +1,25 @@
 #!/bin/bash
+# 1.  Request remote branches only (GitHub)
+# 2.  Remove master from the list (it fails otherwise)
+# 3.  Get date, hash and full branch name of latest commit with [stage-x] tag
+# 4.  Remove extraneous logs
+# 5.  Sort by date desc
+# 6.  Keep only commit hash
+# 7.  Split output by spaces
+# 8.  Get latest part of commit message (assumes [stage-x] tag is the last part), plus date, branch and user
+# 9.  Removes the leading truncation string (.. ) in case it exists
+# 10. Removes empty lines
+# 11. Joins pairs of lines ([stage-x] tag in one line, commit info in the next one)
+# 12. Remove ' - stage-' text used for filtering
+# 13. Remove origin/ part of branch name
+# 14. Remove duplicates of [stage-x] column
 git branch -r \
 | sed '1d' \
 | xargs -n1 git --no-pager log --format="%ct %H %D" --max-count=1 --grep=stage- \
 | grep origin/ \
 | sort -r \
 | cut -d " " -f2 \
-| xargs -n 2 git --no-pager log --format="%<(11,ltrunc)%B%+ci - %<(50)%D - %an - stage-" --max-count=1 \
+| xargs -n2 git --no-pager log --format="%<(11,ltrunc)%B%+ci - %<(50)%D - %an - stage-" --max-count=1 \
 | sed 's/\.\. //g' \
 | grep stage- \
 | sed '$!N;s/\n/ - /' \

--- a/currently-staged.sh
+++ b/currently-staged.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+echo
+echo This command will show which branch has the latest commit referencing a given staging environment.
+echo If a staging environment is not listed, it means it is not currently in use by any active branch.
+echo -e "\033[1;31mWarning: this command will not show information about stage-0\033[0m"
+echo -e "If you have not ran \033[34mgit pull/git fetch\033[0m in a while, you may want to run: \033[34mgit fetch --all\033[0m"
+echo
 # 1.  Request remote branches only (GitHub)
 # 2.  Remove master from the list (it fails otherwise)
 # 3.  Get date, hash and full branch name of latest commit with [stage-x] tag

--- a/currently-staged.sh
+++ b/currently-staged.sh
@@ -2,8 +2,8 @@
 echo
 echo This command will show which branch has the latest commit referencing a given staging environment.
 echo If a staging environment is not listed, it means it is not currently in use by any active branch.
-echo -e "\033[1;31mWarning: this command will not show information about stage-0\033[0m"
-echo -e "If you have not ran \033[34mgit pull/git fetch\033[0m in a while, you may want to run: \033[34mgit fetch --all\033[0m"
+echo -e "\033[1;31mWarning: this command will not show information about stage-0, unless it appears in the commit message\033[0m"
+echo -e "If you have not ran \033[34mgit pull/git fetch\033[0m in a while, you may want to run: \033[34mgit fetch --prune\033[0m"
 echo
 # 1.  Request remote branches only (GitHub)
 # 2.  Remove master from the list (it fails otherwise)
@@ -25,8 +25,8 @@ git branch -r \
 | grep origin/ \
 | sort -r \
 | cut -d " " -f2 \
-| xargs -n2 git --no-pager log --format="%<(11,ltrunc)%B%+ci - %<(50)%D - %an - stage-" --max-count=1 \
-| sed 's/\.\. //g' \
+| xargs -n2 git --no-pager log --format="%<(11,ltrunc)%B%+ci - %<(30)%an - %D - stage-" --max-count=1 \
+| sed 's/^.*\[stage-\([0-9]\).*/[stage-\1]/' \
 | grep stage- \
 | sed '$!N;s/\n/ - /' \
 | sed 's/- stage-//g' \

--- a/currently-staged.sh
+++ b/currently-staged.sh
@@ -1,0 +1,12 @@
+git branch -r \
+| sed '1d' \
+| xargs -n1 git --no-pager log --format="%ct %H %D" --max-count=1 --grep=stage- \
+| grep origin/ \
+| sort -r \
+| cut -d " " -f2 \
+| xargs -n 2 git --no-pager log --format="%<(11,ltrunc)%B%+ci - %<(50)%D - %an - stage-" --max-count=1 \
+| sed 's/\.\. //g' \
+| grep stage- \
+| sed '$!N;s/\n/ - /' \
+| sed 's/- stage-//g' \
+| sed 's/origin\///g'


### PR DESCRIPTION
@Rise-Vision/apps this became much more complex than I expected (mainly because of new lines before the [stage-x] tags), but it's a decent solution. Let me know what you think! You should be able to just run ./currently-staged.sh in Apps directory. A good improvement would be removing the environments which have already appeared in the logs, but since it's sorted by date I think we can do fine without that feature.
