### PR TITLE
Show Pro Toggle for all Player types, to be able to turn it off (disabled in other cases)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v2.3.2",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/show-toggle-3rd-party",
     "oauthio-web": "0.6.2",
     "ng-tags-input": "^3.2.0"
   },

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/show-toggle-3rd-party",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v2.3.3",
     "oauthio-web": "0.6.2",
     "ng-tags-input": "^3.2.0"
   },

--- a/test/unit/displays/controllers/ctr-display-details.tests.js
+++ b/test/unit/displays/controllers/ctr-display-details.tests.js
@@ -356,24 +356,36 @@ describe('controller: display details', function() {
     });
   });
 
-  describe('isProApplicable:', function() {
+  describe('isProToggleEnabled:', function() {
+    beforeEach(function() {
+      $scope.display = { playerProAuthorized: false };
+    });
+
     it('should return false if it is a third party player', function () {
       sandbox.stub(playerProFactory, 'is3rdPartyPlayer').returns(true);
 
-      expect($scope.isProApplicable()).to.be.false;
+      expect($scope.isProToggleEnabled()).to.be.false;
     });
 
     it('should return false if it is an unsupported player', function () {
       sandbox.stub(playerProFactory, 'isUnsupportedPlayer').returns(true);
 
-      expect($scope.isProApplicable()).to.be.false;
+      expect($scope.isProToggleEnabled()).to.be.false;
     });
 
     it('should return true if it is a supported player', function () {
       sandbox.stub(playerProFactory, 'is3rdPartyPlayer').returns(false);
       sandbox.stub(playerProFactory, 'isUnsupportedPlayer').returns(false);
 
-      expect($scope.isProApplicable()).to.be.true;
+      expect($scope.isProToggleEnabled()).to.be.true;
+    });
+
+    it('should return true if playerProAuthorized = true', function () {
+      $scope.display = { playerProAuthorized: true };
+      sandbox.stub(playerProFactory, 'is3rdPartyPlayer').returns(true);
+      sandbox.stub(playerProFactory, 'isUnsupportedPlayer').returns(true);
+
+      expect($scope.isProToggleEnabled()).to.be.true;
     });
   });
 

--- a/web/partials/displays/display-details.html
+++ b/web/partials/displays/display-details.html
@@ -4,9 +4,9 @@
     <h1 translate>displays-app.details.title</h1>
   </div>
 
-  <div class="global-actions" require-role="da" ng-show="isProApplicable()">
+  <div class="global-actions" require-role="da">
     <div class="toggle-group">
-      <input type="checkbox" id="on-off-switch" ng-model="display.playerProAuthorized" ng-change="toggleProAuthorized()" ng-disabled="updatingRPP">
+      <input type="checkbox" id="on-off-switch" ng-model="display.playerProAuthorized" ng-change="toggleProAuthorized()" ng-disabled="updatingRPP || !isProToggleEnabled()">
       <label for="on-off-switch">
         <span translate>displays-app.details.rpp-is</span>
         <span class="bold" ng-class="display.playerProAuthorized ? 'text-green' : 'text-error'" ng-show="!updatingRPP">

--- a/web/partials/displays/display-details.html
+++ b/web/partials/displays/display-details.html
@@ -42,6 +42,13 @@
         </div>
       </div>
     </div>
+    <div class="row" ng-show="!isProToggleEnabled()">
+      <div class="col-sm-12">
+        <div class="alert alert-warning" role="alert">
+          <span translate>displays-app.details.rpp-not-supported</span>
+        </div>
+      </div>
+    </div>
 
     <display-fields></display-fields>
 

--- a/web/partials/displays/display-details.html
+++ b/web/partials/displays/display-details.html
@@ -42,7 +42,7 @@
         </div>
       </div>
     </div>
-    <div class="row" ng-show="!isProToggleEnabled()">
+    <div class="row" ng-show="!isProSupported()">
       <div class="col-sm-12">
         <div class="alert alert-warning" role="alert">
           <span translate>displays-app.details.rpp-not-supported</span>

--- a/web/scripts/displays/controllers/ctr-display-details.js
+++ b/web/scripts/displays/controllers/ctr-display-details.js
@@ -101,7 +101,7 @@ angular.module('risevision.displays.controllers')
       };
 
       $scope.isProToggleEnabled = function () {
-        return $scope.display.playerProAuthorized || $scope.isProSupported();
+        return ($scope.display && $scope.display.playerProAuthorized) || $scope.isProSupported();
       };
 
       $scope.isValidEmail = function (email) {

--- a/web/scripts/displays/controllers/ctr-display-details.js
+++ b/web/scripts/displays/controllers/ctr-display-details.js
@@ -93,9 +93,11 @@ angular.module('risevision.displays.controllers')
         return planFactory.isPlanActive() && $scope.getProLicenseCount() > 0 && !$scope.areAllProLicensesUsed();
       };
 
-      $scope.isProApplicable = function () {
-        return !playerProFactory.is3rdPartyPlayer($scope.display) &&
-          !playerProFactory.isUnsupportedPlayer($scope.display);
+      $scope.isProToggleEnabled = function () {
+        var thirdParty = playerProFactory.is3rdPartyPlayer($scope.display);
+        var unsupported = playerProFactory.isUnsupportedPlayer($scope.display);
+
+        return $scope.display.playerProAuthorized || (!thirdParty && !unsupported);
       };
 
       $scope.isValidEmail = function (email) {

--- a/web/scripts/displays/controllers/ctr-display-details.js
+++ b/web/scripts/displays/controllers/ctr-display-details.js
@@ -93,11 +93,15 @@ angular.module('risevision.displays.controllers')
         return planFactory.isPlanActive() && $scope.getProLicenseCount() > 0 && !$scope.areAllProLicensesUsed();
       };
 
-      $scope.isProToggleEnabled = function () {
+      $scope.isProSupported = function () {
         var thirdParty = playerProFactory.is3rdPartyPlayer($scope.display);
         var unsupported = playerProFactory.isUnsupportedPlayer($scope.display);
 
-        return $scope.display.playerProAuthorized || (!thirdParty && !unsupported);
+        return !thirdParty && !unsupported;
+      };
+
+      $scope.isProToggleEnabled = function () {
+        return $scope.display.playerProAuthorized || $scope.isProSupported();
       };
 
       $scope.isValidEmail = function (email) {


### PR DESCRIPTION
This is deployed on stage-1. You can test the failing scenario we had using the following displays (please, don't turn Pro off on the first one):

- Third Party with Pro license: https://apps-stage-1.risevision.com/displays/details/9KGARZAJ7JJQ?cid=44ac909d-ade3-436f-80b7-a122d7b23ead
- Third Party without Pro license: https://apps-stage-1.risevision.com/displays/details/6VZJ3RDUGUJK?cid=44ac909d-ade3-436f-80b7-a122d7b23ead
 
I did not add a text message mainly because I was not sure where to add it. If you have a suggestion about it, let me know and I'll add it.

@Rise-Vision/apps please review
