### PR TITLE
Check if plan is active or pro license subscription is active when checking license count

### DIFF
--- a/test/unit/displays/controllers/ctr-display-details.tests.js
+++ b/test/unit/displays/controllers/ctr-display-details.tests.js
@@ -104,7 +104,7 @@ describe('controller: display details', function() {
         showPlansModal: function () {},
         getProLicenseCount: function () {},
         areAllProLicensesUsed: function () {},
-        isPlanActive: function () {}
+        hasProfessionalLicenses: function () {}
       };
     });
     $provide.factory('enableCompanyProduct', function() {
@@ -333,14 +333,14 @@ describe('controller: display details', function() {
 
   describe('isProAvailable:', function() {
     it('should return false if available licenses are zero (Free Plan)', function () {
-      sandbox.stub(planFactory, 'isPlanActive').returns(false);
+      sandbox.stub(planFactory, 'hasProfessionalLicenses').returns(false);
       sandbox.stub($scope, 'getProLicenseCount').returns(0);
 
       expect($scope.isProAvailable()).to.be.false;
     });
 
     it('should return false if all available licenses are used', function () {
-      sandbox.stub(planFactory, 'isPlanActive').returns(true);
+      sandbox.stub(planFactory, 'hasProfessionalLicenses').returns(true);
       sandbox.stub($scope, 'getProLicenseCount').returns(1);
       sandbox.stub($scope, 'areAllProLicensesUsed').returns(true);
 
@@ -348,7 +348,7 @@ describe('controller: display details', function() {
     });
 
     it('should return true if there are available licenses', function () {
-      sandbox.stub(planFactory, 'isPlanActive').returns(true);
+      sandbox.stub(planFactory, 'hasProfessionalLicenses').returns(true);
       sandbox.stub($scope, 'getProLicenseCount').returns(1);
       sandbox.stub($scope, 'areAllProLicensesUsed').returns(false);
 

--- a/web/scripts/displays/controllers/ctr-display-details.js
+++ b/web/scripts/displays/controllers/ctr-display-details.js
@@ -90,7 +90,7 @@ angular.module('risevision.displays.controllers')
       };
 
       $scope.isProAvailable = function () {
-        return planFactory.isPlanActive() && $scope.getProLicenseCount() > 0 && !$scope.areAllProLicensesUsed();
+        return planFactory.hasProfessionalLicenses() && $scope.getProLicenseCount() > 0 && !$scope.areAllProLicensesUsed();
       };
 
       $scope.isProSupported = function () {


### PR DESCRIPTION
This is deployed on apps-beta.risevision.com, since the issue happens on one of our Uptime Displays (which runs with production data)

You can check the display in:

https://apps-beta.risevision.com/displays/details/FB6SAP8CVZNK?cid=fee1f642-cdd1-4bc4-8f93-1fc97cb00d55

To test this actually works, you have to toggle off the Pro license and validate the authorization file (link below) is updated:

https://storage.googleapis.com/risevision-display-notifications/FB6SAP8CVZNK/authorization/c4b368be86245bf9501baaa6e0b00df9719869fd.json

To check the previous (invalid) behavior, use:

https://apps.risevision.com/displays/details/FB6SAP8CVZNK?cid=fee1f642-cdd1-4bc4-8f93-1fc97cb00d55

Please turn the toggle on after testing!

@Rise-Vision/apps please review
