### PR TITLE
Add fallback flag to fix Firefox

### DIFF
--- a/web/scripts/common/directives/dtv-rv-sortable.js
+++ b/web/scripts/common/directives/dtv-rv-sortable.js
@@ -19,6 +19,7 @@ angular.module('risevision.apps.directives')
             animation: 150,
             handle: '.rv-sortable-handle',
             draggable: '.rv-sortable-item',
+            forceFallback: true,
             onEnd: function (evt) {
               if ($scope.onSort) {
                 $scope.onSort({


### PR DESCRIPTION
Fix for #538 

Seems there is a Firefox bug with the drag handler not being called correctly. Setting this flag should fix the issue however I believe it's no longer using HTML5 native functionality anymore if the flag is set. However, it seems to work as before either way.

https://github.com/RubaXa/Sortable/issues/370

[stage-3]

@Rise-Vision/apps please review. Thanks!
