### PR TITLE
Improve error messages for Presentations

### DIFF
--- a/test/unit/editor/services/svc-editor-factory.tests.js
+++ b/test/unit/editor/services/svc-editor-factory.tests.js
@@ -991,4 +991,83 @@ describe('service: editorFactory:', function() {
       },10);
     });
   });
+
+  describe('processErrorCode: ', function() {
+    var itemName = 'Presentation';
+    var action = 'Add';
+
+    it('should process empty error objects', function() {
+      expect(editorFactory.processErrorCode(itemName, action)).to.equal('An Error has Occurred');
+      expect(editorFactory.processErrorCode(itemName, action, {})).to.equal('An Error has Occurred');
+    });
+
+    it('should process 400 error codes', function() {
+      expect(editorFactory.processErrorCode(itemName, action, {
+        status: 400
+      })).to.equal('The Presentation could not be added. Please try again; you may need to reload the page.');
+
+      expect(editorFactory.processErrorCode(itemName, action, {
+        status: 400,
+        result: { error: { message: 'Field name is not editable.' } }
+      })).to.equal('The Presentation could not be added. Field name is not editable.');
+
+      expect(editorFactory.processErrorCode(itemName, action, {
+        status: 400,
+        result: { error: { message: 'Field name is required.' } }
+      })).to.equal('The Presentation could not be added. Field name is required.');
+    });
+
+    it('should process 401 error codes', function() {
+      expect(editorFactory.processErrorCode(itemName, action, {
+        status: 401
+      })).to.equal('You do not have permissions to add this Presentation, because you are not authenticated. Please, sign in.');
+    });
+
+    it('should process 403 error codes', function() {
+      expect(editorFactory.processErrorCode(itemName, action, {
+        status: 403
+      })).to.equal('The Presentation could not be added. You may have not have the required permissions, or an action is required by parent Company.');
+
+      expect(editorFactory.processErrorCode(itemName, action, {
+        status: 403,
+        result: { error: { message: 'User is not allowed access' } }
+      })).to.equal('The Presentation could not be added. Action required by parent Company.');
+
+      expect(editorFactory.processErrorCode(itemName, action, {
+        status: 403,
+        result: { error: { message: 'User does not have the necessary rights' } }
+      })).to.equal('The Presentation could not be added. You do not have the required permissions.');
+
+      expect(editorFactory.processErrorCode(itemName, action, {
+        status: 403,
+        result: { error: { message: 'Premium Template requires Purchase' } }
+      })).to.equal('The Presentation could not be added. You need to be subscribed to a Plan to use the Template Library.');
+    });
+
+    it('should process 404 error codes', function() {
+      expect(editorFactory.processErrorCode(itemName, action, {
+        status: 404
+      })).to.equal('The Presentation could not be found. Please validate it still exists.');
+    });
+
+    it('should process 409 error codes', function() {
+      expect(editorFactory.processErrorCode(itemName, action, {
+        status: 409,
+        result: { error: { message: 'The Schedule is not valid.' } }
+      })).to.equal('The Presentation could not be added. The Schedule is not valid.');
+    });
+
+    it('should process 500 error codes', function() {
+      expect(editorFactory.processErrorCode(itemName, action, {
+        status: 500
+      })).to.equal('An error occurred while trying to add the Presentation. Please try again; you may need to reload the page.');
+    });
+
+    it('should process 503 error codes', function() {
+      expect(editorFactory.processErrorCode(itemName, action, {
+        status: 503
+      })).to.equal('An error occurred while trying to add the Presentation. Please try again; you may need to reload the page.');
+    });
+  });
+
 });

--- a/test/unit/editor/services/svc-editor-factory.tests.js
+++ b/test/unit/editor/services/svc-editor-factory.tests.js
@@ -264,7 +264,7 @@ describe('service: editorFactory:', function() {
         expect(editorFactory.errorMessage).to.be.ok;
         expect(editorFactory.errorMessage).to.equal("Failed to Get Presentation.");
         expect(editorFactory.apiError).to.be.ok;
-        expect(editorFactory.apiError).to.equal("ERROR; could not get presentation");
+        expect(editorFactory.apiError).to.contain("The Presentation could not be loaded.");
 
         expect(messageBoxStub).to.have.been.called;
 

--- a/web/scripts/storage/directives/dtv-upload.js
+++ b/web/scripts/storage/directives/dtv-upload.js
@@ -41,7 +41,7 @@
 
             $scope.retryFailedUpload = function (file) {
               if (file.isError) {
-                FileUploader.retryItem(file);                
+                FileUploader.retryItem(file);
               }
             };
 


### PR DESCRIPTION
This is the main idea for improving the user facing messages, after looking at the different exceptions Core can generate while working with Presentations. Originally I planned on modifying Core, but I think we can avoid doing that, mainly because we can't only rely on error codes and need to analyze error messages (for instance, Conflict -409- is used for a bunch of situations). The same logic used here can be applied to svc-display-factory.js and svc-schedule-factory.js. 

Let me know if you agree with this, or you'd rather do it differently. One obvious improvement would be using translation strings, of course.

@Rise-Vision/apps please review