### PR TITLE
Only use fallback when browser is Firefox

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/ghost-dragging",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v2.4.7",
     "oauthio-web": "0.6.2",
     "ng-tags-input": "^3.2.0"
   },

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v2.4.4",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/ghost-dragging",
     "oauthio-web": "0.6.2",
     "ng-tags-input": "^3.2.0"
   },

--- a/web/scripts/common/directives/dtv-rv-sortable.js
+++ b/web/scripts/common/directives/dtv-rv-sortable.js
@@ -19,7 +19,7 @@ angular.module('risevision.apps.directives')
             animation: 150,
             handle: '.rv-sortable-handle',
             draggable: '.rv-sortable-item',
-            forceFallback: true,
+            forceFallback: isFirefox(),
             onEnd: function (evt) {
               if ($scope.onSort) {
                 $scope.onSort({
@@ -32,6 +32,10 @@ angular.module('risevision.apps.directives')
           $scope.$on('$destroy', function () {
             sortable.destroy();
           });
+        }
+
+        function isFirefox () {
+          return navigator.userAgent.indexOf('Firefox') >= 0;
         }
       }
     };


### PR DESCRIPTION
This version only uses fallback when the browser is Firefox, to avoid ghosting issues. Since this causes Firefox to present the ghosting problem, a style was added here as a workaround: https://github.com/Rise-Vision/common-header/pull/817

Regarding the browser detection part, I kept it as simple as possible (maybe too simple, actually); I'm not sure if we have a common module we can use for this kind of functions. The obvious alternative is using something like https://www.npmjs.com/package/detect-browser, but I'm not sure we actually need it.

This is deployed on stage-1.

@Rise-Vision/apps please review
