### PR TITLE
Fix cache buser timestamp & serve secure url

### DIFF
--- a/test/unit/storage/directives/dtv-thumbnail-image.tests.js
+++ b/test/unit/storage/directives/dtv-thumbnail-image.tests.js
@@ -37,7 +37,9 @@ describe('directive: thumbnail-image', function() {
 
     $rootScope.file = {
       name: "file1.jpg",
-      timeCreated: '123',
+      timeCreated: {
+        value: '123'
+      },
       metadata: {
         thumbnail: 'http://example.com/thumb.jpg'
       }
@@ -50,10 +52,10 @@ describe('directive: thumbnail-image', function() {
     $rootScope.$apply();
   }
 
-  it('should render thumbnail appending timeCreated for cache bursting', function() {
+  it('should render thumbnail appending timeCreated for cache bursting and using secure url', function() {
     _compile();
     expect(element.scope().isSvg).to.be.false;
-    expect(element.scope().imgSrc).to.equal('http://example.com/thumb.jpg?_=123');
+    expect(element.scope().imgSrc).to.equal('https://example.com/thumb.jpg?_=123');
     expect(element.scope().imgClasses).to.equal('');
   });
 

--- a/web/scripts/storage/directives/dtv-thumbnail-image.js
+++ b/web/scripts/storage/directives/dtv-thumbnail-image.js
@@ -38,7 +38,10 @@
                   if (scope.file.metadata && scope.file.metadata.thumbnail) {
                     isSvg = false;
                     imgSrc = scope.file.metadata.thumbnail + '?_=' +
-                      scope.file.timeCreated;
+                      (scope.file.timeCreated && scope.file.timeCreated.value);
+                    if (imgSrc.indexOf('http://') === 0) {
+                      imgSrc = imgSrc.replace('http://', 'https://');
+                    }
                   } else if (scope.storageFactory.fileIsImage(scope.file)) {
                     imgSrc = 'https://s3.amazonaws.com/Rise-Images/UI/storage-image-icon%402x.png';
                   } else if (scope.storageFactory.fileIsVideo(scope.file)) {


### PR DESCRIPTION
Based on my testing, when you upload a file the timeCreated value updates. There are other fields that could be use for a cachebuster but this one seems to do the trick.

Fix for #661 

[stage-0]

@Rise-Vision/apps please review. Thanks!