### PR TITLE
Fix/prevent twitter settings from sending empty screen name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ npm install
 
 * download components with bower
 ```bash
-bower install```
+bower install
+```
 
 ### Run Local
 
-* under the root directory run gulp default task which will build and watch directories for changes 
+* under the root directory run gulp default task which will build and watch directories for changes
 so building and reloading the browser after a change
 ```bash
 gulp
@@ -50,7 +51,7 @@ gulp
 
 ### Staging summary
 
-When pushing changes to chore/fix/feature branches, an optional staging environment can be indicated at the end of the commit message. The format is [stage-x], with x ranging from 0 to 9 (defaulting to 0, in case it's not provided). 
+When pushing changes to chore/fix/feature branches, an optional staging environment can be indicated at the end of the commit message. The format is [stage-x], with x ranging from 0 to 9 (defaulting to 0, in case it's not provided).
 
 #### Staging Assignments by Team
 

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#c11ffe9",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v2.6.4",
     "oauthio-web": "0.6.2",
     "ng-tags-input": "^3.2.0"
   },

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v2.6.5",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v2.6.6",
     "oauthio-web": "0.6.2",
     "ng-tags-input": "^3.2.0"
   },

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v2.6.4",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v2.6.5",
     "oauthio-web": "0.6.2",
     "ng-tags-input": "^3.2.0"
   },

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#f8c6fc3",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#c11ffe9",
     "oauthio-web": "0.6.2",
     "ng-tags-input": "^3.2.0"
   },

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v2.6.3",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#f8c6fc3",
     "oauthio-web": "0.6.2",
     "ng-tags-input": "^3.2.0"
   },

--- a/web/partials/widgets/twitter-settings-modal.html
+++ b/web/partials/widgets/twitter-settings-modal.html
@@ -23,14 +23,14 @@
 		  <div class="form-group">
 		    <!--label class="control-label">Enter a #hashtag or @handle to display Tweets from any public account</label>
 		    <input type="text" class="form-control" placeholder="#hashtag/@handle"-->
-	      <label class="control-label">{{"widget-twitter.screenNameText" | translate }}</label>
+	      <label class="control-label">{{"widget-twitter.screenName.text" | translate }}</label>
 		    <div class="input-group">
 		      <span class="input-group-addon" id="basic-addon1">@</span>
 		      <input id="twitterScreenName" type="text" class="form-control" placeholder="username" required ng-model="settings.additionalParams.screenName">
 		    </div>
 			</div><!--form-inline-->
 
-		  <h4>{{"widget-twitter.previewLable" | translate }}</h4>
+		  <h4>{{"widget-twitter.previewLabel" | translate }}</h4>
 		  <div class="alert alert-info">
 		  	<div class="alert-body">
 		  		{{"widget-twitter.previewText" | translate }}

--- a/web/partials/widgets/twitter-settings-modal.html
+++ b/web/partials/widgets/twitter-settings-modal.html
@@ -23,7 +23,7 @@
 		  <div class="form-group">
 		    <!--label class="control-label">Enter a #hashtag or @handle to display Tweets from any public account</label>
 		    <input type="text" class="form-control" placeholder="#hashtag/@handle"-->
-	      <label class="control-label">{{"widget-twitter.screenName.text" | translate }}</label>
+	      <label class="control-label">{{"widget-twitter.screenName.text" | translate }} *</label>
 		    <div class="input-group">
 		      <span class="input-group-addon" id="basic-addon1">@</span>
 		      <input id="twitterScreenName" type="text" class="form-control" placeholder="username" required ng-model="settings.additionalParams.screenName">

--- a/web/partials/widgets/twitter-settings-modal.html
+++ b/web/partials/widgets/twitter-settings-modal.html
@@ -20,14 +20,17 @@
 		</div>
 
 		<form role="form" name="settingsForm">
-		  <div class="form-group">
+		  <div ng-class="{'form-group':true, 'has-error':settingsForm.screenName.$invalid}">
 		    <!--label class="control-label">Enter a #hashtag or @handle to display Tweets from any public account</label>
 		    <input type="text" class="form-control" placeholder="#hashtag/@handle"-->
 	      <label class="control-label">{{"widget-twitter.screenName.text" | translate }} *</label>
 		    <div class="input-group">
 		      <span class="input-group-addon" id="basic-addon1">@</span>
-		      <input id="twitterScreenName" type="text" class="form-control" placeholder="username" required ng-model="settings.additionalParams.screenName">
+		      <input id="twitterScreenName" name="screenName" type="text" class="form-control" placeholder="username" required ng-model="settings.additionalParams.screenName">
 		    </div>
+        <p class="text-danger" ng-show="settingsForm.screenName.$error.required">
+          {{"widget-twitter.screenName.error" | translate}}
+        </p>
 			</div><!--form-inline-->
 
 		  <h4>{{"widget-twitter.previewLabel" | translate }}</h4>

--- a/web/partials/widgets/twitter-settings-modal.html
+++ b/web/partials/widgets/twitter-settings-modal.html
@@ -26,7 +26,8 @@
 	      <label class="control-label">{{"widget-twitter.screenName.text" | translate }} *</label>
 		    <div class="input-group">
 		      <span class="input-group-addon" id="basic-addon1">@</span>
-		      <input id="twitterScreenName" name="screenName" type="text" class="form-control" placeholder="username" required ng-model="settings.additionalParams.screenName">
+		      <input id="twitterScreenName" name="screenName" type="text" class="form-control"
+					  placeholder="username" required ng-model="settings.additionalParams.screenName">
 		    </div>
 			</div><!--form-inline-->
 

--- a/web/partials/widgets/twitter-settings-modal.html
+++ b/web/partials/widgets/twitter-settings-modal.html
@@ -26,10 +26,11 @@
 	      <label class="control-label">{{"widget-twitter.screenNameText" | translate }}</label>
 		    <div class="input-group">
 		      <span class="input-group-addon" id="basic-addon1">@</span>
-		      <input id="twitterScreenName" type="text" class="form-control" placeholder="username" ng-model="settings.additionalParams.screenName">
+		      <input id="twitterScreenName" type="text" class="form-control" placeholder="username"
+						required ng-model="settings.additionalParams.screenName">
 		    </div>
 			</div><!--form-inline-->
-			
+
 		  <h4>{{"widget-twitter.previewLable" | translate }}</h4>
 		  <div class="alert alert-info">
 		  	<div class="alert-body">
@@ -46,8 +47,8 @@
 		  	</div>
 		  </div>
 
-		  
-		  
+
+
 
 		</form>
 	</div>

--- a/web/partials/widgets/twitter-settings-modal.html
+++ b/web/partials/widgets/twitter-settings-modal.html
@@ -20,7 +20,7 @@
 		</div>
 
 		<form role="form" name="settingsForm">
-		  <div ng-class="{'form-group':true, 'has-error':settingsForm.screenName.$invalid}">
+		  <div class="form-group" ng-class="{'has-error': !settingsForm.screenName.$pristine && settingsForm.screenName.$invalid}" show-errors>
 		    <!--label class="control-label">Enter a #hashtag or @handle to display Tweets from any public account</label>
 		    <input type="text" class="form-control" placeholder="#hashtag/@handle"-->
 	      <label class="control-label">{{"widget-twitter.screenName.text" | translate }} *</label>
@@ -28,6 +28,9 @@
 		      <span class="input-group-addon" id="basic-addon1">@</span>
 		      <input id="twitterScreenName" name="screenName" type="text" class="form-control" placeholder="username" required ng-model="settings.additionalParams.screenName">
 		    </div>
+				<p class="text-danger" ng-show="!settingsForm.screenName.$pristine && settingsForm.screenName.$invalid" translate>
+					widget-twitter.screenName.error
+			  </p>
 			</div><!--form-inline-->
 
 		  <h4>{{"widget-twitter.previewLabel" | translate }}</h4>
@@ -49,7 +52,7 @@
 		</form>
 	</div>
 	<div class="modal-footer">
-	  <widget-button-toolbar save="saveSettings()" cancel="closeSettings()" disable-save="settingsForm.$invalid || !twitterConnected">
+	  <widget-button-toolbar save="saveSettings()" cancel="closeSettings()" disable-save="settingsForm.$invalid">
 	  </widget-button-toolbar>
 	</div>
 </div>

--- a/web/partials/widgets/twitter-settings-modal.html
+++ b/web/partials/widgets/twitter-settings-modal.html
@@ -55,7 +55,7 @@
 		</form>
 	</div>
 	<div class="modal-footer">
-	  <widget-button-toolbar save="saveSettings()" cancel="closeSettings()" disable-save="settingsForm.$invalid || !twitterConnected">
+	  <widget-button-toolbar save="saveSettings()" cancel="closeSettings()" disable-save="settingsForm.$invalid">
 	  </widget-button-toolbar>
 	</div>
 </div>

--- a/web/partials/widgets/twitter-settings-modal.html
+++ b/web/partials/widgets/twitter-settings-modal.html
@@ -26,8 +26,7 @@
 	      <label class="control-label">{{"widget-twitter.screenName.text" | translate }} *</label>
 		    <div class="input-group">
 		      <span class="input-group-addon" id="basic-addon1">@</span>
-		      <input id="twitterScreenName" name="screenName" type="text" class="form-control"
-					  placeholder="username" required ng-model="settings.additionalParams.screenName">
+		      <input id="twitterScreenName" name="screenName" type="text" class="form-control" placeholder="username" required ng-model="settings.additionalParams.screenName">
 		    </div>
 			</div><!--form-inline-->
 

--- a/web/partials/widgets/twitter-settings-modal.html
+++ b/web/partials/widgets/twitter-settings-modal.html
@@ -26,8 +26,7 @@
 	      <label class="control-label">{{"widget-twitter.screenNameText" | translate }}</label>
 		    <div class="input-group">
 		      <span class="input-group-addon" id="basic-addon1">@</span>
-		      <input id="twitterScreenName" type="text" class="form-control" placeholder="username"
-						required ng-model="settings.additionalParams.screenName">
+		      <input id="twitterScreenName" type="text" class="form-control" placeholder="username" required ng-model="settings.additionalParams.screenName">
 		    </div>
 			</div><!--form-inline-->
 

--- a/web/partials/widgets/twitter-settings-modal.html
+++ b/web/partials/widgets/twitter-settings-modal.html
@@ -49,7 +49,7 @@
 		</form>
 	</div>
 	<div class="modal-footer">
-	  <widget-button-toolbar save="saveSettings()" cancel="closeSettings()" disable-save="settingsForm.$invalid">
+	  <widget-button-toolbar save="saveSettings()" cancel="closeSettings()" disable-save="settingsForm.$invalid || !twitterConnected">
 	  </widget-button-toolbar>
 	</div>
 </div>

--- a/web/partials/widgets/twitter-settings-modal.html
+++ b/web/partials/widgets/twitter-settings-modal.html
@@ -28,9 +28,6 @@
 		      <span class="input-group-addon" id="basic-addon1">@</span>
 		      <input id="twitterScreenName" name="screenName" type="text" class="form-control" placeholder="username" required ng-model="settings.additionalParams.screenName">
 		    </div>
-        <p class="text-danger" ng-show="settingsForm.screenName.$error.required">
-          {{"widget-twitter.screenName.error" | translate}}
-        </p>
 			</div><!--form-inline-->
 
 		  <h4>{{"widget-twitter.previewLabel" | translate }}</h4>
@@ -48,9 +45,6 @@
 		  		</div>
 		  	</div>
 		  </div>
-
-
-
 
 		</form>
 	</div>

--- a/web/partials/widgets/twitter-settings-modal.html
+++ b/web/partials/widgets/twitter-settings-modal.html
@@ -52,7 +52,7 @@
 		</form>
 	</div>
 	<div class="modal-footer">
-	  <widget-button-toolbar save="saveSettings()" cancel="closeSettings()" disable-save="settingsForm.$invalid">
+	  <widget-button-toolbar save="saveSettings()" cancel="closeSettings()" disable-save="settingsForm.$invalid || !twitterConnected">
 	  </widget-button-toolbar>
 	</div>
 </div>


### PR DESCRIPTION
This makes the Twitter screen name required. The Save option won't be enabled unless an screen name is provided.

Staged version here, with twitter connection check disabled so the validation can be tested:

https://apps-stage-6.risevision.com/editor/workspace/be4fb65e-c2f3-43a7-b339-932222b49665/?cid=23aacc88-ff55-4af2-bb05-e104127b57b7


I also did a minor correction to README.md, so build instructions are properly formatted.
