### PR TITLE
Improve e2e tests. Run smaller, independent, CircleCI Workflow steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
       - image: jenkinsrise/apps-node:8.1.4
     steps:
       - run_e2e_cases:
-          casesfile: "test/e2e/circle.container0.js"
+          casesfile: "test/e2e/circle.launcher-schedules.js"
   e2e_common:
     working_directory: ~/rise-vision-apps
     docker:
@@ -189,7 +189,7 @@ workflows:
             - dependencies
       - e2e_editor:
           requires:
-            - e2e_common
+            - dependencies
       - e2e_displays:
           requires:
             - dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,20 +57,13 @@ jobs:
           path: ~/rise-vision-apps/reports
       - store_artifacts:
           path: ~/rise-vision-apps/reports
-  e2e_launcher:
+  e2e_launcher_schedules:
     working_directory: ~/rise-vision-apps
     docker:
       - image: jenkinsrise/apps-node:8.1.4
     steps:
       - run_e2e_cases:
-          casesfile: "test/e2e/launcher/launcher.cases.js"
-  e2e_schedules:
-    working_directory: ~/rise-vision-apps
-    docker:
-      - image: jenkinsrise/apps-node:8.1.4
-    steps:
-      - run_e2e_cases:
-          casesfile: "test/e2e/schedules/schedules.cases.js"
+          casesfile: "test/e2e/circle.container0.js"
   e2e_common:
     working_directory: ~/rise-vision-apps
     docker:
@@ -188,12 +181,9 @@ workflows:
       - test_unit:
           requires:
             - dependencies
-      - e2e_launcher:
+      - e2e_launcher_schedules:
           requires:
             - dependencies
-      - e2e_schedules:
-          requires:
-            - e2e_launcher
       - e2e_common:
           requires:
             - dependencies
@@ -209,8 +199,9 @@ workflows:
       - deploy_production:
           requires:
             - test_unit
-            - e2e_launcher
+            - e2e_launcher_schedules
             - e2e_common
+            - e2e_editor
             - e2e_displays
             - e2e_storage
           filters:
@@ -225,8 +216,9 @@ workflows:
       - deploy_beta:
           requires:
             - test_unit
-            - e2e_launcher
+            - e2e_launcher_schedules
             - e2e_common
+            - e2e_editor
             - e2e_displays
             - e2e_storage
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,42 +57,42 @@ jobs:
           path: ~/rise-vision-apps/reports
       - store_artifacts:
           path: ~/rise-vision-apps/reports
-  test_e2e_launcher:
+  e2e_launcher:
     working_directory: ~/rise-vision-apps
     docker:
       - image: jenkinsrise/apps-node:8.1.4
     steps:
       - run_e2e_cases:
           casesfile: "test/e2e/launcher/launcher.cases.js"
-  test_e2e_schedules:
+  e2e_schedules:
     working_directory: ~/rise-vision-apps
     docker:
       - image: jenkinsrise/apps-node:8.1.4
     steps:
       - run_e2e_cases:
           casesfile: "test/e2e/schedules/schedules.cases.js"
-  test_e2e_common:
+  e2e_common:
     working_directory: ~/rise-vision-apps
     docker:
       - image: jenkinsrise/apps-node:8.1.4
     steps:
       - run_e2e_cases:
           casesfile: "test/e2e/common/common.cases.js"
-  test_e2e_editor:
+  e2e_editor:
     working_directory: ~/rise-vision-apps
     docker:
       - image: jenkinsrise/apps-node:8.1.4
     steps:
       - run_e2e_cases:
           casesfile: "test/e2e/editor/editor.cases.js"
-  test_e2e_displays:
+  e2e_displays:
     working_directory: ~/rise-vision-apps
     docker:
       - image: jenkinsrise/apps-node:8.1.4
     steps:
       - run_e2e_cases:
           casesfile: "test/e2e/displays/displays.cases.js"
-  test_e2e_storage:
+  e2e_storage:
     working_directory: ~/rise-vision-apps
     docker:
       - image: jenkinsrise/apps-node:8.1.4
@@ -188,28 +188,31 @@ workflows:
       - test_unit:
           requires:
             - dependencies
-      - test_e2e_launcher:
+      - e2e_launcher:
           requires:
             - dependencies
-      - test_e2e_schedules:
+      - e2e_schedules:
           requires:
-            - test_e2e_launcher
-      - test_e2e_common:
+            - e2e_launcher
+      - e2e_common:
           requires:
             - dependencies
-      - test_e2e_editor:
+      - e2e_editor:
           requires:
-            - test_e2e_common
-      - test_e2e_displays:
+            - e2e_common
+      - e2e_displays:
           requires:
-            - test_e2e_editor
-      - test_e2e_storage:
+            - dependencies
+      - e2e_storage:
           requires:
-            - test_e2e_displays
+            - dependencies
       - deploy_production:
           requires:
             - test_unit
-            - test_e2e_common
+            - e2e_launcher
+            - e2e_common
+            - e2e_displays
+            - e2e_storage
           filters:
             branches:
               only: master
@@ -222,7 +225,10 @@ workflows:
       - deploy_beta:
           requires:
             - test_unit
-            - test_e2e_common
+            - e2e_launcher
+            - e2e_common
+            - e2e_displays
+            - e2e_storage
           filters:
             branches:
               only: /(beta).*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,37 +57,48 @@ jobs:
           path: ~/rise-vision-apps/reports
       - store_artifacts:
           path: ~/rise-vision-apps/reports
-#  test_e2e:
-#    working_directory: ~/rise-vision-apps
-#    docker:
-#      - image: jenkinsrise/apps-node:8.1.4
-#    parallelism: 2
-#    steps:
-#      - attach_workspace:
-#          at: ~/
-#      - run: echo $CHROME_INSTANCES
-#      # Install latest chrome
-#      - run: wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-#      - run: echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee -a /etc/apt/sources.list
-#      - run: sudo apt-get update -qq
-#      - run: sudo apt-get install -y google-chrome-stable
-#      - run:
-#          name: e2e_tests
-#          command: |
-#            # TEST_FILES=$(circleci tests glob "test/e2e/*/*.cases.js" | circleci tests split)
-#            TEST_FILES=$(circleci tests glob "test/e2e/circle.container*.js" | circleci tests split)
-#            NODE_ENV=test XUNIT_FILE=~/rise-vision-apps/reports/angular-xunit.xml PROSHOT_DIR=~/rise-vision-apps/reports/screenshots DBUS_SESSION_BUS_ADDRESS=/dev/null xvfb-run node run-test.js $TEST_FILES
-#      - store_test_results:
-#          path: ~/rise-vision-apps/reports
-#      - store_artifacts:
-#          path: ~/rise-vision-apps/reports
+  test_e2e_launcher:
+    working_directory: ~/rise-vision-apps
+    docker:
+      - image: jenkinsrise/apps-node:8.1.4
+    steps:
+      - run_e2e_cases:
+          casesfile: "test/e2e/launcher/launcher.cases.js"
+  test_e2e_schedules:
+    working_directory: ~/rise-vision-apps
+    docker:
+      - image: jenkinsrise/apps-node:8.1.4
+    steps:
+      - run_e2e_cases:
+          casesfile: "test/e2e/schedules/schedules.cases.js"
   test_e2e_common:
     working_directory: ~/rise-vision-apps
     docker:
       - image: jenkinsrise/apps-node:8.1.4
     steps:
       - run_e2e_cases:
+          casesfile: "test/e2e/common/common.cases.js"
+  test_e2e_editor:
+    working_directory: ~/rise-vision-apps
+    docker:
+      - image: jenkinsrise/apps-node:8.1.4
+    steps:
+      - run_e2e_cases:
           casesfile: "test/e2e/editor/editor.cases.js"
+  test_e2e_displays:
+    working_directory: ~/rise-vision-apps
+    docker:
+      - image: jenkinsrise/apps-node:8.1.4
+    steps:
+      - run_e2e_cases:
+          casesfile: "test/e2e/displays/displays.cases.js"
+  test_e2e_storage:
+    working_directory: ~/rise-vision-apps
+    docker:
+      - image: jenkinsrise/apps-node:8.1.4
+    steps:
+      - run_e2e_cases:
+          casesfile: "test/e2e/storage/storage.cases.js"
   deploy_staging:
     working_directory: ~/rise-vision-apps
     docker:
@@ -177,12 +188,24 @@ workflows:
       - test_unit:
           requires:
             - dependencies
-#      - test_e2e:
-#          requires:
-#            - dependencies
+      - test_e2e_launcher:
+          requires:
+            - dependencies
+      - test_e2e_schedules:
+          requires:
+            - test_e2e_launcher
       - test_e2e_common:
           requires:
             - dependencies
+      - test_e2e_editor:
+          requires:
+            - test_e2e_common
+      - test_e2e_displays:
+          requires:
+            - test_e2e_editor
+      - test_e2e_storage:
+          requires:
+            - test_e2e_displays
       - deploy_production:
           requires:
             - test_unit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 commands:
   run_e2e_cases:
-    description: "Runs a specific cases file"
+    description: "Runs a specific cases file as a workflow step"
     parameters:
       casesfile:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,30 @@
-version: 2
+version: 2.1
+
+commands:
+  run_e2e_cases:
+    description: "Runs a specific cases file"
+    parameters:
+      casesfile:
+        type: string
+        default: "invalid_path"
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: echo $CHROME_INSTANCES
+      # Install latest chrome
+      - run: wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+      - run: echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee -a /etc/apt/sources.list
+      - run: sudo apt-get update -qq
+      - run: sudo apt-get install -y google-chrome-stable
+      - run:
+          name: e2e_tests
+          command: |
+            TEST_FILES=$(circleci tests glob "<< parameters.casesfile >>" | circleci tests split)
+            NODE_ENV=test XUNIT_FILE=~/rise-vision-apps/reports/angular-xunit.xml PROSHOT_DIR=~/rise-vision-apps/reports/screenshots DBUS_SESSION_BUS_ADDRESS=/dev/null xvfb-run node run-test.js $TEST_FILES
+      - store_test_results:
+          path: ~/rise-vision-apps/reports
+      - store_artifacts:
+          path: ~/rise-vision-apps/reports
 
 jobs:
   dependencies:
@@ -31,30 +57,37 @@ jobs:
           path: ~/rise-vision-apps/reports
       - store_artifacts:
           path: ~/rise-vision-apps/reports
-  test_e2e:
+#  test_e2e:
+#    working_directory: ~/rise-vision-apps
+#    docker:
+#      - image: jenkinsrise/apps-node:8.1.4
+#    parallelism: 2
+#    steps:
+#      - attach_workspace:
+#          at: ~/
+#      - run: echo $CHROME_INSTANCES
+#      # Install latest chrome
+#      - run: wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+#      - run: echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee -a /etc/apt/sources.list
+#      - run: sudo apt-get update -qq
+#      - run: sudo apt-get install -y google-chrome-stable
+#      - run:
+#          name: e2e_tests
+#          command: |
+#            # TEST_FILES=$(circleci tests glob "test/e2e/*/*.cases.js" | circleci tests split)
+#            TEST_FILES=$(circleci tests glob "test/e2e/circle.container*.js" | circleci tests split)
+#            NODE_ENV=test XUNIT_FILE=~/rise-vision-apps/reports/angular-xunit.xml PROSHOT_DIR=~/rise-vision-apps/reports/screenshots DBUS_SESSION_BUS_ADDRESS=/dev/null xvfb-run node run-test.js $TEST_FILES
+#      - store_test_results:
+#          path: ~/rise-vision-apps/reports
+#      - store_artifacts:
+#          path: ~/rise-vision-apps/reports
+  test_e2e_common:
     working_directory: ~/rise-vision-apps
     docker:
       - image: jenkinsrise/apps-node:8.1.4
-    parallelism: 2
     steps:
-      - attach_workspace:
-          at: ~/
-      - run: echo $CHROME_INSTANCES
-      # Install latest chrome
-      - run: wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-      - run: echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee -a /etc/apt/sources.list
-      - run: sudo apt-get update -qq
-      - run: sudo apt-get install -y google-chrome-stable
-      - run:
-          name: e2e_tests
-          command: |
-            # TEST_FILES=$(circleci tests glob "test/e2e/*/*.cases.js" | circleci tests split)
-            TEST_FILES=$(circleci tests glob "test/e2e/circle.container*.js" | circleci tests split)
-            NODE_ENV=test XUNIT_FILE=~/rise-vision-apps/reports/angular-xunit.xml PROSHOT_DIR=~/rise-vision-apps/reports/screenshots DBUS_SESSION_BUS_ADDRESS=/dev/null xvfb-run node run-test.js $TEST_FILES
-      - store_test_results:
-          path: ~/rise-vision-apps/reports
-      - store_artifacts:
-          path: ~/rise-vision-apps/reports
+      - run_e2e_cases:
+          casesfile: "test/e2e/editor/editor.cases.js"
   deploy_staging:
     working_directory: ~/rise-vision-apps
     docker:
@@ -144,13 +177,16 @@ workflows:
       - test_unit:
           requires:
             - dependencies
-      - test_e2e:
+#      - test_e2e:
+#          requires:
+#            - dependencies
+      - test_e2e_common:
           requires:
             - dependencies
       - deploy_production:
           requires:
             - test_unit
-            - test_e2e
+            - test_e2e_common
           filters:
             branches:
               only: master
@@ -163,7 +199,7 @@ workflows:
       - deploy_beta:
           requires:
             - test_unit
-            - test_e2e
+            - test_e2e_common
           filters:
             branches:
               only: /(beta).*/

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "gulp-util": "^3.0.8",
     "jshint-stylish": "^2.0.1",
     "run-sequence": "^1.1.1",
-    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git",
+    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git#chore/improve-e2e-tests",
     "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
   },
   "repository": {

--- a/test/e2e/apps.scenarios.js
+++ b/test/e2e/apps.scenarios.js
@@ -1,6 +1,6 @@
+require('./launcher/launcher.cases.js');
 require('./schedules/schedules.cases.js');
 require('./displays/displays.cases.js');
 require('./editor/editor.cases.js');
 require('./storage/storage.cases.js');
 require('./common/common.cases.js');
-require('./launcher/launcher.cases.js');

--- a/test/e2e/apps.scenarios.js
+++ b/test/e2e/apps.scenarios.js
@@ -1,6 +1,6 @@
-require('./launcher/launcher.cases.js');
 require('./schedules/schedules.cases.js');
 require('./displays/displays.cases.js');
 require('./editor/editor.cases.js');
 require('./storage/storage.cases.js');
 require('./common/common.cases.js');
+require('./launcher/launcher.cases.js');

--- a/test/e2e/circle.launcher-schedules.js
+++ b/test/e2e/circle.launcher-schedules.js
@@ -1,0 +1,2 @@
+require('./launcher/launcher.cases.js');
+require('./schedules/schedules.cases.js');

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -133,6 +133,10 @@ var FirstSigninScenarios = function() {
         expect(getStartedPage.getGetStartedContainer().isDisplayed()).to.eventually.be.false;
       });
 
+      it('removes current SubCompany',function(){
+        commonHeaderPage.deleteCurrentCompany();
+      });
+
       xdescribe('Onboarding Bar: ', function() {
         it('should show Add Presentation CTA home page', function () {
           helper.wait(homepage.getPresentationCTA(), 'Presentation Call to Action');
@@ -255,13 +259,9 @@ var FirstSigninScenarios = function() {
 
       });
 
-      it('removes current SubCompany',function(){
-        commonHeaderPage.deleteCurrentCompany();
-      });
-
-      after(function() {
-        commonHeaderPage.deleteAllSubCompanies();
-      });
+//      after(function() {
+//        commonHeaderPage.deleteAllSubCompanies();
+//      });
     });
   });
 };

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -66,7 +66,7 @@ var FirstSigninScenarios = function() {
       });
 
       it('should progress to the Second Step', function() {
-        getStartedPage.getGetStartedButton1().click();
+        helper.clickWhenClickable(getStartedPage.getGetStartedButton1(), 'Get Started Button 1');
 
         expect(getStartedPage.getWizardStep2().isDisplayed()).to.eventually.be.true;
         
@@ -74,7 +74,7 @@ var FirstSigninScenarios = function() {
       });
 
       it('should progress to the Third Step', function() {
-        getStartedPage.getGetStartedButton2().click();
+        helper.clickWhenClickable(getStartedPage.getGetStartedButton2(), 'Get Started Button 2');
 
         expect(getStartedPage.getWizardStep3().isDisplayed()).to.eventually.be.true;
         

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -60,6 +60,7 @@ var FirstSigninScenarios = function() {
       });
       
       it('should show the First Step', function() {
+        browser.sleep(1000);
         expect(getStartedPage.getWizardStep1().isDisplayed()).to.eventually.be.true;
         
         expect(getStartedPage.getGetStartedButton1().isDisplayed()).to.eventually.be.true;
@@ -67,6 +68,7 @@ var FirstSigninScenarios = function() {
 
       it('should progress to the Second Step', function() {
         helper.clickWhenClickable(getStartedPage.getGetStartedButton1(), 'Get Started Button 1');
+        browser.sleep(1000);
 
         expect(getStartedPage.getWizardStep2().isDisplayed()).to.eventually.be.true;
         
@@ -75,6 +77,7 @@ var FirstSigninScenarios = function() {
 
       it('should progress to the Third Step', function() {
         helper.clickWhenClickable(getStartedPage.getGetStartedButton2(), 'Get Started Button 2');
+        browser.sleep(1000);
 
         expect(getStartedPage.getWizardStep3().isDisplayed()).to.eventually.be.true;
         
@@ -83,6 +86,7 @@ var FirstSigninScenarios = function() {
 
       it('should progress to the Last Step', function() {
         helper.clickWhenClickable(getStartedPage.getGetStartedButton3(), 'Get Started Button 3');
+        browser.sleep(1000);
 
         expect(getStartedPage.getWizardStep4().isDisplayed()).to.eventually.be.true;
         

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -60,7 +60,7 @@ var FirstSigninScenarios = function() {
       });
       
       it('should show the First Step', function() {
-        browser.sleep(1000);
+        browser.sleep(500);
         expect(getStartedPage.getWizardStep1().isDisplayed()).to.eventually.be.true;
         
         expect(getStartedPage.getGetStartedButton1().isDisplayed()).to.eventually.be.true;
@@ -68,7 +68,7 @@ var FirstSigninScenarios = function() {
 
       it('should progress to the Second Step', function() {
         helper.clickWhenClickable(getStartedPage.getGetStartedButton1(), 'Get Started Button 1');
-        browser.sleep(1000);
+        browser.sleep(500);
 
         expect(getStartedPage.getWizardStep2().isDisplayed()).to.eventually.be.true;
         
@@ -77,7 +77,7 @@ var FirstSigninScenarios = function() {
 
       it('should progress to the Third Step', function() {
         helper.clickWhenClickable(getStartedPage.getGetStartedButton2(), 'Get Started Button 2');
-        browser.sleep(1000);
+        browser.sleep(500);
 
         expect(getStartedPage.getWizardStep3().isDisplayed()).to.eventually.be.true;
         
@@ -86,7 +86,7 @@ var FirstSigninScenarios = function() {
 
       it('should progress to the Last Step', function() {
         helper.clickWhenClickable(getStartedPage.getGetStartedButton3(), 'Get Started Button 3');
-        browser.sleep(1000);
+        browser.sleep(500);
 
         expect(getStartedPage.getWizardStep4().isDisplayed()).to.eventually.be.true;
         
@@ -263,9 +263,9 @@ var FirstSigninScenarios = function() {
 
       });
 
-//      after(function() {
-//        commonHeaderPage.deleteAllSubCompanies();
-//      });
+      after(function() {
+        commonHeaderPage.deleteAllSubCompanies();
+      });
     });
   });
 };

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -48,7 +48,7 @@ var FirstSigninScenarios = function() {
       before(function () {
         homepage.get();
         signInPage.signIn();
-        var subCompanyName = 'E2E TEST SUBCOMPANY';
+        var subCompanyName = 'E2E TEST SUBCOMPANY - FIRST SIGN IN';
         commonHeaderPage.createSubCompany(subCompanyName);
         commonHeaderPage.selectSubCompany(subCompanyName);   
       });
@@ -263,9 +263,9 @@ var FirstSigninScenarios = function() {
 
       });
 
-      after(function() {
-        commonHeaderPage.deleteAllSubCompanies();
-      });
+//      after(function() {
+//        commonHeaderPage.deleteAllSubCompanies();
+//      });
     });
   });
 };

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -82,7 +82,7 @@ var FirstSigninScenarios = function() {
       });
 
       it('should progress to the Last Step', function() {
-        getStartedPage.getGetStartedButton3().click();
+        helper.clickWhenClickable(getStartedPage.getGetStartedButton3(), 'Get Started Button 3');
 
         expect(getStartedPage.getWizardStep4().isDisplayed()).to.eventually.be.true;
         
@@ -99,11 +99,11 @@ var FirstSigninScenarios = function() {
       });
 
       it('should start a new presentation', function () {
-        getStartedPage.getGetStartedAddPresentation().click();
+        helper.clickWhenClickable(getStartedPage.getGetStartedAddPresentation(), 'Get Started Add Presentation');
 
         helper.wait(storeProductsModalPage.getStoreProductsModal(), 'Select Content Modal');
         helper.waitDisappear(storeProductsModalPage.getStoreProductsLoader());
-        storeProductsModalPage.getAddBlankPresentation().click();
+        helper.clickWhenClickable(storeProductsModalPage.getAddBlankPresentation(), 'Add Blank Presentation');
         
         helper.wait(workspacePage.getWorkspaceContainer(), 'Workspace Container');
         expect(workspacePage.getWorkspaceContainer().isDisplayed()).to.eventually.be.true;
@@ -117,16 +117,16 @@ var FirstSigninScenarios = function() {
         browser.sleep(500);
 
         helper.clickWhenClickable(workspacePage.getAddPlaceholderButton(), 'Add Placeholder button');
-        workspacePage.getSaveButton().click();
+        helper.clickWhenClickable(workspacePage.getSaveButton(), 'Save Button');
 
         helper.wait(autoScheduleModalPage.getAutoScheduleModal());
 
         expect(autoScheduleModalPage.getAutoScheduleModal().isDisplayed()).to.eventually.be.true;
-        autoScheduleModalPage.getCloseButton().click();
+        helper.clickWhenClickable(autoScheduleModalPage.getCloseButton(), 'Close Button');
       });
 
       it('should no longer show the Get Started Page', function () {
-        commonHeaderPage.getCommonHeaderMenuItems().get(0).click();
+        helper.clickWhenClickable(commonHeaderPage.getCommonHeaderMenuItems().get(0), 'First Common Header Menu Item');
 
         helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
 
@@ -259,9 +259,9 @@ var FirstSigninScenarios = function() {
 
       });
 
-//      after(function() {
-//        commonHeaderPage.deleteAllSubCompanies();
-//      });
+      after(function() {
+        commonHeaderPage.deleteAllSubCompanies();
+      });
     });
   });
 };

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -16,7 +16,7 @@ var DisplayAddModalPage = require('./../../displays/pages/displayAddModalPage.js
 var FirstSigninScenarios = function() {
 
   browser.driver.manage().window().setSize(1400, 900);
-  xdescribe('First Signin', function () {
+  describe('First Signin', function () {
     var homepage;
     var signInPage;
     var commonHeaderPage;

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -16,7 +16,7 @@ var DisplayAddModalPage = require('./../../displays/pages/displayAddModalPage.js
 var FirstSigninScenarios = function() {
 
   browser.driver.manage().window().setSize(1400, 900);
-  describe('First Signin', function () {
+  xdescribe('First Signin', function () {
     var homepage;
     var signInPage;
     var commonHeaderPage;

--- a/test/e2e/editor/cases/artboard.js
+++ b/test/e2e/editor/cases/artboard.js
@@ -73,7 +73,8 @@ var ArtboardScenarios = function() {
         });
 
         it('should be able to Cancel and go back to Editor',function(){
-          unsavedChangesModalPage.getCancelButton().click();
+          helper.clickWhenClickable(unsavedChangesModalPage.getCancelButton(), 'Cancel Button');
+          helper.waitDisappear(unsavedChangesModalPage.getUnsavedChangesModal(), 'Unsaved Changed Modal');
           expect(unsavedChangesModalPage.getUnsavedChangesModal().isPresent()).to.eventually.be.false;
           expect(workspacePage.getArtboardContainer().isDisplayed()).to.eventually.be.true;
         });

--- a/test/e2e/editor/cases/presentation-properties.js
+++ b/test/e2e/editor/cases/presentation-properties.js
@@ -41,7 +41,7 @@ var PresentationPropertiesScenarios = function() {
 
       describe('Given a user clicks on the presentation properties cog icon', function () {
         it('should open the properties modal when clicking cog', function () {
-          workspacePage.getPresentationPropertiesButton().click();
+          helper.clickWhenClickable(workspacePage.getPresentationPropertiesButton(), 'Presentation Properties Button');
           helper.wait(presentationPropertiesModalPage.getPresentationPropertiesModal(), 'Presentation Properties Modal');
           browser.sleep(500);
           

--- a/test/e2e/editor/cases/presentation-properties.js
+++ b/test/e2e/editor/cases/presentation-properties.js
@@ -49,10 +49,10 @@ var PresentationPropertiesScenarios = function() {
         });
 
         it('should open the properties modal when clicking Presentation name', function () {
-          presentationPropertiesModalPage.getCancelButton().click();
+          helper.clickWhenClickable(presentationPropertiesModalPage.getCancelButton(), 'Cancel Button');
           expect(presentationPropertiesModalPage.getPresentationPropertiesModal().isPresent()).to.eventually.be.false;
         
-          workspacePage.getPresentationNameContainer().click();
+          helper.clickWhenClickable(workspacePage.getPresentationNameContainer(), 'Presentation Name Container');
           helper.wait(presentationPropertiesModalPage.getPresentationPropertiesModal(), 'Presentation Properties Modal');
           browser.sleep(500);
           

--- a/test/e2e/editor/cases/professional-widgets.js
+++ b/test/e2e/editor/cases/professional-widgets.js
@@ -19,7 +19,7 @@ var ProfessionalWidgetsScenarios = function() {
 
   browser.driver.manage().window().setSize(1920, 1080);
   describe('Professional Widgets', function () {
-    var subCompanyName = 'E2E TEST SUBCOMPANY';
+    var subCompanyName = 'E2E TEST SUBCOMPANY - PROFESSIONAL WIDGETS';
     var homepage;
     var signInPage;
     var commonHeaderPage;

--- a/test/e2e/editor/cases/professional-widgets.js
+++ b/test/e2e/editor/cases/professional-widgets.js
@@ -81,7 +81,7 @@ var ProfessionalWidgetsScenarios = function() {
 
       helper.wait(autoScheduleModalPage.getAutoScheduleModal(), 'Auto Schedule Modal');
 
-      autoScheduleModalPage.getCloseButton().click();
+      helper.clickWhenClickable(autoScheduleModalPage.getCloseButton(), 'Auto Schedule Modal - Close Button');
 
       helper.waitDisappear(autoScheduleModalPage.getAutoScheduleModal(), 'Auto Schedule Modal');
 

--- a/test/e2e/editor/cases/template-add.js
+++ b/test/e2e/editor/cases/template-add.js
@@ -15,7 +15,7 @@ var TemplateAddScenarios = function() {
 
   browser.driver.manage().window().setSize(1920, 1080);
   describe('Template Add', function () {
-    var subCompanyName = 'E2E TEST SUBCOMPANY';
+    var subCompanyName = 'E2E TEST SUBCOMPANY - TEMPLATE ADD';
     var homepage;
     var signInPage;
     var commonHeaderPage;

--- a/test/e2e/launcher/pages/signInPage.js
+++ b/test/e2e/launcher/pages/signInPage.js
@@ -110,8 +110,8 @@ var SignInPage = function() {
     });
   };
 
-  this.signIn = this.customSignIn;
-  //this.signIn = this.googleSignIn;
+  //this.signIn = this.customSignIn;
+  this.signIn = this.googleSignIn;
 
 };
 

--- a/test/e2e/launcher/pages/signInPage.js
+++ b/test/e2e/launcher/pages/signInPage.js
@@ -23,6 +23,12 @@ var SignInPage = function() {
   var signinButton = element(by.cssContainingText('button.btn-primary', 'Sign In'));
   var incorrectCredentialsError = element(by.cssContainingText('.bg-danger', 'incorrect'));
 
+  var customAuth = {
+    usernameField: element(by.id('username')),
+    passwordField: element(by.id('password')),
+    signInButton: element(by.id('sign-in-button'))
+  };
+
   this.get = function() {
     browser.get(url);
   };
@@ -69,7 +75,7 @@ var SignInPage = function() {
     signInGoogleLink.click();
   };
 
-  this.signIn = function() {
+  this.googleSignIn = function() {
     //wait for spinner to go away.
     helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - Before Sign In');
 
@@ -84,6 +90,28 @@ var SignInPage = function() {
     
     // helper.wait(onboardingPage.getOnboardingBar(), 'Onboarding bar');
   };
+
+  this.customSignIn = function () {
+    var username = 'rise.customauth@gmail.com';
+    var password = 'Jenkins1';
+
+    //wait for spinner to go away.
+    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+
+    customAuth.signInButton.isDisplayed().then(function (state) {
+      var enter = '\ue007';
+
+      customAuth.usernameField.sendKeys(username);
+      customAuth.passwordField.sendKeys(password + enter);
+
+      helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+    }, function() {
+      console.log('Sign In button is not visible, most likely user has already signed in');
+    });
+  };
+
+  this.signIn = this.customSignIn;
+  //this.signIn = this.googleSignIn;
 
 };
 

--- a/test/e2e/launcher/pages/signInPage.js
+++ b/test/e2e/launcher/pages/signInPage.js
@@ -23,12 +23,6 @@ var SignInPage = function() {
   var signinButton = element(by.cssContainingText('button.btn-primary', 'Sign In'));
   var incorrectCredentialsError = element(by.cssContainingText('.bg-danger', 'incorrect'));
 
-  var customAuth = {
-    usernameField: element(by.id('username')),
-    passwordField: element(by.id('password')),
-    signInButton: element(by.id('sign-in-button'))
-  };
-
   this.get = function() {
     browser.get(url);
   };
@@ -91,26 +85,6 @@ var SignInPage = function() {
     // helper.wait(onboardingPage.getOnboardingBar(), 'Onboarding bar');
   };
 
-  this.customSignIn = function () {
-    var username = 'rise.customauth@gmail.com';
-    var password = 'Jenkins1';
-
-    //wait for spinner to go away.
-    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - Before Custom Sign In');
-
-    customAuth.signInButton.isDisplayed().then(function (state) {
-      var enter = '\ue007';
-
-      customAuth.usernameField.sendKeys(username);
-      customAuth.passwordField.sendKeys(password + enter);
-
-      helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - After Custom Sign In');
-    }, function() {
-      console.log('Sign In button is not visible, most likely user has already signed in');
-    });
-  };
-
-  //this.signIn = this.customSignIn;
   this.signIn = this.googleSignIn;
 
 };

--- a/test/e2e/launcher/pages/signInPage.js
+++ b/test/e2e/launcher/pages/signInPage.js
@@ -71,13 +71,13 @@ var SignInPage = function() {
 
   this.signIn = function() {
     //wait for spinner to go away.
-    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - Before Sign In');
 
     signInGoogleLink.isPresent().then(function (state) {
       if (state) {
         signInGoogleLink.click().then(function () {
           googleAuthPage.signin();
-          helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+          helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - After Sign In');
         });
       }
     });

--- a/test/e2e/launcher/pages/signInPage.js
+++ b/test/e2e/launcher/pages/signInPage.js
@@ -70,20 +70,20 @@ var SignInPage = function() {
   };
 
   this.getGoogleLogin = function() {
-    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - Get Google Login');
     helper.wait(signInGoogleLink, 'Sign In Google Link', 1000);
     signInGoogleLink.click();
   };
 
   this.googleSignIn = function() {
     //wait for spinner to go away.
-    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - Before Sign In');
+    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - Before Google Sign In');
 
     signInGoogleLink.isPresent().then(function (state) {
       if (state) {
         signInGoogleLink.click().then(function () {
           googleAuthPage.signin();
-          helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - After Sign In');
+          helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - After Google Sign In');
         });
       }
     });
@@ -96,7 +96,7 @@ var SignInPage = function() {
     var password = 'Jenkins1';
 
     //wait for spinner to go away.
-    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - Before Custom Sign In');
 
     customAuth.signInButton.isDisplayed().then(function (state) {
       var enter = '\ue007';
@@ -104,7 +104,7 @@ var SignInPage = function() {
       customAuth.usernameField.sendKeys(username);
       customAuth.passwordField.sendKeys(password + enter);
 
-      helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+      helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - After Custom Sign In');
     }, function() {
       console.log('Sign In button is not visible, most likely user has already signed in');
     });

--- a/test/e2e/launcher/pages/signInPage.js
+++ b/test/e2e/launcher/pages/signInPage.js
@@ -77,7 +77,11 @@ var SignInPage = function() {
 
   this.googleSignIn = function() {
     //wait for spinner to go away.
-    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - Before Google Sign In');
+    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - Before Google Sign In', 5000)
+    .catch(function () {
+      console.log("Failed waiting for spinner to disappear befor Google Sign In");
+      browser.refresh();
+    });
 
     signInGoogleLink.isPresent().then(function (state) {
       if (state) {

--- a/test/e2e/launcher/pages/signInPage.js
+++ b/test/e2e/launcher/pages/signInPage.js
@@ -77,11 +77,7 @@ var SignInPage = function() {
 
   this.googleSignIn = function() {
     //wait for spinner to go away.
-    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - Before Google Sign In', 5000)
-    .catch(function () {
-      console.log("Failed waiting for spinner to disappear befor Google Sign In");
-      browser.refresh();
-    });
+    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - Before Google Sign In');
 
     signInGoogleLink.isPresent().then(function (state) {
       if (state) {
@@ -114,8 +110,8 @@ var SignInPage = function() {
     });
   };
 
-  //this.signIn = this.customSignIn;
-  this.signIn = this.googleSignIn;
+  this.signIn = this.customSignIn;
+  //this.signIn = this.googleSignIn;
 
 };
 

--- a/test/e2e/storage/cases/trial.js
+++ b/test/e2e/storage/cases/trial.js
@@ -41,7 +41,7 @@ var FirstSigninScenarios = function() {
       before(function () {
         homepage.getStorage();
         signInPage.signIn();
-        var subCompanyName = 'E2E TEST SUBCOMPANY';
+        var subCompanyName = 'E2E TEST SUBCOMPANY - STORAGE TRIAL';
         commonHeaderPage.createSubCompany(subCompanyName);
         commonHeaderPage.selectSubCompany(subCompanyName);   
       });
@@ -60,7 +60,7 @@ var FirstSigninScenarios = function() {
       });
 
       xit('should start a new presentation', function () {
-        homepage.getPresentationCTAButton().click();
+        helper.clickWhenClickable(homepage.getPresentationCTAButton(), 'Presentation CTA button');
 
         helper.wait(storeProductsModalPage.getStoreProductsModal(), 'Select Content Modal');
         helper.waitDisappear(storeProductsModalPage.getStoreProductsLoader());


### PR DESCRIPTION
This PR improves a few situations:

- Better handle of clicking
- Some explicit delays in a test that was constantly failing and for which it was not possible to wait for some explicit element
- Use different Sub Company name for some conflicting test suites
- Break e2e_tests workflow step into smaller steps, which allow for running them in parallel and retrying them individually

@Rise-Vision/apps please review
