### PR TITLE
Disable Preview button if Schedule contains mixed Presentation Types

### DIFF
--- a/test/unit/editor/controllers/ctr-presentation-selector-modal.tests.js
+++ b/test/unit/editor/controllers/ctr-presentation-selector-modal.tests.js
@@ -32,9 +32,10 @@ describe('controller: Presentation Selector Modal', function() {
   it('should close modal when clicked on a presentation',function(){
     var presentationId = 'presentationId';
     var presentationName = 'presentationName';
-    $scope.select(presentationId, presentationName);
+    var presentationType = 'presentationType';
+    $scope.select(presentationId, presentationName, presentationType);
 
-    $modalInstance.close.should.have.been.calledWith([presentationId, presentationName]);
+    $modalInstance.close.should.have.been.calledWith([presentationId, presentationName, presentationType]);
   });
 
   it('should dismiss modal when clicked on close with no action',function(){

--- a/test/unit/schedules/directives/dtv-schedule-fields.tests.js
+++ b/test/unit/schedules/directives/dtv-schedule-fields.tests.js
@@ -44,11 +44,11 @@ describe('directive: scheduleFields', function() {
       expect($scope.isPreviewAvailable()).to.be.true;
       $scope.schedule.content = [ classicPres1, classicPres2 ];
       expect($scope.isPreviewAvailable()).to.be.true;
-      $scope.schedule.content = [ htmlPres1 ];
-      expect($scope.isPreviewAvailable()).to.be.true;
     });
 
     it('should not have Preview button available', function() {
+      $scope.schedule.content = [ htmlPres1 ];
+      expect($scope.isPreviewAvailable()).to.be.false;
       $scope.schedule.content = [ classicPres1, htmlPres1 ];
       expect($scope.isPreviewAvailable()).to.be.false;
       $scope.schedule.content = [ classicPres1, classicPres2, htmlPres1 ];

--- a/test/unit/schedules/directives/dtv-schedule-fields.tests.js
+++ b/test/unit/schedules/directives/dtv-schedule-fields.tests.js
@@ -1,0 +1,58 @@
+'use strict';
+describe('directive: scheduleFields', function() {
+  var $scope, $rootScope;
+  var classicPres1 = { name: 'classic1' };
+  var classicPres2 = { name: 'classic2' };
+  var htmlPres1 = { name: 'html1', presentationType: 'HTML Template' };
+  var items = [ classicPres1, classicPres2, htmlPres1 ];
+  var element;
+
+  beforeEach(module('risevision.editor.services'));
+  beforeEach(module('risevision.schedules.directives'));
+  beforeEach(module(mockTranlate()));
+  beforeEach(module(function ($provide) {
+    $provide.service('$modal', function() {
+      return {
+        open: function() {
+        }
+      };
+    });
+    $provide.service('playlistFactory', function() {
+      return {
+      };
+    });
+    $provide.service('scheduleFactory', function() {
+      return {
+        getPreviewUrl: function () {}
+      };
+    });
+  }));
+
+  beforeEach(inject(function($compile, _$rootScope_, $templateCache){
+    $templateCache.put('partials/schedules/schedule-fields.html', '<p>mock</p>');
+    $rootScope = _$rootScope_;
+    $scope = $rootScope.$new();
+    $scope.schedule = {};
+
+    element = $compile('<schedule-fields></schedule-fields>')($scope);
+    $rootScope.$digest();
+  }));
+
+  describe('isPreviewAvailable:', function() {
+    it('should have Preview button available', function() {
+      $scope.schedule.content = [];
+      expect($scope.isPreviewAvailable()).to.be.true;
+      $scope.schedule.content = [ classicPres1, classicPres2 ];
+      expect($scope.isPreviewAvailable()).to.be.true;
+      $scope.schedule.content = [ htmlPres1 ];
+      expect($scope.isPreviewAvailable()).to.be.true;
+    });
+
+    it('should not have Preview button available', function() {
+      $scope.schedule.content = [ classicPres1, htmlPres1 ];
+      expect($scope.isPreviewAvailable()).to.be.false;
+      $scope.schedule.content = [ classicPres1, classicPres2, htmlPres1 ];
+      expect($scope.isPreviewAvailable()).to.be.false;
+    });
+  });
+});

--- a/web/partials/editor/presentation-selector-list.html
+++ b/web/partials/editor/presentation-selector-list.html
@@ -22,7 +22,7 @@
         </thead>
 
         <tbody class="table-body">
-          <tr class="table-body__row u_clickable" data-ng-click="toggleObject.item = $index; select(presentation.id, presentation.name);" data-ng-class="{'active' : toggleObject.item == $index}" ng-repeat="presentation in factory.items.list">
+          <tr class="table-body__row u_clickable" data-ng-click="toggleObject.item = $index; select(presentation.id, presentation.name, presentation.presentationType);" data-ng-class="{'active' : toggleObject.item == $index}" ng-repeat="presentation in factory.items.list">
             <td id="presentationName" class="table-body__cell">{{presentation.name}}</td>
             <td class="table-body__cell text-right"><span ng-class="{'text-danger': presentation.revisionStatus==1}">{{presentation.revisionStatusName | presentationStatus}}</span></td>
           </tr>

--- a/web/partials/schedules/schedule-fields.html
+++ b/web/partials/schedules/schedule-fields.html
@@ -49,7 +49,9 @@
       </ul>
     </div>
   </div>
-  <a class="btn btn-default" id="previewButton" target="_blank" ng-href="{{previewUrl}}" ng-show="previewUrl">{{'schedules-app.actions.preview' | translate}} <i class="fa fa-play icon-right"></i></a>
+  <a class="btn btn-default" id="previewButton" target="_blank" ng-href="{{previewUrl}}" ng-show="previewUrl" ng-disabled="!isPreviewAvailable()">
+    {{'schedules-app.actions.preview' | translate}} <i class="fa fa-play icon-right"></i>
+  </a>
 </div>
 
 <playlist playlist-items="schedule.content"></playlist>

--- a/web/partials/schedules/schedule-fields.html
+++ b/web/partials/schedules/schedule-fields.html
@@ -49,7 +49,7 @@
       </ul>
     </div>
   </div>
-  <a class="btn btn-default" id="previewButton" target="_blank" ng-href="{{previewUrl}}" ng-show="previewUrl" ng-disabled="!isPreviewAvailable()">
+  <a class="btn btn-default" id="previewButton" target="_blank" ng-href="{{previewUrl}}" ng-show="previewUrl && isPreviewAvailable()">
     {{'schedules-app.actions.preview' | translate}} <i class="fa fa-play icon-right"></i>
   </a>
 </div>

--- a/web/scripts/editor/controllers/ctr-presentation-selector-modal.js
+++ b/web/scripts/editor/controllers/ctr-presentation-selector-modal.js
@@ -3,8 +3,8 @@
 angular.module('risevision.editor.controllers')
   .controller('PresentationSelectorModal', ['$scope', '$modalInstance',
     function ($scope, $modalInstance) {
-      $scope.select = function (presentationId, presentationName) {
-        $modalInstance.close([presentationId, presentationName]);
+      $scope.select = function (presentationId, presentationName, presentationType) {
+        $modalInstance.close([presentationId, presentationName, presentationType]);
       };
 
       $scope.dismiss = function () {

--- a/web/scripts/schedules/directives/dtv-schedule-fields.js
+++ b/web/scripts/schedules/directives/dtv-schedule-fields.js
@@ -47,7 +47,7 @@ angular.module('risevision.schedules.directives')
               return presentationUtils.isHtmlPresentation(presentation);
             });
 
-            return htmlPresentations.length === 0 || htmlPresentations.length === $scope.schedule.content.length;
+            return htmlPresentations.length === 0;
           };
         } //link()
       };

--- a/web/scripts/schedules/directives/dtv-schedule-fields.js
+++ b/web/scripts/schedules/directives/dtv-schedule-fields.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.schedules.directives')
-  .directive('scheduleFields', ['$modal', 'scheduleFactory', 'playlistFactory',
-    function ($modal, scheduleFactory, playlistFactory) {
+  .directive('scheduleFields', ['$modal', 'scheduleFactory', 'playlistFactory', 'presentationUtils',
+    function ($modal, scheduleFactory, playlistFactory, presentationUtils) {
       return {
         restrict: 'E',
         templateUrl: 'partials/schedules/schedule-fields.html',
@@ -36,11 +36,19 @@ angular.module('risevision.schedules.directives')
               var playlistItem = playlistFactory.getNewPresentationItem();
               playlistItem.objectReference = presentationDetails[0];
               playlistItem.name = presentationDetails[1];
+              playlistItem.presentationType = presentationDetails[2];
 
               openPlaylistModal(playlistItem);
             });
           };
 
+          $scope.isPreviewAvailable = function () {
+            var htmlPresentations = _.filter($scope.schedule.content, function (presentation) {
+              return presentationUtils.isHtmlPresentation(presentation);
+            });
+
+            return htmlPresentations.length === 0 || htmlPresentations.length === $scope.schedule.content.length;
+          };
         } //link()
       };
     }


### PR DESCRIPTION
With the changes in this PR, the Preview button is disabled if you add a Presentation of type "HTML Template" and "Legacy" or "URL" playlist items exist in the Schedule. For greater clarity, the Preview button will only be available if:

- All the playlist items are "Legacy" or "URL"
- All the playlist items are "HTML Templates"

You can see this Schedule for testing (ideally, create a new Schedule if you want to test saving): https://apps-stage-1.risevision.com/schedules/details/5d3b3258-4290-41c0-8a76-4c279b7d1ed3?cid=a847f5bb-e61a-4925-817a-552075edf203

There are Core changes needed for this to work, and the default version could be changed by the time you test this. Let me know if you have issues and I'll update accordingly.

@Rise-Vision/apps @santiagonoguez @stulees please review
