### PR TITLE
Add missing writable fields when adding presentation [stage-8]

### DIFF
--- a/web/scripts/editor/services/svc-presentation.js
+++ b/web/scripts/editor/services/svc-presentation.js
@@ -4,7 +4,8 @@
 
 angular.module('risevision.editor.services')
   .constant('PRESENTAION_WRITABLE_FIELDS', [
-    'name', 'layout', 'distribution', 'isTemplate', 'embeddedIds'
+    'name', 'layout', 'distribution', 'isTemplate', 'embeddedIds', 'productId',
+    'presentationType', 'templateAttributeData'
   ])
   .constant('PRESENTAION_SEARCH_FIELDS', [
     'name', 'id', 'revisionStatusName'


### PR DESCRIPTION
`productId`, `presentationType`, and `templateAttributeData` need to be writable fields for adding presentation