### PR TITLE
Feature/overall editor layout

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -237,6 +237,9 @@
   <script src="scripts/editor/directives/dtv-presentation-name.js"></script>
   <script src="scripts/editor/directives/dtv-rv-popover.js"></script>
 
+  <script src="scripts/template-editor/directives/dtv-attribute-editor.js"></script>
+  <script src="scripts/template-editor/directives/dtv-editor-preview-holder.js"></script>
+  <script src="scripts/template-editor/directives/dtv-footer.js"></script>
   <script src="scripts/template-editor/directives/dtv-toolbar.js"></script>
 
   <!-- storage -->

--- a/web/index.html
+++ b/web/index.html
@@ -237,8 +237,6 @@
   <script src="scripts/editor/directives/dtv-presentation-name.js"></script>
   <script src="scripts/editor/directives/dtv-rv-popover.js"></script>
 
-  <script src="scripts/template-editor/directives/dtv-toolbar.js"></script>
-
   <!-- storage -->
   <script src="scripts/storage/services/svc-storage-factory.js"></script>
   <script src="scripts/storage/services/svc-storage-utils.js"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -237,6 +237,8 @@
   <script src="scripts/editor/directives/dtv-presentation-name.js"></script>
   <script src="scripts/editor/directives/dtv-rv-popover.js"></script>
 
+  <script src="scripts/template-editor/directives/dtv-toolbar.js"></script>
+
   <!-- storage -->
   <script src="scripts/storage/services/svc-storage-factory.js"></script>
   <script src="scripts/storage/services/svc-storage-utils.js"></script>

--- a/web/partials/template-editor/attribute-editor.html
+++ b/web/partials/template-editor/attribute-editor.html
@@ -1,0 +1,1 @@
+attribute editor

--- a/web/partials/template-editor/footer.html
+++ b/web/partials/template-editor/footer.html
@@ -1,0 +1,7 @@
+<button class="btn btn-primary btn-block">
+  {{ 'common.save' | translate }}
+</button>
+
+<button disabled class="btn btn-primary btn-block">
+  {{'common.publish' | translate}}
+</button>

--- a/web/partials/template-editor/preview-holder.html
+++ b/web/partials/template-editor/preview-holder.html
@@ -1,0 +1,3 @@
+<div style="background-color: #C0C0C0">
+  preview
+</div>

--- a/web/partials/template-editor/template-editor.html
+++ b/web/partials/template-editor/template-editor.html
@@ -1,33 +1,14 @@
 <style>
-  .html-template-editor .footer {
+  .template-editor .footer {
     padding: 10px;
   }
 
-  .html-template-editor .footer button {
+  .template-editor .footer button {
   }
 </style>
 
-<div class="container-flow html-template-editor">
-  <div class="workspace-toolbar">
-    <!-- Presentation Name -->
-    <h2 class="presentation-name">
-      {{factory.presentation.name}}
-      <i class="fa fa-pencil u_margin-left"></i>
-      <i class="fa fa-pencil u_margin-left hidden-xs"></i>
-    </h2>
- 
-    <div class="toolbar-right">
-      <button class="btn btn-primary btn-fixed-width u_margin-right hidden-xs">
-        {{ 'common.save' | translate }}
-      </button>
-
-      <button disabled class="btn btn-primary btn-fixed-width u_margin-right hidden-xs">
-        {{'common.publish' | translate}}
-      </button>
-
-      <i class="fa fa-pencil u_margin-left visible-xs"></i>
-    </div>
-  </div>
+<div class="container-flow template-editor">
+  <template-editor-toolbar class="workspace-toolbar"></template-editor-toolbar>
   <div class="row">
     <div class="col-sm-8 col-sm-push-4" style="background-color: #C0C0C0">
       preview

--- a/web/partials/template-editor/template-editor.html
+++ b/web/partials/template-editor/template-editor.html
@@ -1,3 +1,48 @@
-<div>This is the main page of the new HTML Templates Editor</div>
-<div>Presentation name: {{factory.presentation.name}}</div>
-<div>Template Attribute Data: {{factory.presentation.templateAttributeData}}</div>
+<style>
+  .template-editor .footer {
+    padding: 10px;
+  }
+
+  .template-editor .footer button {
+  }
+</style>
+
+<div class="container-flow template-editor">
+  <toolbar class="workspace-toolbar" id="workspaceToolbar">
+    <!-- Presentation Name -->
+    <h2 class="presentation-name" id="title">
+      {{factory.presentation.name}}
+      <i class="fa fa-pencil u_margin-left"></i>
+      <i class="fa fa-pencil u_margin-left hidden-xs"></i>
+    </h2>
+
+    <div class="toolbar-right">
+      <button id="saveButton" class="btn btn-primary btn-fixed-width u_margin-right hidden-xs">
+        {{ 'common.save' | translate }}
+      </button>
+
+      <button id="publishButton" disabled class="btn btn-primary btn-fixed-width u_margin-right hidden-xs">
+        {{'common.publish' | translate}}
+      </button>
+
+      <i class="fa fa-pencil u_margin-left visible-xs"></i>
+    </div>
+  </toolbar>
+  <div class="row">
+    <div class="col-sm-8 col-sm-push-4" style="background-color: #C0C0C0">
+      preview
+    </div>
+    <sidebar class="col-sm-4 col-sm-pull-8">
+      attribute editor
+    </sidebar>
+  </div>
+  <footer class="footer navbar-fixed-bottom visible-xs">
+    <button id="saveButtonMobile" class="btn btn-primary btn-block">
+      {{ 'common.save' | translate }}
+    </button>
+
+    <button id="publishButtonMobile" disabled class="btn btn-primary btn-block">
+      {{'common.publish' | translate}}
+    </button>
+  </footer>
+</div>

--- a/web/partials/template-editor/template-editor.html
+++ b/web/partials/template-editor/template-editor.html
@@ -8,22 +8,18 @@
 </style>
 
 <div class="container-flow template-editor">
-  <template-editor-toolbar class="workspace-toolbar"></template-editor-toolbar>
-  <div class="row">
-    <div class="col-sm-8 col-sm-push-4" style="background-color: #C0C0C0">
-      preview
-    </div>
-    <div class="col-sm-4 col-sm-pull-8">
-      attribute editor
-    </div>
-  </div>
-  <div class="footer navbar-fixed-bottom visible-xs">
-    <button class="btn btn-primary btn-block">
-      {{ 'common.save' | translate }}
-    </button>
 
-    <button disabled class="btn btn-primary btn-block">
-      {{'common.publish' | translate}}
-    </button>
+  <template-editor-toolbar class="workspace-toolbar"></template-editor-toolbar>
+
+  <div class="row">
+    <template-editor-preview-holder class="col-sm-8 col-sm-push-4">
+    </template-editor-preview-holder>
+
+    <template-attribute-editor class="col-sm-4 col-sm-pull-8">
+    </template-attribute-editor>
   </div>
+
+  <template-editor-footer class="footer navbar-fixed-bottom visible-xs">
+  </template-editor-footer>
+
 </div>

--- a/web/partials/template-editor/template-editor.html
+++ b/web/partials/template-editor/template-editor.html
@@ -8,20 +8,20 @@
 </style>
 
 <div class="container-flow template-editor">
-  <toolbar class="workspace-toolbar" id="workspaceToolbar">
+  <toolbar class="workspace-toolbar">
     <!-- Presentation Name -->
-    <h2 class="presentation-name" id="title">
+    <h2 class="presentation-name">
       {{factory.presentation.name}}
       <i class="fa fa-pencil u_margin-left"></i>
       <i class="fa fa-pencil u_margin-left hidden-xs"></i>
     </h2>
 
     <div class="toolbar-right">
-      <button id="saveButton" class="btn btn-primary btn-fixed-width u_margin-right hidden-xs">
+      <button class="btn btn-primary btn-fixed-width u_margin-right hidden-xs">
         {{ 'common.save' | translate }}
       </button>
 
-      <button id="publishButton" disabled class="btn btn-primary btn-fixed-width u_margin-right hidden-xs">
+      <button disabled class="btn btn-primary btn-fixed-width u_margin-right hidden-xs">
         {{'common.publish' | translate}}
       </button>
 
@@ -37,11 +37,11 @@
     </sidebar>
   </div>
   <footer class="footer navbar-fixed-bottom visible-xs">
-    <button id="saveButtonMobile" class="btn btn-primary btn-block">
+    <button class="btn btn-primary btn-block">
       {{ 'common.save' | translate }}
     </button>
 
-    <button id="publishButtonMobile" disabled class="btn btn-primary btn-block">
+    <button disabled class="btn btn-primary btn-block">
       {{'common.publish' | translate}}
     </button>
   </footer>

--- a/web/partials/template-editor/template-editor.html
+++ b/web/partials/template-editor/template-editor.html
@@ -1,14 +1,39 @@
 <style>
-  .template-editor .footer {
+  .html-template-editor .footer {
     padding: 10px;
   }
 
-  .template-editor .footer button {
+  .html-template-editor .footer button {
+  }
+
+  .html-template-editor-toolbar {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    z-index: 100;
+    background-color: #FFF;
+    border-bottom: 1px solid #f2f2f2;
+    border-top: 1px solid #f2f2f2;
+    padding: 8px 10px;
+  }
+
+  .html-template-editor-toolbar .presentation-name {
+    max-width: calc(100vw - 240px);
+    font-size: 16px;
+    margin: 0;
+    padding: 0;
+    line-height: 32px;
+  }
+
+  .html-template-editor-toolbar .toolbar-right {
+      display: flex;
+      margin-left: auto;
+      flex-wrap: nowrap;
   }
 </style>
 
-<div class="container-flow template-editor">
-  <toolbar class="workspace-toolbar">
+<div class="container-flow html-template-editor">
+  <toolbar class="html-template-editor-toolbar">
     <!-- Presentation Name -->
     <h2 class="presentation-name">
       {{factory.presentation.name}}

--- a/web/partials/template-editor/template-editor.html
+++ b/web/partials/template-editor/template-editor.html
@@ -15,7 +15,7 @@
       <i class="fa fa-pencil u_margin-left"></i>
       <i class="fa fa-pencil u_margin-left hidden-xs"></i>
     </h2>
-
+ 
     <div class="toolbar-right">
       <button class="btn btn-primary btn-fixed-width u_margin-right hidden-xs">
         {{ 'common.save' | translate }}

--- a/web/partials/template-editor/template-editor.html
+++ b/web/partials/template-editor/template-editor.html
@@ -5,35 +5,10 @@
 
   .html-template-editor .footer button {
   }
-
-  .html-template-editor-toolbar {
-    display: flex;
-    align-items: center;
-    width: 100%;
-    z-index: 100;
-    background-color: #FFF;
-    border-bottom: 1px solid #f2f2f2;
-    border-top: 1px solid #f2f2f2;
-    padding: 8px 10px;
-  }
-
-  .html-template-editor-toolbar .presentation-name {
-    max-width: calc(100vw - 240px);
-    font-size: 16px;
-    margin: 0;
-    padding: 0;
-    line-height: 32px;
-  }
-
-  .html-template-editor-toolbar .toolbar-right {
-      display: flex;
-      margin-left: auto;
-      flex-wrap: nowrap;
-  }
 </style>
 
 <div class="container-flow html-template-editor">
-  <toolbar class="html-template-editor-toolbar">
+  <div class="workspace-toolbar">
     <!-- Presentation Name -->
     <h2 class="presentation-name">
       {{factory.presentation.name}}
@@ -52,16 +27,16 @@
 
       <i class="fa fa-pencil u_margin-left visible-xs"></i>
     </div>
-  </toolbar>
+  </div>
   <div class="row">
     <div class="col-sm-8 col-sm-push-4" style="background-color: #C0C0C0">
       preview
     </div>
-    <sidebar class="col-sm-4 col-sm-pull-8">
+    <div class="col-sm-4 col-sm-pull-8">
       attribute editor
-    </sidebar>
+    </div>
   </div>
-  <footer class="footer navbar-fixed-bottom visible-xs">
+  <div class="footer navbar-fixed-bottom visible-xs">
     <button class="btn btn-primary btn-block">
       {{ 'common.save' | translate }}
     </button>
@@ -69,5 +44,5 @@
     <button disabled class="btn btn-primary btn-block">
       {{'common.publish' | translate}}
     </button>
-  </footer>
+  </div>
 </div>

--- a/web/partials/template-editor/toolbar.html
+++ b/web/partials/template-editor/toolbar.html
@@ -1,0 +1,18 @@
+<!-- Presentation Name -->
+<h2 class="presentation-name">
+  {{factory.presentation.name}}
+  <i class="fa fa-pencil u_margin-left"></i>
+  <i class="fa fa-pencil u_margin-left hidden-xs"></i>
+</h2>
+
+<div class="toolbar-right">
+  <button class="btn btn-primary btn-fixed-width u_margin-right hidden-xs">
+    {{ 'common.save' | translate }}
+  </button>
+
+  <button disabled class="btn btn-primary btn-fixed-width u_margin-right hidden-xs">
+    {{'common.publish' | translate}}
+  </button>
+
+  <i class="fa fa-pencil u_margin-left visible-xs"></i>
+</div>

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -14,15 +14,4 @@ angular.module('risevision.template-editor.controllers')
         }
       });
     }
-  ])
-  .directive('template-editor-toolbar', ['templateEditorFactory',
-    function (templateEditorFactory) {
-      return {
-        restrict: 'E',
-        templateUrl: 'partials/template-editor/toolbar.html',
-        link: function ($scope) {
-          $scope.factory = templateEditorFactory;
-        }
-      };
-    }
   ]);

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -15,3 +15,16 @@ angular.module('risevision.template-editor.controllers')
       });
     }
   ]);
+
+angular.module('risevision.template-editor.directives')
+  .directive('template-editor-toolbar', ['templateEditorFactory',
+    function (templateEditorFactory) {
+      return {
+        restrict: 'E',
+        templateUrl: 'partials/template-editor/toolbar.html',
+        link: function ($scope) {
+          $scope.factory = templateEditorFactory;
+        }
+      };
+    }
+  ]);

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -14,9 +14,7 @@ angular.module('risevision.template-editor.controllers')
         }
       });
     }
-  ]);
-
-angular.module('risevision.template-editor.directives')
+  ])
   .directive('template-editor-toolbar', ['templateEditorFactory',
     function (templateEditorFactory) {
       return {

--- a/web/scripts/template-editor/directives/dtv-attribute-editor.js
+++ b/web/scripts/template-editor/directives/dtv-attribute-editor.js
@@ -1,0 +1,14 @@
+'use strict';
+
+angular.module('risevision.template-editor.directives')
+  .directive('templateAttributeEditor', ['templateEditorFactory',
+    function (templateEditorFactory) {
+      return {
+        restrict: 'E',
+        templateUrl: 'partials/template-editor/attribute-editor.html',
+        link: function ($scope) {
+          $scope.factory = templateEditorFactory;
+        }
+      };
+    }
+  ]);

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -1,0 +1,14 @@
+'use strict';
+
+angular.module('risevision.template-editor.directives')
+  .directive('templateEditorPreviewHolder', ['templateEditorFactory',
+    function (templateEditorFactory) {
+      return {
+        restrict: 'E',
+        templateUrl: 'partials/template-editor/preview-holder.html',
+        link: function ($scope) {
+          $scope.factory = templateEditorFactory;
+        }
+      };
+    }
+  ]);

--- a/web/scripts/template-editor/directives/dtv-footer.js
+++ b/web/scripts/template-editor/directives/dtv-footer.js
@@ -1,0 +1,14 @@
+'use strict';
+
+angular.module('risevision.template-editor.directives')
+  .directive('templateEditorFooter', ['templateEditorFactory',
+    function (templateEditorFactory) {
+      return {
+        restrict: 'E',
+        templateUrl: 'partials/template-editor/footer.html',
+        link: function ($scope) {
+          $scope.factory = templateEditorFactory;
+        }
+      };
+    }
+  ]);

--- a/web/scripts/template-editor/directives/dtv-toolbar.js
+++ b/web/scripts/template-editor/directives/dtv-toolbar.js
@@ -5,7 +5,7 @@ angular.module('risevision.template-editor.directives')
     function (templateEditorFactory) {
       return {
         restrict: 'E',
-        template: 'partials/template-editor/toolbar.html',
+        templateUrl: 'partials/template-editor/toolbar.html',
         link: function ($scope) {
           $scope.factory = templateEditorFactory;
         }

--- a/web/scripts/template-editor/directives/dtv-toolbar.js
+++ b/web/scripts/template-editor/directives/dtv-toolbar.js
@@ -1,0 +1,14 @@
+'use strict';
+
+angular.module('risevision.template-editor.directives')
+  .directive('template-editor-toolbar', ['templateEditorFactory',
+    function (templateEditorFactory) {
+      return {
+        restrict: 'E',
+        templateUrl: 'partials/template-editor/toolbar.html',
+        link: function ($scope) {
+          $scope.factory = templateEditorFactory;
+        }
+      };
+    }
+  ]);

--- a/web/scripts/template-editor/directives/dtv-toolbar.js
+++ b/web/scripts/template-editor/directives/dtv-toolbar.js
@@ -5,7 +5,7 @@ angular.module('risevision.template-editor.directives')
     function (templateEditorFactory) {
       return {
         restrict: 'E',
-        templateUrl: 'partials/template-editor/toolbar.html',
+        template: 'partials/template-editor/toolbar.html',
         link: function ($scope) {
           $scope.factory = templateEditorFactory;
         }

--- a/web/scripts/template-editor/directives/dtv-toolbar.js
+++ b/web/scripts/template-editor/directives/dtv-toolbar.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
-  .directive('template-editor-toolbar', ['templateEditorFactory',
+  .directive('templateEditorToolbar', ['templateEditorFactory',
     function (templateEditorFactory) {
       return {
         restrict: 'E',


### PR DESCRIPTION
This separates the template editor in 4 sections: toolbar, attribute editor, preview, and footer. This is intended to achieve separation of those sections, and help reduce blocks other cards may have in this one.

Styles to match Mat's design are still incomplete.
Style code in the views are preliminary, will be separated later into common-header.

Preliminary view here:
https://apps-stage-9.risevision.com/templates/edit/d7e74f95-8c7c-495e-a3da-76fb514049c1?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c

Check also responsive behavior.
