### PR TITLE
Checking Templates Library authorization prior to opening HTML Template presentation

### DIFF
--- a/test/unit/editor/controllers/ctr-presentation-list.tests.js
+++ b/test/unit/editor/controllers/ctr-presentation-list.tests.js
@@ -40,6 +40,11 @@ describe('controller: Presentation List', function() {
         go: sinon.stub()
       };
     });
+    $provide.service('presentationUtils', function() {
+      return {
+        openPresentation: sinon.stub()
+      };
+    });
   }));
   var $scope, $loading, $loadingStartSpy, $loadingStopSpy;
   beforeEach(function(){
@@ -62,15 +67,15 @@ describe('controller: Presentation List', function() {
 
   it('should exist',function(){
     expect($scope).to.be.ok;
-    
+
     expect($scope.factory).to.be.ok;
     expect($scope.factory.loadingItems).to.be.false;
     expect($scope.search).to.be.ok;
     expect($scope.filterConfig).to.be.ok;
     expect($scope.presentationTracker).to.be.ok;
-    
+
   });
-  
+
   it('should init the scope objects',function(){
     expect($scope.search).to.be.ok;
     expect($scope.search).to.have.property('sortBy');
@@ -81,18 +86,18 @@ describe('controller: Presentation List', function() {
   it('should attach presentation list to editorFactory',function(){
     expect($scope.editorFactory.presentations).to.be.ok;
   });
-  
+
   describe('$loading: ', function() {
     it('should stop spinner', function() {
       $loadingStopSpy.should.have.been.calledWith('presentation-list-loader');
     });
-    
+
     it('should start spinner', function(done) {
       $scope.factory.loadingItems = true;
       $scope.$digest();
       setTimeout(function() {
         $loadingStartSpy.should.have.been.calledWith('presentation-list-loader');
-        
+
         done();
       }, 10);
     });

--- a/test/unit/editor/services/svc-presentation-utils.tests.js
+++ b/test/unit/editor/services/svc-presentation-utils.tests.js
@@ -4,15 +4,35 @@ describe('service: presentationUtils:', function() {
   beforeEach(module('risevision.editor.services'));
   beforeEach(module(function ($provide) {
     $provide.service('$q', function() { return Q; });
+
+    $provide.service('$state', function() {
+      return {
+        go: sinon.stub()
+      };
+    });
+
+    $provide.service('checkTemplateAccess',function(){
+      return sinon.spy(function () {
+        return storeAuthorize ? Q.resolve() : Q.reject();
+      });
+    });
+
+    $provide.service('plansFactory', function() {
+      return plansFactory = {
+        showPlansModal: sinon.stub()
+      }
+    })
   }));
 
-  var presentationUtils, HTML_TEMPLATE_TYPE, HTML_PRESENTATION_TYPE;
+  var presentationUtils, HTML_TEMPLATE_TYPE, HTML_PRESENTATION_TYPE, $state, checkTemplateAccessSpy, storeAuthorize, plansFactory;
 
   beforeEach(function() {
-    inject(function($injector) {
+    inject(function($injector, checkTemplateAccess) {
       presentationUtils = $injector.get('presentationUtils');
       HTML_TEMPLATE_TYPE = $injector.get('HTML_TEMPLATE_TYPE');
       HTML_PRESENTATION_TYPE = $injector.get('HTML_PRESENTATION_TYPE');
+      $state = $injector.get('$state');
+      checkTemplateAccessSpy = checkTemplateAccess;
     });
   });
 
@@ -44,4 +64,37 @@ describe('service: presentationUtils:', function() {
       expect(presentationUtils.isHtmlPresentation({ presentationType: 'Other Type' })).to.be.false;
     });
   });
+
+  describe( 'openPresentation:', function() {
+    it( "should route to editor workspace when not a HTML template", function() {
+      presentationUtils.openPresentation({ id: 'test-id', presentationType: 'legacy' });
+
+      expect($state.go).to.have.been.calledWith('apps.editor.workspace.artboard', {presentationId: 'test-id'});
+    } );
+
+    it( "should route to template editor when presentation type is HTML template and authorized", function(done) {
+      storeAuthorize = true;
+      presentationUtils.openPresentation({ id: 'test-id', presentationType: 'HTML Template', productCode: 'abc123' });
+
+      expect(checkTemplateAccessSpy).to.have.been.calledWith('abc123');
+      setTimeout(function() {
+        expect($state.go).to.have.been.calledWith('apps.editor.templates.edit', {presentationId: 'test-id'});
+        done();
+      }, 10);
+
+    } );
+
+    it( "should open plans modal when presentation type is HTML template and not authorized", function(done) {
+      storeAuthorize = false;
+      presentationUtils.openPresentation({ id: 'test-id', presentationType: 'HTML Template', productCode: 'abc123' });
+
+      expect(checkTemplateAccessSpy).to.have.been.calledWith('abc123');
+
+      setTimeout(function() {
+        plansFactory.showPlansModal.should.have.been.called;
+        done();
+      }, 10);
+
+    });
+  })
 });

--- a/test/unit/launcher/controllers/ctr-home.tests.js
+++ b/test/unit/launcher/controllers/ctr-home.tests.js
@@ -10,7 +10,7 @@ describe('controller: Home', function() {
           stopGlobal: sinon.spy(),
           stop: sinon.spy()
         };
-      });    
+      });
       $provide.service('launcherFactory', function() {
         return launcherFactory = {
           load: sinon.spy(),
@@ -18,12 +18,17 @@ describe('controller: Home', function() {
           schedules: { loadingItems: true , items: { list: [ ] } },
           displays: { loadingItems: true , items: { list: [ ] } }
         };
-      }); 
+      });
       $provide.service('editorFactory', function() {
         return {};
-      });      
+      });
       $provide.service('displayFactory', function() {
         return {};
+      });
+      $provide.service('presentationUtils', function() {
+        return {
+          openPresentation: sinon.stub()
+        };
       });
     })
     inject(function($injector,$rootScope, $controller) {

--- a/web/partials/editor/presentation-list.html
+++ b/web/partials/editor/presentation-list.html
@@ -47,9 +47,9 @@
         </thead>
         <tbody class="table-body">
           <tr class="table-body__row" ng-repeat="presentation in factory.items.list" ng-click="openPresentation(presentation)">
-            <td class="table-body__cell col-sm-9"><a ng-click="openPresentation(presentation)"><strong>{{presentation.name}}</strong></a></td>
-            <td class="table-body__cell col-sm-9 hidden-xs"><span ng-click="openPresentation(presentation)"><span ng-class="{'text-danger': presentation.revisionStatusName==='Revised'}">{{presentation.revisionStatusName | presentationStatus}}</span></span></td>
-            <td class="table-body__cell col-sm-2 hidden-xs u_nowrap" ><span ng-click="openPresentation(presentation)">{{presentation.changeDate | date:'d-MMM-yyyy h:mm a'}}</span></td>
+            <td class="table-body__cell col-sm-9"><a ng-click="openPresentation(presentation); $event.stopPropagation();"><strong>{{presentation.name}}</strong></a></td>
+            <td class="table-body__cell col-sm-9 hidden-xs"><span ng-click="openPresentation(presentation); $event.stopPropagation();"><span ng-class="{'text-danger': presentation.revisionStatusName==='Revised'}">{{presentation.revisionStatusName | presentationStatus}}</span></span></td>
+            <td class="table-body__cell col-sm-2 hidden-xs u_nowrap" ><span ng-click="openPresentation(presentation); $event.stopPropagation();">{{presentation.changeDate | date:'d-MMM-yyyy h:mm a'}}</span></td>
           </tr>
           <!-- If no presentation available -->
           <tr class="table-body__row" ng-show="factory.items.list.length === 0 && !search.query">

--- a/web/partials/editor/presentation-list.html
+++ b/web/partials/editor/presentation-list.html
@@ -46,10 +46,10 @@
           </tr>
         </thead>
         <tbody class="table-body">
-          <tr class="table-body__row" ng-repeat="presentation in factory.items.list" ui-sref="{{ presentation | presentationLink }}">
-            <td class="table-body__cell col-sm-9"><a ui-sref="{{ presentation | presentationLink }}"><strong>{{presentation.name}}</strong></a></td>
-            <td class="table-body__cell col-sm-9 hidden-xs"><span ui-sref="{{ presentation | presentationLink }}"><span ng-class="{'text-danger': presentation.revisionStatusName==='Revised'}">{{presentation.revisionStatusName | presentationStatus}}</span></span></td>
-            <td class="table-body__cell col-sm-2 hidden-xs u_nowrap" ><span ui-sref="{{ presentation | presentationLink }}">{{presentation.changeDate | date:'d-MMM-yyyy h:mm a'}}</span></td>
+          <tr class="table-body__row" ng-repeat="presentation in factory.items.list" ng-click="openPresentation(presentation)">
+            <td class="table-body__cell col-sm-9"><a ng-click="openPresentation(presentation)"><strong>{{presentation.name}}</strong></a></td>
+            <td class="table-body__cell col-sm-9 hidden-xs"><span ng-click="openPresentation(presentation)"><span ng-class="{'text-danger': presentation.revisionStatusName==='Revised'}">{{presentation.revisionStatusName | presentationStatus}}</span></span></td>
+            <td class="table-body__cell col-sm-2 hidden-xs u_nowrap" ><span ng-click="openPresentation(presentation)">{{presentation.changeDate | date:'d-MMM-yyyy h:mm a'}}</span></td>
           </tr>
           <!-- If no presentation available -->
           <tr class="table-body__row" ng-show="factory.items.list.length === 0 && !search.query">

--- a/web/partials/launcher/app-launcher.html
+++ b/web/partials/launcher/app-launcher.html
@@ -23,7 +23,7 @@
             </div>
 
             <div class="list" ng-class="{'help-active' : showHelp}" ng-hide="launcherFactory.presentations.list.length == 0">
-              <div class="list-item u_clickable" ng-repeat="presentation in launcherFactory.presentations.list" ui-sref="{{ presentation | presentationLink }}">
+              <div class="list-item u_clickable" ng-repeat="presentation in launcherFactory.presentations.list" ng-click="openPresentation(presentation)">
                 <h4>{{presentation.name}}</h4>
               </div><!--list-item-->
             </div>

--- a/web/scripts/editor/controllers/ctr-presentation-list.js
+++ b/web/scripts/editor/controllers/ctr-presentation-list.js
@@ -2,9 +2,9 @@
 angular.module('risevision.editor.controllers')
   .controller('PresentationListController', ['$scope',
     'ScrollingListService', 'presentation', 'editorFactory', 'templateEditorFactory', '$loading',
-    '$filter', 'presentationTracker',
+    '$filter', 'presentationTracker', 'presentationUtils',
     function ($scope, ScrollingListService, presentation, editorFactory, templateEditorFactory,
-      $loading, $filter, presentationTracker) {
+      $loading, $filter, presentationTracker, presentationUtils) {
       $scope.search = {
         sortBy: 'changeDate',
         reverse: true,
@@ -18,6 +18,7 @@ angular.module('risevision.editor.controllers')
       $scope.editorFactory = editorFactory;
       $scope.templateEditorFactory = templateEditorFactory;
       $scope.presentationTracker = presentationTracker;
+      $scope.openPresentation = presentationUtils.openPresentation;
 
       $scope.filterConfig = {
         placeholder: $filter('translate')(

--- a/web/scripts/editor/services/svc-presentation-utils.js
+++ b/web/scripts/editor/services/svc-presentation-utils.js
@@ -3,7 +3,8 @@
 angular.module('risevision.editor.services')
   .constant('HTML_PRESENTATION_TYPE', 'HTML Template')
   .factory('presentationUtils', ['HTML_TEMPLATE_TYPE', 'HTML_PRESENTATION_TYPE',
-    function (HTML_TEMPLATE_TYPE, HTML_PRESENTATION_TYPE) {
+    '$state', 'checkTemplateAccess', 'plansFactory',
+    function (HTML_TEMPLATE_TYPE, HTML_PRESENTATION_TYPE, $state, checkTemplateAccess, plansFactory) {
       var factory = {};
 
       factory.isHtmlTemplate = function (product) {
@@ -12,6 +13,20 @@ angular.module('risevision.editor.services')
 
       factory.isHtmlPresentation = function (presentation) {
         return presentation.presentationType === HTML_PRESENTATION_TYPE;
+      };
+
+      factory.openPresentation = function(presentation) {
+        if (presentation.presentationType !== HTML_PRESENTATION_TYPE) {
+          $state.go('apps.editor.workspace.artboard', { presentationId: presentation.id });
+        } else {
+          checkTemplateAccess(presentation.productCode)
+            .then(function () {
+              $state.go('apps.editor.templates.edit', { presentationId: presentation.id });
+            })
+            .catch(function () {
+              plansFactory.showPlansModal();
+            });
+        }
       };
 
       return factory;

--- a/web/scripts/launcher/controllers/ctr-home.js
+++ b/web/scripts/launcher/controllers/ctr-home.js
@@ -2,12 +2,13 @@
 
 angular.module('risevision.apps.launcher.controllers')
   .controller('HomeCtrl', ['$scope', 'launcherFactory', 'editorFactory',
-    'displayFactory', '$loading',
+    'displayFactory', '$loading', 'presentationUtils',
     function ($scope, launcherFactory, editorFactory, displayFactory,
-      $loading) {
+      $loading, presentationUtils) {
       $scope.launcherFactory = launcherFactory;
       $scope.editorFactory = editorFactory;
       $scope.displayFactory = displayFactory;
+      $scope.openPresentation = presentationUtils.openPresentation;
 
       $loading.startGlobal('launcher.loading');
 


### PR DESCRIPTION
- When presentation is not a HTML Template, the presentation opens in existing workspace editor
- When presentation is HTML Template type, first check users template access based on TEMPLATE_LIBRARY_CODE and also providing presentation `productCode` for secondary access check.
- If user is authorized (on a plan), HTML template presentation opens in new template editor 
- If user is not authorized (not on a plan), presentation does not open and instead opens the plans modal

@santiagonoguez @fjvallarino I've tested locally and on [stage-8](https://apps-stage-8.risevision.com/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443). In order to test showing the plans modal when not authorized, I could only test this locally as I don't have a way to test on staging. 

I'm also not considering this high risk that Apps team needs to review, I think @fjvallarino is sufficient. Cheers