### PR TITLE
Fix responsive styling of template editor toolbar and Name [stage-8]

### DIFF
--- a/web/partials/template-editor/template-editor.html
+++ b/web/partials/template-editor/template-editor.html
@@ -20,25 +20,13 @@
   }
 
   .template-editor-toolbar .presentation-name {
-    max-width: 378px;
     font-size: 16px;
     margin: 0;
     padding: 0;
     line-height: 32px;
-  }
-
-  .template-editor-toolbar .presentation-name div {
-    max-width: 278px;
-    display: inline-block;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    vertical-align: middle;
-    margin-right: 10px;
-  }
-
-  .template-editor-toolbar .presentation-name i {
-    font-size: 18px;
   }
 
   .template-editor-toolbar .toolbar-right {
@@ -82,11 +70,7 @@
 
   @media screen and (min-width:768px) {
     .template-editor-toolbar .presentation-name {
-      max-width: calc(100vw - 390px);
-    }
-
-    .template-editor-toolbar .presentation-name div {
-      max-width: calc(100vw - 490px);
+      max-width: calc(100vw - 440px);
     }
 
     .preview-holder {

--- a/web/partials/template-editor/toolbar.html
+++ b/web/partials/template-editor/toolbar.html
@@ -1,9 +1,11 @@
 <!-- Presentation Name -->
 <h2 class="presentation-name">
   {{factory.presentation.name}}
+</h2>
+<div>
   <i class="fa fa-pencil u_margin-left"></i>
   <i class="fa fa-trash-o u_margin-left hidden-xs"></i>
-</h2>
+</div>
 
 <div class="toolbar-right">
   <button id="saveButton"


### PR DESCRIPTION
This fixes the responsive ellipsis being applied, @santiagonoguez will apply these changes to common header

Validate with https://apps-stage-8.risevision.com/templates/edit/950a62bf-6ca4-4d1a-81b5-9faf611858f3?cid=a489ce69-e0fb-496c-b3d3-49643923adf6