### PR TITLE
Feature/display financial component label

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.4.5",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.4.6",
     "oauthio-web": "0.6.2"
   },
   "devDependencies": {

--- a/web/partials/template-editor/attribute-list.html
+++ b/web/partials/template-editor/attribute-list.html
@@ -28,7 +28,8 @@
   <div class="col-xs-10 pl-0 attribute-desc">
     <i class="mr-2 fa fa-lg {{ getAttributeIcon(comp) }}"></i>
     <span>
-      {{ comp.type + " - " + comp.id }}
+      {{ ( "template." + comp.type ) | translate }} -
+      {{ comp.label | translate }}
     </span>
   </div>
   <div class="col-xs-2 pr-0 align-right">


### PR DESCRIPTION
Display labels that come from commons-header, example of it running here:

https://apps-stage-9.risevision.com/templates/edit/487112b1-44e1-4973-9cab-497207289f8a?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c
