### PR TITLE
Redirect unauthenticated template requests to signup

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.5.3",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/root-redirect",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git"
   },
@@ -36,6 +36,7 @@
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
     "jquery": "^2",
-    "font-awesome": "~4.7.0"
+    "font-awesome": "~4.7.0",
+    "common-header": "fix/root-redirect"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/root-redirect",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.5.6",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git"
   },
@@ -36,7 +36,6 @@
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
     "jquery": "^2",
-    "font-awesome": "~4.7.0",
-    "common-header": "fix/root-redirect"
+    "font-awesome": "~4.7.0"
   }
 }

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -371,15 +371,14 @@ angular.module('risevision.apps', [
                 }
 
                 return canAccessApps(signup).then(function () {
-                  if ($stateParams.presentationId && $stateParams.presentationId !== 'new') {
-                    return editorFactory.getPresentation($stateParams.presentationId);
-                  } else if (!$stateParams.copyPresentation) {
-                    if (copyOf) {
-                      return editorFactory.copyTemplate(null, copyOf);
-                    }
-                    return editorFactory.newPresentation();
-                  } else {
+                  if ($stateParams.copyPresentation) {
                     return editorFactory.presentation;
+                  } else if ($stateParams.presentationId && $stateParams.presentationId !== 'new') {
+                    return editorFactory.getPresentation($stateParams.presentationId);
+                  } else if (copyOf) {
+                    return editorFactory.copyTemplate(null, copyOf);
+                  } else {
+                    return editorFactory.newPresentation();
                   }
                 });
               }

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -363,11 +363,17 @@ angular.module('risevision.apps', [
           resolve: {
             presentationInfo: ['canAccessApps', 'editorFactory', '$stateParams', '$location',
               function (canAccessApps, editorFactory, $stateParams, $location) {
-                return canAccessApps().then(function () {
+                var signup = false;
+                var copyOf = $location.search().copyOf;
+
+                if ($stateParams.presentationId === 'new' && !$stateParams.copyPresentation && copyOf) {
+                  signup = true;
+                }
+
+                return canAccessApps(signup).then(function () {
                   if ($stateParams.presentationId && $stateParams.presentationId !== 'new') {
                     return editorFactory.getPresentation($stateParams.presentationId);
                   } else if (!$stateParams.copyPresentation) {
-                    var copyOf = $location.search().copyOf;
                     if (copyOf) {
                       return editorFactory.copyTemplate(null, copyOf);
                     }
@@ -387,31 +393,16 @@ angular.module('risevision.apps', [
             return $templateCache.get('partials/editor/artboard.html');
           }],
           reloadOnSearch: false,
-          controller: 'ArtboardController',
-          resolve: {
-            canAccess: ['canAccessApps',
-              function (canAccessApps) {
-                return canAccessApps();
-              }
-            ]
-          }
+          controller: 'ArtboardController'
         })
 
         .state('apps.editor.workspace.htmleditor', {
           url: '/htmleditor',
           templateProvider: ['$templateCache', function ($templateCache) {
-            return $templateCache.get(
-              'partials/editor/html-editor.html');
+            return $templateCache.get('partials/editor/html-editor.html');
           }],
           reloadOnSearch: false,
-          controller: 'HtmlEditorController',
-          resolve: {
-            canAccess: ['canAccessApps',
-              function (canAccessApps) {
-                return canAccessApps();
-              }
-            ]
-          }
+          controller: 'HtmlEditorController'
         })
 
         .state('apps.editor.templates', {


### PR DESCRIPTION
Do not check canAccessApps for editor substates
Otherwise it overwrites call from main editor state

Refactor and simplify editor state logic

Fix blank state encoding issue in Common Header

[stage-3]