### PR TITLE
Remove unnecessary double quotes in constant value for base API url […

### DIFF
--- a/web/scripts/template-editor/services/svc-instrument-search.js
+++ b/web/scripts/template-editor/services/svc-instrument-search.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('risevision.template-editor.services')
-  .constant('INSTRUMENT_SEARCH_BASE_URL', '"https://contentfinancial2.appspot.com/_ah/api/financial/v1.00/"')
+  .constant('INSTRUMENT_SEARCH_BASE_URL', 'https://contentfinancial2.appspot.com/_ah/api/financial/v1.00/')
   .service('instrumentSearchService', ['$q', '$log', '$http', 'INSTRUMENT_SEARCH_BASE_URL',
     function ($q, $log, $http, INSTRUMENT_SEARCH_BASE_URL) {
       var factory = {},


### PR DESCRIPTION
This fixes the reason the domain is being prefixed to the url when browser makes network request. 

cc: @Rise-Vision/apps 