### PR TITLE
adds functions to set and retrieve template attribute data [stage-9]

### DIFF
--- a/test/unit/template-editor/controllers/ctr-template-editor.tests.js
+++ b/test/unit/template-editor/controllers/ctr-template-editor.tests.js
@@ -18,15 +18,73 @@ describe('controller: TemplateEditor', function() {
 
       $controller('TemplateEditorController', {
         $scope: $scope,
-        editorFactory: $injector.get('templateEditorFactory')
+        editorFactory: $injector.get('templateEditorFactory'),
+        presentation: { templateAttributeData: {} }
       });
 
       $scope.$digest();
     });
   });
 
-  it('should exist',function(){
+  it('should exist', function() {
     expect($scope).to.be.truely;
     expect($scope.factory).to.be.truely;
+    expect($scope.presentation).to.be.ok;
+    expect($scope.presentation.templateAttributeData).to.deep.equal({});
   });
+
+  it('should define attribute data functions',function() {
+    expect($scope.getAttributeData).to.be.a('function');
+    expect($scope.setAttributeData).to.be.a('function');
+  });
+
+  it('should get empty attribute data',function() {
+    var data = $scope.getAttributeData("test-id");
+
+    expect(data).to.deep.equal({ id: "test-id" });
+    expect($scope.presentation.templateAttributeData).to.deep.equal({
+      components: [
+        { id: "test-id" }
+      ]
+    });
+  });
+
+  it('should get undefined attribute data value',function() {
+    var data = $scope.getAttributeData("test-id", "symbols");
+
+    expect(data).to.not.be.ok;
+  });
+
+  it('should set an attribute data value',function() {
+    $scope.setAttributeData("test-id", "symbols", "CADUSD=X|MXNUSD=X");
+
+    expect($scope.presentation.templateAttributeData).to.deep.equal({
+      components: [
+        {
+          id: "test-id",
+          symbols: "CADUSD=X|MXNUSD=X"
+        }
+      ]
+    });
+  });
+
+  it('should get an attribute data value',function() {
+    $scope.setAttributeData("test-id", "symbols", "CADUSD=X|MXNUSD=X");
+
+    var data = $scope.getAttributeData("test-id", "symbols");
+
+    expect(data).to.equal("CADUSD=X|MXNUSD=X");
+  });
+
+  it('should get attribute data',function() {
+    $scope.setAttributeData("test-id", "symbols", "CADUSD=X|MXNUSD=X");
+
+    var data = $scope.getAttributeData("test-id");
+
+    expect(data).to.deep.equal({
+      id: "test-id",
+      symbols: "CADUSD=X|MXNUSD=X"
+    });
+  });
+
 });

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -5,5 +5,36 @@ angular.module('risevision.template-editor.controllers')
     function ($scope, templateEditorFactory, presentation) {
       $scope.factory = templateEditorFactory;
       $scope.presentation = presentation;
+
+      $scope.getAttributeData = function(componentId, attributeKey) {
+        var component = _componentFor(componentId);
+
+        // if the attributeKey is not provided, it returns the full component structure
+        return attributeKey ? component[attributeKey] : component;
+      }
+
+      $scope.setAttributeData = function(componentId, attributeKey, value) {
+        var component = _componentFor(componentId);
+
+        component[attributeKey] = value;
+      }
+
+      function _componentFor(componentId) {
+        var attributeData = $scope.presentation.templateAttributeData;
+
+        if(!attributeData.components) {
+          attributeData.components = [];
+        }
+
+        var component = _.find(attributeData.components, {id: componentId});
+
+        if(!component) {
+          component = { id: componentId };
+
+          attributeData.components.push(component);
+        }
+
+        return component;
+      }
     }
   ]);


### PR DESCRIPTION
This defines two functions to easily get and set attribute data from a presentation.

These functions also initialize the data structure for a component if it's still not present in the attribute data object.

Unit tests are included also.
