### PR TITLE
Feature/remove instrument

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-financial.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-financial.tests.js
@@ -85,6 +85,7 @@ describe('directive: TemplateComponentFinancial', function() {
   it('should exist', function() {
     expect($scope).to.be.ok;
     expect($scope.factory).to.be.ok;
+    expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" } })
     expect($scope.registerDirective).to.have.been.called;
 
     var directive = $scope.registerDirective.getCall(0).args[0];

--- a/test/unit/template-editor/components/directives/dtv-component-financial.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-financial.tests.js
@@ -230,4 +230,38 @@ describe('directive: TemplateComponentFinancial', function() {
     }, 100);
   });
 
+  it('should remove an instrument by symbol', function() {
+    $scope.instruments = keywordResults;
+
+    // normally set up by start() function
+    $scope.componentId = "TEST-ID";
+
+    $scope.removeInstrument('LLY');
+
+    var expectedInstruments = [
+      {
+        "symbol": "SXFc1",
+        "name": "Montreal Exchange S&P/TSX 60 Index Future Continuation 1",
+        "category": "Stocks"
+      },
+      {
+        "symbol": "FCSc1",
+        "name": "Montreal Exchange S&P/TSX CompositeTM Mini Index Future Continuation 1",
+        "category": "Stocks"
+      }
+    ];
+
+    expect($scope.instruments).to.deep.equal(expectedInstruments);
+
+    expect($scope.setAttributeData).to.have.been.called.twice;
+
+    expect($scope.setAttributeData.calledWith(
+      "TEST-ID", "instruments", expectedInstruments
+    )).to.be.true;
+
+    expect($scope.setAttributeData.calledWith(
+      "TEST-ID", "symbols", "SXFc1|FCSc1"
+    )).to.be.true;
+  });
+
 });

--- a/web/partials/template-editor/components/component-financial.html
+++ b/web/partials/template-editor/components/component-financial.html
@@ -7,7 +7,9 @@
       <div class="instrument-rate">{{ instr.symbol | uppercase }}</div>
     </div>
     <div class="col-xs-2 instrument-delete">
-      <a href="#" translate>editor-app.details.remove</a>
+      <a href="#"
+         ng-click="removeInstrument(instr.symbol)"
+         translate>editor-app.details.remove</a>
     </div>
   </div>
 </div>

--- a/web/scripts/template-editor/components/directives/dtv-component-financial.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-financial.js
@@ -152,6 +152,12 @@ angular.module('risevision.template-editor.directives')
             return 'template.financial.most-popular-category.' + $scope.category;
           };
 
+          $scope.removeInstrument = function(symbol) {
+            var filtered = _.reject($scope.instruments, {symbol: symbol});
+
+            _setInstruments(filtered);
+          }
+
           function _changeInstrumentView(enteringSelector, delay) {
             $scope.showInstrumentList = false;
             $scope.showSymbolSelector = false;

--- a/web/scripts/template-editor/components/directives/dtv-component-financial.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-financial.js
@@ -23,22 +23,21 @@ angular.module('risevision.template-editor.directives')
           }
 
           function _loadInstrumentList() {
-            var componentId = $scope.factory.selected.id;
             var instruments =
-              $scope.getAttributeData(componentId, "instruments");
+              $scope.getAttributeData($scope.componentId, "instruments");
 
             if(instruments) {
               $scope.instruments = instruments;
             } else {
-              _buildInstrumentListFromBlueprint(componentId);
+              _buildInstrumentListFromBlueprint();
             }
           }
 
-          function _buildInstrumentListFromBlueprint(componentId) {
-            var symbolString = $scope.getBlueprintData(componentId, "symbols");
+          function _buildInstrumentListFromBlueprint() {
+            var symbolString = $scope.getBlueprintData($scope.componentId, "symbols");
 
             if(!symbolString) {
-              $log.error("The component blueprint data is not providing default symbols value: " + componentId)
+              $log.error("The component blueprint data is not providing default symbols value: " + $scope.componentId)
 
               return;
             }
@@ -46,12 +45,12 @@ angular.module('risevision.template-editor.directives')
             var instruments = [];
             var symbols = symbolString.split("|");
 
-            _buildListRecursive(componentId, instruments, symbols);
+            _buildListRecursive(instruments, symbols);
           }
 
-          function _buildListRecursive(componentId, instruments, symbols) {
+          function _buildListRecursive(instruments, symbols) {
             if( symbols.length === 0 ) {
-              _setInstruments(componentId, instruments);
+              _setInstruments(instruments);
 
               return;
             }
@@ -72,7 +71,7 @@ angular.module('risevision.template-editor.directives')
               $log.error( error );
             })
             .finally( function() {
-              _buildListRecursive(componentId, instruments, symbols);
+              _buildListRecursive(instruments, symbols);
             });
           }
 
@@ -82,12 +81,12 @@ angular.module('risevision.template-editor.directives')
             }).join("|");
           }
 
-          function _setInstruments(componentId, instruments) {
+          function _setInstruments(instruments) {
             var value = angular.copy(instruments);
 
             $scope.instruments = value;
-            $scope.setAttributeData(componentId, "instruments", value);
-            $scope.setAttributeData(componentId, "symbols", _symbolsFor(value));
+            $scope.setAttributeData($scope.componentId, "instruments", value);
+            $scope.setAttributeData($scope.componentId, "symbols", _symbolsFor(value));
           }
 
           _reset();
@@ -100,6 +99,8 @@ angular.module('risevision.template-editor.directives')
               element.show();
 
               _reset();
+              $scope.componentId = $scope.factory.selected.id;
+
               _loadInstrumentList();
               $scope.enteringInstrumentSelector = true;
 


### PR DESCRIPTION
This removes the instrument from the list, with unit tests.

I also added the componentId to scope to avoid having to pass it to several function calls and thus simplify the _setInstruments() function that is leveraged here.

Test it here:

https://apps-stage-9.risevision.com/templates/edit/d4a5a9c7-2cc7-4f99-87cf-1e8457d0ea9a?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c