### PR TITLE
add spinner to instruments list [stage-9]

### DIFF
--- a/web/partials/template-editor/components/component-financial.html
+++ b/web/partials/template-editor/components/component-financial.html
@@ -1,6 +1,8 @@
 <div class="instrument-list"
     ng-class="{ 'instrument-list-show': enteringInstrumentSelector, 'instrument-list-cover': enteringSymbolSelector, 'instrument-list-uncover': exitingSymbolSelector }"
-    ng-show="showInstrumentList || enteringInstrumentSelector || exitingSymbolSelector">
+    ng-show="showInstrumentList || enteringInstrumentSelector || exitingSymbolSelector"
+    rv-spinner rv-spinner-key="template-editor-loader"
+    rv-spinner-start-active="1">
   <div class="row instrument-row" ng-repeat="instr in instruments">
     <div class="col-xs-10">
       <div class="instrument-name">{{ instr.name | uppercase }}</div>

--- a/web/scripts/template-editor/components/directives/dtv-component-financial.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-financial.js
@@ -34,6 +34,7 @@ angular.module('risevision.template-editor.directives')
           }
 
           function _buildInstrumentListFromBlueprint() {
+            $scope.factory.loadingPresentation = true;
             var symbolString = $scope.getBlueprintData($scope.componentId, "symbols");
 
             if(!symbolString) {
@@ -51,6 +52,7 @@ angular.module('risevision.template-editor.directives')
           function _buildListRecursive(instruments, symbols) {
             if( symbols.length === 0 ) {
               _setInstruments(instruments);
+              $scope.factory.loadingPresentation = false;
 
               return;
             }

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -1,8 +1,9 @@
 'use strict';
 
 angular.module('risevision.template-editor.controllers')
-  .controller('TemplateEditorController', ['$scope', 'templateEditorFactory',
-    function ($scope, templateEditorFactory) {
+  .controller('TemplateEditorController',
+    ['$scope', 'templateEditorFactory', '$loading',
+    function ($scope, templateEditorFactory, $loading) {
       $scope.factory = templateEditorFactory;
 
       $scope.getBlueprintData = function(componentId, attributeKey) {
@@ -54,5 +55,13 @@ angular.module('risevision.template-editor.controllers')
 
         return component;
       }
+
+      $scope.$watch('factory.loadingPresentation', function(loading) {
+        if (loading) {
+          $loading.start('template-editor-loader');
+        } else {
+          $loading.stop('template-editor-loader');
+        }
+      });
     }
   ]);


### PR DESCRIPTION
I added the spinner for the instruments list.

You can check it here when entering the instruments list:

https://apps-stage-9.risevision.com/templates/edit/7ee39d6b-61dd-4a55-a8b6-db2d9d27ab86?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c

It also enables the spinner for the save and other actions that were already using the loadingPresentation variable.
