### PR TITLE
Add selected instruments to Instrument list

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-financial.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-financial.tests.js
@@ -315,6 +315,112 @@ describe('directive: TemplateComponentFinancial', function() {
     expect($scope.instrumentSearch).to.deep.equal(popularResults);
   });
 
+  it("should disable adding instruments until at least one instrument is selected", function() {
+    $scope.selectInstruments();
+    timeout.flush();
+    $scope.$digest();
+    $scope.showSymbolSearch();
+
+    expect($scope.canAddInstrument).to.be.false;
+
+    $scope.selectInstrument(1);
+
+    expect($scope.canAddInstrument).to.be.true;
+
+    $scope.selectInstrument(1);
+
+    expect($scope.canAddInstrument).to.be.false;
+  });
+
+  it('should add selected instruments to instruments list and prioritize them to top of list', function() {
+    var directive = $scope.registerDirective.getCall(0).args[0];
+    var instruments = [
+      {
+        "symbol": "CADUSD=X",
+        "name": "CANADIAN DOLLAR",
+        "category": "currencies",
+        "logo": "https://risecontentlogos.s3.amazonaws.com/financial/CAD-USD.svg"
+      }
+    ];
+
+    $scope.getAttributeData = function() {
+      return instruments;
+    };
+
+    directive.show();
+
+    expect($scope.instruments).to.deep.equal(instruments);
+
+    timeout.flush();
+
+    $scope.showSymbolSearch();
+    timeout.flush();
+    $scope.$digest();
+
+    $scope.selectInstrument(1);
+    $scope.selectInstrument(2);
+
+    $scope.addInstrument();
+
+    expect($scope.instruments).to.deep.equal([
+      {
+        "symbol": "CHFUSD=X",
+        "name": "SWISS FRANC",
+        "category": "currencies",
+        "logo": "https://risecontentlogos.s3.amazonaws.com/financial/CHF-USD.svg"
+      },
+      {
+        "symbol": "HKDUSD=X",
+        "name": "HONG KONG DOLLAR",
+        "category": "currencies",
+        "logo": "https://risecontentlogos.s3.amazonaws.com/financial/HKD-USD.svg"
+      },
+      {
+        "symbol": "CADUSD=X",
+        "name": "CANADIAN DOLLAR",
+        "category": "currencies",
+        "logo": "https://risecontentlogos.s3.amazonaws.com/financial/CAD-USD.svg"
+      }
+    ]);
+  });
+
+  it('should not add duplicate instruments', function() {
+    var directive = $scope.registerDirective.getCall(0).args[0];
+    var instruments = [
+      {
+        "symbol": "CADUSD=X",
+        "name": "CANADIAN DOLLAR",
+        "category": "currencies",
+        "logo": "https://risecontentlogos.s3.amazonaws.com/financial/CAD-USD.svg"
+      },
+      {
+        "symbol": "HKDUSD=X",
+        "name": "HONG KONG DOLLAR",
+        "category": "currencies",
+        "logo": "https://risecontentlogos.s3.amazonaws.com/financial/HKD-USD.svg"
+      }
+    ];
+
+    $scope.getAttributeData = function() {
+      return instruments;
+    };
+
+    directive.show();
+
+    expect($scope.instruments).to.deep.equal(instruments);
+
+    timeout.flush();
+
+    $scope.showSymbolSearch();
+    timeout.flush();
+    $scope.$digest();
+
+    $scope.selectInstrument(2);
+    $scope.addInstrument();
+
+    expect($scope.instruments).to.deep.equal(instruments);
+  });
+
   it('should get the open symbol button label', function() {
     $scope.category = 'currencies';
 

--- a/web/partials/template-editor/components/component-financial.html
+++ b/web/partials/template-editor/components/component-financial.html
@@ -74,7 +74,7 @@
 
 <div class="row financial-action-button-bar" ng-show="showSymbolSelector">
   <div class="col-sm-4">
-    <button class="btn btn-primary btn-block" ng-disabled="!canAddInstrument">
+    <button class="btn btn-primary btn-block" ng-disabled="!canAddInstrument" ng-click="addInstrument()">
       <strong translate>template.financial.add-selected</strong>
     </button>
   </div>

--- a/web/partials/template-editor/components/component-financial.html
+++ b/web/partials/template-editor/components/component-financial.html
@@ -74,7 +74,7 @@
 
 <div class="row financial-action-button-bar" ng-show="showSymbolSelector">
   <div class="col-sm-4">
-    <button class="btn btn-primary btn-block" ng-click="selectInstruments()">
+    <button class="btn btn-primary btn-block" ng-disabled="!canAddInstrument">
       <strong translate>template.financial.add-selected</strong>
     </button>
   </div>

--- a/web/scripts/template-editor/components/directives/dtv-component-financial.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-financial.js
@@ -144,6 +144,36 @@ angular.module('risevision.template-editor.directives')
             });
           };
 
+          $scope.addInstrument = function() {
+            var instrumentsSelected = _.chain($scope.instrumentSearch)
+              .filter(function (instrument) { return instrument.isSelected; })
+              .sortBy('symbol')
+              .map(function(instrument) {
+                delete instrument.isSelected;
+                return instrument;
+              })
+              .value()
+              .reverse();
+
+            var instrumentsToAdd = _.reject(instrumentsSelected, function(instrument) {
+              return _.find($scope.instruments, function(item) {
+                return item.symbol === instrument.symbol;
+              }) !== undefined;
+            });
+
+            if (instrumentsToAdd.length && instrumentsToAdd.length > 0) {
+              var instruments = angular.copy($scope.instruments);
+
+              instrumentsToAdd.forEach(function(item) {
+                instruments.unshift(item);
+              });
+
+              _setInstruments(instruments);
+            }
+
+            $scope.selectInstruments();
+          };
+
           $scope.searchInstruments = function() {
             var promise = $scope.searchKeyword ?
               instrumentSearchService.keywordSearch( $scope.category, $scope.searchKeyword ) :

--- a/web/scripts/template-editor/components/directives/dtv-component-financial.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-financial.js
@@ -18,13 +18,13 @@ angular.module('risevision.template-editor.directives')
             $scope.exitingSymbolSelector = false;
 
             // TODO: hardcoding category for now until templates have component surface category attribute
-            $scope.category = "currencies";
+            $scope.category = 'currencies';
             $scope.instruments = [];
           }
 
           function _loadInstrumentList() {
             var instruments =
-              $scope.getAttributeData($scope.componentId, "instruments");
+              $scope.getAttributeData($scope.componentId, 'instruments');
 
             if(instruments) {
               $scope.instruments = instruments;
@@ -35,16 +35,16 @@ angular.module('risevision.template-editor.directives')
 
           function _buildInstrumentListFromBlueprint() {
             $scope.factory.loadingPresentation = true;
-            var symbolString = $scope.getBlueprintData($scope.componentId, "symbols");
+            var symbolString = $scope.getBlueprintData($scope.componentId, 'symbols');
 
             if(!symbolString) {
-              $log.error("The component blueprint data is not providing default symbols value: " + $scope.componentId)
+              $log.error('The component blueprint data is not providing default symbols value: ' + $scope.componentId)
 
               return;
             }
 
             var instruments = [];
-            var symbols = symbolString.split("|");
+            var symbols = symbolString.split('|');
 
             _buildListRecursive(instruments, symbols);
           }
@@ -66,7 +66,7 @@ angular.module('risevision.template-editor.directives')
               if(instrument) {
                 instruments.push(instrument);
               } else {
-                $log.warn("no instrument found for symbol: " + symbol);
+                $log.warn('no instrument found for symbol: ' + symbol);
               }
             })
             .catch( function(error) {
@@ -80,15 +80,15 @@ angular.module('risevision.template-editor.directives')
           function _symbolsFor(instruments) {
             return _.map(instruments, function(instrument) {
               return instrument.symbol;
-            }).join("|");
+            }).join('|');
           }
 
           function _setInstruments(instruments) {
             var value = angular.copy(instruments);
 
             $scope.instruments = value;
-            $scope.setAttributeData($scope.componentId, "instruments", value);
-            $scope.setAttributeData($scope.componentId, "symbols", _symbolsFor(value));
+            $scope.setAttributeData($scope.componentId, 'instruments', value);
+            $scope.setAttributeData($scope.componentId, 'symbols', _symbolsFor(value));
           }
 
           _reset();
@@ -164,7 +164,7 @@ angular.module('risevision.template-editor.directives')
           };
 
           $scope.resetSearch = function() {
-            $scope.searchKeyword = "";
+            $scope.searchKeyword = '';
             $scope.searchInstruments();
           };
 
@@ -212,7 +212,7 @@ angular.module('risevision.template-editor.directives')
             }, !isNaN(delay) ? delay : 500);
           }
 
-          $scope.$watch("showInstrumentList", function(value) {
+          $scope.$watch('showInstrumentList', function(value) {
             if (value) {
               $scope.searching = false;
 

--- a/web/scripts/template-editor/components/directives/dtv-component-financial.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-financial.js
@@ -139,6 +139,9 @@ angular.module('risevision.template-editor.directives')
               return;
             }
             $scope.instrumentSearch[ key ].isSelected = !$scope.instrumentSearch[ key ].isSelected;
+            $scope.canAddInstrument = _.some($scope.instrumentSearch, function(item) {
+              return item.isSelected === true;
+            });
           };
 
           $scope.searchInstruments = function() {
@@ -147,6 +150,8 @@ angular.module('risevision.template-editor.directives')
               instrumentSearchService.popularSearch( $scope.category );
 
             $scope.searching = true;
+            $scope.canAddInstrument = false;
+
             promise.then( function( res ) {
               $scope.instrumentSearch = angular.copy( res );
               $scope.popularResults = !$scope.searchKeyword;


### PR DESCRIPTION
- Disable _Add Selected_ button when no instruments selected in instrument selector list
- Add selected instruments to instruments list
  - Adding selected instruments to beginning of Instruments list
  - Ensuring no duplicates are added to Instruments list, based on `symbol` value

Validation at https://apps-stage-8.risevision.com/templates/edit/69421d64-e0a2-48f5-95df-923d501c42f8?cid=5ed8d6e8-7eac-4e88-840b-c067d16862a5

@fjvallarino @santiagonoguez FYI there is a discrepancy between the names of instruments provided via financial server _common_ API and _search_ API. The _common_ API is returning a more read-friendly name. I'm going to raise this on my card, but to clarify it does not impact the functionality or  review of this PR. 

cc: @Rise-Vision/apps 