### PR TITLE
Handle Unsaved state in Template Editor

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/preview-hides-common-header",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.5.11",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git"
   },
@@ -36,7 +36,6 @@
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
     "jquery": "^2",
-    "font-awesome": "~4.7.0",
-    "common-header": "fix/preview-hides-common-header"
+    "font-awesome": "~4.7.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.5.9",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/preview-hides-common-header",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git"
   },
@@ -36,6 +36,7 @@
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
     "jquery": "^2",
-    "font-awesome": "~4.7.0"
+    "font-awesome": "~4.7.0",
+    "common-header": "fix/preview-hides-common-header"
   }
 }

--- a/test/unit/template-editor/controllers/ctr-unsaved-changes-modal.tests.js
+++ b/test/unit/template-editor/controllers/ctr-unsaved-changes-modal.tests.js
@@ -1,0 +1,68 @@
+'use strict';
+describe('controller: TemplateEditorUnsavedChangesModalController', function() {
+  beforeEach(module('risevision.template-editor.controllers'));
+  beforeEach(module(mockTranlate()));
+  beforeEach(module(function ($provide) {
+    $provide.service('$modalInstance',function(){
+      return {
+        close : function(){},
+        dismiss : function(){}
+      }
+    }); 
+    $provide.service('templateEditorFactory',function(){
+      return {
+        save : function(){
+          return Q.resolve();
+        }
+      }
+    });    
+  }));
+  var $scope, $modalInstance, $modalInstanceDismissSpy, $modalInstanceCloseSpy, templateEditorFactory;
+
+  beforeEach(function(){
+
+    inject(function($injector,$rootScope, $controller){
+      $scope = $rootScope.$new();
+      $modalInstance = $injector.get('$modalInstance');
+      templateEditorFactory = $injector.get('templateEditorFactory');
+      
+      $modalInstanceDismissSpy = sinon.spy($modalInstance, 'dismiss');
+      $modalInstanceCloseSpy = sinon.spy($modalInstance, 'close');
+
+      $controller('TemplateEditorUnsavedChangesModalController', {
+        $scope: $scope,
+        $modalInstance : $modalInstance
+      });
+      $scope.$digest();
+    });
+  });
+  
+  it('should exist',function(){
+    expect($scope).to.be.ok;
+    expect($scope.save).to.be.a('function');
+    expect($scope.dontSave).to.be.a('function');
+    expect($scope.dismiss).to.be.a('function');
+    expect($scope.templateEditorFactory).to.equal(templateEditorFactory);
+  });
+
+  it('should dismiss modal',function(){
+      $scope.dismiss();
+      $modalInstanceDismissSpy.should.have.been.called;
+  });
+
+  it('should close modal after dontSave()',function(){
+      $scope.dontSave();
+      $modalInstanceCloseSpy.should.have.been.called;
+  });
+
+  it('should save presentation and dismiss modal on save()',function(done){
+    var saveSpy = sinon.spy(templateEditorFactory,'save');
+    $scope.save();
+    saveSpy.should.have.been.called;
+    setTimeout(function() {
+      $modalInstanceCloseSpy.should.have.been.called; 
+      done()
+    }, 10);
+  });
+
+});

--- a/web/index.html
+++ b/web/index.html
@@ -200,6 +200,7 @@
   <script src="scripts/template-editor/services/svc-template-editor-factory.js"></script>
   <script src="scripts/template-editor/services/svc-instrument-search.js"></script>
   <script src="scripts/template-editor/controllers/ctr-template-editor.js"></script>
+  <script src="scripts/template-editor/controllers/ctr-unsaved-changes-modal.js"></script>
 
   <script src="scripts/editor/services/svc-gadget.js"></script>
   <script src="scripts/editor/services/svc-gadget-factory.js"></script>

--- a/web/partials/template-editor/unsaved-changes-modal.html
+++ b/web/partials/template-editor/unsaved-changes-modal.html
@@ -1,0 +1,16 @@
+<div id="unsavedChangesModal">
+	<div class="modal-body u_padding-lg">
+		<button id="closeButton" class="close button-badge" ng-click="dismiss()" aria-hidden="true">
+			<i class="fa fa-times"></i>
+		</button>
+		<h3 translate>common.saveBeforeLeave</h3>
+		<p translate>common.changesWillBeLost</p>
+	</div>
+	<div class="modal-footer u_padding-lg">
+		<button id="unsavedChangesDontSaveButton" class="btn btn-danger pull-left" ng-click="dontSave()" translate>common.dontSave</button>
+
+		<button id="unsavedChangesSaveButton" class="btn btn-primary" ng-click="save()">
+		{{ editorFactory.savingPresentation ? ('common.saving' | translate) : ('common.save' | translate)}} <i class="fa fa-check icon-right"></i></button>
+		<button id="unsavedChangesCancelButton" class="btn btn-default" ng-click="dismiss()">{{'common.cancel' | translate}} <i class="fa fa-times icon-right"></i></button>
+	</div>
+</div>

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -7,6 +7,7 @@ angular.module('risevision.template-editor.controllers')
       $scope.factory = templateEditorFactory;
       $scope.isSubcompanySelected = userState.isSubcompanySelected;
       $scope.isTestCompanySelected = userState.isTestCompanySelected;
+      $scope.hasUnsavedChanges = false;
 
       $scope.getBlueprintData = function(componentId, attributeKey) {
         var components = $scope.factory.blueprintData.components;

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -2,8 +2,8 @@
 
 angular.module('risevision.template-editor.controllers')
   .controller('TemplateEditorController',
-    ['$scope', '$loading', '$modal', '$state', '$timeout', '$window', 'templateEditorFactory', 'userState',
-    function ($scope, $loading, $modal, $state, $timeout, $window, templateEditorFactory, userState) {
+    ['$scope', '$filter', '$loading', '$modal', '$state', '$timeout', '$window', 'templateEditorFactory', 'userState',
+    function ($scope, $filter, $loading, $modal, $state, $timeout, $window, templateEditorFactory, userState) {
       $scope.factory = templateEditorFactory;
       $scope.isSubcompanySelected = userState.isSubcompanySelected;
       $scope.isTestCompanySelected = userState.isTestCompanySelected;

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -2,7 +2,7 @@
 
 angular.module('risevision.template-editor.controllers')
   .controller('TemplateEditorController',
-    ['$scope', '$loading', '$modal', '$state', '$timeout', '$window', 'userState', 'templateEditorFactory',
+    ['$scope', '$loading', '$modal', '$state', '$timeout', '$window', 'templateEditorFactory', 'userState',
     function ($scope, $loading, $modal, $state, $timeout, $window, templateEditorFactory, userState) {
       $scope.factory = templateEditorFactory;
       $scope.isSubcompanySelected = userState.isSubcompanySelected;
@@ -58,7 +58,7 @@ angular.module('risevision.template-editor.controllers')
         return component;
       }
 
-      var _bypass = false, _initializing = false;
+      var _bypassUnsaved = false, _initializing = false;
       var _setUnsavedChanges = function (state) {
         $timeout(function () {
           $scope.hasUnsavedChanges = state;
@@ -85,8 +85,8 @@ angular.module('risevision.template-editor.controllers')
       $scope.$on('presentationDeleted', _setUnsavedChanges.bind(null, false));
 
       $scope.$on('$stateChangeStart', function (event, toState, toParams) {
-        if (_bypass) {
-          _bypass = false;
+        if (_bypassUnsaved) {
+          _bypassUnsaved = false;
           return;
         }
         if ($scope.hasUnsavedChanges && toState.name.indexOf('apps.editor.templates') === -1) {
@@ -97,7 +97,7 @@ angular.module('risevision.template-editor.controllers')
             controller: 'TemplateEditorUnsavedChangesModalController'
           });
           modalInstance.result.then(function () {
-            _bypass = true;
+            _bypassUnsaved = true;
             $state.go(toState, toParams);
           });
         }

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -2,8 +2,8 @@
 
 angular.module('risevision.template-editor.controllers')
   .controller('TemplateEditorController',
-    ['$scope', 'templateEditorFactory', '$loading', 'userState',
-    function ($scope, templateEditorFactory, $loading, userState) {
+    ['$scope', '$loading', '$modal', '$state', '$timeout', '$window', 'userState', 'templateEditorFactory',
+    function ($scope, $loading, $modal, $state, $timeout, $window, templateEditorFactory, userState) {
       $scope.factory = templateEditorFactory;
       $scope.isSubcompanySelected = userState.isSubcompanySelected;
       $scope.isTestCompanySelected = userState.isTestCompanySelected;
@@ -57,6 +57,61 @@ angular.module('risevision.template-editor.controllers')
 
         return component;
       }
+
+      var _bypass = false, _initializing = false;
+      var _setUnsavedChanges = function (state) {
+        $timeout(function () {
+          $scope.hasUnsavedChanges = state;
+        });
+      };
+
+      $scope.$watch('factory.presentation', function (newValue, oldValue) {
+        if ($scope.hasUnsavedChanges) {
+          return;
+        }
+        if (_initializing) {
+          $timeout(function () {
+            _initializing = false;
+          });
+        } else {
+          if (!_.isEqual(newValue, oldValue)) {
+            _setUnsavedChanges(true);
+          }
+        }
+      }, true);
+
+      $scope.$on('presentationCreated', _setUnsavedChanges.bind(null, false));
+      $scope.$on('presentationUpdated', _setUnsavedChanges.bind(null, false));
+      $scope.$on('presentationDeleted', _setUnsavedChanges.bind(null, false));
+
+      $scope.$on('$stateChangeStart', function (event, toState, toParams) {
+        if (_bypass) {
+          _bypass = false;
+          return;
+        }
+        if ($scope.hasUnsavedChanges && toState.name.indexOf('apps.editor.templates') === -1) {
+          event.preventDefault();
+          var modalInstance = $modal.open({
+            templateUrl: 'partials/template-editor/unsaved-changes-modal.html',
+            size: 'md',
+            controller: 'TemplateEditorUnsavedChangesModalController'
+          });
+          modalInstance.result.then(function () {
+            _bypass = true;
+            $state.go(toState, toParams);
+          });
+        }
+      });
+
+      $window.onbeforeunload = function () {
+        if ($scope.hasUnsavedChanges) {
+          return $filter('translate')('common.saveBeforeLeave');
+        }
+      };
+
+      $scope.$on('$destroy', function () {
+        $window.onbeforeunload = undefined;
+      });
 
       $scope.$watch('factory.loadingPresentation', function(loading) {
         if (loading) {

--- a/web/scripts/template-editor/controllers/ctr-unsaved-changes-modal.js
+++ b/web/scripts/template-editor/controllers/ctr-unsaved-changes-modal.js
@@ -9,7 +9,7 @@
 
         $scope.save = function () {
           templateEditorFactory.save().then(function () {
-            $modalInstance.dismiss();
+            $modalInstance.close();
           });
         };
 

--- a/web/scripts/template-editor/controllers/ctr-unsaved-changes-modal.js
+++ b/web/scripts/template-editor/controllers/ctr-unsaved-changes-modal.js
@@ -1,0 +1,25 @@
+(function () {
+  'use strict';
+
+  angular.module('risevision.template-editor.controllers')
+    .controller('TemplateEditorUnsavedChangesModalController', ['$scope', '$modalInstance',
+      'templateEditorFactory',
+      function ($scope, $modalInstance, templateEditorFactory) {
+        $scope.templateEditorFactory = templateEditorFactory;
+
+        $scope.save = function () {
+          templateEditorFactory.save().then(function () {
+            $modalInstance.dismiss();
+          });
+        };
+
+        $scope.dontSave = function () {
+          $modalInstance.close();
+        };
+
+        $scope.dismiss = function () {
+          $modalInstance.dismiss();
+        };
+      }
+    ]);
+}());


### PR DESCRIPTION
In general, this follows the same logic as Legacy Editor. This means:

- If you create a Presentation, do not modify anything and navigate away, you will not be prompted to save
- If you create/load a Presentation, modify something and navigate away, you will be prompted to save
- If you modify something, save and navigate away, you will not be prompted to save

The only difference is, after saving when prompted because you tried to navigate away, you will go to the selected destination. The Legacy Editor reloads the Presentation in place

I will update the Common Header branch as soon as it's merged

@santiagonoguez @stulees please review

@Rise-Vision/apps FYI
