### PR TITLE
Saving a new presentation created from template creates a duplicate

### DIFF
--- a/web/scripts/editor/services/svc-editor-factory.js
+++ b/web/scripts/editor/services/svc-editor-factory.js
@@ -182,7 +182,8 @@ angular.module('risevision.editor.services')
               $rootScope.$broadcast('presentationCreated');
 
               $state.go('apps.editor.workspace.artboard', {
-                presentationId: resp.item.id
+                presentationId: resp.item.id,
+                copyPresentation: null
               }).then(function () {
                 scheduleFactory.createFirstSchedule(resp.item.id,
                     resp.item.name)

--- a/web/scripts/editor/services/svc-editor-factory.js
+++ b/web/scripts/editor/services/svc-editor-factory.js
@@ -183,7 +183,7 @@ angular.module('risevision.editor.services')
 
               $state.go('apps.editor.workspace.artboard', {
                 presentationId: resp.item.id,
-                copyPresentation: null
+                copyPresentation: undefined
               }).then(function () {
                 scheduleFactory.createFirstSchedule(resp.item.id,
                     resp.item.name)


### PR DESCRIPTION
Fix for  #862.

The issue was introduced by the [recent changes in the Apps router](https://github.com/Rise-Vision/rise-vision-apps/commit/ef3497940c12802e013e394b56c569c05a7628c1#diff-8ec8983b9f4c33db4ddae15c48d179b5L367). The order of checking `$stateParams.presentationId` and `$stateParams.copyPresentation` parameters was reversed and that caused the issue. @alex-deaconu FYI 😉

@fjvallarino please review.