### PR TITLE
Fix presentation name ellipsis mistakenly applied on initial render

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,9 +15,9 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.5.11",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#chore/presentation-name",
     "oauthio-web": "0.6.2",
-    "stretchy": "https://github.com/Rise-Vision/stretchy.git"
+    "stretchy": "https://github.com/Rise-Vision/stretchy.git#3a26b97"
   },
   "devDependencies": {
     "q": "1.0.1",
@@ -35,6 +35,7 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
+    "common-header": "chore/presentation-name",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -15,9 +15,9 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#chore/presentation-name",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.5.12",
     "oauthio-web": "0.6.2",
-    "stretchy": "https://github.com/Rise-Vision/stretchy.git#3a26b97"
+    "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
   "devDependencies": {
     "q": "1.0.1",
@@ -35,7 +35,6 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
-    "common-header": "chore/presentation-name",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }


### PR DESCRIPTION
- Stop applying `max-width` to the presentation input
- Stretchy width calculation for input _text_ type needs 1 additional pixel to prevent `text-overflow` styling applying the _ellipsis_ unnecessarily.

Stretchy PR - https://github.com/Rise-Vision/stretchy/pull/1
Common-Header PR - https://github.com/Rise-Vision/common-header/pull/930

Validate with https://apps-stage-8.risevision.com/templates/edit/64200a83-7461-449c-9156-94f67cd24562?cid=36748004-5ec5-4432-bab6-8fdc7014edde

Feel free to re-save with different presentation name values. 

I will change the dependencies in bower.json to target real versions once you've validated/approved. 
