### PR TITLE
UI fixes for Template Editor

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.5.12",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/preview-windows-scrollbars",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -35,6 +35,7 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
+    "common-header": "fix/preview-windows-scrollbars",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/preview-windows-scrollbars",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.5.13",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -35,7 +35,6 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
-    "common-header": "fix/preview-windows-scrollbars",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }

--- a/web/partials/template-editor/components/component-financial.html
+++ b/web/partials/template-editor/components/component-financial.html
@@ -6,7 +6,7 @@
     rv-spinner-start-active="1">
   <div class="row instrument-row" ng-repeat="instr in instruments track by $index">
     <div class="col-xs-10 pl-0">
-      <div class="instrument-name">{{ instr.name | uppercase }}</div>
+      <div class="instrument-name instrument-name-ellipsis">{{ instr.name | uppercase }}</div>
       <div class="instrument-rate">{{ instr.symbol | uppercase }}</div>
     </div>
     <div class="col-xs-2 pr-0 instrument-delete">

--- a/web/partials/template-editor/toolbar.html
+++ b/web/partials/template-editor/toolbar.html
@@ -1,5 +1,5 @@
 <!-- Presentation Name -->
-<input type="text" class="input-stretchy presentation-name"
+<input type="text" class="input-stretchy presentation-name" ng-keyup="presentationNameKeyUp($event)"
        ng-model="factory.presentation.name" ng-blur="onPresentationNameBlur()" ng-disabled="!isEditingName">
 <div>
   <button ng-disabled="isEditingName" type="button" class="edit-name pr-0" ng-click="isEditingName=true">

--- a/web/scripts/template-editor/directives/dtv-toolbar.js
+++ b/web/scripts/template-editor/directives/dtv-toolbar.js
@@ -60,6 +60,13 @@ angular.module('risevision.template-editor.directives')
             });
           };
 
+          $scope.presentationNameKeyUp = function(keyEvent) {
+            // handle enter key
+            if ( keyEvent.which === 13 && $scope.isEditingName) {
+              $scope.isEditingName = false;
+            }
+          };
+
           function setFocus(elem) {
             if (elem !== null) {
               if (elem.createTextRange) {


### PR DESCRIPTION
- Fixing Editor Preview scrollbars appearing on Windows by applying `overflow: auto` instead of `scroll` per each overflow- x/y.
- Adding a class to add ellipsis for instrument name
- Supporting Enter key for committing presentation name change

Common Header PR - https://github.com/Rise-Vision/common-header/pull/931

Validated with https://apps-stage-8.risevision.com/templates/edit/64200a83-7461-449c-9156-94f67cd24562?cid=36748004-5ec5-4432-bab6-8fdc7014edde

I'll update common-header dependency once approved/validated. 