### PR TITLE
Fixes #866 - Image Widget not rendering

### DIFF
--- a/web/scripts/editor/services/svc-widget-renderer.js
+++ b/web/scripts/editor/services/svc-widget-renderer.js
@@ -111,6 +111,9 @@ angular.module('risevision.editor.services')
 
       gadgetsApi.rpc.register('rsevent_ready', function (id) {
         gadgetsApi.rpc.call(IFRAME_PREFIX + id, 'rscmd_play_' + id);
+        //force redraw to fix #866
+        angular.element('#' + IFRAME_PREFIX + id).parent().css('top', '+=1'); 
+        $window.setTimeout(function(){angular.element('#' + IFRAME_PREFIX + id).parent().css('top', '-=1'); },0)
       });
 
       gadgetsApi.rpc.register('rsparam_get', function (id, param) {


### PR DESCRIPTION
 [stage-4]

@alex-deaconu @olegrise 
I spent quite some time to replicate and find a fix for this issue. Basically, it seems a browser rendering issue.
I fixed it by hacking a refresh, which I am not proud of, but I tried multiple solutions and this was the only one that worked.
Let me know if you have any other suggestions or if this is ok to go. Thanks
Video overview: https://drive.google.com/file/d/107HDr9R8BOQhqmM8w-3bEBNgXFCKbepD/view?usp=sharing
