### PR TITLE
Fix Enter key behaviour on Display Details page

### DIFF
--- a/test/e2e/displays/cases/displaymanage.js
+++ b/test/e2e/displays/cases/displaymanage.js
@@ -96,6 +96,12 @@ var DisplayAddScenarios = function() {
       expect(displayManagePage.getSaveButton().getText()).to.eventually.equal('Save');
     });
 
+    it('should save the display on Enter', function () {
+      displayManagePage.getDisplayNameField().sendKeys(protractor.Key.ENTER);
+      helper.waitDisappear(displayManagePage.getDisplayLoader(), 'Display loader');
+      expect(displayManagePage.getSaveButton().getText()).to.eventually.equal('Save');
+    });
+
     it('should show correct timezone after reload',function(done){
       browser.refresh();
       helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');

--- a/web/partials/displays/display-details.html
+++ b/web/partials/displays/display-details.html
@@ -59,7 +59,7 @@
 <div id="display-loader" rv-spinner rv-spinner-key="display-loader" rv-spinner-start-active="0"></div> 
 
 <div>
-  <form role="form" name="displayDetails">
+  <form role="form" name="displayDetails" ng-submit="save()">
     <div class="row" ng-show="!isProSupported()">
       <div class="col-sm-12">
         <div class="alert alert-warning" role="alert">
@@ -67,6 +67,8 @@
         </div>
       </div>
     </div>
+
+    
 
     <display-fields></display-fields>
 
@@ -83,12 +85,12 @@
       </button>
       <span class="hidden-xs u_margin-right"><last-modified change-date="display.changeDate" changed-by="display.changedBy"></last-modified></span>
       <!-- Indicates a successful or positive action -->
-      <button id="saveButton" type="submit" class="btn btn-primary" ng-click="save()" ng-disabled="displayDetails.$invalid || factory.savingDisplay" require-role="da">
+      <button id="saveButton" type="submit" class="btn btn-primary" ng-disabled="displayDetails.$invalid || factory.savingDisplay" require-role="da">
         {{ factory.savingDisplay ? ('common.saving' | translate) : ('common.save' | translate)}}
         <i class="fa fa-check icon-right"></i>
       </button>
       <!-- Indicates cancel or non-destructive action -->
-      <button id="cancelButton" ui-sref="apps.displays.list" class="btn btn-default">
+      <button id="cancelButton" type="button" ui-sref="apps.displays.list" class="btn btn-default">
         {{'common.cancel' | translate}}
         <i class="fa fa-times icon-right"></i>
       </button>

--- a/web/partials/displays/display-fields.html
+++ b/web/partials/displays/display-fields.html
@@ -167,7 +167,7 @@
           <tr class="table-body__row text-center u_padding-md" ng-show="!currentPlanFactory.isPlanActive() && !display.playerProAuthorized">
             <td colspan="2">
               <span translate>displays-app.fields.player.rpp.unlock</span><br/>
-              <button ng-click="showPlansModal()" class="btn btn-xs btn-primary u_margin-sm-top" translate>
+              <button type="button" ng-click="showPlansModal()" class="btn btn-xs btn-primary u_margin-sm-top" translate>
                 displays-app.fields.player.rpp.start-trial
               </button>
             </td>
@@ -214,7 +214,7 @@
             <!-- ACTIVE -->
             <td class="table-body__cell" ng-show="playerProFactory.isDisplayControlCompatiblePlayer(display)">
               <span translate> displays-app.fields.player.displayControl.description </span>
-              <button class="btn btn-primary btn-xs" ng-click="playerProFactory.openConfigureDisplayControl(display)" ng-disabled="!display.playerProAuthorized" require-role="da" translate>
+              <button type="button" class="btn btn-primary btn-xs" ng-click="playerProFactory.openConfigureDisplayControl(display)" ng-disabled="!display.playerProAuthorized" require-role="da" translate>
                 displays-app.fields.player.displayControl.configure
               </button>
             </td>

--- a/web/partials/displays/screenshot.html
+++ b/web/partials/displays/screenshot.html
@@ -1,7 +1,7 @@
 <div>
   <div class="u_lh-normal u_margin-sm-bottom">
     <label class="control-label">{{ 'displays-app.fields.screenshot.title' | translate }}</label>
-    <button id="btnUpdateScreenshot" class="btn btn-default pull-right" ng-click="screenshotFactory.requestScreenshot(displayId)" ng-disabled="reloadScreenshotDisabled(display)">
+    <button id="btnUpdateScreenshot" type="button" class="btn btn-default pull-right" ng-click="screenshotFactory.requestScreenshot(displayId)" ng-disabled="reloadScreenshotDisabled(display)">
       <i class="fa fa-refresh fa-white half-left"></i> {{ 'displays-app.fields.screenshot.updateScreenshot' | translate }}
     </button>
   </div>
@@ -16,12 +16,12 @@
     <div class="panel-body display-screenshot" ng-show="screenshotState(display) === 'upgrade-player'">
       <p>{{ 'displays-app.fields.screenshot.notAvailable' | translate }}</p>
       <p>{{ 'displays-app.fields.screenshot.upgradeRequired' | translate }}</p>
-      <button class="btn btn-xs btn-primary" ng-click="factory.addDisplayModal(display)">{{ 'displays-app.fields.screenshot.upgradePlayer' | translate }}</button>
+      <button type="button" class="btn btn-xs btn-primary" ng-click="factory.addDisplayModal(display)">{{ 'displays-app.fields.screenshot.upgradePlayer' | translate }}</button>
     </div>
     <div class="panel-body display-screenshot" ng-show="screenshotState(display) === 'os-not-supported'">
       <p>{{ 'displays-app.fields.screenshot.notAvailable' | translate }}</p>
       <p>{{ 'displays-app.fields.screenshot.osNotSupported' | translate }}</p>
-      <button class="btn btn-link" onclick="window.open('https://help.risevision.com/hc/en-us/articles/115000860926-Displays','_blank')">
+      <button type="button" class="btn btn-link" onclick="window.open('https://help.risevision.com/hc/en-us/articles/115000860926-Displays','_blank')">
         {{ 'displays-app.fields.screenshot.learnSupportedOS1' | translate }}
         <br>
         {{ 'displays-app.fields.screenshot.learnSupportedOS2' | translate }}
@@ -34,7 +34,7 @@
     <div class="panel-body display-screenshot" ng-show="screenshotState(display) === 'not-installed'">
       <p class="text-muted">{{ 'displays-app.fields.screenshot.notAvailable' | translate }}</p>
       <p class="text-muted">{{ 'displays-app.fields.screenshot.playerNotInstalled' | translate }}</p>
-      <button class="btn btn-xs btn-primary" ng-click="factory.addDisplayModal(display)">{{ 'displays-app.fields.screenshot.playerInstall' | translate }}</button>
+      <button type="button" class="btn btn-xs btn-primary" ng-click="factory.addDisplayModal(display)">{{ 'displays-app.fields.screenshot.playerInstall' | translate }}</button>
     </div>
     <div class="panel-body display-screenshot" ng-show="screenshotState(display) === 'no-screenshot-available'">
       <p>{{ 'displays-app.fields.screenshot.missing1' | translate }}</p>


### PR DESCRIPTION
Default type for buttons is "submit", which was causing another button to be triggered instead of Save button [stage-4]

Staged at https://apps-stage-4.risevision.com/displays/details/TRMPZUK8GVSZ?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

@Rise-Vision/apps Please review. Thanks!