### PR TITLE
Feature/provide attribute data to html template

### DIFF
--- a/web/partials/template-editor/preview-holder.html
+++ b/web/partials/template-editor/preview-holder.html
@@ -1,6 +1,6 @@
 <div class="preview-parent">
   <iframe id="template-editor-preview" scrolling="no"
-    ng-src="{{ factory.getEditorPreviewUrl(factory.presentation.productCode) }}"
+    ng-src="{{ getEditorPreviewUrl(factory.presentation.productCode) }}"
   >
   </iframe>
 </div>

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -20,7 +20,7 @@ angular.module('risevision.template-editor.directives')
               value : JSON.stringify(value);
 
             var iframe = $window.document.getElementById('template-editor-preview');
-            var domain = 'risevision.com';  // $window.location.origin;
+            var domain = 'widgets.risevision.com';  // $window.location.origin;
 
             iframe.contentWindow.postMessage(attributeDataText, domain);
 

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -20,13 +20,13 @@ angular.module('risevision.template-editor.directives')
               value : JSON.stringify(value);
 
             var iframe = $window.document.getElementById('template-editor-preview');
-            var domain = 'https://widgets.risevision.com';  // $window.location.origin;
+            var domain = 'https://widgets.risevision.com';
 
             iframe.contentWindow.postMessage(attributeDataText, domain);
 
             console.log('attribute data text');
             console.log(attributeDataText);
-            console.log($window.location.origin);
+            console.log(iframe.src);
           }, true);
         }
       };

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -27,7 +27,7 @@ angular.module('risevision.template-editor.directives')
             console.log('attribute data text');
             console.log(attributeDataText);
             console.log(domain);
-          });
+          }, true);
         }
       };
     }

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -20,7 +20,7 @@ angular.module('risevision.template-editor.directives')
               value : JSON.stringify(value);
 
             var iframe = $window.document.getElementById('template-editor-preview');
-            var domain = $window.location.origin;
+            var domain = 'risevision.com';  // $window.location.origin;
 
             iframe.contentWindow.postMessage(attributeDataText, domain);
 

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -38,8 +38,6 @@ angular.module('risevision.template-editor.directives')
             }
 
             iframe.contentWindow.postMessage(attributeDataText, WIDGETS_DOMAIN);
-            console.log('attribute data text');
-            console.log(attributeDataText);
 
             attributeDataText = null;
           }

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -1,13 +1,19 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
-  .directive('templateEditorPreviewHolder', ['templateEditorFactory',
-    function (templateEditorFactory) {
+  .directive('templateEditorPreviewHolder', ['$sce', 'templateEditorFactory', 'HTML_TEMPLATE_URL',
+    function ($sce, templateEditorFactory, HTML_TEMPLATE_URL) {
       return {
         restrict: 'E',
         templateUrl: 'partials/template-editor/preview-holder.html',
         link: function ($scope) {
           $scope.factory = templateEditorFactory;
+
+          $scope.getEditorPreviewUrl = function(productCode) {
+            var url = HTML_TEMPLATE_URL.replace('PRODUCT_CODE', productCode);
+
+            return $sce.trustAsResourceUrl(url);
+          }
         }
       };
     }

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
-  .directive('templateEditorPreviewHolder', ['$window', '$sce', 'templateEditorFactory', 'HTML_TEMPLATE_URL',
-    function ($window, $sce, templateEditorFactory, HTML_TEMPLATE_URL) {
+  .directive('templateEditorPreviewHolder', ['$window', '$sce', 'templateEditorFactory', 'HTML_TEMPLATE_URL', 'WIDGETS_DOMAIN',
+    function ($window, $sce, templateEditorFactory, HTML_TEMPLATE_URL, WIDGETS_DOMAIN) {
       return {
         restrict: 'E',
         templateUrl: 'partials/template-editor/preview-holder.html',
@@ -20,13 +20,17 @@ angular.module('risevision.template-editor.directives')
               value : JSON.stringify(value);
 
             var iframe = $window.document.getElementById('template-editor-preview');
-            var domain = 'https://widgets.risevision.com';
 
-            iframe.contentWindow.postMessage(attributeDataText, domain);
+            iframe.contentWindow.postMessage(attributeDataText, WIDGETS_DOMAIN);
 
             console.log('attribute data text');
             console.log(attributeDataText);
             console.log(iframe.src);
+
+            iframe.contentWindow.onload = function() {
+              console.log('content window loaded');
+              console.log(iframe.src);
+            }
           }, true);
         }
       };

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -9,6 +9,16 @@ angular.module('risevision.template-editor.directives')
         link: function ($scope) {
           $scope.factory = templateEditorFactory;
 
+          var iframeLoaded = false;
+          var attributeDataText = null;
+          var iframe = $window.document.getElementById('template-editor-preview');
+
+          iframe.onload = function() {
+            iframeLoaded = true;
+
+            _postAttributeData();
+          }
+
           $scope.getEditorPreviewUrl = function(productCode) {
             var url = HTML_TEMPLATE_URL.replace('PRODUCT_CODE', productCode);
 
@@ -16,23 +26,23 @@ angular.module('risevision.template-editor.directives')
           }
 
           $scope.$watch('factory.presentation.templateAttributeData', function (value) {
-            var attributeDataText = typeof value === 'string' ?
+            attributeDataText = typeof value === 'string' ?
               value : JSON.stringify(value);
 
-            var iframe = $window.document.getElementById('template-editor-preview');
+            _postAttributeData();
+          }, true);
+
+          function _postAttributeData() {
+            if( !attributeDataText || !iframeLoaded ) {
+              return;
+            }
 
             iframe.contentWindow.postMessage(attributeDataText, WIDGETS_DOMAIN);
-
             console.log('attribute data text');
             console.log(attributeDataText);
-            console.log(iframe.src);
-            console.log(iframe.contentWindow.location.origin);
 
-            iframe.onload = function() {
-              console.log('content window loaded');
-              console.log(iframe.src);
-            }
-          }, true);
+            attributeDataText = null;
+          }
         }
       };
     }

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
-  .directive('templateEditorPreviewHolder', ['$sce', 'templateEditorFactory', 'HTML_TEMPLATE_URL',
-    function ($sce, templateEditorFactory, HTML_TEMPLATE_URL) {
+  .directive('templateEditorPreviewHolder', ['$window', '$sce', 'templateEditorFactory', 'HTML_TEMPLATE_URL',
+    function ($window, $sce, templateEditorFactory, HTML_TEMPLATE_URL) {
       return {
         restrict: 'E',
         templateUrl: 'partials/template-editor/preview-holder.html',
@@ -14,6 +14,20 @@ angular.module('risevision.template-editor.directives')
 
             return $sce.trustAsResourceUrl(url);
           }
+
+          $scope.$watch('factory.presentation.templateAttributeData', function (value) {
+            var attributeDataText = typeof value === 'string' ?
+              value : JSON.stringify(value);
+
+            var iframe = $window.document.getElementById('template-editor-preview');
+            var domain = $window.location.origin;
+
+            iframe.contentWindow.postMessage(attributeDataText, domain);
+
+            console.log('attribute data text');
+            console.log(attributeDataText);
+            console.log(domain);
+          });
         }
       };
     }

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -20,7 +20,7 @@ angular.module('risevision.template-editor.directives')
               value : JSON.stringify(value);
 
             var iframe = $window.document.getElementById('template-editor-preview');
-            var domain = 'widgets.risevision.com';  // $window.location.origin;
+            var domain = 'https://widgets.risevision.com';  // $window.location.origin;
 
             iframe.contentWindow.postMessage(attributeDataText, domain);
 

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -26,8 +26,9 @@ angular.module('risevision.template-editor.directives')
             console.log('attribute data text');
             console.log(attributeDataText);
             console.log(iframe.src);
+            console.log(iframe.contentWindow.location.origin);
 
-            iframe.contentWindow.onload = function() {
+            iframe.onload = function() {
               console.log('content window loaded');
               console.log(iframe.src);
             }

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
-  .directive('templateEditorPreviewHolder', ['$window', '$sce', 'templateEditorFactory', 'HTML_TEMPLATE_URL', 'WIDGETS_DOMAIN',
-    function ($window, $sce, templateEditorFactory, HTML_TEMPLATE_URL, WIDGETS_DOMAIN) {
+  .directive('templateEditorPreviewHolder', ['$window', '$sce', 'templateEditorFactory', 'HTML_TEMPLATE_DOMAIN', 'HTML_TEMPLATE_URL',
+    function ($window, $sce, templateEditorFactory, HTML_TEMPLATE_DOMAIN, HTML_TEMPLATE_URL) {
       return {
         restrict: 'E',
         templateUrl: 'partials/template-editor/preview-holder.html',
@@ -37,7 +37,7 @@ angular.module('risevision.template-editor.directives')
               return;
             }
 
-            iframe.contentWindow.postMessage(attributeDataText, WIDGETS_DOMAIN);
+            iframe.contentWindow.postMessage(attributeDataText, HTML_TEMPLATE_DOMAIN);
 
             attributeDataText = null;
           }

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -26,7 +26,7 @@ angular.module('risevision.template-editor.directives')
 
             console.log('attribute data text');
             console.log(attributeDataText);
-            console.log(domain);
+            console.log($window.location.origin);
           }, true);
         }
       };

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -3,10 +3,10 @@
 angular.module('risevision.template-editor.services')
   .constant('BLUEPRINT_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/blueprint.json')
   .constant('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/src/template.html')
-  .factory('templateEditorFactory', ['$q', '$log', '$sce', '$state', '$rootScope', '$http', 'messageBox', 'presentation', 'processErrorCode', 'userState',
-    'HTML_PRESENTATION_TYPE', 'BLUEPRINT_URL', 'HTML_TEMPLATE_URL', 'REVISION_STATUS_REVISED', 'REVISION_STATUS_PUBLISHED',
-    function ($q, $log, $sce, $state, $rootScope, $http, messageBox, presentation, processErrorCode, userState,
-      HTML_PRESENTATION_TYPE, BLUEPRINT_URL, HTML_TEMPLATE_URL, REVISION_STATUS_REVISED, REVISION_STATUS_PUBLISHED) {
+  .factory('templateEditorFactory', ['$q', '$log', '$state', '$rootScope', '$http', 'messageBox', 'presentation', 'processErrorCode', 'userState',
+    'HTML_PRESENTATION_TYPE', 'BLUEPRINT_URL', 'REVISION_STATUS_REVISED', 'REVISION_STATUS_PUBLISHED',
+    function ($q, $log, $state, $rootScope, $http, messageBox, presentation, processErrorCode, userState,
+      HTML_PRESENTATION_TYPE, BLUEPRINT_URL, REVISION_STATUS_REVISED, REVISION_STATUS_PUBLISHED) {
       var factory = {};
 
       var _setPresentation = function (presentation) {
@@ -228,12 +228,6 @@ angular.module('risevision.template-editor.services')
 
         return deferred.promise;
       };
-
-      factory.getEditorPreviewUrl = function(productCode) {
-        var url = HTML_TEMPLATE_URL.replace('PRODUCT_CODE', productCode);
-
-        return $sce.trustAsResourceUrl(url);
-      }
 
       var _parseJSON = function (json) {
         try {

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -3,7 +3,7 @@
 angular.module('risevision.template-editor.services')
   .constant('BLUEPRINT_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/blueprint.json')
   .constant('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/src/template.html')
-  .constant('WIDGETS_DOMAIN', 'https://widgets.risevision.com')
+  .constant('HTML_TEMPLATE_DOMAIN', 'https://widgets.risevision.com')
   .factory('templateEditorFactory', ['$q', '$log', '$state', '$rootScope', '$http', 'messageBox', 'presentation', 'processErrorCode', 'userState',
     'HTML_PRESENTATION_TYPE', 'BLUEPRINT_URL', 'REVISION_STATUS_REVISED', 'REVISION_STATUS_PUBLISHED',
     function ($q, $log, $state, $rootScope, $http, messageBox, presentation, processErrorCode, userState,

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -2,7 +2,7 @@
 
 angular.module('risevision.template-editor.services')
   .constant('BLUEPRINT_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/blueprint.json')
-  .constant('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/beta/templates/PRODUCT_CODE/src/template.html')
+  .constant('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/src/template.html')
   .factory('templateEditorFactory', ['$q', '$log', '$sce', '$state', '$rootScope', '$http', 'messageBox', 'presentation', 'processErrorCode', 'userState',
     'HTML_PRESENTATION_TYPE', 'BLUEPRINT_URL', 'HTML_TEMPLATE_URL', 'REVISION_STATUS_REVISED', 'REVISION_STATUS_PUBLISHED',
     function ($q, $log, $sce, $state, $rootScope, $http, messageBox, presentation, processErrorCode, userState,

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -3,6 +3,7 @@
 angular.module('risevision.template-editor.services')
   .constant('BLUEPRINT_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/blueprint.json')
   .constant('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/src/template.html')
+  .constant('WIDGETS_DOMAIN', 'https://widgets.risevision.com')
   .factory('templateEditorFactory', ['$q', '$log', '$state', '$rootScope', '$http', 'messageBox', 'presentation', 'processErrorCode', 'userState',
     'HTML_PRESENTATION_TYPE', 'BLUEPRINT_URL', 'REVISION_STATUS_REVISED', 'REVISION_STATUS_PUBLISHED',
     function ($q, $log, $state, $rootScope, $http, messageBox, presentation, processErrorCode, userState,


### PR DESCRIPTION
Provides attribute data once there is a change ( including first state ) and only if the iframe code has already been loaded ( which was a problem for the first notification ).

Templates are now read from stable ( so they match blueprint file )
I also moved all preview related code to the preview directive.

I manually validated it here:

https://apps-stage-9.risevision.com/templates/edit/d4a5a9c7-2cc7-4f99-87cf-1e8457d0ea9a?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c
