### PR TITLE
Replace deleteAllSubCompanies calls with deleteCurrentCompany

### DIFF
--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -15,7 +15,6 @@ var FirstSigninScenarios = function() {
 
   browser.driver.manage().window().setSize(1400, 900);
   describe('First Signin', function () {
-    var subCompanyName = 'E2E TEST SUBCOMPANY - FIRST SIGN IN';
     var homepage;
     var signInPage;
     var commonHeaderPage;
@@ -43,7 +42,7 @@ var FirstSigninScenarios = function() {
       before(function () {
         homepage.get();
         signInPage.signIn();
-
+        var subCompanyName = 'E2E TEST SUBCOMPANY - FIRST SIGN IN';
         commonHeaderPage.createSubCompany(subCompanyName);
         commonHeaderPage.selectSubCompany(subCompanyName);
       });
@@ -260,11 +259,6 @@ var FirstSigninScenarios = function() {
           helper.waitDisappear(displayAddModalPage.getDisplayAddModal(), 'Display Add Modal');
         });
 
-      });
-
-      after(function() {
-        commonHeaderPage.selectSubCompany(subCompanyName);
-        commonHeaderPage.deleteCurrentCompany();
       });
     });
   });

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -135,7 +135,7 @@ var FirstSigninScenarios = function() {
         expect(getStartedPage.getGetStartedContainer().isDisplayed()).to.eventually.be.false;
       });
 
-      it('removes current SubCompany',function(){
+      after(function() {
         commonHeaderPage.deleteCurrentCompany();
       });
 

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -44,7 +44,7 @@ var FirstSigninScenarios = function() {
         signInPage.signIn();
         var subCompanyName = 'E2E TEST SUBCOMPANY - FIRST SIGN IN';
         commonHeaderPage.createSubCompany(subCompanyName);
-        commonHeaderPage.selectSubCompany(subCompanyName);   
+        commonHeaderPage.selectSubCompany(subCompanyName);
       });
 
       it('should show the Get Started page', function() {
@@ -262,7 +262,7 @@ var FirstSigninScenarios = function() {
       });
 
       after(function() {
-        commonHeaderPage.deleteAllSubCompanies();
+        commonHeaderPage.deleteCurrentCompany();
       });
     });
   });

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -15,6 +15,7 @@ var FirstSigninScenarios = function() {
 
   browser.driver.manage().window().setSize(1400, 900);
   describe('First Signin', function () {
+    var subCompanyName = 'E2E TEST SUBCOMPANY - FIRST SIGN IN';
     var homepage;
     var signInPage;
     var commonHeaderPage;
@@ -42,7 +43,7 @@ var FirstSigninScenarios = function() {
       before(function () {
         homepage.get();
         signInPage.signIn();
-        var subCompanyName = 'E2E TEST SUBCOMPANY - FIRST SIGN IN';
+
         commonHeaderPage.createSubCompany(subCompanyName);
         commonHeaderPage.selectSubCompany(subCompanyName);
       });

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -262,6 +262,7 @@ var FirstSigninScenarios = function() {
       });
 
       after(function() {
+        commonHeaderPage.selectSubCompany(subCompanyName);
         commonHeaderPage.deleteCurrentCompany();
       });
     });

--- a/test/e2e/editor/cases/template-add.js
+++ b/test/e2e/editor/cases/template-add.js
@@ -65,11 +65,6 @@ var TemplateAddScenarios = function() {
       openContentModal();
     });
 
-    after(function() {
-      loadEditor();
-      commonHeaderPage.deleteAllSubCompanies();
-    });
-
     it('should open the Store Templates Modal', function () {
       expect(storeProductsModalPage.getStoreProductsModal().isDisplayed()).to.eventually.be.true;
     });
@@ -220,6 +215,11 @@ var TemplateAddScenarios = function() {
       expect(workspacePage.getCancelButton().isPresent()).to.eventually.be.true;
     });
 
+    after(function() {
+      loadEditor();
+      selectSubCompany();
+      commonHeaderPage.deleteCurrentCompany();
+    });
   });
 };
 module.exports = TemplateAddScenarios;

--- a/test/e2e/template-editor/cases/template-editor-add.js
+++ b/test/e2e/template-editor/cases/template-editor-add.js
@@ -12,9 +12,9 @@ var TemplateAddScenarios = function() {
 
   browser.driver.manage().window().setSize(1920, 1080);
 
-  describe('Template Editor Add', function () {
+  describe('Template Editor', function () {
     var testStartTime = Date.now();
-    var subCompanyName = 'E2E TEST SUBCOMPANY - TEMPLATE EDITOR ADD';
+    var subCompanyName = 'E2E TEST SUBCOMPANY - TEMPLATE EDITOR';
     var presentationName = 'Example Presentation - ' + testStartTime;
     var commonHeaderPage;
     var homepage;


### PR DESCRIPTION
This improves the build situation a little bit, as it avoids having the sub company used by the current workflow step deleted by other step of the same build.

@santiagonoguez @stulees @Rise-Vision/apps please review
