### PR TITLE
Feature/use html template aspect ratio for preview

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.7.4",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#feature/use-html-template-aspect-ratio-for-preview",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -35,6 +35,7 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
+    "common-header": "feature/use-html-template-aspect-ratio-for-preview",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#feature/use-html-template-aspect-ratio-for-preview",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.7.5",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -35,7 +35,6 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
-    "common-header": "feature/use-html-template-aspect-ratio-for-preview",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }

--- a/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
+++ b/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
@@ -122,7 +122,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
     it('should calculate desktop width for 16:9 aspect ratio', function() {
       factory.blueprintData = { width: "1920", height: "1080" };
 
-      var aspectRatio = $scope.getMobileWidth();
+      var aspectRatio = $scope.getDesktopWidth();
 
       expect(aspectRatio).to.equal("889");
     });
@@ -130,7 +130,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
     it('should calculate desktop width for 9:16 aspect ratio', function() {
       factory.blueprintData = { width: "1080", height: "1920" };
 
-      var aspectRatio = $scope.getMobileWidth();
+      var aspectRatio = $scope.getDesktopWidth();
 
       expect(aspectRatio).to.equal("281");
     });

--- a/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
+++ b/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
@@ -28,6 +28,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
     $scope = $rootScope.$new();
 
     sandbox.stub($window.document, 'getElementById').returns({
+      clientHeight: 500,
       setAttribute: function() {}
     });
 
@@ -49,52 +50,90 @@ describe('directive: TemplateEditorPreviewHolder', function() {
     expect($scope.getTemplateAspectRatio).to.be.a('function');
   });
 
-  it('should calculate the 100 aspect ratio', function() {
-    factory.blueprintData = { width: "1000", height: "1000" };
+  describe('getTemplateAspectRatio', function() {
+    it('should calculate the 100 aspect ratio', function() {
+      factory.blueprintData = { width: "1000", height: "1000" };
 
-    var aspectRatio = $scope.getTemplateAspectRatio();
+      var aspectRatio = $scope.getTemplateAspectRatio();
 
-    expect(aspectRatio).to.equal("100.00");
+      expect(aspectRatio).to.equal("100.00");
+    });
+
+    it('should calculate the 200 aspect ratio', function() {
+      factory.blueprintData = { width: "1000", height: "2000" };
+
+      var aspectRatio = $scope.getTemplateAspectRatio();
+
+      expect(aspectRatio).to.equal("200.00");
+    });
+
+    it('should calculate the 50 aspect ratio', function() {
+      factory.blueprintData = { width: "2000", height: "1000" };
+
+      var aspectRatio = $scope.getTemplateAspectRatio();
+
+      expect(aspectRatio).to.equal("50.00");
+    });
+
+    it('should calculate the 16:9 aspect ratio', function() {
+      factory.blueprintData = { width: "1920", height: "1080" };
+
+      var aspectRatio = $scope.getTemplateAspectRatio();
+
+      expect(aspectRatio).to.equal("56.25");
+    });
+
+    it('should calculate the 4:3 aspect ratio', function() {
+      factory.blueprintData = { width: "800", height: "600" };
+
+      var aspectRatio = $scope.getTemplateAspectRatio();
+
+      expect(aspectRatio).to.equal("75.00");
+    });
+
+    it('should calculate a 333.33 aspect ratio', function() {
+      factory.blueprintData = { width: "300", height: "1000" };
+
+      var aspectRatio = $scope.getTemplateAspectRatio();
+
+      expect(aspectRatio).to.equal("333.33");
+    });
   });
 
-  it('should calculate the 200 aspect ratio', function() {
-    factory.blueprintData = { width: "1000", height: "2000" };
+  describe('getMobileWidth', function() {
+    it('should calculate mobile width for 16:9 aspect ratio', function() {
+      factory.blueprintData = { width: "1920", height: "1080" };
 
-    var aspectRatio = $scope.getTemplateAspectRatio();
+      var aspectRatio = $scope.getMobileWidth();
 
-    expect(aspectRatio).to.equal("200.00");
+      expect(aspectRatio).to.equal("284");
+    });
+
+    it('should calculate mobile width for 9:16 aspect ratio', function() {
+      factory.blueprintData = { width: "1080", height: "1920" };
+
+      var aspectRatio = $scope.getMobileWidth();
+
+      expect(aspectRatio).to.equal("90");
+    });
   });
 
-  it('should calculate the 50 aspect ratio', function() {
-    factory.blueprintData = { width: "2000", height: "1000" };
+  describe('getDesktopWidth', function() {
+    it('should calculate desktop width for 16:9 aspect ratio', function() {
+      factory.blueprintData = { width: "1920", height: "1080" };
 
-    var aspectRatio = $scope.getTemplateAspectRatio();
+      var aspectRatio = $scope.getMobileWidth();
 
-    expect(aspectRatio).to.equal("50.00");
-  });
+      expect(aspectRatio).to.equal("889");
+    });
 
-  it('should calculate the 16:9 aspect ratio', function() {
-    factory.blueprintData = { width: "1920", height: "1080" };
+    it('should calculate desktop width for 9:16 aspect ratio', function() {
+      factory.blueprintData = { width: "1080", height: "1920" };
 
-    var aspectRatio = $scope.getTemplateAspectRatio();
+      var aspectRatio = $scope.getMobileWidth();
 
-    expect(aspectRatio).to.equal("56.25");
-  });
-
-  it('should calculate the 4:3 aspect ratio', function() {
-    factory.blueprintData = { width: "800", height: "600" };
-
-    var aspectRatio = $scope.getTemplateAspectRatio();
-
-    expect(aspectRatio).to.equal("75.00");
-  });
-
-  it('should calculate a 333.33 aspect ratio', function() {
-    factory.blueprintData = { width: "300", height: "1000" };
-
-    var aspectRatio = $scope.getTemplateAspectRatio();
-
-    expect(aspectRatio).to.equal("333.33");
+      expect(aspectRatio).to.equal("281");
+    });
   });
 
 });

--- a/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
+++ b/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
@@ -7,7 +7,9 @@ describe('directive: TemplateEditorPreviewHolder', function() {
       factory;
 
   beforeEach(function() {
-    factory = {};
+    factory = {
+      blueprintData: { width: "1000", height: "1000" }
+    };
   });
 
   beforeEach(module('risevision.template-editor.directives'));
@@ -25,7 +27,9 @@ describe('directive: TemplateEditorPreviewHolder', function() {
     $templateCache.put('partials/template-editor/preview-holder.html', '<p>mock</p>');
     $scope = $rootScope.$new();
 
-    sandbox.stub($window.document, 'getElementById').returns({});
+    sandbox.stub($window.document, 'getElementById').returns({
+      setAttribute: function() {}
+    });
 
     element = $compile("<template-editor-preview-holder></template-editor-preview-holder>")($scope);
     $scope.$digest();

--- a/web/partials/template-editor/preview-holder.html
+++ b/web/partials/template-editor/preview-holder.html
@@ -1,5 +1,8 @@
-<div class="preview-parent">
-  <iframe id="template-editor-preview" scrolling="no"
+<div id="template-editor-preview-parent"
+  class="preview-parent embed-responsive"
+>
+  <iframe id="template-editor-preview" class="embed-responsive-item"
+    scrolling="no"
     ng-src="{{ getEditorPreviewUrl(factory.presentation.productCode) }}"
   >
   </iframe>

--- a/web/partials/template-editor/preview-holder.html
+++ b/web/partials/template-editor/preview-holder.html
@@ -1,7 +1,8 @@
 <div id="template-editor-preview-parent"
   class="preview-parent embed-responsive"
 >
-  <iframe id="template-editor-preview" class="embed-responsive-item"
+  <iframe id="template-editor-preview"
+    class="embed-responsive-item"
     scrolling="no"
     ng-src="{{ getEditorPreviewUrl(factory.presentation.productCode) }}"
   >

--- a/web/partials/template-editor/template-editor.html
+++ b/web/partials/template-editor/template-editor.html
@@ -14,7 +14,7 @@
       <template-attribute-editor>
       </template-attribute-editor>
     </div>
-    <div class="preview-holder"
+    <div id="preview-holder" class="preview-holder"
          ng-class="{ 'hidden-xs': factory.selected }">
       <template-editor-preview-holder>
       </template-editor-preview-holder>

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -11,6 +11,7 @@ angular.module('risevision.template-editor.directives')
 
           var DEFAULT_TEMPLATE_WIDTH = 800;
           var DEFAULT_TEMPLATE_HEIGHT = 600;
+          var MOBILE_PREVIEW_HEIGHT = 160;
 
           var iframeLoaded = false;
           var attributeDataText = null;
@@ -42,8 +43,18 @@ angular.module('risevision.template-editor.directives')
             return height ? parseInt( height ) : DEFAULT_TEMPLATE_HEIGHT;
           }
 
+          function _getHeightDividedByWidth() {
+            return _getTemplateHeight() / _getTemplateWidth();
+          }
+
+          $scope.getMobileWidth = function() {
+            var value = MOBILE_PREVIEW_HEIGHT / _getHeightDividedByWidth();
+
+            return value.toFixed(0);
+          }
+
           $scope.getTemplateAspectRatio = function() {
-            var value = ( _getTemplateHeight() / _getTemplateWidth() ) * 100;
+            var value = _getHeightDividedByWidth() * 100;
 
             return value.toFixed(2);
           }
@@ -54,8 +65,10 @@ angular.module('risevision.template-editor.directives')
           ], function() {
             var aspectRatio = $scope.getTemplateAspectRatio();
             var style = 'padding-bottom: ' + aspectRatio + '%';
+            var width = $scope.getMobileWidth() + 'px';
 
             iframeParent.setAttribute('style', style);
+            iframeParent.setAttribute('width', width);
           });
 
           $scope.$watch('factory.presentation.templateAttributeData', function (value) {

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -63,12 +63,13 @@ angular.module('risevision.template-editor.directives')
             'factory.blueprintData.width',
             'factory.blueprintData.height'
           ], function() {
-            var aspectRatio = $scope.getTemplateAspectRatio();
-            var style = 'padding-bottom: ' + aspectRatio + '%';
+            var aspectRatio = $scope.getTemplateAspectRatio() + '%';
             var width = $scope.getMobileWidth() + 'px';
 
+            var style = 'padding-bottom: ' + aspectRatio + ';' +
+              'width: ' + width;
+
             iframeParent.setAttribute('style', style);
-            iframeParent.setAttribute('width', width);
           });
 
           $scope.$watch('factory.presentation.templateAttributeData', function (value) {

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -93,10 +93,15 @@ angular.module('risevision.template-editor.directives')
             'factory.blueprintData.height'
           ], _applyAspectRatio);
 
-          angular.element($window).on('resize', function() {
+          function _onResize() {
             _applyAspectRatio();
 
             $scope.$digest();
+          }
+
+          angular.element($window).on('resize', _onResize);
+          $scope.$on('$destroy', function() {
+            angular.element($window).off('resize', _onResize);
           });
 
           $scope.$watch('factory.presentation.templateAttributeData', function (value) {

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -14,6 +14,8 @@ angular.module('risevision.template-editor.directives')
 
           var iframeLoaded = false;
           var attributeDataText = null;
+
+          var iframeParent = $window.document.getElementById('template-editor-preview-parent');
           var iframe = $window.document.getElementById('template-editor-preview');
 
           iframe.onload = function() {
@@ -45,6 +47,16 @@ angular.module('risevision.template-editor.directives')
 
             return value.toFixed(2);
           }
+
+          $scope.$watchGroup([
+            'factory.blueprintData.width',
+            'factory.blueprintData.height'
+          ], function() {
+            var aspectRatio = $scope.getTemplateAspectRatio();
+            var style = 'padding-bottom: ' + aspectRatio + '%';
+
+            iframeParent.setAttribute('style', style);
+          });
 
           $scope.$watch('factory.presentation.templateAttributeData', function (value) {
             attributeDataText = typeof value === 'string' ?

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -16,6 +16,7 @@ angular.module('risevision.template-editor.directives')
           var iframeLoaded = false;
           var attributeDataText = null;
 
+          var previewHolder = $window.document.getElementById('preview-holder');
           var iframeParent = $window.document.getElementById('template-editor-preview-parent');
           var iframe = $window.document.getElementById('template-editor-preview');
 
@@ -47,10 +48,22 @@ angular.module('risevision.template-editor.directives')
             return _getTemplateHeight() / _getTemplateWidth();
           }
 
-          $scope.getMobileWidth = function() {
-            var value = MOBILE_PREVIEW_HEIGHT / _getHeightDividedByWidth();
+          function _isLandscape() {
+            return _getHeightDividedByWidth() < 1;
+          }
+
+          function _getWidthFor(height) {
+            var value = height / _getHeightDividedByWidth();
 
             return value.toFixed(0);
+          }
+
+          $scope.getMobileWidth = function() {
+            return _getWidthFor(MOBILE_PREVIEW_HEIGHT);
+          }
+
+          $scope.getDesktopWidth = function() {
+            return _getWidthFor(previewHolder.clientHeight);
           }
 
           $scope.getTemplateAspectRatio = function() {
@@ -63,11 +76,17 @@ angular.module('risevision.template-editor.directives')
             'factory.blueprintData.width',
             'factory.blueprintData.height'
           ], function() {
-            var aspectRatio = $scope.getTemplateAspectRatio() + '%';
-            var width = $scope.getMobileWidth() + 'px';
+            var style;
 
-            var style = 'padding-bottom: ' + aspectRatio + ';' +
-              'width: ' + width;
+            if( $window.matchMedia('(max-width: 768px)').matches ) {
+              style = 'width: ' + $scope.getMobileWidth() + 'px';
+            } else if( _isLandscape() ) {
+              var aspectRatio = $scope.getTemplateAspectRatio() + '%';
+
+              style = 'padding-bottom: ' + aspectRatio + ';'
+            } else {
+              style = 'height: 100%; width: ' + $scope.getDesktopWidth() + 'px';
+            }
 
             iframeParent.setAttribute('style', style);
           });

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -72,10 +72,7 @@ angular.module('risevision.template-editor.directives')
             return value.toFixed(2);
           }
 
-          $scope.$watchGroup([
-            'factory.blueprintData.width',
-            'factory.blueprintData.height'
-          ], function() {
+          function _applyAspectRatio() {
             var style;
 
             if( $window.matchMedia('(max-width: 768px)').matches ) {
@@ -89,6 +86,17 @@ angular.module('risevision.template-editor.directives')
             }
 
             iframeParent.setAttribute('style', style);
+          }
+
+          $scope.$watchGroup([
+            'factory.blueprintData.width',
+            'factory.blueprintData.height'
+          ], _applyAspectRatio);
+
+          angular.element($window).on('resize', function() {
+            _applyAspectRatio();
+
+            $scope.$digest();
           });
 
           $scope.$watch('factory.presentation.templateAttributeData', function (value) {


### PR DESCRIPTION
This sets the style for aspect ratio for both desktop and mobile:

https://apps-stage-9.risevision.com/templates/edit/d4a5a9c7-2cc7-4f99-87cf-1e8457d0ea9a?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c

The blueprint file for testing here:

https://console.cloud.google.com/storage/browser/widgets.risevision.com/stable/templates/736a3d01551189406b9b302dccc6230267fe18ad/?project=avid-life-623&pli=1

Can be changed to test different aspect ratios.

Related common-header PR: https://github.com/Rise-Vision/common-header/pull/959

Some captures:

![mobile_landscape](https://user-images.githubusercontent.com/33162690/56754689-43443200-6753-11e9-8c09-73b5570b31f5.png)

![desktop_landscape](https://user-images.githubusercontent.com/33162690/56754703-4b9c6d00-6753-11e9-9b7e-29c831c0a1eb.png)

![mobile_portrait](https://user-images.githubusercontent.com/33162690/56754713-522ae480-6753-11e9-84bc-f0338fd2832c.png)

![desktop_portrait](https://user-images.githubusercontent.com/33162690/56754722-56ef9880-6753-11e9-87a1-0795692674ef.png)

![desktop_portrait_wide](https://user-images.githubusercontent.com/33162690/56754732-5bb44c80-6753-11e9-89cf-62b6d534ed0e.png)

Something to note is that in this last capture, as we are setting width to 100% and height is not controlled ( embedding classes ), a scroll bar appears on desktop mode. I tried to control the height to limit it to the page, but then it complicates setting the width ( as it's not fixed as in mobile ).
