### PR TITLE
Make Apps e2e test cases independent in order to be able to run multiple builds in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,14 +116,15 @@ jobs:
           command: |
             # Set +e flag to fix issue where no stage environment is specified
             set +e
-            export STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')";
+            STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')";
             if [ "$STAGE_ENV" != '' ]; then
               echo "Deploying to $STAGE_ENV";
             fi;
             if [ "$STAGE_ENV" == '' ]; then
               echo "stage deployment environment missing. Deploying to [stage-0].";
-              export STAGE_ENV='stage-0';
+              STAGE_ENV='stage-0';
             fi;
+            echo 'export STAGE_ENV="$STAGE_ENV"' >> $BASH_ENV
       - run: echo "Testing e2e tests - Env $STAGE_ENV"
       - store_artifacts:
           path: ~/rise-vision-apps/dist.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,8 +127,8 @@ jobs:
             echo 'export STAGE_ENV="$STAGE_ENV"' >> $BASH_ENV
             echo "BASH_ENV is $BASH_ENV"
       - run:
-        - name: Do things
-        - command: |
+          name: Do things
+          command: |
             echo $BASH_ENV
             source $BASH_ENV
             echo "Testing e2e tests - Env $STAGE_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ commands:
       casesfile:
         type: string
         default: "invalid_path"
-    working_directory: ~/rise-vision-apps
     steps:
       - attach_workspace:
           at: ~/
@@ -143,6 +142,7 @@ jobs:
               STAGE_ENV='stage-0';
             fi;
             #rsync -rptz -e ssh --delete dist apps@webserver-stage.risevision.com:/rise-front-end/apps/$STAGE_ENV;
+      - run: tar czvf dist.tar.gz dist
       - store_artifacts:
           path: ~/rise-vision-apps/dist.tar.gz
   deploy_beta:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,24 @@ commands:
       - run: sudo apt-get update -qq
       - run: sudo apt-get install -y google-chrome-stable
       - run:
+          name: Set environment variables
+          command: |
+            # Set +e flag to fix issue where no stage environment is specified
+            set +e
+            STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')";
+            if [ "$STAGE_ENV" != '' ]; then
+              echo "Deploying to $STAGE_ENV";
+            fi;
+            if [ "$STAGE_ENV" == '' ]; then
+              echo "stage deployment environment missing. Deploying to [stage-0].";
+              STAGE_ENV='stage-0';
+            fi;
+            echo "$STAGE_ENV" > stage.txt
+      - run:
           name: e2e_tests
           command: |
+            STAGE_ENV=$(cat stage.txt)
+            echo "Running tests on $STAGE_ENV";
             TEST_FILES=$(circleci tests glob "<< parameters.casesfile >>" | circleci tests split)
             NODE_ENV=test XUNIT_FILE=~/rise-vision-apps/reports/angular-xunit.xml PROSHOT_DIR=~/rise-vision-apps/reports/screenshots DBUS_SESSION_BUS_ADDRESS=/dev/null xvfb-run node run-test.js $TEST_FILES
       - store_test_results:
@@ -111,25 +127,13 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - run: NODE_ENV=stage npm run ci-build
+      - run: ssh -o StrictHostKeyChecking=no apps@webserver-stage.risevision.com 'mkdir -p /rise-front-end/apps';
       - run:
-          name: Set environment variables
-          command: |
-            # Set +e flag to fix issue where no stage environment is specified
-            set +e
-            STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')";
-            if [ "$STAGE_ENV" != '' ]; then
-              echo "Deploying to $STAGE_ENV";
-            fi;
-            if [ "$STAGE_ENV" == '' ]; then
-              echo "stage deployment environment missing. Deploying to [stage-0].";
-              STAGE_ENV='stage-0';
-            fi;
-            echo "$STAGE_ENV" > stage.txt
-      - run:
-          name: Do things
+          name: Deploy to stage
           command: |
             STAGE_ENV=$(cat stage.txt)
-            echo "Testing e2e tests - Env $STAGE_ENV"
+            #rsync -rptz -e ssh --delete dist apps@webserver-stage.risevision.com:/rise-front-end/apps/$STAGE_ENV;
       - store_artifacts:
           path: ~/rise-vision-apps/dist.tar.gz
   deploy_beta:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,13 +116,13 @@ jobs:
           command: |
             # Set +e flag to fix issue where no stage environment is specified
             set +e
-            STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')";
+            export STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')";
             if [ "$STAGE_ENV" != '' ]; then
               echo "Deploying to $STAGE_ENV";
             fi;
             if [ "$STAGE_ENV" == '' ]; then
               echo "stage deployment environment missing. Deploying to [stage-0].";
-              STAGE_ENV='stage-0';
+              export STAGE_ENV='stage-0';
             fi;
       - run: echo "Testing e2e tests - Env $STAGE_ENV"
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,13 +124,11 @@ jobs:
               echo "stage deployment environment missing. Deploying to [stage-0].";
               STAGE_ENV='stage-0';
             fi;
-            echo 'export STAGE_ENV="$STAGE_ENV"' >> $BASH_ENV
-            echo "BASH_ENV is $BASH_ENV"
+            echo "$STAGE_ENV" > stage.txt
       - run:
           name: Do things
           command: |
-            echo $BASH_ENV
-            source $BASH_ENV
+            STAGE_ENV=$(cat stage.txt)
             echo "Testing e2e tests - Env $STAGE_ENV"
       - store_artifacts:
           path: ~/rise-vision-apps/dist.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,26 +111,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run: NODE_ENV=stage npm run ci-build
-      - run: ssh -o StrictHostKeyChecking=no apps@webserver-stage.risevision.com 'mkdir -p /rise-front-end/apps';
-      # We have 5 stage environments, apps-stage-0.risevision.com to apps-stage-4.risevision.com
-      # To deploy to one of these environments a tag must be added to the commit message. For instance, [stage-0] for apps-stage-0.risevision.com.
-      # If tag is missing, the [stage-0] is used.
-      - run: 
-          name: Deploy to stage
-          command: |
-            # Set +e flag to fix issue where no stage environment is specified
-            set +e
-            STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')";
-            if [ "$STAGE_ENV" != '' ]; then
-              echo "Deploying to $STAGE_ENV";
-            fi;
-            if [ "$STAGE_ENV" == '' ]; then
-              echo "stage deployment environment missing. Deploying to [stage-0].";
-              STAGE_ENV='stage-0';
-            fi;
-            rsync -rptz -e ssh --delete dist apps@webserver-stage.risevision.com:/rise-front-end/apps/$STAGE_ENV;
-      - run: tar czvf dist.tar.gz dist
+      - run: echo "Testing e2e tests"
       - store_artifacts:
           path: ~/rise-vision-apps/dist.tar.gz
   deploy_beta:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,7 @@ commands:
             # Set +e flag to fix issue where no stage environment is specified
             set +e
             STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')";
-            if [ "$STAGE_ENV" != '' ]; then
-              echo "Deploying to $STAGE_ENV";
-            fi;
             if [ "$STAGE_ENV" == '' ]; then
-              echo "stage deployment environment missing. Deploying to [stage-0].";
               STAGE_ENV='stage-0';
             fi;
             echo "$STAGE_ENV" > stage.txt
@@ -130,10 +126,22 @@ jobs:
           at: ~/
       - run: NODE_ENV=stage npm run ci-build
       - run: ssh -o StrictHostKeyChecking=no apps@webserver-stage.risevision.com 'mkdir -p /rise-front-end/apps';
+      # We have 10 stage environments, apps-stage-0.risevision.com to apps-stage-9.risevision.com
+      # To deploy to one of these environments a tag must be added to the commit message. For instance, [stage-0] for apps-stage-0.risevision.com.
+      # If tag is missing, the [stage-0] is used.
       - run:
           name: Deploy to stage
           command: |
-            STAGE_ENV=$(cat stage.txt)
+            # Set +e flag to fix issue where no stage environment is specified
+            set +e
+            STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')";
+            if [ "$STAGE_ENV" != '' ]; then
+              echo "Deploying to $STAGE_ENV";
+            fi;
+            if [ "$STAGE_ENV" == '' ]; then
+              echo "stage deployment environment missing. Deploying to [stage-0].";
+              STAGE_ENV='stage-0';
+            fi;
             #rsync -rptz -e ssh --delete dist apps@webserver-stage.risevision.com:/rise-front-end/apps/$STAGE_ENV;
       - store_artifacts:
           path: ~/rise-vision-apps/dist.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
           command: |
             export STAGE_ENV=$(cat stage.txt)
             echo "Deploying to $STAGE_ENV";
-            #rsync -rptz -e ssh --delete dist apps@webserver-stage.risevision.com:/rise-front-end/apps/$STAGE_ENV;
+            rsync -rptz -e ssh --delete dist apps@webserver-stage.risevision.com:/rise-front-end/apps/$STAGE_ENV;
       - run: tar czvf dist.tar.gz dist
       - store_artifacts:
           path: ~/rise-vision-apps/dist.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,12 @@ jobs:
             fi;
             echo 'export STAGE_ENV="$STAGE_ENV"' >> $BASH_ENV
             echo "BASH_ENV is $BASH_ENV"
-      - run: echo "Testing e2e tests - Env $STAGE_ENV"
+      - run:
+        - name: Do things
+        - command: |
+            echo $BASH_ENV
+            source $BASH_ENV
+            echo "Testing e2e tests - Env $STAGE_ENV"
       - store_artifacts:
           path: ~/rise-vision-apps/dist.tar.gz
   deploy_beta:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
       - run:
           name: e2e_tests
           command: |
-            STAGE_ENV=$(cat stage.txt)
+            export STAGE_ENV=$(cat stage.txt)
             echo "Running tests on $STAGE_ENV";
             TEST_FILES=$(circleci tests glob "<< parameters.casesfile >>" | circleci tests split)
             NODE_ENV=test XUNIT_FILE=~/rise-vision-apps/reports/angular-xunit.xml PROSHOT_DIR=~/rise-vision-apps/reports/screenshots DBUS_SESSION_BUS_ADDRESS=/dev/null xvfb-run node run-test.js $TEST_FILES

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,7 @@ jobs:
               STAGE_ENV='stage-0';
             fi;
             echo 'export STAGE_ENV="$STAGE_ENV"' >> $BASH_ENV
+            echo "BASH_ENV is $BASH_ENV"
       - run: echo "Testing e2e tests - Env $STAGE_ENV"
       - store_artifacts:
           path: ~/rise-vision-apps/dist.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ commands:
       casesfile:
         type: string
         default: "invalid_path"
+    working_directory: ~/rise-vision-apps
     steps:
       - attach_workspace:
           at: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,16 +17,6 @@ commands:
       - run: sudo apt-get update -qq
       - run: sudo apt-get install -y google-chrome-stable
       - run:
-          name: Set environment variables
-          command: |
-            # Set +e flag to fix issue where no stage environment is specified
-            set +e
-            STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')";
-            if [ "$STAGE_ENV" == '' ]; then
-              STAGE_ENV='stage-0';
-            fi;
-            echo "$STAGE_ENV" > stage.txt
-      - run:
           name: e2e_tests
           command: |
             export STAGE_ENV=$(cat stage.txt)
@@ -51,6 +41,16 @@ jobs:
       - run: 
           name: install bower
           command: bower install
+      - run:
+          name: Set environment variables
+          command: |
+            # Set +e flag to fix issue where no stage environment is specified
+            set +e
+            STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')";
+            if [ "$STAGE_ENV" == '' ]; then
+              STAGE_ENV='stage-0';
+            fi;
+            echo "$STAGE_ENV" > stage.txt
       - persist_to_workspace:
           root: ~/
           paths:
@@ -131,16 +131,8 @@ jobs:
       - run:
           name: Deploy to stage
           command: |
-            # Set +e flag to fix issue where no stage environment is specified
-            set +e
-            STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')";
-            if [ "$STAGE_ENV" != '' ]; then
-              echo "Deploying to $STAGE_ENV";
-            fi;
-            if [ "$STAGE_ENV" == '' ]; then
-              echo "stage deployment environment missing. Deploying to [stage-0].";
-              STAGE_ENV='stage-0';
-            fi;
+            export STAGE_ENV=$(cat stage.txt)
+            echo "Deploying to $STAGE_ENV";
             #rsync -rptz -e ssh --delete dist apps@webserver-stage.risevision.com:/rise-front-end/apps/$STAGE_ENV;
       - run: tar czvf dist.tar.gz dist
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,20 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run: echo "Testing e2e tests"
+      - run:
+          name: Set environment variables
+          command: |
+            # Set +e flag to fix issue where no stage environment is specified
+            set +e
+            STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')";
+            if [ "$STAGE_ENV" != '' ]; then
+              echo "Deploying to $STAGE_ENV";
+            fi;
+            if [ "$STAGE_ENV" == '' ]; then
+              echo "stage deployment environment missing. Deploying to [stage-0].";
+              STAGE_ENV='stage-0';
+            fi;
+      - run: echo "Testing e2e tests - Env $STAGE_ENV"
       - store_artifacts:
           path: ~/rise-vision-apps/dist.tar.gz
   deploy_beta:

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.7.4",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#chore/concurrent-builds",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -36,6 +36,7 @@
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
     "jquery": "^2",
-    "font-awesome": "~4.7.0"
+    "font-awesome": "~4.7.0",
+    "common-header": "chore/concurrent-builds"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#chore/concurrent-builds",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.7.7",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -36,7 +36,6 @@
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
     "jquery": "^2",
-    "font-awesome": "~4.7.0",
-    "common-header": "chore/concurrent-builds"
+    "font-awesome": "~4.7.0"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -293,6 +293,8 @@ gulp.task("test:e2e:core", ["test:webdrive_update"],factory.testE2EAngular({
   loginPass: process.env.E2E_PASS,
   loginUser2: process.env.E2E_USER2,
   loginPass2: process.env.E2E_PASS2,
+  stageEnv: process.env.STAGE_ENV || "local",
+  stageUser: process.env.CIRCLE_USERNAME || "local",
   twitterUser: process.env.TWITTER_USER,
   twitterPass: process.env.TWITTER_PASS,
   testFiles: function(){ 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -299,7 +299,6 @@ gulp.task("test:e2e:core", ["test:webdrive_update"],factory.testE2EAngular({
   twitterPass: process.env.TWITTER_PASS,
   testFiles: function(){ 
     try{
-      console.log("STAGE_ENV is: ", process.env.STAGE_ENV);
       return JSON.parse(fs.readFileSync('/tmp/testFiles.txt').toString())
     } catch (e) {
       return process.env.TEST_FILES

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -289,8 +289,8 @@ gulp.task("server-close", factory.testServerClose());
 gulp.task("test:webdrive_update", factory.webdriveUpdate());
 gulp.task("test:e2e:core", ["test:webdrive_update"],factory.testE2EAngular({
   browser: "chrome",
-  loginUser: process.env.E2E_USER,
-  loginPass: process.env.E2E_PASS,
+  loginUser: "jenkinsrisevision@gmail.com", // process.env.E2E_USER,
+  loginPass: "JenkinsRise#1", //process.env.E2E_PASS,
   loginUser2: process.env.E2E_USER2,
   loginPass2: process.env.E2E_PASS2,
   twitterUser: process.env.TWITTER_USER,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -294,7 +294,6 @@ gulp.task("test:e2e:core", ["test:webdrive_update"],factory.testE2EAngular({
   loginUser2: process.env.E2E_USER2,
   loginPass2: process.env.E2E_PASS2,
   stageEnv: process.env.STAGE_ENV || "local",
-  stageUser: process.env.CIRCLE_USERNAME || "local",
   twitterUser: process.env.TWITTER_USER,
   twitterPass: process.env.TWITTER_PASS,
   testFiles: function(){ 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -299,6 +299,7 @@ gulp.task("test:e2e:core", ["test:webdrive_update"],factory.testE2EAngular({
   twitterPass: process.env.TWITTER_PASS,
   testFiles: function(){ 
     try{
+      console.log("STAGE_ENV is: ", process.env.STAGE_ENV);
       return JSON.parse(fs.readFileSync('/tmp/testFiles.txt').toString())
     } catch (e) {
       return process.env.TEST_FILES

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -289,8 +289,8 @@ gulp.task("server-close", factory.testServerClose());
 gulp.task("test:webdrive_update", factory.webdriveUpdate());
 gulp.task("test:e2e:core", ["test:webdrive_update"],factory.testE2EAngular({
   browser: "chrome",
-  loginUser: "jenkinsrisevision@gmail.com", // process.env.E2E_USER,
-  loginPass: "JenkinsRise#1", //process.env.E2E_PASS,
+  loginUser: process.env.E2E_USER,
+  loginPass: process.env.E2E_PASS,
   loginUser2: process.env.E2E_USER2,
   loginPass2: process.env.E2E_PASS2,
   twitterUser: process.env.TWITTER_USER,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jshint-stylish": "^2.0.1",
     "run-sequence": "^1.1.1",
     "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git",
-    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
+    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git#chore/add-stage-env"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jshint-stylish": "^2.0.1",
     "run-sequence": "^1.1.1",
     "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git",
-    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git#chore/add-stage-env"
+    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
   },
   "repository": {
     "type": "git",

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -40,9 +40,11 @@ var FirstSigninScenarios = function() {
       var displayId;
 
       before(function () {
+        var subCompanyName = 'E2E TEST SUBCOMPANY - FIRST SIGN IN';
         homepage.get();
         signInPage.signIn();
-        var subCompanyName = 'E2E TEST SUBCOMPANY - FIRST SIGN IN';
+        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+
         commonHeaderPage.createSubCompany(subCompanyName);
         commonHeaderPage.selectSubCompany(subCompanyName);
       });

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -43,7 +43,7 @@ var FirstSigninScenarios = function() {
       before(function () {
         homepage.get();
         signInPage.signIn();
-        browser.sleep(1000);
+        browser.sleep(10000);
         helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
         helper.wait(homepage.getPresentationAddButton(), 'Add Presentation Button');
 
@@ -128,10 +128,9 @@ var FirstSigninScenarios = function() {
       });
 
       it('should no longer show the Get Started Page', function () {
-        browser.sleep(500);
         homepage.get();
         signInPage.signIn();
-        browser.sleep(1000);
+        browser.sleep(10000);
         helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
         helper.wait(homepage.getPresentationAddButton(), 'Add Presentation Button');
 

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -37,21 +37,26 @@ var FirstSigninScenarios = function() {
       displayAddModalPage = new DisplayAddModalPage();
     });
 
+    function _waitFullPageLoad() {
+      browser.sleep(10000);
+      helper.waitDisappear(commonHeaderPage.getLoader(), 'CH Spinner Loader');
+      helper.waitDisappear(homepage.getPresentationsListLoader(), 'Presentations List Loader');
+      helper.waitDisappear(homepage.getSchedulesListLoader(), 'Schedules List Loader');
+      helper.waitDisappear(homepage.getDisplaysListLoader(), 'Displays List Loader');
+      helper.wait(homepage.getPresentationAddButton(), 'Add Presentation Button');
+    }
+
     describe('Given a user that just signed up for Rise Vision', function () {
       var displayId;
 
       before(function () {
         homepage.get();
         signInPage.signIn();
-        browser.sleep(10000);
-        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH Spinner Loader');
-        helper.waitDisappear(homepage.getPresentationsListLoader(), 'Presentations List Loader');
-        helper.waitDisappear(homepage.getSchedulesListLoader(), 'Schedules List Loader');
-        helper.waitDisappear(homepage.getDisplaysListLoader(), 'Displays List Loader');
-        helper.wait(homepage.getPresentationAddButton(), 'Add Presentation Button');
+        _waitFullPageLoad();
 
         commonHeaderPage.createSubCompany(subCompanyName);
         commonHeaderPage.selectSubCompany(subCompanyName);
+        _waitFullPageLoad();
       });
 
       it('should show the Get Started page', function() {
@@ -133,24 +138,11 @@ var FirstSigninScenarios = function() {
       it('should no longer show the Get Started Page', function () {
         homepage.get();
         signInPage.signIn();
-        browser.sleep(10000);
-        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH Spinner Loader');
-        helper.waitDisappear(homepage.getPresentationsListLoader(), 'Presentations List Loader');
-        helper.waitDisappear(homepage.getSchedulesListLoader(), 'Schedules List Loader');
-        helper.waitDisappear(homepage.getDisplaysListLoader(), 'Displays List Loader');
-        helper.wait(homepage.getPresentationAddButton(), 'Add Presentation Button');
+        _waitFullPageLoad();
 
         commonHeaderPage.selectSubCompany(subCompanyName);
 
-        helper.wait(commonHeaderPage.getCommonHeaderMenuItems().get(0), 'First Common Header Menu Item');
-        helper.clickWhenClickable(commonHeaderPage.getCommonHeaderMenuItems().get(0), 'First Common Header Menu Item');
-
-        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH Spinner Loader');
-        helper.waitDisappear(homepage.getPresentationsListLoader(), 'Presentations List Loader');
-        helper.waitDisappear(homepage.getSchedulesListLoader(), 'Schedules List Loader');
-        helper.waitDisappear(homepage.getDisplaysListLoader(), 'Displays List Loader');
-        helper.wait(homepage.getPresentationAddButton(), 'Add Presentation Button');
-        browser.sleep(500);
+        _waitFullPageLoad();
 
         expect(getStartedPage.getGetStartedContainer().isDisplayed()).to.eventually.be.false;
       });

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -13,7 +13,7 @@ var DisplayAddModalPage = require('./../../displays/pages/displayAddModalPage.js
 
 var FirstSigninScenarios = function() {
 
-  browser.driver.manage().window().setSize(1400, 900);
+  browser.driver.manage().window().setSize(1920, 1080);
   describe('First Signin', function () {
     var subCompanyName = 'E2E TEST SUBCOMPANY - FIRST SIGN IN';
     var homepage;
@@ -44,7 +44,10 @@ var FirstSigninScenarios = function() {
         homepage.get();
         signInPage.signIn();
         browser.sleep(10000);
-        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH Spinner Loader');
+        helper.waitDisappear(homepage.getPresentationsListLoader(), 'Presentations List Loader');
+        helper.waitDisappear(homepage.getSchedulesListLoader(), 'Schedules List Loader');
+        helper.waitDisappear(homepage.getDisplaysListLoader(), 'Displays List Loader');
         helper.wait(homepage.getPresentationAddButton(), 'Add Presentation Button');
 
         commonHeaderPage.createSubCompany(subCompanyName);
@@ -131,7 +134,10 @@ var FirstSigninScenarios = function() {
         homepage.get();
         signInPage.signIn();
         browser.sleep(10000);
-        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH Spinner Loader');
+        helper.waitDisappear(homepage.getPresentationsListLoader(), 'Presentations List Loader');
+        helper.waitDisappear(homepage.getSchedulesListLoader(), 'Schedules List Loader');
+        helper.waitDisappear(homepage.getDisplaysListLoader(), 'Displays List Loader');
         helper.wait(homepage.getPresentationAddButton(), 'Add Presentation Button');
 
         commonHeaderPage.selectSubCompany(subCompanyName);
@@ -139,7 +145,10 @@ var FirstSigninScenarios = function() {
         helper.wait(commonHeaderPage.getCommonHeaderMenuItems().get(0), 'First Common Header Menu Item');
         helper.clickWhenClickable(commonHeaderPage.getCommonHeaderMenuItems().get(0), 'First Common Header Menu Item');
 
-        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH Spinner Loader');
+        helper.waitDisappear(homepage.getPresentationsListLoader(), 'Presentations List Loader');
+        helper.waitDisappear(homepage.getSchedulesListLoader(), 'Schedules List Loader');
+        helper.waitDisappear(homepage.getDisplaysListLoader(), 'Displays List Loader');
         helper.wait(homepage.getPresentationAddButton(), 'Add Presentation Button');
         browser.sleep(500);
 

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -15,6 +15,7 @@ var FirstSigninScenarios = function() {
 
   browser.driver.manage().window().setSize(1400, 900);
   describe('First Signin', function () {
+    var subCompanyName = 'E2E TEST SUBCOMPANY - FIRST SIGN IN';
     var homepage;
     var signInPage;
     var commonHeaderPage;
@@ -40,7 +41,6 @@ var FirstSigninScenarios = function() {
       var displayId;
 
       before(function () {
-        var subCompanyName = 'E2E TEST SUBCOMPANY - FIRST SIGN IN';
         homepage.get();
         signInPage.signIn();
         browser.sleep(1000);
@@ -128,6 +128,12 @@ var FirstSigninScenarios = function() {
 
       it('should no longer show the Get Started Page', function () {
         browser.sleep(500);
+        homepage.get();
+        signInPage.signIn();
+        browser.sleep(1000);
+        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+
+        commonHeaderPage.selectSubCompany(subCompanyName);
 
         helper.wait(commonHeaderPage.getCommonHeaderMenuItems().get(0), 'First Common Header Menu Item');
         helper.clickWhenClickable(commonHeaderPage.getCommonHeaderMenuItems().get(0), 'First Common Header Menu Item');

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -45,6 +45,7 @@ var FirstSigninScenarios = function() {
         signInPage.signIn();
         browser.sleep(1000);
         helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+        helper.wait(homepage.getPresentationAddButton(), 'Add Presentation Button');
 
         commonHeaderPage.createSubCompany(subCompanyName);
         commonHeaderPage.selectSubCompany(subCompanyName);

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -141,6 +141,7 @@ var FirstSigninScenarios = function() {
         helper.clickWhenClickable(commonHeaderPage.getCommonHeaderMenuItems().get(0), 'First Common Header Menu Item');
 
         helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+        helper.wait(homepage.getPresentationAddButton(), 'Add Presentation Button');
         browser.sleep(500);
 
         expect(getStartedPage.getGetStartedContainer().isDisplayed()).to.eventually.be.false;

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -43,7 +43,7 @@ var FirstSigninScenarios = function() {
         var subCompanyName = 'E2E TEST SUBCOMPANY - FIRST SIGN IN';
         homepage.get();
         signInPage.signIn();
-        browser.wait(1000);
+        browser.sleep(1000);
         helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
 
         commonHeaderPage.createSubCompany(subCompanyName);

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -43,6 +43,7 @@ var FirstSigninScenarios = function() {
         var subCompanyName = 'E2E TEST SUBCOMPANY - FIRST SIGN IN';
         homepage.get();
         signInPage.signIn();
+        browser.wait(1000);
         helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
 
         commonHeaderPage.createSubCompany(subCompanyName);

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -37,12 +37,22 @@ var FirstSigninScenarios = function() {
       displayAddModalPage = new DisplayAddModalPage();
     });
 
-    function _waitFullPageLoad() {
+    function _waitFullPageLoad(retries) {
       browser.sleep(10000);
-      helper.waitDisappear(commonHeaderPage.getLoader(), 'CH Spinner Loader');
-      helper.waitDisappear(homepage.getPresentationsListLoader(), 'Presentations List Loader');
-      helper.waitDisappear(homepage.getSchedulesListLoader(), 'Schedules List Loader');
-      helper.waitDisappear(homepage.getDisplaysListLoader(), 'Displays List Loader');
+      helper.waitDisappear(commonHeaderPage.getLoader(), 'CH Spinner Loader')
+      .then(function () {
+        helper.waitDisappear(homepage.getPresentationsListLoader(), 'Presentations List Loader');
+        helper.waitDisappear(homepage.getSchedulesListLoader(), 'Schedules List Loader');
+        helper.waitDisappear(homepage.getDisplaysListLoader(), 'Displays List Loader');
+      })
+      .catch(function () {
+        retries = typeof(retries) === 'undefined' ? 3 : retries;
+
+        if (retries > 0) {
+          browser.driver.navigate().refresh();
+          _waitFullPageLoad(retries - 1);
+        }
+      });
     }
 
     describe('Given a user that just signed up for Rise Vision', function () {

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -43,7 +43,6 @@ var FirstSigninScenarios = function() {
       helper.waitDisappear(homepage.getPresentationsListLoader(), 'Presentations List Loader');
       helper.waitDisappear(homepage.getSchedulesListLoader(), 'Schedules List Loader');
       helper.waitDisappear(homepage.getDisplaysListLoader(), 'Displays List Loader');
-      helper.wait(homepage.getPresentationAddButton(), 'Add Presentation Button');
     }
 
     describe('Given a user that just signed up for Rise Vision', function () {

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -133,6 +133,7 @@ var FirstSigninScenarios = function() {
         signInPage.signIn();
         browser.sleep(1000);
         helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+        helper.wait(homepage.getPresentationAddButton(), 'Add Presentation Button');
 
         commonHeaderPage.selectSubCompany(subCompanyName);
 

--- a/test/e2e/displays/cases/displayadd.js
+++ b/test/e2e/displays/cases/displayadd.js
@@ -51,7 +51,7 @@ var DisplayAddScenarios = function() {
     });
 
     it('should add display', function () {
-      var displayName = 'TEST_E2E_DISPLAY';
+      var displayName = 'TEST_E2E_DISPLAY ' + commonHeaderPage.getStageEnv();
       displayAddModalPage.getDisplayNameField().sendKeys(displayName);
       expect(displayAddModalPage.getNextButton().isEnabled()).to.eventually.be.true;
       displayAddModalPage.getNextButton().click();

--- a/test/e2e/displays/cases/displaymanage.js
+++ b/test/e2e/displays/cases/displaymanage.js
@@ -35,8 +35,8 @@ var DisplayAddScenarios = function() {
       // Search for recently created Display
       var displayName = 'TEST_E2E_DISPLAY ' + commonHeaderPage.getStageEnv();
 
-      helper.wait(displaysListPage.getSearchFilter(), 'Search Filter');
-      displaysListPage.getSearchFilter().sendKeys(displayName);
+      helper.wait(displaysListPage.getSearchFilterField(), 'Search Filter Field');
+      displaysListPage.getSearchFilterField().sendKeys(displayName);
       helper.wait(displaysListPage.getDisplaysLoader(), 'Displays loader');
       helper.waitDisappear(displaysListPage.getDisplaysLoader(), 'Displays loader');
       displaysListPage.getDisplayItems().first().element(by.tagName('td')).click();

--- a/test/e2e/displays/cases/displaymanage.js
+++ b/test/e2e/displays/cases/displaymanage.js
@@ -31,7 +31,9 @@ var DisplayAddScenarios = function() {
       homepage.getDisplays();
       signInPage.signIn();
       helper.waitDisappear(displaysListPage.getDisplaysLoader(), 'Displays loader');
-      displaysListPage.getDisplayItems().first().element(by.tagName('td')).click();
+
+      var displayName = 'TEST_E2E_DISPLAY ' + commonHeaderPage.getStageEnv();
+      displaysListPage.getCreatedDisplayLink(displayName).click();
     });
 
     it('should load display', function () {

--- a/test/e2e/displays/cases/displaymanage.js
+++ b/test/e2e/displays/cases/displaymanage.js
@@ -19,6 +19,7 @@ var DisplayAddScenarios = function() {
     var displaysListPage;
     var displayManagePage;
     var displayAddModalPage;
+    var displayName;
 
     before(function () {
       homepage = new HomePage();
@@ -33,7 +34,7 @@ var DisplayAddScenarios = function() {
       helper.waitDisappear(displaysListPage.getDisplaysLoader(), 'Displays loader');
 
       // Search for recently created Display
-      var displayName = 'TEST_E2E_DISPLAY ' + commonHeaderPage.getStageEnv();
+      displayName = 'TEST_E2E_DISPLAY ' + commonHeaderPage.getStageEnv();
 
       helper.wait(displaysListPage.getSearchFilterField(), 'Search Filter Field');
       displaysListPage.getSearchFilterField().sendKeys(displayName);
@@ -45,7 +46,7 @@ var DisplayAddScenarios = function() {
     it('should load display', function () {
       helper.waitDisappear(displayManagePage.getDisplayLoader(), 'Display loader');
       expect(displayManagePage.getDisplayNameField().isPresent()).to.eventually.be.true;
-      expect(displayManagePage.getDisplayNameField().getAttribute('value')).to.eventually.equal('TEST_E2E_DISPLAY');
+      expect(displayManagePage.getDisplayNameField().getAttribute('value')).to.eventually.equal(displayName);
     });
 
     it('should show User Company Address Checkbox', function () {

--- a/test/e2e/displays/cases/displaymanage.js
+++ b/test/e2e/displays/cases/displaymanage.js
@@ -32,8 +32,14 @@ var DisplayAddScenarios = function() {
       signInPage.signIn();
       helper.waitDisappear(displaysListPage.getDisplaysLoader(), 'Displays loader');
 
+      // Search for recently created Display
       var displayName = 'TEST_E2E_DISPLAY ' + commonHeaderPage.getStageEnv();
-      displaysListPage.getCreatedDisplayLink(displayName).click();
+
+      helper.wait(displaysListPage.getSearchFilter(), 'Search Filter');
+      displaysListPage.getSearchFilter().sendKeys(displayName);
+      helper.wait(displaysListPage.getDisplaysLoader(), 'Displays loader');
+      helper.waitDisappear(displaysListPage.getDisplaysLoader(), 'Displays loader');
+      displaysListPage.getDisplayItems().first().element(by.tagName('td')).click();
     });
 
     it('should load display', function () {

--- a/test/e2e/displays/displays.cases.js
+++ b/test/e2e/displays/displays.cases.js
@@ -8,8 +8,8 @@
 
   describe('Displays', function() {
     var alertsScenarios = new AlertsScenarios();
-    var displayListScenarios = new DisplayListScenarios();
     var displayAddScenarios = new DisplayAddScenarios();
+    var displayListScenarios = new DisplayListScenarios();
     var displayManageScenarios = new DisplayManageScenarios();
   });
 

--- a/test/e2e/displays/pages/displaysListPage.js
+++ b/test/e2e/displays/pages/displaysListPage.js
@@ -3,6 +3,7 @@ var DisplaysListPage = function() {
   var displaysAppContainer = element(by.css('.displays-app'));
   var title = element(by.id('title'));
   var searchFilter = element(by.tagName('search-filter'));
+  var searchFilterField = element(by.css('search-filter div input'));
   var displayAddButton = element(by.id('displayAddButton'));
   var displaysListTable = element(by.id('displaysListTable'));
   var tableHeaderName = element(by.id('tableHeaderName'));
@@ -21,6 +22,10 @@ var DisplaysListPage = function() {
 
   this.getSearchFilter = function() {
     return searchFilter;
+  };
+
+  this.getSearchFilterField = function() {
+    return searchFilterField;
   };
 
   this.getDisplayAddButton = function() {

--- a/test/e2e/displays/pages/displaysListPage.js
+++ b/test/e2e/displays/pages/displaysListPage.js
@@ -58,10 +58,6 @@ var DisplaysListPage = function() {
   this.getFirstRowStatus = function() {
     return displayItems.first().element(by.css('.display-status .u_icon-hover'));
   };
-
-  this.getCreatedDisplayLink = function (displayName) {
-    return element(by.xpath('//a[span/strong[contains(text(), "' + displayName + '")]]'));
-  };
 };
 
 module.exports = DisplaysListPage;

--- a/test/e2e/displays/pages/displaysListPage.js
+++ b/test/e2e/displays/pages/displaysListPage.js
@@ -58,6 +58,10 @@ var DisplaysListPage = function() {
   this.getFirstRowStatus = function() {
     return displayItems.first().element(by.css('.display-status .u_icon-hover'));
   };
+
+  this.getCreatedDisplayLink = function (displayName) {
+    return element(by.xpath('//a[span/strong[contains(text(), "' + displayName + '")]]'));
+  };
 };
 
 module.exports = DisplaysListPage;

--- a/test/e2e/editor/cases/presentation-add.js
+++ b/test/e2e/editor/cases/presentation-add.js
@@ -12,7 +12,7 @@ var ArtboardPage = require('./../pages/artboardPage.js');
 var PresentationAddScenarios = function() {
 
   browser.driver.manage().window().setSize(1920, 1080);
-  xdescribe('Presentation Add', function () {
+  describe('Presentation Add', function () {
     var homepage;
     var signInPage;
     var commonHeaderPage;
@@ -72,7 +72,7 @@ var PresentationAddScenarios = function() {
       workspacePage.getPresentationPropertiesButton().click();
       helper.wait(presentationPropertiesModalPage.getPresentationPropertiesModal(), 'Presentation Properties Modal');
 
-      var presentationName = 'TEST_E2E_PRESENTATION';
+      var presentationName = 'TEST_E2E_PRESENTATION ' + commonHeaderPage.getStageEnv();
 
       helper.wait(presentationPropertiesModalPage.getNameInput(), 'Waiting for Name Input');
       presentationPropertiesModalPage.getNameInput().sendKeys('workaround'); // clear() fails sometimes

--- a/test/e2e/editor/cases/presentation-properties.js
+++ b/test/e2e/editor/cases/presentation-properties.js
@@ -36,11 +36,13 @@ var PresentationPropertiesScenarios = function() {
       });
 
       it('should load the workspace', function () {
+        helper.wait(workspacePage.getWorkspaceContainer(), 'Workspace Container');
         expect(workspacePage.getWorkspaceContainer().isDisplayed()).to.eventually.be.true;
       });
 
       describe('Given a user clicks on the presentation properties cog icon', function () {
         it('should open the properties modal when clicking cog', function () {
+          browser.sleep(500);
           helper.wait(workspacePage.getPresentationPropertiesButton(), 'Presentation Properties Button');
           helper.clickWhenClickable(workspacePage.getPresentationPropertiesButton(), 'Presentation Properties Button');
           helper.wait(presentationPropertiesModalPage.getPresentationPropertiesModal(), 'Presentation Properties Modal');

--- a/test/e2e/editor/cases/template-add.js
+++ b/test/e2e/editor/cases/template-add.js
@@ -174,6 +174,8 @@ var TemplateAddScenarios = function() {
     });
     
     it('should show Select Template button', function() {
+      // Sometimes the trial does not start in time; this section tries to reduce the number of times this step fails
+      browser.sleep(5000);
       // Reload page and select company whose trial has just started
       loadEditor();
       selectSubCompany();

--- a/test/e2e/launcher/cases/weekly-templates.js
+++ b/test/e2e/launcher/cases/weekly-templates.js
@@ -4,7 +4,7 @@ var HomePage = require('./../pages/homepage.js');
 var SignInPage = require('./../pages/signInPage.js');
 var WeeklyTemplatesPage = require('./../pages/weeklyTemplates.js');
 var CommonHeaderPage = require('./../../../../web/bower_components/common-header/test/e2e/pages/commonHeaderPage.js');
-var PresentationListPage = require('./../pages/presentationListPage.js');
+var PresentationListPage = require('./../../editor/pages/presentationListPage.js');
 var helper = require('rv-common-e2e').helper;
 
 var WeeklyTemplatesScenarios = function() {

--- a/test/e2e/launcher/cases/weekly-templates.js
+++ b/test/e2e/launcher/cases/weekly-templates.js
@@ -55,7 +55,8 @@ var WeeklyTemplatesScenarios = function() {
       helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
       expect(weeklyTemplatesPage.getWeeklyTemplatesCloseButton().isDisplayed()).to.eventually.be.true;
       
-      weeklyTemplatesPage.getWeeklyTemplatesCloseButton().click();
+      helper.wait(weeklyTemplatesPage.getWeeklyTemplatesCloseButton());
+      helper.clickWhenClickable(weeklyTemplatesPage.getWeeklyTemplatesCloseButton(), 'Weekly Templates Close Button');
       browser.sleep(500);
 
       expect(weeklyTemplatesPage.getWeeklyTemplatesExpandedView().isPresent()).to.eventually.be.false;
@@ -71,7 +72,8 @@ var WeeklyTemplatesScenarios = function() {
     });
 
     it('should expand Weekly Template Panel',function(){
-      weeklyTemplatesPage.getWeeklyTemplatesNoticeView().click();
+      helper.wait(weeklyTemplatesPage.getWeeklyTemplatesNoticeView(), 'Weekly Templates Notice View');
+      helper.clickWhenClickable(weeklyTemplatesPage.getWeeklyTemplatesNoticeView(), 'Weekly Templates Notice View');
       browser.sleep(500);
       expect(weeklyTemplatesPage.getWeeklyTemplatesExpandedView().isDisplayed()).to.eventually.be.true;
       expect(weeklyTemplatesPage.getWeeklyTemplatesNoticeView().isPresent()).to.eventually.be.false;

--- a/test/e2e/launcher/cases/weekly-templates.js
+++ b/test/e2e/launcher/cases/weekly-templates.js
@@ -46,6 +46,7 @@ var WeeklyTemplatesScenarios = function() {
       browser.sleep(500);
       helper.wait(commonHeaderPage.getCommonHeaderMenuItems().get(1), 'Presentations Common Header Menu Item');
       helper.clickWhenClickable(commonHeaderPage.getCommonHeaderMenuItems().get(1), 'Presentations Common Header Menu Item');
+      helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
       helper.waitDisappear(presentationsListPage.getPresentationsLoader(), 'Presentation loader');
 
       helper.wait(weeklyTemplatesPage.getWeeklyTemplatesMainPanel(), 'Notice View');

--- a/test/e2e/launcher/cases/weekly-templates.js
+++ b/test/e2e/launcher/cases/weekly-templates.js
@@ -68,6 +68,7 @@ var WeeklyTemplatesScenarios = function() {
     it('should persist Weekly Template Panel state on page reload',function(){
       browser.refresh();
       helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+      helper.waitDisappear(presentationsListPage.getPresentationsLoader(), 'Presentation loader');
       helper.wait(weeklyTemplatesPage.getWeeklyTemplatesNoticeView(), 'Notice View');
       expect(weeklyTemplatesPage.getWeeklyTemplatesExpandedView().isPresent()).to.eventually.be.false;
       expect(weeklyTemplatesPage.getWeeklyTemplatesNoticeView().isDisplayed()).to.eventually.be.true;

--- a/test/e2e/launcher/cases/weekly-templates.js
+++ b/test/e2e/launcher/cases/weekly-templates.js
@@ -4,6 +4,7 @@ var HomePage = require('./../pages/homepage.js');
 var SignInPage = require('./../pages/signInPage.js');
 var WeeklyTemplatesPage = require('./../pages/weeklyTemplates.js');
 var CommonHeaderPage = require('./../../../../web/bower_components/common-header/test/e2e/pages/commonHeaderPage.js');
+var PresentationListPage = require('./../pages/presentationListPage.js');
 var helper = require('rv-common-e2e').helper;
 
 var WeeklyTemplatesScenarios = function() {
@@ -15,12 +16,14 @@ var WeeklyTemplatesScenarios = function() {
     var signInPage;
     var weeklyTemplatesPage;
     var commonHeaderPage;
+    var presentationsListPage;
 
     before(function (){
       homepage = new HomePage();
       signInPage = new SignInPage();
       weeklyTemplatesPage = new WeeklyTemplatesPage();
       commonHeaderPage = new CommonHeaderPage();
+      presentationsListPage = new PresentationListPage();
 
       homepage.get();
       signInPage.signIn();
@@ -33,7 +36,7 @@ var WeeklyTemplatesScenarios = function() {
       expect(weeklyTemplatesPage.getWeeklyTemplatesNoticeView().isPresent()).to.eventually.be.false;
     });
 
-    it('should show Weekly Tempaltes for Education Customers',function(){
+    it('should show Weekly Templates for Education Customers',function(){
       //creates an Education sub-company
       var subCompanyName = 'E2E TEST EDUCATION SUBCOMPANY';
       commonHeaderPage.createSubCompany(subCompanyName,'PRIMARY_SECONDARY_EDUCATION');
@@ -43,7 +46,7 @@ var WeeklyTemplatesScenarios = function() {
       browser.sleep(500);
       helper.wait(commonHeaderPage.getCommonHeaderMenuItems().get(1), 'Presentations Common Header Menu Item');
       helper.clickWhenClickable(commonHeaderPage.getCommonHeaderMenuItems().get(1), 'Presentations Common Header Menu Item');
-      helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+      helper.waitDisappear(presentationsListPage.getPresentationsLoader(), 'Presentation loader');
 
       helper.wait(weeklyTemplatesPage.getWeeklyTemplatesMainPanel(), 'Notice View');
       expect(weeklyTemplatesPage.getWeeklyTemplatesMainPanel().isDisplayed()).to.eventually.be.true;
@@ -52,7 +55,6 @@ var WeeklyTemplatesScenarios = function() {
     });
 
     it('should close Weekly Template Panel',function(){
-      helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
       expect(weeklyTemplatesPage.getWeeklyTemplatesCloseButton().isDisplayed()).to.eventually.be.true;
       
       helper.wait(weeklyTemplatesPage.getWeeklyTemplatesCloseButton());


### PR DESCRIPTION
The main changes here are:

- Updating to latest Widget Tester which supports an additional Stage Environment parameter
- Updating to latest Common Header which makes Sub Company handling be stage environment dependent
- Update build process to provide the necessary information to the e2e tests
- Make changes to Displays and Editor tests so they work with stage environment dependent ids
- Make several small changes to make tests more reliable
- Re enable Presentation Add tests (I honestly don't remember why I disabled them 7 months ago, based on git blame)

I pursued the Sub Company with stage environment suffix approach because I could not really figure out an easy way to implement the alternative of using a single Subscribed and a separate Free company for tests dependent on subscription status changes (it required a larger refactor and I didn't think I could make it in time).

I will update Common Header and Widget Tester tags once those PRs are approved. I will also reenable staging deployments before merging (I disabled that to be able to test builds without affecting other environments)

@santiagonoguez @stulees @Rise-Vision/apps please review
