### PR TITLE
Allow to edit HTML Template when plan expired or cancelled

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.7.8",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.7.9",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },

--- a/test/unit/editor/services/svc-presentation-utils.tests.js
+++ b/test/unit/editor/services/svc-presentation-utils.tests.js
@@ -11,12 +11,6 @@ describe('service: presentationUtils:', function() {
       };
     });
 
-    $provide.service('checkTemplateAccess',function(){
-      return sinon.spy(function () {
-        return storeAuthorize ? Q.resolve() : Q.reject();
-      });
-    });
-
     $provide.service('plansFactory', function() {
       return plansFactory = {
         showPlansModal: sinon.stub()
@@ -24,15 +18,14 @@ describe('service: presentationUtils:', function() {
     })
   }));
 
-  var presentationUtils, HTML_TEMPLATE_TYPE, HTML_PRESENTATION_TYPE, $state, checkTemplateAccessSpy, storeAuthorize, plansFactory;
+  var presentationUtils, HTML_TEMPLATE_TYPE, HTML_PRESENTATION_TYPE, $state, plansFactory;
 
   beforeEach(function() {
-    inject(function($injector, checkTemplateAccess) {
+    inject(function($injector) {
       presentationUtils = $injector.get('presentationUtils');
       HTML_TEMPLATE_TYPE = $injector.get('HTML_TEMPLATE_TYPE');
       HTML_PRESENTATION_TYPE = $injector.get('HTML_PRESENTATION_TYPE');
       $state = $injector.get('$state');
-      checkTemplateAccessSpy = checkTemplateAccess;
     });
   });
 
@@ -72,29 +65,14 @@ describe('service: presentationUtils:', function() {
       expect($state.go).to.have.been.calledWith('apps.editor.workspace.artboard', {presentationId: 'test-id'});
     } );
 
-    it( "should route to template editor when presentation type is HTML template and authorized", function(done) {
-      storeAuthorize = true;
+    it( "should route to template editor when presentation type is HTML template", function(done) {
       presentationUtils.openPresentation({ id: 'test-id', presentationType: 'HTML Template', productCode: 'abc123' });
 
-      expect(checkTemplateAccessSpy).to.have.been.calledWith('abc123');
       setTimeout(function() {
         expect($state.go).to.have.been.calledWith('apps.editor.templates.edit', {presentationId: 'test-id'});
         done();
       }, 10);
 
     } );
-
-    it( "should open plans modal when presentation type is HTML template and not authorized", function(done) {
-      storeAuthorize = false;
-      presentationUtils.openPresentation({ id: 'test-id', presentationType: 'HTML Template', productCode: 'abc123' });
-
-      expect(checkTemplateAccessSpy).to.have.been.calledWith('abc123');
-
-      setTimeout(function() {
-        plansFactory.showPlansModal.should.have.been.called;
-        done();
-      }, 10);
-
-    });
   })
 });

--- a/web/partials/template-editor/expired-modal.html
+++ b/web/partials/template-editor/expired-modal.html
@@ -5,8 +5,8 @@
     </button>
   </div>
   <div class="modal-body" stop-event="touchend">
-    <p class="modal-title" translate>{{title}}</p>
-    <p translate>{{message}}</p>
+    <p class="modal-title" translate>{{confirmationTitle}}</p>
+    <p translate>{{confirmationMessage}}</p>
   </div>
   <div class="modal-footer">
     <div class="row">

--- a/web/partials/template-editor/expired-modal.html
+++ b/web/partials/template-editor/expired-modal.html
@@ -1,0 +1,25 @@
+<form id="expiredForm">
+  <div class="modal-header">
+    <button type="button" class="close" ng-click="dismiss()" data-dismiss="modal" aria-hidden="true">
+      <i class="fa fa-times"></i>
+    </button>
+  </div>
+  <div class="modal-body" stop-event="touchend">
+    <p class="modal-title" translate>{{title}}</p>
+    <p translate>{{message}}</p>
+  </div>
+  <div class="modal-footer">
+    <div class="row">
+      <div class="col-xs-6">
+        <button class="btn btn-primary w-100" ng-click="ok()">
+          <span translate="{{confirmationButton}}"></span>
+        </button>
+      </div>
+      <div class="col-xs-6">
+        <button class="btn btn-default w-100" ng-click="cancel()">
+          <span translate="{{cancelButton}}"></span>
+        </button>
+      </div>
+    </div>
+  </div>
+</form>

--- a/web/scripts/editor/services/svc-presentation-utils.js
+++ b/web/scripts/editor/services/svc-presentation-utils.js
@@ -4,7 +4,7 @@ angular.module('risevision.editor.services')
   .constant('HTML_PRESENTATION_TYPE', 'HTML Template')
   .factory('presentationUtils', ['HTML_TEMPLATE_TYPE', 'HTML_PRESENTATION_TYPE',
     '$state', '$window', 'checkTemplateAccess', 'plansFactory',
-    function (HTML_TEMPLATE_TYPE, HTML_PRESENTATION_TYPE, $state, $window, checkTemplateAccess, plansFactory) {
+    function (HTML_TEMPLATE_TYPE, HTML_PRESENTATION_TYPE, $state, $window) {
       var factory = {};
 
       factory.isMobileBrowser = function() {
@@ -25,13 +25,7 @@ angular.module('risevision.editor.services')
         if (presentation.presentationType !== HTML_PRESENTATION_TYPE) {
           $state.go('apps.editor.workspace.artboard', { presentationId: presentation.id });
         } else {
-          checkTemplateAccess(presentation.productCode)
-            .then(function () {
-              $state.go('apps.editor.templates.edit', { presentationId: presentation.id });
-            })
-            .catch(function () {
-              plansFactory.showPlansModal();
-            });
+          $state.go('apps.editor.templates.edit', { presentationId: presentation.id });
         }
       };
 

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -4,9 +4,9 @@ angular.module('risevision.template-editor.services')
   .constant('BLUEPRINT_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/blueprint.json')
   .constant('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/src/template.html')
   .constant('HTML_TEMPLATE_DOMAIN', 'https://widgets.risevision.com')
-  .factory('templateEditorFactory', ['$q', '$log', '$state', '$rootScope', '$http', 'messageBox', 'presentation', 'processErrorCode', 'userState', 'checkTemplateAccess',
+  .factory('templateEditorFactory', ['$q', '$log', '$state', '$rootScope', '$http', 'messageBox', 'presentation', 'processErrorCode', 'userState', 'checkTemplateAccess', '$templateCache', '$modal',
     'HTML_PRESENTATION_TYPE', 'BLUEPRINT_URL', 'REVISION_STATUS_REVISED', 'REVISION_STATUS_PUBLISHED',
-    function ($q, $log, $state, $rootScope, $http, messageBox, presentation, processErrorCode, userState, checkTemplateAccess,
+    function ($q, $log, $state, $rootScope, $http, messageBox, presentation, processErrorCode, userState, checkTemplateAccess, $templateCache, $modal,
       HTML_PRESENTATION_TYPE, BLUEPRINT_URL, REVISION_STATUS_REVISED, REVISION_STATUS_PUBLISHED) {
       var factory = {};
 
@@ -25,14 +25,37 @@ angular.module('risevision.template-editor.services')
           JSON.stringify(presentationVal.templateAttributeData);
 
         return presentationVal;
-      }
+      };
+
+      var _openExpiredModal = function() {
+        var modalInstance = $modal.open({
+          template: $templateCache.get('partials/template-editor/expired-modal.html'),
+          controller: 'confirmInstance',
+          windowClass: 'template-editor-message-box',
+          resolve: {
+            confirmationTitle: function () {
+              return 'template.expired-modal.expired-title';
+            },
+            confirmationMessage: function () {
+              return 'template.expired-modal.expired-message';
+            },
+            confirmationButton: function () {
+              return 'template.expired-modal.confirmation-button';
+            },
+            cancelButton: null
+          }
+        });
+
+        modalInstance.result.then(function () {
+          console.log("navigate to plans modal!");
+        });
+      };
 
       var _checkTemplateAccess = function(productCode) {
         checkTemplateAccess(productCode)
           .catch(function() {
-            // TODO: show expired/cancelled modal
-            console.log("Plan has expired or been cancelled");
-          })
+            _openExpiredModal();
+          });
       };
 
       factory.createFromTemplate = function (productDetails) {

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -4,9 +4,9 @@ angular.module('risevision.template-editor.services')
   .constant('BLUEPRINT_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/blueprint.json')
   .constant('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/src/template.html')
   .constant('HTML_TEMPLATE_DOMAIN', 'https://widgets.risevision.com')
-  .factory('templateEditorFactory', ['$q', '$log', '$state', '$rootScope', '$http', 'messageBox', 'presentation', 'processErrorCode', 'userState',
+  .factory('templateEditorFactory', ['$q', '$log', '$state', '$rootScope', '$http', 'messageBox', 'presentation', 'processErrorCode', 'userState', 'checkTemplateAccess',
     'HTML_PRESENTATION_TYPE', 'BLUEPRINT_URL', 'REVISION_STATUS_REVISED', 'REVISION_STATUS_PUBLISHED',
-    function ($q, $log, $state, $rootScope, $http, messageBox, presentation, processErrorCode, userState,
+    function ($q, $log, $state, $rootScope, $http, messageBox, presentation, processErrorCode, userState, checkTemplateAccess,
       HTML_PRESENTATION_TYPE, BLUEPRINT_URL, REVISION_STATUS_REVISED, REVISION_STATUS_PUBLISHED) {
       var factory = {};
 
@@ -26,6 +26,14 @@ angular.module('risevision.template-editor.services')
 
         return presentationVal;
       }
+
+      var _checkTemplateAccess = function(productCode) {
+        checkTemplateAccess(productCode)
+          .catch(function() {
+            // TODO: show expired/cancelled modal
+            console.log("Plan has expired or been cancelled");
+          })
+      };
 
       factory.createFromTemplate = function (productDetails) {
         _clearMessages();
@@ -143,6 +151,7 @@ angular.module('risevision.template-editor.services')
           })
           .then(function (blueprintData) {
             factory.blueprintData = blueprintData.data;
+            _checkTemplateAccess(factory.presentation.productCode);
 
             deferred.resolve();
           })

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -4,9 +4,10 @@ angular.module('risevision.template-editor.services')
   .constant('BLUEPRINT_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/blueprint.json')
   .constant('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/src/template.html')
   .constant('HTML_TEMPLATE_DOMAIN', 'https://widgets.risevision.com')
-  .factory('templateEditorFactory', ['$q', '$log', '$state', '$rootScope', '$http', 'messageBox', 'presentation', 'processErrorCode', 'userState', 'checkTemplateAccess', '$templateCache', '$modal',
+  .factory('templateEditorFactory', ['$q', '$log', '$state', '$rootScope', '$http', 'messageBox', 'presentation',
+    'processErrorCode', 'userState', 'checkTemplateAccess', '$modal', 'plansFactory',
     'HTML_PRESENTATION_TYPE', 'BLUEPRINT_URL', 'REVISION_STATUS_REVISED', 'REVISION_STATUS_PUBLISHED',
-    function ($q, $log, $state, $rootScope, $http, messageBox, presentation, processErrorCode, userState, checkTemplateAccess, $templateCache, $modal,
+    function ($q, $log, $state, $rootScope, $http, messageBox, presentation, processErrorCode, userState, checkTemplateAccess, $modal, plansFactory,
       HTML_PRESENTATION_TYPE, BLUEPRINT_URL, REVISION_STATUS_REVISED, REVISION_STATUS_PUBLISHED) {
       var factory = {};
 
@@ -29,7 +30,7 @@ angular.module('risevision.template-editor.services')
 
       var _openExpiredModal = function() {
         var modalInstance = $modal.open({
-          template: $templateCache.get('partials/template-editor/expired-modal.html'),
+          templateUrl: 'partials/template-editor/expired-modal.html',
           controller: 'confirmInstance',
           windowClass: 'template-editor-message-box',
           resolve: {
@@ -47,7 +48,7 @@ angular.module('risevision.template-editor.services')
         });
 
         modalInstance.result.then(function () {
-          console.log("navigate to plans modal!");
+          plansFactory.showPlansModal();
         });
       };
 


### PR DESCRIPTION
- When selecting a HTML template presentation, we route directly to Template Editor and open it
- Once opened, check the plan subscription and launch expired/cancelled modal if they don't have subscription
- Upon clicking "Subscribe Now", we open the plans modal.

Validated on https://apps-stage-8.risevision.com/templates/edit/8e2bb42e-bb85-415c-bc9c-33cc26ed9dd6?cid=ea12b71a-5137-45e9-bb9f-d820b7e839ff