### PR TITLE
Fix/preview bottom margin

### DIFF
--- a/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
+++ b/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
@@ -124,7 +124,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
 
       var width = $scope.getDesktopWidth();
 
-      expect(width).to.equal("889");
+      expect(width).to.equal("818");
     });
 
     it('should calculate desktop width for 9:16 aspect ratio', function() {
@@ -132,7 +132,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
 
       var width = $scope.getDesktopWidth();
 
-      expect(width).to.equal("281");
+      expect(width).to.equal("259");
     });
   });
 

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -15,7 +15,7 @@ angular.module('risevision.template-editor.directives')
           var MOBILE_PREVIEW_HEIGHT_SHORT = 140;
           var MOBILE_MARGIN = 10;
           var DESKTOP_MARGIN = 20;
-          var PREVIEW_INITIAL_DELAY_MILLIS = 2000;
+          var PREVIEW_INITIAL_DELAY_MILLIS = 1000;
 
           var iframeLoaded = false;
           var attributeDataText = null;
@@ -133,6 +133,8 @@ angular.module('risevision.template-editor.directives')
             'factory.blueprintData.width',
             'factory.blueprintData.height'
           ], function() {
+            _applyAspectRatio();
+
             setTimeout(_applyAspectRatio, PREVIEW_INITIAL_DELAY_MILLIS);
           });
 

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -12,7 +12,7 @@ angular.module('risevision.template-editor.directives')
           var DEFAULT_TEMPLATE_WIDTH = 800;
           var DEFAULT_TEMPLATE_HEIGHT = 600;
           var MOBILE_PREVIEW_HEIGHT = 200;
-          var MOBILE_PREVIEW_HEIGHT_SMALL = 140;
+          var MOBILE_PREVIEW_HEIGHT_SHORT = 140;
           var MOBILE_MARGIN = 10;
           var DESKTOP_MARGIN = 20;
           var PREVIEW_INITIAL_DELAY_MILLIS = 2000;
@@ -71,8 +71,8 @@ angular.module('risevision.template-editor.directives')
           }
 
           $scope.getMobileWidth = function() {
-            var isSmall = _mediaMatches('(max-height: 570px)');
-            var layerHeight = isSmall ? MOBILE_PREVIEW_HEIGHT_SMALL : MOBILE_PREVIEW_HEIGHT;
+            var isShort = _mediaMatches('(max-height: 570px)');
+            var layerHeight = isShort ? MOBILE_PREVIEW_HEIGHT_SHORT : MOBILE_PREVIEW_HEIGHT;
 
             var offset = 2 * MOBILE_MARGIN;
             var value = _getWidthFor(layerHeight - offset) + offset;

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -96,10 +96,6 @@ angular.module('risevision.template-editor.directives')
           }
 
           function _applyAspectRatio() {
-            console.log('CLIENT...............................');
-            console.log(previewHolder.clientWidth);
-            console.log(previewHolder.clientHeight);
-
             var frameStyle, parentStyle;
             var isMobile = $window.matchMedia('(max-width: 768px)').matches;
             var offset = ( isMobile ? MOBILE_MARGIN : DESKTOP_MARGIN ) * 2;

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -14,6 +14,7 @@ angular.module('risevision.template-editor.directives')
           var MOBILE_PREVIEW_HEIGHT = 200;
           var MOBILE_MARGIN = 10;
           var DESKTOP_MARGIN = 20;
+          var PREVIEW_INITIAL_DELAY_MILLIS = 2000;
 
           var iframeLoaded = false;
           var attributeDataText = null;
@@ -128,7 +129,7 @@ angular.module('risevision.template-editor.directives')
             'factory.blueprintData.width',
             'factory.blueprintData.height'
           ], function() {
-            setTimeout(_applyAspectRatio, 5000);
+            setTimeout(_applyAspectRatio, PREVIEW_INITIAL_DELAY_MILLIS);
           });
 
           function _onResize() {

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -95,6 +95,10 @@ angular.module('risevision.template-editor.directives')
           }
 
           function _applyAspectRatio() {
+            console.log('CLIENT...............................');
+            console.log(previewHolder.clientWidth);
+            console.log(previewHolder.clientHeight);
+
             var frameStyle, parentStyle;
             var isMobile = $window.matchMedia('(max-width: 768px)').matches;
             var offset = ( isMobile ? MOBILE_MARGIN : DESKTOP_MARGIN ) * 2;

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -12,6 +12,7 @@ angular.module('risevision.template-editor.directives')
           var DEFAULT_TEMPLATE_WIDTH = 800;
           var DEFAULT_TEMPLATE_HEIGHT = 600;
           var MOBILE_PREVIEW_HEIGHT = 200;
+          var MOBILE_PREVIEW_HEIGHT_SMALL = 140;
           var MOBILE_MARGIN = 10;
           var DESKTOP_MARGIN = 20;
           var PREVIEW_INITIAL_DELAY_MILLIS = 2000;
@@ -65,9 +66,16 @@ angular.module('risevision.template-editor.directives')
             return value;
           }
 
+          function _mediaMatches(mediaQuery) {
+            return $window.matchMedia(mediaQuery).matches
+          }
+
           $scope.getMobileWidth = function() {
+            var isSmall = _mediaMatches('(max-height: 570px)');
+            var layerHeight = isSmall ? MOBILE_PREVIEW_HEIGHT_SMALL : MOBILE_PREVIEW_HEIGHT;
+
             var offset = 2 * MOBILE_MARGIN;
-            var value = _getWidthFor(MOBILE_PREVIEW_HEIGHT - offset) + offset;
+            var value = _getWidthFor(layerHeight - offset) + offset;
 
             return value.toFixed(0);
           }
@@ -97,7 +105,7 @@ angular.module('risevision.template-editor.directives')
 
           function _applyAspectRatio() {
             var frameStyle, parentStyle;
-            var isMobile = $window.matchMedia('(max-width: 768px)').matches;
+            var isMobile = _mediaMatches('(max-width: 768px)');
             var offset = ( isMobile ? MOBILE_MARGIN : DESKTOP_MARGIN ) * 2;
 
             if( isMobile ) {

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -127,7 +127,9 @@ angular.module('risevision.template-editor.directives')
           $scope.$watchGroup([
             'factory.blueprintData.width',
             'factory.blueprintData.height'
-          ], _applyAspectRatio);
+          ], function() {
+            setTimeout(_applyAspectRatio, 5000);
+          });
 
           function _onResize() {
             _applyAspectRatio();

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -72,7 +72,10 @@ angular.module('risevision.template-editor.directives')
           }
 
           $scope.getDesktopWidth = function() {
-            return _getWidthFor(previewHolder.clientHeight).toFixed(0);
+            var offset = 2 * DESKTOP_MARGIN;
+            var height = previewHolder.clientHeight - offset;
+
+            return _getWidthFor(height).toFixed(0);
           }
 
           $scope.getTemplateAspectRatio = function() {


### PR DESCRIPTION
Solves:
- The preview bottom margin issue. Some browsers were initially reporting a slightly higher client width and height, which was corrected if the window was resized shortly after. I assume it's related to the browser's own layer size calculations. So as workaround I added a small delay for the calculation and it worked.
- I also considered the margin on the calculations for desktop width.
- The mobile problem with small heights, was solved by taking into account the short mobile rule here: https://github.com/Rise-Vision/common-header/blob/master/src/scss/sections/template-editor-layout.scss#L44

Demo: https://apps-stage-9.risevision.com/templates/edit/c88d9cfd-5d49-467f-8e3e-0615c7e5fdf6?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c