### PR TITLE
Always save text changes in Text component [stage-3]

### DIFF
--- a/web/partials/template-editor/components/component-text.html
+++ b/web/partials/template-editor/components/component-text.html
@@ -1,3 +1,3 @@
 <div class="row attribute-row">
-  <input type="text" class="form-control" ng-model="value" placeholder="Enter your text">
+  <input type="text" class="form-control" ng-model="value" placeholder="Enter your text" ng-change="save()">
 </div>

--- a/web/scripts/template-editor/components/directives/dtv-component-text.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-text.js
@@ -13,9 +13,9 @@ angular.module('risevision.template-editor.directives')
             $scope.value = $scope.getAttributeData($scope.componentId, 'value');
           }
 
-          function _save() {
+          $scope.save = function() {
             $scope.setAttributeData($scope.componentId, 'value', $scope.value);
-          }
+          };
 
           $scope.registerDirective({
             type: 'rise-text',
@@ -25,10 +25,6 @@ angular.module('risevision.template-editor.directives')
               element.show();
               $scope.componentId = $scope.factory.selected.id;
               _load();
-            },
-            onBackHandler: function () {
-              _save();
-              return false;
             }
           });
 


### PR DESCRIPTION
@andrecardoso please review. There is no callback for the "Save" button, so the component's directive can't capture the moment when this button is pressed. I opted out for saving on every text change in `<input>` element. I think this is a better option as it gives user immediate visual feedback in Preview.