### PR TITLE
Refactor e2e template editor tests to make them "component friendly"

### DIFF
--- a/test/e2e/editor/pages/storeProductsModalPage.js
+++ b/test/e2e/editor/pages/storeProductsModalPage.js
@@ -29,8 +29,6 @@ var StoreProductsModalPage = function() {
   var addWidgetByUrlButton = element(by.id('addWidgetByUrl'));
   var closeButton = element(by.css('.close'));
 
-  var addExampleTemplate = element(by.id('example-financial-template'));
-
   this.getFreeProducts = function() {
     return freeProducts;
   }
@@ -131,8 +129,9 @@ var StoreProductsModalPage = function() {
     return closeButton;
   };
 
-  this.getAddExampleTemplate = function() {
-    return addExampleTemplate;
+  this.getAddButtonById = function(id) {
+    return element(by.id(id));
+    ;
   };
 };
 

--- a/test/e2e/editor/pages/storeProductsModalPage.js
+++ b/test/e2e/editor/pages/storeProductsModalPage.js
@@ -131,7 +131,6 @@ var StoreProductsModalPage = function() {
 
   this.getAddButtonById = function(id) {
     return element(by.id(id));
-    ;
   };
 };
 

--- a/test/e2e/template-editor/cases/components/financial.js
+++ b/test/e2e/template-editor/cases/components/financial.js
@@ -1,0 +1,77 @@
+'use strict';
+
+var expect = require('rv-common-e2e').expect;
+var PresentationListPage = require('./../../pages/presentationListPage.js');
+var TemplateEditorPage = require('./../../pages/templateEditorPage.js');
+var helper = require('rv-common-e2e').helper;
+
+var FinancialComponentScenarios = function () {
+
+  browser.driver.manage().window().setSize(1920, 1080);
+
+  describe('Financial Component', function () {
+    var testStartTime = Date.now();
+    var presentationName = 'Financial Component Presentation - ' + testStartTime;
+    var presentationsListPage;
+    var templateEditorPage;
+
+    before(function () {
+      presentationsListPage = new PresentationListPage();
+      templateEditorPage = new TemplateEditorPage();
+
+      presentationsListPage.loadCurrentCompanyPresentationList();
+      presentationsListPage.createNewPresentationFromTemplate("Example Financial Template", "example-financial-template");
+    });
+
+    describe('basic operations', function () {
+
+      function _loadFinancialSelector() {
+        helper.wait(templateEditorPage.getAttributeList(), 'Attribute List');
+        helper.wait(templateEditorPage.getFinancialComponentEdit(), 'Financial Component Edit');
+        helper.clickWhenClickable(templateEditorPage.getFinancialComponentEdit(), 'Financial Component Edit');
+        expect(templateEditorPage.getAddCurrenciesButton().isEnabled()).to.eventually.be.true;
+      }
+
+      it('should show one Financial Component', function () {
+        // presentationsListPage.loadPresentation(presentationName);
+        _loadFinancialSelector();
+        expect(templateEditorPage.getInstrumentItems().count()).to.eventually.equal(3);
+      });
+
+      it('should show open the Instrument Selector', function () {
+        helper.wait(templateEditorPage.getAddCurrenciesButton(), 'Add Currencies');
+        helper.clickWhenClickable(templateEditorPage.getAddCurrenciesButton(), 'Add Currencies');
+        expect(templateEditorPage.getAddInstrumentButton().isPresent()).to.eventually.be.true;
+      });
+
+      it('should add JPY/USD instrument', function () {
+        helper.wait(templateEditorPage.getJpyUsdSelector(), 'JPY/USD Selector');
+        helper.clickWhenClickable(templateEditorPage.getJpyUsdSelector(), 'JPY/USD Selector');
+        helper.wait(templateEditorPage.getAddInstrumentButton(), 'Add Instrument');
+        helper.clickWhenClickable(templateEditorPage.getAddInstrumentButton(), 'Add Instrument');
+        expect(templateEditorPage.getAddCurrenciesButton().isPresent()).to.eventually.be.true;
+      });
+
+      it('should save the Presentation, reload it, and validate changes were saved', function () {
+
+        presentationsListPage.changePresentationName(presentationName);
+        presentationsListPage.savePresentation();
+
+        //log presentaion / company URL for troubeshooting 
+        browser.getCurrentUrl().then(function(actualUrl) {
+          console.log(actualUrl);
+        });
+        browser.sleep(100);
+
+        expect(templateEditorPage.getSaveButton().isEnabled()).to.eventually.be.true;
+
+        presentationsListPage.loadPresentation(presentationName);
+        _loadFinancialSelector();
+
+        expect(templateEditorPage.getInstrumentItems().count()).to.eventually.equal(4);
+      });
+    });
+  });
+};
+
+module.exports = FinancialComponentScenarios;

--- a/test/e2e/template-editor/cases/template-editor-add.js
+++ b/test/e2e/template-editor/cases/template-editor-add.js
@@ -1,9 +1,5 @@
 'use strict';
 var expect = require('rv-common-e2e').expect;
-var CommonHeaderPage = require('./../../../../web/bower_components/common-header/test/e2e/pages/commonHeaderPage.js');
-var HomePage = require('./../../launcher/pages/homepage.js');
-var SignInPage = require('./../../launcher/pages/signInPage.js');
-var PlansModalPage = require('./../../common/pages/plansModalPage.js');
 var PresentationListPage = require('./../pages/presentationListPage.js');
 var TemplateEditorPage = require('./../pages/templateEditorPage.js');
 var helper = require('rv-common-e2e').helper;
@@ -12,41 +8,11 @@ var TemplateAddScenarios = function() {
 
   browser.driver.manage().window().setSize(1920, 1080);
 
-  describe('Template Editor', function () {
+  describe('Template Editor Add', function () {
     var testStartTime = Date.now();
-    var subCompanyName = 'E2E TEST SUBCOMPANY - TEMPLATE EDITOR';
     var presentationName = 'Example Presentation - ' + testStartTime;
-    var commonHeaderPage;
-    var homepage;
-    var signInPage;
-    var plansModalPage;
     var presentationsListPage;
     var templateEditorPage;
-
-    function _loadPresentationsList() {
-      homepage.getEditor();
-      signInPage.signIn();
-    }
-
-    function _createSubCompany() {
-      commonHeaderPage.createSubCompany(subCompanyName);
-    }
-
-    function _selectSubCompany() {
-      commonHeaderPage.selectSubCompany(subCompanyName);
-    }
-
-    function _startTrial() {
-      helper.waitDisappear(presentationsListPage.getPresentationsLoader(), 'Presentation loader');
-      helper.wait(templateEditorPage.seePlansLink(), 'See Plans Link');
-      helper.clickWhenClickable(templateEditorPage.seePlansLink(), 'See Plans Link');
-
-      helper.wait(plansModalPage.getPlansModal(), 'Plans Modal');
-      helper.wait(plansModalPage.getStartTrialBasicButton(), 'Start Trial Basic Button');
-      helper.clickWhenClickable(plansModalPage.getStartTrialBasicButton(), 'Start Trial Basic Button');
-
-      helper.waitDisappear(plansModalPage.getPlansModal(), 'Plans Modal');
-    }
 
     function _loadCurrentCompanyPresentationList() {
       helper.clickWhenClickable(templateEditorPage.getPresentationsListLink(), 'Presentations List');
@@ -69,22 +35,8 @@ var TemplateAddScenarios = function() {
     }
 
     before(function () {
-      commonHeaderPage = new CommonHeaderPage();
-      homepage = new HomePage();
-      signInPage = new SignInPage();
       presentationsListPage = new PresentationListPage();
-      plansModalPage = new PlansModalPage();
       templateEditorPage = new TemplateEditorPage();
-
-      _loadPresentationsList();
-      _createSubCompany();
-      _selectSubCompany();
-      _startTrial();
-      // Sometimes the trial does not start in time; this section tries to reduce the number of times this step fails
-      browser.sleep(5000);
-      _loadPresentationsList();
-      _selectSubCompany();
-      // Continue as usual
       presentationsListPage.openNewExampleTemplate();
     });
 
@@ -172,12 +124,6 @@ var TemplateAddScenarios = function() {
 
         expect(templateEditorPage.getInstrumentItems().count()).to.eventually.equal(4);
       });
-    });
-
-    after(function() {
-      // Loading the Presentation List is a workaround to a Chrome Driver issue that has it fail to click on elements over the Preview iframe
-      _loadCurrentCompanyPresentationList();
-      commonHeaderPage.deleteCurrentCompany();
     });
   });
 };

--- a/test/e2e/template-editor/cases/template-editor-add.js
+++ b/test/e2e/template-editor/cases/template-editor-add.js
@@ -14,30 +14,10 @@ var TemplateAddScenarios = function() {
     var presentationsListPage;
     var templateEditorPage;
 
-    function _loadCurrentCompanyPresentationList() {
-      helper.clickWhenClickable(templateEditorPage.getPresentationsListLink(), 'Presentations List');
-      helper.waitDisappear(presentationsListPage.getPresentationsLoader(), 'Presentation loader');
-    }
-
-    function _loadPresentation (presentationName) {
-      _loadCurrentCompanyPresentationList();
-      helper.clickWhenClickable(templateEditorPage.getCreatedPresentationLink(presentationName), 'Presentation Link');
-      helper.waitDisappear(presentationsListPage.getPresentationsLoader(), 'Presentation loader');
-      helper.wait(templateEditorPage.getAttributeList(), 'Attribute List');
-      browser.sleep(500); // Wait for transition to finish
-    }
-
-    function _savePresentation () {
-      helper.wait(templateEditorPage.getSaveButton(), 'Save Button');
-      helper.clickWhenClickable(templateEditorPage.getSaveButton(), 'Save Button');
-      expect(templateEditorPage.getSaveButton().getText()).to.eventually.equal('Saving');
-      helper.wait(templateEditorPage.getSaveButton(), 'Save Button');
-    }
-
     before(function () {
       presentationsListPage = new PresentationListPage();
       templateEditorPage = new TemplateEditorPage();
-      presentationsListPage.openNewExampleTemplate();
+      presentationsListPage.createNewPresentationFromTemplate("Example Financial Template", "example-financial-template");
     });
 
     describe('basic operations', function () {
@@ -47,22 +27,20 @@ var TemplateAddScenarios = function() {
       });
 
       it('should edit the Presentation name', function () {
-        expect(templateEditorPage.getPresentationName().isEnabled()).to.eventually.be.false;
-        templateEditorPage.getEditNameButton().click();
-        expect(templateEditorPage.getPresentationName().isEnabled()).to.eventually.be.true;
-        templateEditorPage.getPresentationName().sendKeys(presentationName + protractor.Key.ENTER);
+        presentationsListPage.changePresentationName(presentationName);
+        expect(templateEditorPage.getPresentationName().getAttribute('value')).to.eventually.equal(presentationName);
       });
 
       it('should save the Presentation', function () {
-        _savePresentation();
+        presentationsListPage.savePresentation();
 
         expect(templateEditorPage.getSaveButton().isEnabled()).to.eventually.be.true;
       });
 
       it('should publish the Presentation', function () {
         // Since the first time a Presentation is saved it's also Published, to test the button an additional Save is needed
-        _savePresentation();
-        _savePresentation();
+        presentationsListPage.savePresentation();
+        presentationsListPage.savePresentation();
 
         helper.clickWhenClickable(templateEditorPage.getPublishButton(), 'Publish Button');
         helper.wait(templateEditorPage.getSaveButton(), 'Save Button (after Publish)');
@@ -70,7 +48,7 @@ var TemplateAddScenarios = function() {
       });
 
       it('should load the newly created Presentation', function () {
-        _loadPresentation(presentationName);
+        presentationsListPage.loadPresentation(presentationName);
 
         expect(templateEditorPage.getComponentItems().count()).to.eventually.be.above(1);
         expect(templateEditorPage.getImageComponentEdit().isPresent()).to.eventually.be.true;
@@ -84,45 +62,6 @@ var TemplateAddScenarios = function() {
         helper.wait(templateEditorPage.getAttributeList(), 'Attribute List');
         browser.sleep(500); // Wait for transition to finish
         expect(templateEditorPage.getComponentItems().count()).to.eventually.be.above(1);
-      });
-
-      function _loadFinancialSelector () {
-        helper.wait(templateEditorPage.getAttributeList(), 'Attribute List');
-        helper.wait(templateEditorPage.getFinancialComponentEdit(), 'Financial Component Edit');
-        helper.clickWhenClickable(templateEditorPage.getFinancialComponentEdit(), 'Financial Component Edit');
-        expect(templateEditorPage.getAddCurrenciesButton().isEnabled()).to.eventually.be.true;
-      }
-
-      it('should show one Financial Component', function () {
-        _loadPresentation(presentationName);
-        _loadFinancialSelector();
-        expect(templateEditorPage.getInstrumentItems().count()).to.eventually.equal(3);
-      });
-
-      it('should show open the Instrument Selector', function () {
-        helper.wait(templateEditorPage.getAddCurrenciesButton(), 'Add Currencies');
-        helper.clickWhenClickable(templateEditorPage.getAddCurrenciesButton(), 'Add Currencies');
-        expect(templateEditorPage.getAddInstrumentButton().isPresent()).to.eventually.be.true;
-      });
-
-      it('should add JPY/USD instrument', function () {
-        helper.wait(templateEditorPage.getJpyUsdSelector(), 'JPY/USD Selector');
-        helper.clickWhenClickable(templateEditorPage.getJpyUsdSelector(), 'JPY/USD Selector');
-        helper.wait(templateEditorPage.getAddInstrumentButton(), 'Add Instrument');
-        helper.clickWhenClickable(templateEditorPage.getAddInstrumentButton(), 'Add Instrument');
-        expect(templateEditorPage.getAddCurrenciesButton().isPresent()).to.eventually.be.true;
-      });
-
-      it('should save the Presentation, reload it, and validate changes were saved', function () {
-        helper.wait(templateEditorPage.getSaveButton(), 'Save Button');
-        helper.clickWhenClickable(templateEditorPage.getSaveButton(), 'Save Button');
-        expect(templateEditorPage.getSaveButton().getText()).to.eventually.equal('Saving');
-        helper.wait(templateEditorPage.getSaveButton(), 'Save Button');
-
-        _loadPresentation(presentationName);
-        _loadFinancialSelector();
-
-        expect(templateEditorPage.getInstrumentItems().count()).to.eventually.equal(4);
       });
     });
   });

--- a/test/e2e/template-editor/pages/presentationListPage.js
+++ b/test/e2e/template-editor/pages/presentationListPage.js
@@ -1,6 +1,9 @@
 'use strict';
 
+var expect = require('rv-common-e2e').expect;
 var helper = require('rv-common-e2e').helper;
+var HomePage = require('./../../launcher/pages/homepage.js');
+var SignInPage = require('./../../launcher/pages/signInPage.js');
 var StoreProductsModalPage = require('../../editor/pages/storeProductsModalPage.js');
 var TemplateEditorPage = require('./templateEditorPage.js');
 
@@ -12,22 +15,57 @@ var PresentationListPage = function() {
 
   var presentationsLoader = element(by.xpath('//div[@spinner-key="presentation-list-loader"]'));
 
-  this.openNewExampleTemplate = function() {
-    var storeProductsModalPage = new StoreProductsModalPage();
-    var templateEditorPage = new TemplateEditorPage();
+  var homepage = new HomePage();
+  var signInPage = new SignInPage();
+  var storeProductsModalPage = new StoreProductsModalPage();
+  var templateEditorPage = new TemplateEditorPage();
+
+  this.createNewPresentationFromTemplate = function(templateName, addTemplateButtonId) {
 
     helper.waitDisappear(presentationsLoader, 'Presentation loader');
     helper.wait(presentationAddButton, 'Add Presentation Button');
     helper.clickWhenClickable(presentationAddButton, 'Add Presentation Button');
     helper.wait(storeProductsModalPage.getStoreProductsModal(), 'Select Content Modal');
     helper.waitDisappear(storeProductsModalPage.getStoreProductsLoader(), 'Store Products Loader');
-    storeProductsModalPage.getSearchInput().sendKeys('Example Financial');
-    helper.wait(storeProductsModalPage.getAddExampleTemplate(), 'Add Example Template Button');
-    helper.clickWhenClickable(storeProductsModalPage.getAddExampleTemplate(), 'Add Example Template Button');
+    storeProductsModalPage.getSearchInput().sendKeys('"' + templateName + '"');
+    helper.wait(storeProductsModalPage.getAddButtonById(addTemplateButtonId), 'Add Example Template Button');
+    helper.clickWhenClickable(storeProductsModalPage.getAddButtonById(addTemplateButtonId), 'Add Example Template Button');
 
     helper.wait(templateEditorPage.getTemplateEditorContainer(), 'Template Editor Container');
     browser.sleep(500);
   };
+
+  this.loadPresentationsList = function() {
+    homepage.getEditor();
+    signInPage.signIn();
+  }
+
+  this.loadCurrentCompanyPresentationList = function() {
+    helper.clickWhenClickable(templateEditorPage.getPresentationsListLink(), 'Presentations List');
+    helper.waitDisappear(this.getPresentationsLoader(), 'Presentation loader');
+  }
+
+  this.loadPresentation = function(presentationName) {
+    this.loadCurrentCompanyPresentationList();
+    helper.clickWhenClickable(templateEditorPage.getCreatedPresentationLink(presentationName), 'Presentation Link');
+    helper.waitDisappear(this.getPresentationsLoader(), 'Presentation loader');
+    helper.wait(templateEditorPage.getAttributeList(), 'Attribute List');
+    browser.sleep(500); // Wait for transition to finish
+  }
+
+  this.savePresentation = function() {
+    helper.wait(templateEditorPage.getSaveButton(), 'Save Button');
+    helper.clickWhenClickable(templateEditorPage.getSaveButton(), 'Save Button');
+    expect(templateEditorPage.getSaveButton().getText()).to.eventually.equal('Saving');
+    helper.wait(templateEditorPage.getSaveButton(), 'Save Button');
+  }
+
+  this.changePresentationName = function(presentationName) {
+    expect(templateEditorPage.getPresentationName().isEnabled()).to.eventually.be.false;
+    templateEditorPage.getEditNameButton().click();
+    expect(templateEditorPage.getPresentationName().isEnabled()).to.eventually.be.true;
+    templateEditorPage.getPresentationName().sendKeys(presentationName + protractor.Key.ENTER);
+}
 
   this.getPresentationAddButton = function() {
     return presentationAddButton;

--- a/test/e2e/template-editor/template-editor.cases.js
+++ b/test/e2e/template-editor/template-editor.cases.js
@@ -1,31 +1,22 @@
 (function() {
   'use strict';
 
-  var expect = require('rv-common-e2e').expect;
   var CommonHeaderPage = require('./../../../web/bower_components/common-header/test/e2e/pages/commonHeaderPage.js');
-  var HomePage = require('./../launcher/pages/homepage.js');
-  var SignInPage = require('./../launcher/pages/signInPage.js');
   var PlansModalPage = require('./../common/pages/plansModalPage.js');
   var PresentationListPage = require('./pages/presentationListPage.js');
   var TemplateEditorPage = require('./pages/templateEditorPage.js');
   var helper = require('rv-common-e2e').helper;
   
   var TemplateEditorAddScenarios = require('./cases/template-editor-add.js');
+  var FinancialComponentScenarios = require('./cases/components/financial.js');
 
   describe('Template Editor', function() {
 
     var subCompanyName = 'E2E TEST SUBCOMPANY - TEMPLATE EDITOR';
     var commonHeaderPage;
-    var homepage;
-    var signInPage;
     var plansModalPage;
     var presentationsListPage;
     var templateEditorPage;
-
-    function _loadPresentationsList() {
-      homepage.getEditor();
-      signInPage.signIn();
-    }
 
     function _createSubCompany() {
       commonHeaderPage.createSubCompany(subCompanyName);
@@ -47,34 +38,28 @@
       helper.waitDisappear(plansModalPage.getPlansModal(), 'Plans Modal');
     }
 
-    function _loadCurrentCompanyPresentationList() {
-      helper.clickWhenClickable(templateEditorPage.getPresentationsListLink(), 'Presentations List');
-      helper.waitDisappear(presentationsListPage.getPresentationsLoader(), 'Presentation loader');
-    }
-
     before(function () {
       commonHeaderPage = new CommonHeaderPage();
-      homepage = new HomePage();
-      signInPage = new SignInPage();
       presentationsListPage = new PresentationListPage();
       plansModalPage = new PlansModalPage();
       templateEditorPage = new TemplateEditorPage();
 
-      _loadPresentationsList();
+      presentationsListPage.loadPresentationsList();
       _createSubCompany();
       _selectSubCompany();
       _startTrial();
       // Sometimes the trial does not start in time; this section tries to reduce the number of times this step fails
       browser.sleep(5000);
-      _loadPresentationsList();
+      presentationsListPage.loadPresentationsList();
       _selectSubCompany();
     });
 
     var templateEditorAddScenarios = new TemplateEditorAddScenarios();
+    var financialComponentScenarios = new FinancialComponentScenarios();
 
     after(function() {
       // Loading the Presentation List is a workaround to a Chrome Driver issue that has it fail to click on elements over the Preview iframe
-      _loadCurrentCompanyPresentationList();
+      presentationsListPage.loadCurrentCompanyPresentationList();
       commonHeaderPage.deleteCurrentCompany();
     });
   });

--- a/test/e2e/template-editor/template-editor.cases.js
+++ b/test/e2e/template-editor/template-editor.cases.js
@@ -1,10 +1,81 @@
 (function() {
   'use strict';
 
+  var expect = require('rv-common-e2e').expect;
+  var CommonHeaderPage = require('./../../../web/bower_components/common-header/test/e2e/pages/commonHeaderPage.js');
+  var HomePage = require('./../launcher/pages/homepage.js');
+  var SignInPage = require('./../launcher/pages/signInPage.js');
+  var PlansModalPage = require('./../common/pages/plansModalPage.js');
+  var PresentationListPage = require('./pages/presentationListPage.js');
+  var TemplateEditorPage = require('./pages/templateEditorPage.js');
+  var helper = require('rv-common-e2e').helper;
+  
   var TemplateEditorAddScenarios = require('./cases/template-editor-add.js');
 
-  describe('Editor', function() {
-    var templateEditorAddScenarios = new TemplateEditorAddScenarios();
-  });
+  describe('Template Editor', function() {
 
+    var subCompanyName = 'E2E TEST SUBCOMPANY - TEMPLATE EDITOR';
+    var commonHeaderPage;
+    var homepage;
+    var signInPage;
+    var plansModalPage;
+    var presentationsListPage;
+    var templateEditorPage;
+
+    function _loadPresentationsList() {
+      homepage.getEditor();
+      signInPage.signIn();
+    }
+
+    function _createSubCompany() {
+      commonHeaderPage.createSubCompany(subCompanyName);
+    }
+
+    function _selectSubCompany() {
+      commonHeaderPage.selectSubCompany(subCompanyName);
+    }
+
+    function _startTrial() {
+      helper.waitDisappear(presentationsListPage.getPresentationsLoader(), 'Presentation loader');
+      helper.wait(templateEditorPage.seePlansLink(), 'See Plans Link');
+      helper.clickWhenClickable(templateEditorPage.seePlansLink(), 'See Plans Link');
+
+      helper.wait(plansModalPage.getPlansModal(), 'Plans Modal');
+      helper.wait(plansModalPage.getStartTrialBasicButton(), 'Start Trial Basic Button');
+      helper.clickWhenClickable(plansModalPage.getStartTrialBasicButton(), 'Start Trial Basic Button');
+
+      helper.waitDisappear(plansModalPage.getPlansModal(), 'Plans Modal');
+    }
+
+    function _loadCurrentCompanyPresentationList() {
+      helper.clickWhenClickable(templateEditorPage.getPresentationsListLink(), 'Presentations List');
+      helper.waitDisappear(presentationsListPage.getPresentationsLoader(), 'Presentation loader');
+    }
+
+    before(function () {
+      commonHeaderPage = new CommonHeaderPage();
+      homepage = new HomePage();
+      signInPage = new SignInPage();
+      presentationsListPage = new PresentationListPage();
+      plansModalPage = new PlansModalPage();
+      templateEditorPage = new TemplateEditorPage();
+
+      _loadPresentationsList();
+      _createSubCompany();
+      _selectSubCompany();
+      _startTrial();
+      // Sometimes the trial does not start in time; this section tries to reduce the number of times this step fails
+      browser.sleep(5000);
+      _loadPresentationsList();
+      _selectSubCompany();
+    });
+
+    var templateEditorAddScenarios = new TemplateEditorAddScenarios();
+
+    after(function() {
+      // Loading the Presentation List is a workaround to a Chrome Driver issue that has it fail to click on elements over the Preview iframe
+      _loadCurrentCompanyPresentationList();
+      commonHeaderPage.deleteCurrentCompany();
+    });
+  });
 })();


### PR DESCRIPTION
- Create test sub-company once and re-use for all  template-editor test cases
- Test cases for the editor and financial component are separated

@andrecardoso please review.
@fjvallarino I wonder f you could review it too.

@alex-deaconu @ezequielc @stulees @santiagonoguez FYI 