### PR TITLE
Feature/images list support default images

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-image.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.tests.js
@@ -51,7 +51,7 @@ describe('directive: TemplateComponentImage', function() {
     $scope.showNextPanel = sinon.stub();
     $scope.getBlueprintData = function() {
       return null;
-    }
+    };
 
     timeout = $timeout;
     element = $compile("<template-component-image></template-component-image>")($scope);
@@ -80,7 +80,7 @@ describe('directive: TemplateComponentImage', function() {
 
     $scope.getAttributeData = function() {
       return sampleImages;
-    }
+    };
 
     directive.show();
 
@@ -97,10 +97,10 @@ describe('directive: TemplateComponentImage', function() {
 
     $scope.getAttributeData = function() {
       return sampleImages;
-    }
+    };
     $scope.getBlueprintData = function() {
       return "image.png";
-    }
+    };
 
     directive.show();
 
@@ -117,10 +117,10 @@ describe('directive: TemplateComponentImage', function() {
 
     $scope.getAttributeData = function() {
       return sampleImages;
-    }
+    };
     $scope.getBlueprintData = function() {
       return "default.png";
-    }
+    };
 
     directive.show();
 
@@ -135,10 +135,10 @@ describe('directive: TemplateComponentImage', function() {
 
     $scope.getAttributeData = function() {
       return null;
-    }
+    };
     $scope.getBlueprintData = function() {
       return TEST_FILE;
-    }
+    };
 
     directive.show();
     timeout.flush();

--- a/test/unit/template-editor/components/directives/dtv-component-image.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.tests.js
@@ -49,6 +49,9 @@ describe('directive: TemplateComponentImage', function() {
     $scope.registerDirective = sinon.stub();
     $scope.setAttributeData = sinon.stub();
     $scope.showNextPanel = sinon.stub();
+    $scope.getBlueprintData = function() {
+      return null;
+    }
 
     timeout = $timeout;
     element = $compile("<template-component-image></template-component-image>")($scope);
@@ -82,6 +85,46 @@ describe('directive: TemplateComponentImage', function() {
     directive.show();
 
     expect($scope.selectedImages).to.deep.equal(sampleImages);
+
+    timeout.flush();
+  });
+
+  it('should detect default images', function() {
+    var directive = $scope.registerDirective.getCall(0).args[0];
+    var sampleImages = [
+      { "file": "image.png", "thumbnail-url": "http://image" }
+    ];
+
+    $scope.getAttributeData = function() {
+      return sampleImages;
+    }
+    $scope.getBlueprintData = function() {
+      return "image.png";
+    }
+
+    directive.show();
+
+    expect($scope.isDefaultImageList).to.be.true;
+
+    timeout.flush();
+  });
+
+  it('should not consider a default value if it is not', function() {
+    var directive = $scope.registerDirective.getCall(0).args[0];
+    var sampleImages = [
+      { "file": "image.png", "thumbnail-url": "http://image" }
+    ];
+
+    $scope.getAttributeData = function() {
+      return sampleImages;
+    }
+    $scope.getBlueprintData = function() {
+      return "default.png";
+    }
+
+    directive.show();
+
+    expect($scope.isDefaultImageList).to.be.false;
 
     timeout.flush();
   });

--- a/web/scripts/displays/controllers/ctr-display-details.js
+++ b/web/scripts/displays/controllers/ctr-display-details.js
@@ -89,7 +89,8 @@ angular.module('risevision.displays.controllers')
       };
 
       $scope.isProAvailable = function () {
-        return playerLicenseFactory.hasProfessionalLicenses() && $scope.getProLicenseCount() > 0 && !$scope.areAllProLicensesUsed();
+        return playerLicenseFactory.hasProfessionalLicenses() && $scope.getProLicenseCount() > 0 && !$scope
+          .areAllProLicensesUsed();
       };
 
       $scope.isProSupported = function () {

--- a/web/scripts/template-editor/components/directives/dtv-component-financial.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-financial.js
@@ -37,7 +37,8 @@ angular.module('risevision.template-editor.directives')
             var symbolString = $scope.getBlueprintData($scope.componentId, 'symbols');
 
             if (!symbolString) {
-              $log.error('The component blueprint data is not providing default symbols value: ' + $scope.componentId);
+              $log.error('The component blueprint data is not providing default symbols value: ' + $scope
+                .componentId);
 
               return;
             }
@@ -124,7 +125,8 @@ angular.module('risevision.template-editor.directives')
               }, 1000);
             },
             isHeaderBottomRuleVisible: function () {
-              return $scope.enteringInstrumentSelector || $scope.showInstrumentList || $scope.exitingInstrumentSelector ||
+              return $scope.enteringInstrumentSelector || $scope.showInstrumentList || $scope
+                .exitingInstrumentSelector ||
                 $scope.exitingSymbolSelector;
             },
             onBackHandler: function () {

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -18,7 +18,8 @@ angular.module('risevision.template-editor.directives')
             },
             addFile: function (file) {
               console.log('Added file to uploadManager', file);
-              var selectedImages = _.cloneDeep($scope.selectedImages);
+              var selectedImages = $scope.isDefaultImageList ? [] : _.cloneDeep($scope.selectedImages);
+
               var newFile = {
                 file: file.name,
                 'thumbnail-url': file.metadata.thumbnail
@@ -40,6 +41,7 @@ angular.module('risevision.template-editor.directives')
           function _reset() {
             $scope.selectedImages = [];
             $scope.isUploading = false;
+            $scope.isDefaultImageList = false;
           }
 
           function _loadSelectedImages() {
@@ -52,9 +54,13 @@ angular.module('risevision.template-editor.directives')
             }
           }
 
+          function _getDefaultFilesAttribute() {
+            return $scope.getBlueprintData($scope.componentId, 'files');
+          }
+
           function _buildSelectedImagesFromBlueprint() {
             $scope.factory.loadingPresentation = true;
-            var files = $scope.getBlueprintData($scope.componentId, 'files');
+            var files = _getDefaultFilesAttribute();
 
             var metadata = [];
             var fileNames = files ? files.split('|') : [];
@@ -134,10 +140,13 @@ angular.module('risevision.template-editor.directives')
 
           function _setMetadata(metadata) {
             var value = angular.copy(metadata);
+            var filesAttribute = _filesAttributeFor(value);
 
             $scope.selectedImages = value;
+            $scope.isDefaultImageList = filesAttribute === _getDefaultFilesAttribute();
+
             $scope.setAttributeData($scope.componentId, 'metadata', value);
-            $scope.setAttributeData($scope.componentId, 'files', _filesAttributeFor(value));
+            $scope.setAttributeData($scope.componentId, 'files', filesAttribute);
           }
 
           _reset();

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -39,16 +39,15 @@ angular.module('risevision.template-editor.directives')
           };
 
           function _reset() {
-            $scope.selectedImages = [];
+            _setSelectedImages([]);
             $scope.isUploading = false;
-            $scope.isDefaultImageList = false;
           }
 
           function _loadSelectedImages() {
             var selectedImages = $scope.getAttributeData($scope.componentId, 'metadata');
 
             if (selectedImages) {
-              $scope.selectedImages = selectedImages;
+              _setSelectedImages(selectedImages);
             } else {
               _buildSelectedImagesFromBlueprint();
             }
@@ -139,14 +138,20 @@ angular.module('risevision.template-editor.directives')
           }
 
           function _setMetadata(metadata) {
-            var value = angular.copy(metadata);
-            var filesAttribute = _filesAttributeFor(value);
+            var selectedImages = angular.copy(metadata);
+            var filesAttribute = _filesAttributeFor(selectedImages);
 
-            $scope.selectedImages = value;
-            $scope.isDefaultImageList = filesAttribute === _getDefaultFilesAttribute();
+            _setSelectedImages(selectedImages);
 
-            $scope.setAttributeData($scope.componentId, 'metadata', value);
+            $scope.setAttributeData($scope.componentId, 'metadata', selectedImages);
             $scope.setAttributeData($scope.componentId, 'files', filesAttribute);
+          }
+
+          function _setSelectedImages(selectedImages) {
+            var filesAttribute = _filesAttributeFor(selectedImages);
+
+            $scope.selectedImages = selectedImages;
+            $scope.isDefaultImageList = filesAttribute === _getDefaultFilesAttribute();
           }
 
           _reset();

--- a/web/scripts/widgets/common/services/svc-oauth.js
+++ b/web/scripts/widgets/common/services/svc-oauth.js
@@ -10,7 +10,8 @@ angular.module('risevision.widgets.services')
       var key = '';
 
       var _getRequestOptions = function () {
-        var authorization = (userState.getAccessToken().token_type === 'Bearer') ? userState.getAccessToken().token_type +
+        var authorization = (userState.getAccessToken().token_type === 'Bearer') ? userState.getAccessToken()
+          .token_type +
           ' ' + userState.getAccessToken().access_token : userState.getAccessToken().access_token;
         var requestOptions = {
           'headers': {
@@ -46,7 +47,8 @@ angular.module('risevision.widgets.services')
         var deferred = $q.defer();
         _getStatus()
           .then(function (response) {
-            if (response.data && Array.isArray(response.data.authenticated) && response.data.authenticated.length) {
+            if (response.data && Array.isArray(response.data.authenticated) && response.data.authenticated
+              .length) {
               key = userState.getSelectedCompanyId() + ':' + provider + ':' + response.data.authenticated[0];
               deferred.resolve(true);
             } else {


### PR DESCRIPTION
The default attributes are removed if a user makes an explicit selection. We consider the user is using the default attributes if the current items correspond exactly to the blueprint files.

The linter added 3 corrections to this PR, but the implementation here is dtv-component-image.js.

Validation: https://apps-stage-9.risevision.com/templates/edit/d4a5a9c7-2cc7-4f99-87cf-1e8457d0ea9a?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c
   -  Upload an image, and after that the default selection will disappear. Upload more images and that will have no effect on previous selections.
   - Please don't save the presentation so others can also test.
