### PR TITLE
Restrict image types displayed in Storage Selector, if a set of valid extensions is provided

### DIFF
--- a/test/unit/template-editor/directives/dtv-basic-storage-selector.tests.js
+++ b/test/unit/template-editor/directives/dtv-basic-storage-selector.tests.js
@@ -24,7 +24,7 @@ describe('directive: basicStorageSelector', function() {
   }));
 
   beforeEach(inject(function($injector, $compile, $rootScope, $templateCache) {
-    $rootScope.validExtensions = '.jpg';
+    $rootScope.validExtensions = '.jpg, .png';
     $rootScope.storageManager = {
       addSelectedItems: sandbox.stub()
     };
@@ -52,19 +52,6 @@ describe('directive: basicStorageSelector', function() {
     expect($scope.isSelected).to.be.a.function;
     expect($scope.addSelected).to.be.a.function;
     expect($scope.loadItems).to.be.a.function;
-  });
-
-  describe('isFolder', function () {
-    it('should return true for paths belonging to folders', function () {
-      expect($scope.isFolder('folder/')).to.be.true;
-      expect($scope.isFolder('folder/subfolder/')).to.be.true;
-    });
-
-    it('should return false for paths belonging to files', function () {
-      expect($scope.isFolder('')).to.be.false;
-      expect($scope.isFolder('file.txt')).to.be.false;
-      expect($scope.isFolder('folder/file.txt')).to.be.false;
-    });
   });
 
   describe('fileNameOf', function () {
@@ -122,6 +109,31 @@ describe('directive: basicStorageSelector', function() {
         name: 'folder/file1.jpg'
       }, {
         name: 'folder/file2.jpg'
+      }];
+
+      sandbox.stub(storage.files, 'get').returns(Q.resolve({ files: files }));
+
+      $scope.loadItems('folder/')
+      .then(function () {
+        expect($loading.start).to.have.been.called;
+        expect($loading.stop).to.have.been.called;
+        expect($scope.selectedItems).to.be.empty;
+        expect($scope.storageUploadManager.folderPath).to.equal('folder/');
+        expect($scope.folderItems).to.have.lengthOf(2);
+
+        done();
+      });
+    });
+
+    it('should only load the files with the provided extensions', function (done) {
+      var files = [{
+        name: 'folder/'
+      }, {
+        name: 'folder/file1.jpg'
+      }, {
+        name: 'folder/file2.png'
+      }, {
+        name: 'folder/file3.pdf'
       }];
 
       sandbox.stub(storage.files, 'get').returns(Q.resolve({ files: files }));

--- a/test/unit/template-editor/services/svc-template-editor-utils.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-utils.tests.js
@@ -95,4 +95,34 @@ describe('service: templateEditorUtils:', function() {
       expect(items).to.have.lengthOf(2);
     });
   });
+
+  describe('fileHasValidExtension', function () {
+    var extensions = ['.jpg', '.png', '.svg'];
+
+    it('should return true for files with valid extensions', function () {
+      expect(templateEditorUtils.fileHasValidExtension('test.jpg', extensions)).to.be.true;
+      expect(templateEditorUtils.fileHasValidExtension('folder/test.svg', extensions)).to.be.true;
+      expect(templateEditorUtils.fileHasValidExtension('folder/test.mpg')).to.be.true;
+      expect(templateEditorUtils.fileHasValidExtension('folder/test.mpg', [])).to.be.true;
+    });
+
+    it('should return false for files with not valid extensions', function () {
+      expect(templateEditorUtils.fileHasValidExtension('', extensions)).to.be.false;
+      expect(templateEditorUtils.fileHasValidExtension('folder/', extensions)).to.be.false;
+      expect(templateEditorUtils.fileHasValidExtension('folder/test.mpg', extensions)).to.be.false;
+    });
+  });
+
+  describe('isFolder', function () {
+    it('should return true for paths belonging to folders', function () {
+      expect(templateEditorUtils.isFolder('folder/')).to.be.true;
+      expect(templateEditorUtils.isFolder('folder/subfolder/')).to.be.true;
+    });
+
+    it('should return false for paths belonging to files', function () {
+      expect(templateEditorUtils.isFolder('')).to.be.false;
+      expect(templateEditorUtils.isFolder('file.txt')).to.be.false;
+      expect(templateEditorUtils.isFolder('folder/file.txt')).to.be.false;
+    });
+  });
 });

--- a/test/unit/template-editor/services/svc-template-editor-utils.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-utils.tests.js
@@ -99,11 +99,15 @@ describe('service: templateEditorUtils:', function() {
   describe('fileHasValidExtension', function () {
     var extensions = ['.jpg', '.png', '.svg'];
 
+    it('should return true if an empty list of extensions was provided', function () {
+      expect(templateEditorUtils.fileHasValidExtension('folder/test.mpg')).to.be.true;
+      expect(templateEditorUtils.fileHasValidExtension('folder/test.mpg', [])).to.be.true;
+    });
+
     it('should return true for files with valid extensions', function () {
       expect(templateEditorUtils.fileHasValidExtension('test.jpg', extensions)).to.be.true;
       expect(templateEditorUtils.fileHasValidExtension('folder/test.svg', extensions)).to.be.true;
-      expect(templateEditorUtils.fileHasValidExtension('folder/test.mpg')).to.be.true;
-      expect(templateEditorUtils.fileHasValidExtension('folder/test.mpg', [])).to.be.true;
+      expect(templateEditorUtils.fileHasValidExtension('folder/TEST.SVG', extensions)).to.be.true;
     });
 
     it('should return false for files with not valid extensions', function () {

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -2,7 +2,7 @@
 
 angular.module('risevision.template-editor.directives')
   .constant('DEFAULT_IMAGE_THUMBNAIL', 'https://s3.amazonaws.com/Rise-Images/UI/storage-image-icon%402x.png')
-  .constant('SUPPORTED_IMAGE_TYPES', '.png, .jpg, .gif, .tif, .tiff')
+  .constant('SUPPORTED_IMAGE_TYPES', '.png, .jpg, .gif, .tif, .tiff, .svg')
   .directive('templateComponentImage', ['$log', 'templateEditorFactory', 'templateEditorUtils', 'storageAPILoader',
     'DEFAULT_IMAGE_THUMBNAIL', 'SUPPORTED_IMAGE_TYPES',
     function ($log, templateEditorFactory, templateEditorUtils, storageAPILoader, DEFAULT_IMAGE_THUMBNAIL, SUPPORTED_IMAGE_TYPES) {

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -2,7 +2,7 @@
 
 angular.module('risevision.template-editor.directives')
   .constant('DEFAULT_IMAGE_THUMBNAIL', 'https://s3.amazonaws.com/Rise-Images/UI/storage-image-icon%402x.png')
-  .constant('SUPPORTED_IMAGE_TYPES', '.png, .jpg, .gif, .tif, .tiff, .svg')
+  .constant('SUPPORTED_IMAGE_TYPES', '.bmp, .gif, .jpeg, .jpg, .png, .tif, .tiff, .svg, .webp')
   .directive('templateComponentImage', ['$log', 'templateEditorFactory', 'templateEditorUtils', 'storageAPILoader',
     'DEFAULT_IMAGE_THUMBNAIL', 'SUPPORTED_IMAGE_TYPES',
     function ($log, templateEditorFactory, templateEditorUtils, storageAPILoader, DEFAULT_IMAGE_THUMBNAIL, SUPPORTED_IMAGE_TYPES) {

--- a/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
+++ b/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
@@ -13,6 +13,7 @@ angular.module('risevision.template-editor.directives')
         templateUrl: 'partials/template-editor/basic-storage-selector.html',
         link: function ($scope) {
           var spinnerId = 'storage-' + $scope.storageSelectorId + '-spinner';
+          var validExtensionsList = $scope.validExtensions ? $scope.validExtensions.split(',') : [];
 
           $scope.folderItems = [];
           $scope.selectedItems = [];
@@ -51,9 +52,7 @@ angular.module('risevision.template-editor.directives')
             $scope.storageUploadManager.folderPath = '';
           }
 
-          $scope.isFolder = function (path) {
-            return path[path.length - 1] === '/';
-          };
+          $scope.isFolder = templateEditorUtils.isFolder;
 
           $scope.fileNameOf = function (path) {
             var parts = path.split('/');
@@ -74,7 +73,9 @@ angular.module('risevision.template-editor.directives')
               $scope.selectedItems = [];
               $scope.storageUploadManager.folderPath = newFolderPath;
               $scope.folderItems = items.files.filter(function (item) {
-                return item.name !== newFolderPath;
+                var isValid = templateEditorUtils.fileHasValidExtension(item.name, validExtensionsList);
+
+                return item.name !== newFolderPath && ($scope.isFolder(item.name) || isValid);
               });
             })
             .catch(function (err) {

--- a/web/scripts/template-editor/services/svc-template-editor-utils.js
+++ b/web/scripts/template-editor/services/svc-template-editor-utils.js
@@ -34,6 +34,15 @@ angular.module('risevision.template-editor.services')
         return list;
       };
 
+      svc.isFolder = function (path) {
+        return path[path.length - 1] === '/';
+      };
+
+      svc.fileHasValidExtension = function (file, extensions) {
+        return !extensions || extensions.length === 0 || _.some(extensions, function (extension) {
+          return _.endsWith(file, extension.trim());
+        });
+      };
+
       return svc;
     }]);
-

--- a/web/scripts/template-editor/services/svc-template-editor-utils.js
+++ b/web/scripts/template-editor/services/svc-template-editor-utils.js
@@ -40,7 +40,7 @@ angular.module('risevision.template-editor.services')
 
       svc.fileHasValidExtension = function (file, extensions) {
         return !extensions || extensions.length === 0 || _.some(extensions, function (extension) {
-          return _.endsWith(file, extension.trim());
+          return _.endsWith(file.toLowerCase(), extension.trim().toLowerCase());
         });
       };
 


### PR DESCRIPTION
This PR adds filtering of valid file types (if a list of extensions is provided) to Storage Selector. It also adds .svg as a valid file type for uploads.

You can test with: https://apps-stage-7.risevision.com/templates/edit/1919032c-a981-42ac-98fb-0d0d5731c978?cid=87977ab8-38b6-47fb-ad5e-256b8cc4b46d

@santiagonoguez please review
