### PR TITLE
Add explicit check for valid formats on Upload

### DIFF
--- a/test/unit/template-editor/services/svc-template-editor-factory.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-factory.tests.js
@@ -57,8 +57,10 @@ describe('service: templateEditorFactory:', function() {
       });
     });
 
-    $provide.factory('messageBox', function() {
-      return sandbox.stub();
+    $provide.factory('templateEditorUtils', function() {
+      return {
+        showMessageWindow: sandbox.stub()
+      };
     });
 
     $provide.factory('$modal', function() {
@@ -78,7 +80,7 @@ describe('service: templateEditorFactory:', function() {
     });
   }));
 
-  var $state, $httpBackend, $modal, templateEditorFactory, messageBox, presentation, processErrorCode,
+  var $state, $httpBackend, $modal, templateEditorFactory, templateEditorUtils, presentation, processErrorCode,
     HTML_PRESENTATION_TYPE, blueprintUrl, storeAuthorize, checkTemplateAccessSpy, store, plansFactory;
 
   beforeEach(function() {
@@ -92,7 +94,7 @@ describe('service: templateEditorFactory:', function() {
       presentation = $injector.get('presentation');
       plansFactory = $injector.get('plansFactory');
       store = $injector.get('store');
-      messageBox = $injector.get('messageBox');
+      templateEditorUtils = $injector.get('templateEditorUtils');
       processErrorCode = $injector.get('processErrorCode');
       HTML_PRESENTATION_TYPE = $injector.get('HTML_PRESENTATION_TYPE');
 
@@ -128,7 +130,7 @@ describe('service: templateEditorFactory:', function() {
       .then(function () {
         expect(templateEditorFactory.createFromTemplate).to.have.been.calledWith(sampleProduct);
         expect(plansFactory.showPlansModal).to.not.have.been.called;
-        expect(messageBox).to.not.have.been.called;
+        expect(templateEditorUtils.showMessageWindow).to.not.have.been.called;
 
         done();
       });
@@ -144,7 +146,7 @@ describe('service: templateEditorFactory:', function() {
         expect(templateEditorFactory.createFromTemplate).to.not.have.been.called;
         expect(plansFactory.showPlansModal).to.have.been.called;
         expect($state.go).to.have.been.calledWith('apps.editor.list');
-        expect(messageBox).to.not.have.been.called;
+        expect(templateEditorUtils.showMessageWindow).to.not.have.been.called;
 
         done();
       });
@@ -160,7 +162,7 @@ describe('service: templateEditorFactory:', function() {
         expect(templateEditorFactory.createFromTemplate).to.not.have.been.called;
         expect(plansFactory.showPlansModal).to.not.have.been.called;
         expect(err.result.error.message).to.equal('Invalid Product Id');
-        expect(messageBox).to.have.been.called;
+        expect(templateEditorUtils.showMessageWindow).to.have.been.called;
 
         done();
       });
@@ -218,7 +220,7 @@ describe('service: templateEditorFactory:', function() {
 
       templateEditorFactory.addPresentation()
         .then(function() {
-          expect(messageBox).to.not.have.been.called;
+          expect(templateEditorUtils.showMessageWindow).to.not.have.been.called;
           expect(templateEditorFactory.savingPresentation).to.be.true;
           expect(templateEditorFactory.loadingPresentation).to.be.true;
 
@@ -254,7 +256,7 @@ describe('service: templateEditorFactory:', function() {
 
           processErrorCode.should.have.been.calledWith('Presentation', 'add', e);
           expect(templateEditorFactory.apiError).to.be.ok;
-          expect(messageBox).to.have.been.called;
+          expect(templateEditorUtils.showMessageWindow).to.have.been.called;
 
           setTimeout(function() {
             expect(templateEditorFactory.loadingPresentation).to.be.false;
@@ -289,7 +291,7 @@ describe('service: templateEditorFactory:', function() {
 
       templateEditorFactory.updatePresentation()
         .then(function() {
-          expect(messageBox).to.not.have.been.called;
+          expect(templateEditorUtils.showMessageWindow).to.not.have.been.called;
           expect(templateEditorFactory.savingPresentation).to.be.true;
           expect(templateEditorFactory.loadingPresentation).to.be.true;
 
@@ -324,7 +326,7 @@ describe('service: templateEditorFactory:', function() {
 
           processErrorCode.should.have.been.calledWith('Presentation', 'update', e);
           expect(templateEditorFactory.apiError).to.be.ok;
-          expect(messageBox).to.have.been.called;
+          expect(templateEditorUtils.showMessageWindow).to.have.been.called;
 
           setTimeout(function() {
             expect(templateEditorFactory.loadingPresentation).to.be.false;
@@ -439,7 +441,7 @@ describe('service: templateEditorFactory:', function() {
 
         processErrorCode.should.have.been.calledWith('Presentation', 'get', e);
         expect(templateEditorFactory.apiError).to.be.ok;
-        expect(messageBox).to.have.been.called;
+        expect(templateEditorUtils.showMessageWindow).to.have.been.called;
 
         setTimeout(function() {
           expect(templateEditorFactory.loadingPresentation).to.be.false;
@@ -549,7 +551,7 @@ describe('service: templateEditorFactory:', function() {
       templateEditorFactory.getPresentation('presentationId')
         .then(templateEditorFactory.deletePresentation.bind(templateEditorFactory))
         .then(function() {
-          expect(messageBox).to.not.have.been.called;
+          expect(templateEditorUtils.showMessageWindow).to.not.have.been.called;
           expect(templateEditorFactory.savingPresentation).to.be.true;
           expect(templateEditorFactory.loadingPresentation).to.be.true;
 
@@ -581,7 +583,7 @@ describe('service: templateEditorFactory:', function() {
           setTimeout(function() {
             expect(presentation.delete.getCall(0).args[0]).to.equal('presentationId');
             expect(processErrorCode).to.have.been.calledWith('Presentation', 'delete', e);
-            expect(messageBox).to.have.been.called;
+            expect(templateEditorUtils.showMessageWindow).to.have.been.called;
             expect($state.go).to.not.have.been.called;
             expect(templateEditorFactory.apiError).to.be.ok;
             expect(templateEditorFactory.savingPresentation).to.be.false;
@@ -640,7 +642,7 @@ describe('service: templateEditorFactory:', function() {
           return templateEditorFactory.publishPresentation(templateEditorFactory);
         })
         .then(function() {
-          expect(messageBox).to.not.have.been.called;
+          expect(templateEditorUtils.showMessageWindow).to.not.have.been.called;
           expect(templateEditorFactory.savingPresentation).to.be.true;
           expect(templateEditorFactory.loadingPresentation).to.be.true;
 
@@ -675,7 +677,7 @@ describe('service: templateEditorFactory:', function() {
             expect(templateEditorFactory.loadingPresentation).to.be.false;
             expect(templateEditorFactory.errorMessage).to.be.ok;
             expect(templateEditorFactory.apiError).to.be.ok;
-            expect(messageBox).to.have.been.called;
+            expect(templateEditorUtils.showMessageWindow).to.have.been.called;
 
             done();
           }, 10);

--- a/test/unit/template-editor/services/svc-template-editor-utils.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-utils.tests.js
@@ -129,4 +129,24 @@ describe('service: templateEditorUtils:', function() {
       expect(templateEditorUtils.isFolder('folder/file.txt')).to.be.false;
     });
   });
+
+  describe('showInvalidExtensionsMessage', function () {
+    it('should call the correct functions', function () {
+      sandbox.stub(templateEditorUtils, 'showMessageWindow');
+      sandbox.stub(templateEditorUtils, 'getValidExtensionsMessage');
+
+      templateEditorUtils.showInvalidExtensionsMessage([]);
+
+      expect(templateEditorUtils.showMessageWindow).to.have.been.called;
+      expect(templateEditorUtils.getValidExtensionsMessage).to.have.been.called;
+    });
+  });
+
+  describe('getValidExtensionsMessage', function () {
+    it('should return the correct message for the given set of extensions', function () {
+      expect(templateEditorUtils.getValidExtensionsMessage(['.gif'])).to.equal('Rise Vision supports .GIF');
+      expect(templateEditorUtils.getValidExtensionsMessage(['.gif', '.jpg'])).to.equal('Rise Vision supports .GIF and .JPG');
+      expect(templateEditorUtils.getValidExtensionsMessage(['.gif', '.jpg', '.png'])).to.equal('Rise Vision supports .GIF, .JPG and .PNG');
+    });
+  });
 });

--- a/web/partials/template-editor/basic-uploader.html
+++ b/web/partials/template-editor/basic-uploader.html
@@ -11,7 +11,6 @@
           </a>
           <span class="pull-right text-muted u_margin-left u_margin-right"> {{ item.file.size | fileSizeFilter }}</span>
           <span class="u_ellipsis-lg" ng-class="{'text-danger': item.isError }">
-            <i class="fa fa-exclamation u_icon-red icon-left" ng-show="item.isError"></i>
             {{ fileNameOf(item.file.name) }}
           </span>
         </p>

--- a/web/partials/template-editor/basic-uploader.html
+++ b/web/partials/template-editor/basic-uploader.html
@@ -25,7 +25,7 @@
 
   <div class="modal fade" tabindex="-1">
     <form id="upload-form-{{uploaderId}}">
-      <input type="file" id="{{uploaderId}}" storage-file-select uploader="uploader" multiple accept="{{validExtensions}}">
+      <input type="file" id="{{uploaderId}}" uploader="uploader" multiple accept="{{validExtensions}}">
     </form>
   </div>
 </div>

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -4,7 +4,8 @@ angular.module('risevision.template-editor.directives')
   .constant('SUPPORTED_IMAGE_TYPES', '.bmp, .gif, .jpeg, .jpg, .png, .tif, .tiff, .svg, .webp')
   .directive('templateComponentImage', ['$log', 'templateEditorFactory', 'templateEditorUtils', 'storageAPILoader',
     'DEFAULT_IMAGE_THUMBNAIL', 'SUPPORTED_IMAGE_TYPES',
-    function ($log, templateEditorFactory, templateEditorUtils, storageAPILoader, DEFAULT_IMAGE_THUMBNAIL, SUPPORTED_IMAGE_TYPES) {
+    function ($log, templateEditorFactory, templateEditorUtils, storageAPILoader, DEFAULT_IMAGE_THUMBNAIL,
+      SUPPORTED_IMAGE_TYPES) {
       return {
         restrict: 'E',
         templateUrl: 'partials/template-editor/components/component-image.html',
@@ -34,7 +35,7 @@ angular.module('risevision.template-editor.directives')
             $scope.isUploading = false;
           }
 
-          function _addFilesToMetadata (files) {
+          function _addFilesToMetadata(files) {
             var selectedImages = $scope.isDefaultImageList ? [] : _.cloneDeep($scope.selectedImages);
 
             files.forEach(function (file) {
@@ -44,10 +45,15 @@ angular.module('risevision.template-editor.directives')
             _setMetadata(selectedImages);
           }
 
-          function _addFileToSet (selectedImages, file) {
-            var newFile = { file: file.name, 'thumbnail-url': file.metadata.thumbnail };
+          function _addFileToSet(selectedImages, file) {
+            var newFile = {
+              file: file.name,
+              'thumbnail-url': file.metadata.thumbnail
+            };
 
-            templateEditorUtils.addOrReplace(selectedImages, { file: file.name }, newFile);
+            templateEditorUtils.addOrReplace(selectedImages, {
+              file: file.name
+            }, newFile);
           }
 
           function _loadSelectedImages() {
@@ -180,8 +186,7 @@ angular.module('risevision.template-editor.directives')
             onBackHandler: function () {
               if ($scope.getCurrentPanel() !== storagePanelSelector || !$scope.storageManager.onBackHandler()) {
                 return $scope.showPreviousPanel();
-              }
-              else {
+              } else {
                 return true;
               }
             }

--- a/web/scripts/template-editor/directives/dtv-attribute-editor.js
+++ b/web/scripts/template-editor/directives/dtv-attribute-editor.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
-  .directive('templateAttributeEditor', ['$timeout', 'templateEditorFactory',
-    function ($timeout, templateEditorFactory) {
+  .directive('templateAttributeEditor', ['$timeout', 'templateEditorFactory', 'templateEditorUtils',
+    function ($timeout, templateEditorFactory, templateEditorUtils) {
       return {
         restrict: 'E',
         templateUrl: 'partials/template-editor/attribute-editor.html',
@@ -91,10 +91,6 @@ angular.module('risevision.template-editor.directives')
             return !!previousPanel;
           };
 
-          function _findElement(selector) {
-            return document.querySelector(selector) && angular.element(document.querySelector(selector));
-          }
-
           function _showAttributeList(value, delay) {
             $timeout(function () {
               $scope.showAttributeList = value;
@@ -102,7 +98,7 @@ angular.module('risevision.template-editor.directives')
           }
 
           function _removeAnimationClasses(selector) {
-            var element = _findElement(selector);
+            var element = templateEditorUtils.findElement(selector);
 
             if (element) {
               element.removeClass('attribute-editor-show-from-right');
@@ -113,7 +109,7 @@ angular.module('risevision.template-editor.directives')
           }
 
           function _showElement(selector, delay) {
-            var element = _findElement(selector);
+            var element = templateEditorUtils.findElement(selector);
 
             if (element) {
               setTimeout(function () {
@@ -123,7 +119,7 @@ angular.module('risevision.template-editor.directives')
           }
 
           function _hideElement(selector, delay) {
-            var element = _findElement(selector);
+            var element = templateEditorUtils.findElement(selector);
 
             if (element) {
               setTimeout(function () {
@@ -133,7 +129,7 @@ angular.module('risevision.template-editor.directives')
           }
 
           function _setCurrentClass(selector, currentClass) {
-            var element = _findElement(selector);
+            var element = templateEditorUtils.findElement(selector);
 
             if (element) {
               _removeAnimationClasses(selector);

--- a/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
+++ b/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
@@ -49,7 +49,7 @@ angular.module('risevision.template-editor.directives')
             }
           });
 
-          function _reset () {
+          function _reset() {
             $scope.folderItems = [];
             $scope.selectedItems = [];
             $scope.storageUploadManager.folderPath = '';
@@ -75,22 +75,24 @@ angular.module('risevision.template-editor.directives')
           $scope.loadItems = function (newFolderPath) {
             $loading.start(spinnerId);
 
-            return storage.files.get({ folderPath: newFolderPath })
-            .then(function (items) {
-              $scope.selectedItems = [];
-              $scope.storageUploadManager.folderPath = newFolderPath;
-              $scope.folderItems = items.files.filter(function (item) {
-                var isValid = templateEditorUtils.fileHasValidExtension(item.name, validExtensionsList);
+            return storage.files.get({
+                folderPath: newFolderPath
+              })
+              .then(function (items) {
+                $scope.selectedItems = [];
+                $scope.storageUploadManager.folderPath = newFolderPath;
+                $scope.folderItems = items.files.filter(function (item) {
+                  var isValid = templateEditorUtils.fileHasValidExtension(item.name, validExtensionsList);
 
-                return item.name !== newFolderPath && ($scope.isFolder(item.name) || isValid);
+                  return item.name !== newFolderPath && ($scope.isFolder(item.name) || isValid);
+                });
+              })
+              .catch(function (err) {
+                console.log('Failed to load files', err);
+              })
+              .finally(function () {
+                $loading.stop(spinnerId);
               });
-            })
-            .catch(function (err) {
-              console.log('Failed to load files', err);
-            })
-            .finally(function () {
-              $loading.stop(spinnerId);
-            });
           };
 
           $scope.selectItem = function (item) {

--- a/web/scripts/template-editor/directives/dtv-basic-uploader.js
+++ b/web/scripts/template-editor/directives/dtv-basic-uploader.js
@@ -11,11 +11,13 @@ angular.module('risevision.template-editor.directives')
           validExtensions: '=?'
         },
         templateUrl: 'partials/template-editor/basic-uploader.html',
-        link: function ($scope) {
+        link: function ($scope, element) {
           var FileUploader = fileUploaderFactory();
+          var inputElement = element.find('input');
 
           $scope.uploader = FileUploader;
           $scope.status = {};
+          $scope.warnings = [];
 
           function _isUploading() {
             return $scope.activeUploadCount() > 0;
@@ -23,6 +25,7 @@ angular.module('risevision.template-editor.directives')
 
           $scope.removeItem = function (item) {
             FileUploader.removeFromQueue(item);
+            $scope.uploadManager.onUploadStatus(_isUploading());
           };
 
           $scope.activeUploadCount = function () {
@@ -36,6 +39,31 @@ angular.module('risevision.template-editor.directives')
           };
 
           $scope.fileNameOf = templateEditorUtils.fileNameOf;
+
+          $scope.uploadSelectedFiles = function (selectedFiles) {
+            var validExtensions = $scope.validExtensions ? $scope.validExtensions.split(',') : [];
+            var validFiles = selectedFiles.filter(function (file) {
+              return templateEditorUtils.fileHasValidExtension(file.name, validExtensions);
+            });
+
+            if (validExtensions.length > 0 && validFiles.length < selectedFiles.length) {
+              templateEditorUtils.showInvalidExtensionsMessage(validExtensions);
+            }
+
+            return $scope.uploader.removeExif(validFiles)
+              .then(function (fileItems) {
+                return $scope.uploader.addToQueue(fileItems);
+              });
+          };
+
+          inputElement.bind('change', function () {
+            var selectedFiles = Array.from(this.files);
+
+            $scope.uploadSelectedFiles(selectedFiles)
+              .finally(function () {
+                inputElement.prop('value', null);
+              });
+          });
 
           FileUploader.onAfterAddingFile = function (fileItem) {
             console.info('onAfterAddingFile', fileItem.file.name);

--- a/web/scripts/template-editor/directives/dtv-basic-uploader.js
+++ b/web/scripts/template-editor/directives/dtv-basic-uploader.js
@@ -1,7 +1,8 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
-  .directive('basicUploader', ['storage', 'fileUploaderFactory', 'UploadURIService', 'templateEditorUtils', 'STORAGE_UPLOAD_CHUNK_SIZE',
+  .directive('basicUploader', ['storage', 'fileUploaderFactory', 'UploadURIService', 'templateEditorUtils',
+    'STORAGE_UPLOAD_CHUNK_SIZE',
     function (storage, fileUploaderFactory, UploadURIService, templateEditorUtils, STORAGE_UPLOAD_CHUNK_SIZE) {
       return {
         restrict: 'E',

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -4,11 +4,11 @@ angular.module('risevision.template-editor.services')
   .constant('BLUEPRINT_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/blueprint.json')
   .constant('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/src/template.html')
   .constant('HTML_TEMPLATE_DOMAIN', 'https://widgets.risevision.com')
-  .factory('templateEditorFactory', ['$q', '$log', '$state', '$rootScope', '$http', 'messageBox', 'presentation',
-    'processErrorCode', 'userState', 'checkTemplateAccess', '$modal', 'plansFactory', 'store',
+  .factory('templateEditorFactory', ['$q', '$log', '$state', '$rootScope', '$http', 'presentation',
+    'processErrorCode', 'userState', 'checkTemplateAccess', '$modal', 'plansFactory', 'store', 'templateEditorUtils',
     'HTML_PRESENTATION_TYPE', 'BLUEPRINT_URL', 'REVISION_STATUS_REVISED', 'REVISION_STATUS_PUBLISHED',
-    function ($q, $log, $state, $rootScope, $http, messageBox, presentation, processErrorCode, userState,
-      checkTemplateAccess, $modal, plansFactory, store,
+    function ($q, $log, $state, $rootScope, $http, presentation, processErrorCode, userState,
+      checkTemplateAccess, $modal, plansFactory, store, templateEditorUtils,
       HTML_PRESENTATION_TYPE, BLUEPRINT_URL, REVISION_STATUS_REVISED, REVISION_STATUS_PUBLISHED) {
       var factory = {};
 
@@ -313,8 +313,7 @@ angular.module('risevision.template-editor.services')
 
         $log.error(factory.errorMessage, e);
 
-        messageBox(factory.errorMessage, factory.apiError, null, 'template-editor-message-box',
-          'partials/template-editor/message-box.html');
+        templateEditorUtils.showMessageWindow(factory.errorMessage, factory.apiError);
       };
 
       var _clearMessages = function () {

--- a/web/scripts/template-editor/services/svc-template-editor-utils.js
+++ b/web/scripts/template-editor/services/svc-template-editor-utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('risevision.template-editor.services')
-  .factory('templateEditorUtils', [function () {
+  .factory('templateEditorUtils', ['messageBox', function (messageBox) {
       var svc = {};
 
       svc.fileNameOf = function(path) {
@@ -42,6 +42,36 @@ angular.module('risevision.template-editor.services')
         return !extensions || extensions.length === 0 || _.some(extensions, function (extension) {
           return _.endsWith(file.toLowerCase(), extension.trim().toLowerCase());
         });
+      };
+
+      svc.findElement = function (selector) {
+        return document.querySelector(selector) && angular.element(document.querySelector(selector));
+      };
+
+      svc.showMessageWindow = function (title, message, buttonLabel) {
+        var partial = 'partials/template-editor/message-box.html';
+        var windowClass = 'template-editor-message-box';
+
+        messageBox(title, message, buttonLabel, windowClass, partial);
+      };
+
+      svc.showInvalidExtensionsMessage = function (validExtensions) {
+        var title = 'This file type is not supported';
+        var message = svc.getValidExtensionsMessage(validExtensions);
+
+        svc.showMessageWindow(title, message);
+      };
+
+      svc.getValidExtensionsMessage = function (validExtensions) {
+        var prefix = validExtensions;
+        var suffix = '';
+
+        if (validExtensions.length > 1) {
+          prefix = validExtensions.slice(0, validExtensions.length - 1);
+          suffix = ' and ' + validExtensions[validExtensions.length - 1].toUpperCase();
+        }
+
+        return 'Rise Vision supports ' +  prefix.join(', ').toUpperCase() + suffix;
       };
 
       return svc;

--- a/web/scripts/template-editor/services/svc-template-editor-utils.js
+++ b/web/scripts/template-editor/services/svc-template-editor-utils.js
@@ -2,77 +2,75 @@
 
 angular.module('risevision.template-editor.services')
   .factory('templateEditorUtils', ['messageBox', function (messageBox) {
-      var svc = {};
+    var svc = {};
 
-      svc.fileNameOf = function(path) {
-        return path.split('/').pop();
-      };
+    svc.fileNameOf = function (path) {
+      return path.split('/').pop();
+    };
 
-      svc.addOrRemove = function (list, oldItem, newItem) {
-        var idx = _.findIndex(list, oldItem);
+    svc.addOrRemove = function (list, oldItem, newItem) {
+      var idx = _.findIndex(list, oldItem);
 
-        if (idx >= 0) {
-          list.splice(idx, 1);
-        }
-        else {
-          list.push(newItem);
-        }
+      if (idx >= 0) {
+        list.splice(idx, 1);
+      } else {
+        list.push(newItem);
+      }
 
-        return list;
-      };
+      return list;
+    };
 
-      svc.addOrReplace = function (list, oldItem, newItem) {
-        var idx = _.findIndex(list, oldItem);
+    svc.addOrReplace = function (list, oldItem, newItem) {
+      var idx = _.findIndex(list, oldItem);
 
-        if (idx >= 0) {
-          list.splice(idx, 1, newItem);
-        }
-        else {
-          list.push(newItem);
-        }
+      if (idx >= 0) {
+        list.splice(idx, 1, newItem);
+      } else {
+        list.push(newItem);
+      }
 
-        return list;
-      };
+      return list;
+    };
 
-      svc.isFolder = function (path) {
-        return path[path.length - 1] === '/';
-      };
+    svc.isFolder = function (path) {
+      return path[path.length - 1] === '/';
+    };
 
-      svc.fileHasValidExtension = function (file, extensions) {
-        return !extensions || extensions.length === 0 || _.some(extensions, function (extension) {
-          return _.endsWith(file.toLowerCase(), extension.trim().toLowerCase());
-        });
-      };
+    svc.fileHasValidExtension = function (file, extensions) {
+      return !extensions || extensions.length === 0 || _.some(extensions, function (extension) {
+        return _.endsWith(file.toLowerCase(), extension.trim().toLowerCase());
+      });
+    };
 
-      svc.findElement = function (selector) {
-        return document.querySelector(selector) && angular.element(document.querySelector(selector));
-      };
+    svc.findElement = function (selector) {
+      return document.querySelector(selector) && angular.element(document.querySelector(selector));
+    };
 
-      svc.showMessageWindow = function (title, message, buttonLabel) {
-        var partial = 'partials/template-editor/message-box.html';
-        var windowClass = 'template-editor-message-box';
+    svc.showMessageWindow = function (title, message, buttonLabel) {
+      var partial = 'partials/template-editor/message-box.html';
+      var windowClass = 'template-editor-message-box';
 
-        messageBox(title, message, buttonLabel, windowClass, partial);
-      };
+      messageBox(title, message, buttonLabel, windowClass, partial);
+    };
 
-      svc.showInvalidExtensionsMessage = function (validExtensions) {
-        var title = 'This file type is not supported';
-        var message = svc.getValidExtensionsMessage(validExtensions);
+    svc.showInvalidExtensionsMessage = function (validExtensions) {
+      var title = 'This file type is not supported';
+      var message = svc.getValidExtensionsMessage(validExtensions);
 
-        svc.showMessageWindow(title, message);
-      };
+      svc.showMessageWindow(title, message);
+    };
 
-      svc.getValidExtensionsMessage = function (validExtensions) {
-        var prefix = validExtensions;
-        var suffix = '';
+    svc.getValidExtensionsMessage = function (validExtensions) {
+      var prefix = validExtensions;
+      var suffix = '';
 
-        if (validExtensions.length > 1) {
-          prefix = validExtensions.slice(0, validExtensions.length - 1);
-          suffix = ' and ' + validExtensions[validExtensions.length - 1].toUpperCase();
-        }
+      if (validExtensions.length > 1) {
+        prefix = validExtensions.slice(0, validExtensions.length - 1);
+        suffix = ' and ' + validExtensions[validExtensions.length - 1].toUpperCase();
+      }
 
-        return 'Rise Vision supports ' +  prefix.join(', ').toUpperCase() + suffix;
-      };
+      return 'Rise Vision supports ' + prefix.join(', ').toUpperCase() + suffix;
+    };
 
-      return svc;
-    }]);
+    return svc;
+  }]);


### PR DESCRIPTION
Since uploads on mobile can bypass the default restrictions, we need to add an extra validation step. This can't really be tested on Desktop, only on mobile by browsing the file system with a non-default tool. You can test with: https://apps-stage-7.risevision.com/templates/edit/1919032c-a981-42ac-98fb-0d0d5731c978?cid=87977ab8-38b6-47fb-ad5e-256b8cc4b46d

@santiagonoguez @stulees please review