### PR TITLE
Fix scope problems when loading multiple component directives 

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-financial.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-financial.tests.js
@@ -80,6 +80,7 @@ describe('directive: TemplateComponentFinancial', function() {
 
     timeout = $timeout;
     element = $compile("<template-component-financial></template-component-financial>")($scope);
+    $scope = element.scope();
     $scope.$digest();
   }));
 

--- a/test/unit/template-editor/components/directives/dtv-component-image.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.tests.js
@@ -55,6 +55,7 @@ describe('directive: TemplateComponentImage', function() {
 
     timeout = $timeout;
     element = $compile("<template-component-image></template-component-image>")($scope);
+    $scope = element.scope();
     $scope.$digest();
   }));
 

--- a/test/unit/template-editor/components/directives/dtv-component-text.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-text.tests.js
@@ -28,6 +28,7 @@ describe('directive: templateComponentText', function() {
     $scope.setAttributeData = sinon.stub();
 
     element = $compile("<template-component-text></template-component-text>")($scope);
+    $scope = element.scope();
     $scope.$digest();
   }));
 

--- a/web/scripts/template-editor/components/directives/dtv-component-financial.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-financial.js
@@ -5,6 +5,7 @@ angular.module('risevision.template-editor.directives')
     function ($log, $timeout, templateEditorFactory, instrumentSearchService) {
       return {
         restrict: 'E',
+        scope: true,
         templateUrl: 'partials/template-editor/components/component-financial.html',
         link: function ($scope, element) {
           $scope.factory = templateEditorFactory;

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -8,6 +8,7 @@ angular.module('risevision.template-editor.directives')
       SUPPORTED_IMAGE_TYPES) {
       return {
         restrict: 'E',
+        scope: true,
         templateUrl: 'partials/template-editor/components/component-image.html',
         link: function ($scope, element) {
           var storagePanelSelector = '.storage-selector-container';

--- a/web/scripts/template-editor/components/directives/dtv-component-text.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-text.js
@@ -5,6 +5,7 @@ angular.module('risevision.template-editor.directives')
     function (templateEditorFactory) {
       return {
         restrict: 'E',
+        scope: true,
         templateUrl: 'partials/template-editor/components/component-text.html',
         link: function ($scope, element) {
           $scope.factory = templateEditorFactory;

--- a/web/scripts/template-editor/components/directives/dtv-component-weather.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-weather.js
@@ -5,8 +5,8 @@ angular.module('risevision.template-editor.directives')
     function (templateEditorFactory) {
       return {
         restrict: 'E',
-        templateUrl: 'partials/template-editor/components/component-weather.html',
         scope: true,
+        templateUrl: 'partials/template-editor/components/component-weather.html',
         link: function ($scope, element) {
           $scope.factory = templateEditorFactory;
 


### PR DESCRIPTION
[stage-2]

When multiple components were used, $scope.save() was being overwritten in every component directive as the $scope was shared between them and only the last directive would work. I set individual scopes to prevent that from happening.

I updated unit tests, manually tested and didn't find problems with this approach.

@alex-deaconu Please review.

@stulees @andrecardoso @olegrise @fjvallarino @santiagonoguez fyi.
Thanks!



