### PR TITLE
Show current folder and corresponding icon in navigation bar

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#feature/folder-name-in-navigation-bar",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.7.26",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -36,7 +36,6 @@
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
     "jquery": "^2",
-    "font-awesome": "~4.7.0",
-    "common-header": "feature/folder-name-in-navigation-bar"
+    "font-awesome": "~4.7.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.7.23",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#feature/folder-name-in-navigation-bar",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -36,6 +36,7 @@
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
     "jquery": "^2",
-    "font-awesome": "~4.7.0"
+    "font-awesome": "~4.7.0",
+    "common-header": "feature/folder-name-in-navigation-bar"
   }
 }

--- a/test/unit/template-editor/directives/dtv-basic-storage-selector.tests.js
+++ b/test/unit/template-editor/directives/dtv-basic-storage-selector.tests.js
@@ -26,7 +26,8 @@ describe('directive: basicStorageSelector', function() {
   beforeEach(inject(function($injector, $compile, $rootScope, $templateCache) {
     $rootScope.validExtensions = '.jpg, .png';
     $rootScope.storageManager = {
-      addSelectedItems: sandbox.stub()
+      addSelectedItems: sandbox.stub(),
+      handleNavigation: sandbox.stub()
     };
 
     $loading = $injector.get('$loading');
@@ -120,6 +121,7 @@ describe('directive: basicStorageSelector', function() {
         expect($scope.selectedItems).to.be.empty;
         expect($scope.storageUploadManager.folderPath).to.equal('folder/');
         expect($scope.folderItems).to.have.lengthOf(2);
+        expect($scope.storageManager.handleNavigation).to.have.been.calledWith('folder/');
 
         done();
       });

--- a/test/unit/template-editor/directives/dtv-component-icon.tests.js
+++ b/test/unit/template-editor/directives/dtv-component-icon.tests.js
@@ -11,10 +11,9 @@ describe('directive: ComponentIcon', function () {
 
   beforeEach(inject(function ($compile, $rootScope) {
     $scope = $rootScope.$new();
-    //the directive is using "replaceWith()" function, so in order to see rendered HTML we need to wrap it into <div> 
-    //ref: https://stackoverflow.com/questions/18895738/#18898115
-    element = $compile('<div> <component-icon icon="{{iconValue}}" type="{{typeValue}}"></component-icon> </div>')($scope);
-    elementScope = element.children().isolateScope();
+
+    element = $compile('<component-icon icon="{{iconValue}}" type="{{typeValue}}"></component-icon>')($scope);
+    elementScope = element.isolateScope();
     $scope.$digest();
   }));
 

--- a/test/unit/template-editor/services/svc-template-editor-utils.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-utils.tests.js
@@ -130,6 +130,15 @@ describe('service: templateEditorUtils:', function() {
     });
   });
 
+  describe('fileNameOf', function () {
+    it('should return the name of the last valid element in the provided path', function () {
+      expect(templateEditorUtils.fileNameOf('file1.jpg')).to.equal('file1.jpg');
+      expect(templateEditorUtils.fileNameOf('folder/')).to.equal('folder');
+      expect(templateEditorUtils.fileNameOf('folder/file1.jpg')).to.equal('file1.jpg');
+      expect(templateEditorUtils.fileNameOf('folder/subfolder/')).to.equal('subfolder');
+    });
+  });
+
   describe('showInvalidExtensionsMessage', function () {
     it('should call the correct functions', function () {
       sandbox.stub(templateEditorUtils, 'showMessageWindow');

--- a/web/partials/template-editor/component.html
+++ b/web/partials/template-editor/component.html
@@ -7,11 +7,19 @@
         <span translate>template.attribute-editor.back-to-list</span>
       </span>
     </a>
-    <component-icon icon="{{ getComponentIcon(factory.selected) }}" type="{{ getComponentIconType(factory.selected) }}"></component-icon>
-    <span>
+    <component-icon ng-if="!panelIcon"
+                    icon="{{ getComponentIcon(factory.selected) }}"
+                    type="{{ getComponentIconType(factory.selected) }}">
+    </component-icon>
+    <component-icon ng-if="panelIcon"
+                    icon="{{ panelIcon }}"
+                    type="{{ panelIconType }}">
+    </component-icon>
+    <span ng-show="!panelTitle">
       {{ ( "template." + factory.selected.type ) | translate }} -
       {{ factory.selected.label }}
     </span>
+    <span ng-show="panelTitle">{{ panelTitle }}</span>
   </div>
 </div>
 <div class="component-container">

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -27,6 +27,18 @@ angular.module('risevision.template-editor.directives')
               _addFilesToMetadata(newSelectedItems);
 
               $scope.showPreviousPanel();
+            },
+            handleNavigation: function (folderPath) {
+              var folderName = templateEditorUtils.fileNameOf(folderPath);
+
+              if (folderName) {
+                $scope.setPanelIcon('fa-folder');
+                $scope.setPanelTitle(folderName);
+              }
+              else {
+                $scope.setPanelIcon('riseStorage', 'riseSvg');
+                $scope.setPanelTitle('Rise Storage');
+              }
             }
           };
 
@@ -186,7 +198,12 @@ angular.module('risevision.template-editor.directives')
               $scope.showNextPanel('.image-component-container');
             },
             onBackHandler: function () {
-              if ($scope.getCurrentPanel() !== storagePanelSelector || !$scope.storageManager.onBackHandler()) {
+              if ($scope.getCurrentPanel() !== storagePanelSelector) {
+                return $scope.showPreviousPanel();
+              } else if (!$scope.storageManager.onBackHandler()) {
+                $scope.setPanelIcon();
+                $scope.setPanelTitle();
+
                 return $scope.showPreviousPanel();
               } else {
                 return true;

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -34,8 +34,7 @@ angular.module('risevision.template-editor.directives')
               if (folderName) {
                 $scope.setPanelIcon('fa-folder');
                 $scope.setPanelTitle(folderName);
-              }
-              else {
+              } else {
                 $scope.setPanelIcon('riseStorage', 'riseSvg');
                 $scope.setPanelTitle('Rise Storage');
               }

--- a/web/scripts/template-editor/directives/dtv-attribute-editor.js
+++ b/web/scripts/template-editor/directives/dtv-attribute-editor.js
@@ -88,7 +88,21 @@ angular.module('risevision.template-editor.directives')
 
             _swapToRight(currentPanel, previousPanel);
 
+            if (!previousPanel) {
+              $scope.setPanelIcon(null, null);
+              $scope.setPanelTitle(null);
+            }
+
             return !!previousPanel;
+          };
+
+          $scope.setPanelIcon = function (panelIcon, panelIconType) {
+            $scope.panelIcon = panelIcon;
+            $scope.panelIconType = panelIconType;
+          };
+
+          $scope.setPanelTitle = function (panelTitle) {
+            $scope.panelTitle = panelTitle;
           };
 
           function _showAttributeList(value, delay) {

--- a/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
+++ b/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
@@ -57,15 +57,7 @@ angular.module('risevision.template-editor.directives')
 
           $scope.isFolder = templateEditorUtils.isFolder;
 
-          $scope.fileNameOf = function (path) {
-            var parts = path.split('/');
-
-            if ($scope.isFolder(path)) {
-              return parts[parts.length - 2];
-            } else {
-              return parts.pop();
-            }
-          };
+          $scope.fileNameOf = templateEditorUtils.fileNameOf;
 
           $scope.thumbnailFor = function (item) {
             return item.metadata && item.metadata.thumbnail ?
@@ -75,6 +67,7 @@ angular.module('risevision.template-editor.directives')
           $scope.loadItems = function (newFolderPath) {
             $loading.start(spinnerId);
             $scope.currentFolder = $scope.fileNameOf(newFolderPath);
+            $scope.storageManager.handleNavigation(newFolderPath);
 
             return storage.files.get({
                 folderPath: newFolderPath

--- a/web/scripts/template-editor/directives/dtv-component-icon.js
+++ b/web/scripts/template-editor/directives/dtv-component-icon.js
@@ -16,9 +16,9 @@ angular.module('risevision.template-editor.directives')
                 $scope.icon + '</svg>';
             } else if ($scope.type === 'riseSvg') {
               return '<svg class="mr-2 fa fa-lg" viewBox="0 0 32 32" width="24" height="18" xmlns="http://www.w3.org/2000/svg">' +
-                       '<path fill="#4d4d4d" d="' + iconsList.icons1[$scope.icon] + '"></path>' +
-                       '<path fill="#4d4d4d" d="' + iconsList.icons2[$scope.icon] + '"></path>' +
-                     '</svg>';
+                '<path fill="#4d4d4d" d="' + iconsList.icons1[$scope.icon] + '"></path>' +
+                '<path fill="#4d4d4d" d="' + iconsList.icons2[$scope.icon] + '"></path>' +
+                '</svg>';
             } else {
               return '<i class="mr-2 fa fa-lg ' + $scope.icon + '"></i>';
             }

--- a/web/scripts/template-editor/directives/dtv-component-icon.js
+++ b/web/scripts/template-editor/directives/dtv-component-icon.js
@@ -15,9 +15,9 @@ angular.module('risevision.template-editor.directives')
               return '<svg class="mr-2 fa fa-lg" width="24px" height="18px" viewBox="0 0 24 18" xmlns="http://www.w3.org/2000/svg">' +
                 $scope.icon + '</svg>';
             } else if ($scope.type === 'riseSvg') {
-              return '<svg class="mr-2 fa fa-lg" viewBox="0 0 32 32" width="24" height="18" xmlns="http://www.w3.org/2000/svg">' +
-                '<path fill="#4d4d4d" d="' + iconsList.icons1[$scope.icon] + '"></path>' +
-                '<path fill="#4d4d4d" d="' + iconsList.icons2[$scope.icon] + '"></path>' +
+              return '<svg class="mr-2" viewBox="0 0 32 32" width="24" height="18" xmlns="http://www.w3.org/2000/svg">' +
+                '<path d="' + iconsList.icons1[$scope.icon] + '"></path>' +
+                '<path d="' + iconsList.icons2[$scope.icon] + '"></path>' +
                 '</svg>';
             } else {
               return '<i class="mr-2 fa fa-lg ' + $scope.icon + '"></i>';

--- a/web/scripts/template-editor/directives/dtv-component-icon.js
+++ b/web/scripts/template-editor/directives/dtv-component-icon.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
-  .directive('componentIcon', [
-    function () {
+  .directive('componentIcon', ['iconsList',
+    function (iconsList) {
       return {
         restrict: 'E',
         scope: {
@@ -14,6 +14,11 @@ angular.module('risevision.template-editor.directives')
             if ($scope.type === 'svg') {
               return '<svg class="mr-2 fa fa-lg" width="24px" height="18px" viewBox="0 0 24 18" xmlns="http://www.w3.org/2000/svg">' +
                 $scope.icon + '</svg>';
+            } else if ($scope.type === 'riseSvg') {
+              return '<svg class="mr-2 fa fa-lg" viewBox="0 0 32 32" width="24" height="18" xmlns="http://www.w3.org/2000/svg">' +
+                       '<path fill="#4d4d4d" d="' + iconsList.icons1[$scope.icon] + '"></path>' +
+                       '<path fill="#4d4d4d" d="' + iconsList.icons2[$scope.icon] + '"></path>' +
+                     '</svg>';
             } else {
               return '<i class="mr-2 fa fa-lg ' + $scope.icon + '"></i>';
             }
@@ -21,7 +26,7 @@ angular.module('risevision.template-editor.directives')
 
           $scope.$watch('icon', function (icon) {
             if (icon) {
-              element.replaceWith(_html());
+              element.html(_html());
             }
           });
         }

--- a/web/scripts/template-editor/services/svc-template-editor-utils.js
+++ b/web/scripts/template-editor/services/svc-template-editor-utils.js
@@ -36,6 +36,16 @@ angular.module('risevision.template-editor.services')
       return path[path.length - 1] === '/';
     };
 
+    svc.fileNameOf = function (path) {
+      var parts = path.split('/');
+
+      if (svc.isFolder(path)) {
+        return parts[parts.length - 2];
+      } else {
+        return parts.pop();
+      }
+    };
+
     svc.fileHasValidExtension = function (file, extensions) {
       return !extensions || extensions.length === 0 || _.some(extensions, function (extension) {
         return _.endsWith(file.toLowerCase(), extension.trim().toLowerCase());


### PR DESCRIPTION
This PR shows the current folder name in the navigation bar when using Template Editor's Storage. It follows the styling as defined in Zeplin, which shows "Rise Storage" when in root, using an svg icon, and the folder name with 'fa-folder' when inside a specific folder.

- Root: https://app.zeplin.io/project/5c58a8a2b74a443081a59e09/screen/5ca038ed50d7a876f7748612
- Folder: https://app.zeplin.io/project/5c58a8a2b74a443081a59e09/screen/5ca038ed99837405aba3d750

You can test it here, using "Image Component" and clicking on "Select from Storage": https://apps-stage-7.risevision.com/templates/edit/808cf50c-199a-4f2e-bb0a-e80937c21614?cid=87977ab8-38b6-47fb-ad5e-256b8cc4b46d

I modified the existing `component-icon` directive in order to allow using some predefined SVG icons we have in Common Header (in particular, the one for Storage). I switched to `html` instead of `replaceWith` since I was having issues with duplicate icons when navigating back and forth. Oleg, please let me know if you are fine with this change!

There is also the issue that you can't really change the color of an SVG image once it's created. Since this is the Component Icon directive and it should match the colors we use for fonts, I'm setting the fill color while creating the SVG image, although it's not really clean. If you have ideas on how to improve this, please let me know. I evaluated exposing a `color` attribute that would be provided from the HTML partials, but I'm not sure it would be much of an improvement.

@olegrise @santiagonoguez @stulees please review