### PR TITLE
Wait for $digest cycle before updating list [stage-2]

### DIFF
--- a/web/scripts/common/directives/dtv-rv-sortable.js
+++ b/web/scripts/common/directives/dtv-rv-sortable.js
@@ -26,8 +26,10 @@ angular.module('risevision.apps.directives')
 
           sortable.on('sortable:stop', function (evt) {
             if ($scope.onSort) {
-              $scope.onSort({
-                evt: evt
+              $scope.$evalAsync(function() {
+                $scope.onSort({
+                  evt: evt
+                });
               });
             }
           });


### PR DESCRIPTION
Fix for #960 and #979.

The issue seems to stem from the fact that the `$digest` cycle does not occur correctly. The drag & drop action sets off one `$digest` cycle and the list update sets another. The second cycle seems to not occur correctly and the updated list is not applied.

The solution would be to use a `$timeout` to delay the second `$digest`, but I found that `$evalAsync` is executed right after the `$digest`, as opposed to a `$timeout` which is executed randomly. Also, there's no need to explicitly call `$digest` as updating the list does so implicitly.

Main side effect is that the list may scroll up/down after the element is dropped. This is an indication that the second `$digest` is applying its changes.

@ezequielc please review. Thanks!