### PR TITLE
Fix duplicate cid parameter added to the route

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -406,7 +406,7 @@ angular.module('risevision.apps', [
         })
 
         .state('apps.editor.templates', {
-          url: '/templates?cid',
+          url: '/templates',
           abstract: true,
           template: '<div class="templates-app" ui-view></div>'
         })

--- a/web/scripts/common/controllers/ctr-app.js
+++ b/web/scripts/common/controllers/ctr-app.js
@@ -20,7 +20,9 @@ angular.module('risevision.apps.controllers')
           'apps.editor.home',
           'apps.editor.list',
           'apps.editor.workspace.artboard',
-          'apps.editor.workspace.htmleditor'
+          'apps.editor.workspace.htmleditor',
+          'apps.editor.templates.add',
+          'apps.editor.templates.edit'
         ]
       }, {
         title: 'Schedules',


### PR DESCRIPTION
`apps.editor.templates` route inherits `apps.editor`
additional cid parameter is not needed

add template editor routes to editor navStates

[stage-2]