### PR TITLE
Preview should not include offset on width calculation

### DIFF
--- a/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
+++ b/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
@@ -126,7 +126,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
 
       var width = $scope.getMobileWidth();
 
-      expect(width).to.equal("340");
+      expect(width).to.equal("356");
     });
 
     it('should calculate mobile width for 9:16 aspect ratio', function() {
@@ -134,7 +134,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
 
       var width = $scope.getMobileWidth();
 
-      expect(width).to.equal("121");
+      expect(width).to.equal("113");
     });
   });
 

--- a/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
+++ b/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
@@ -144,7 +144,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
 
       var width = $scope.getDesktopWidth();
 
-      expect(width).to.equal("818");
+      expect(width).to.equal("889");
     });
 
     it('should calculate desktop width for 9:16 aspect ratio', function() {
@@ -152,7 +152,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
 
       var width = $scope.getDesktopWidth();
 
-      expect(width).to.equal("259");
+      expect(width).to.equal("281");
     });
   });
 

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -85,8 +85,7 @@ angular.module('risevision.template-editor.directives')
           };
 
           $scope.getDesktopWidth = function () {
-            var offset = 2 * DESKTOP_MARGIN;
-            var height = previewHolder.clientHeight - offset;
+            var height = previewHolder.clientHeight;
 
             return _getWidthFor(height).toFixed(0);
           };

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -78,8 +78,7 @@ angular.module('risevision.template-editor.directives')
             var isShort = _mediaMatches('(max-height: 570px)');
             var layerHeight = isShort ? MOBILE_PREVIEW_HEIGHT_SHORT : MOBILE_PREVIEW_HEIGHT;
 
-            var offset = 2 * MOBILE_MARGIN;
-            var value = _getWidthFor(layerHeight - offset) + offset;
+            var value = _getWidthFor(layerHeight);
 
             return value.toFixed(0);
           };


### PR DESCRIPTION
Fixes #959. It was including `offset` when calculating the aspect ratio.

Video on how to replicate the issue and validate the fix: https://drive.google.com/open?id=12DkNctc46HhJaIU7xFN7JC9gv0NkLHUO

Sample Presentation https://apps-stage-1.risevision.com/templates/edit/c90842d6-3e0b-49b4-b6bd-813e31a94134?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

[stage-1]

@alex-deaconu Please review