### PR TITLE
Fix link from Template gallery [stage-0]

### DIFF
--- a/test/unit/app.tests.js
+++ b/test/unit/app.tests.js
@@ -83,7 +83,7 @@ describe('app:', function() {
     it('should register state',function(){
       var state = $state.get('apps.editor.workspace');
       expect(state).to.be.ok;
-      expect(state.url).to.equal('/editor/workspace/:presentationId?copyOf');
+      expect(state.url).to.equal('/editor/workspace/:presentationId/?copyOf');
       expect(state.controller).to.be.ok;
       expect(state.params).to.be.ok;
       expect(state.abstract).to.be.true;

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -355,7 +355,7 @@ angular.module('risevision.apps', [
         })
 
         .state('apps.editor.workspace', {
-          url: '/editor/workspace/:presentationId?copyOf',
+          url: '/editor/workspace/:presentationId/?copyOf',
           abstract: true,
           templateProvider: ['$templateCache', function ($templateCache) {
             return $templateCache.get('partials/editor/workspace.html');


### PR DESCRIPTION
Should work:
https://apps.risevision.com/editor/workspace/new/?copyOf=e14f5f58-7c57-49fb-8c7e-d99d0079c838&industry=

Instead, this works:
https://apps.risevision.com/editor/workspace/new?copyOf=e14f5f58-7c57-49fb-8c7e-d99d0079c838&industry=

Adding back the missing slash `/`.

@ezequielc please review. Thanks!