### PR TITLE
Prevent empty list UI showing during list initialization

### DIFF
--- a/web/partials/template-editor/components/component-financial.html
+++ b/web/partials/template-editor/components/component-financial.html
@@ -15,7 +15,7 @@
          translate>editor-app.details.remove</a>
     </div>
   </div>
-  <div class="row instrument-list-empty" ng-hide="instruments.length !== 0">
+  <div class="row instrument-list-empty" ng-hide="instruments.length !== 0 || factory.loadingPresentation">
     <div class="col-xs-12">
       <h2 translate>template.financial.empty-list.title</h2>
       <p>{{ getEmptyListSuggestionText() | translate }}</p>

--- a/web/partials/template-editor/components/component-image/image-list.html
+++ b/web/partials/template-editor/components/component-image/image-list.html
@@ -36,7 +36,7 @@
     </div>
   </div>
 
-  <div class="image-component-list-empty" ng-show="selectedImages.length === 0 && !isUploading">
+  <div class="image-component-list-empty" ng-hide="selectedImages.length !== 0 || factory.loadingPresentation">
     <div class="row">
       <div class="col-xs-12">
         <h2>You have no images here.</h2>

--- a/web/partials/template-editor/components/component-image/image-list.html
+++ b/web/partials/template-editor/components/component-image/image-list.html
@@ -10,7 +10,10 @@
     </div>
   </div>
 </div>
-<div class="image-component-list te-scrollable-container" ng-class="{'active-duration' : selectedImages.length > 1 && !isUploading}">
+<div class="image-component-list te-scrollable-container"
+     ng-class="{'active-duration' : selectedImages.length > 1 && !isUploading}"
+     rv-spinner rv-spinner-key="template-editor-loader"
+     rv-spinner-start-active="1">
   <div class="pl-0 image-row"
     ng-repeat="image in selectedImages track by $index"
     ng-show="selectedImages.length > 0 && !isUploading">

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -349,13 +349,13 @@ angular.module('risevision.apps', [
               canAccessApps().then(function () {
                 if ($stateParams.productId) {
                   editorFactory.addFromProductId($stateParams.productId)
-                    .then(function() {
+                    .then(function () {
                       $location.replace();
                     });
                 } else {
                   editorFactory.addPresentationModal();
 
-                  $state.go('apps.editor.list');                  
+                  $state.go('apps.editor.list');
                 }
               });
             }

--- a/web/scripts/schedules/controllers/ctr-auto-schedule-modal.js
+++ b/web/scripts/schedules/controllers/ctr-auto-schedule-modal.js
@@ -2,7 +2,7 @@
 
 angular.module('risevision.schedules.controllers')
   .controller('AutoScheduleModalController', ['$scope', '$modalInstance',
-  'presentationName', 'displayFactory',
+    'presentationName', 'displayFactory',
     function ($scope, $modalInstance, presentationName, displayFactory) {
       $scope.presentationName = presentationName;
       $scope.displayFactory = displayFactory;

--- a/web/scripts/schedules/services/svc-schedule-factory.js
+++ b/web/scripts/schedules/services/svc-schedule-factory.js
@@ -64,8 +64,8 @@ angular.module('risevision.schedules.services')
         return deferred.promise;
       };
 
-      
-      var _checkFirstSchedule = function() {
+
+      var _checkFirstSchedule = function () {
         var deferred = $q.defer();
 
         if (!_hasSchedules) {

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -5,7 +5,8 @@ angular.module('risevision.template-editor.services')
   .constant('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/src/template.html')
   .constant('HTML_TEMPLATE_DOMAIN', 'https://widgets.risevision.com')
   .factory('templateEditorFactory', ['$q', '$log', '$state', '$rootScope', '$http', 'presentation',
-    'processErrorCode', 'userState', 'checkTemplateAccess', '$modal', 'scheduleFactory', 'plansFactory', 'templateEditorUtils',
+    'processErrorCode', 'userState', 'checkTemplateAccess', '$modal', 'scheduleFactory', 'plansFactory',
+    'templateEditorUtils',
     'HTML_PRESENTATION_TYPE', 'BLUEPRINT_URL', 'REVISION_STATUS_REVISED', 'REVISION_STATUS_PUBLISHED',
     function ($q, $log, $state, $rootScope, $http, presentation, processErrorCode, userState,
       checkTemplateAccess, $modal, scheduleFactory, plansFactory, templateEditorUtils,


### PR DESCRIPTION
- Both Financial and Image empty list UI now leverage `factory.loadingPresentation` as a conditional on showing or not, which is only applicable during an initial build of the list from a new presentation. 
- This fixes issue #1026 

Validate with https://apps-stage-8.risevision.com/editor/list?cid=dd474bee-b237-46e3-aa20-98e975679773 and add a new _Example Financial Template_ presentation and click into Financial and then back and click into Image. You should not see the empty list UI in either scenario. 

@ezequielc FYI