### PR TITLE
Feature/auto save

### DIFF
--- a/test/e2e/apps.scenarios.js
+++ b/test/e2e/apps.scenarios.js
@@ -1,7 +1,7 @@
-//require('./launcher/launcher.cases.js');
-//require('./schedules/schedules.cases.js');
-//require('./displays/displays.cases.js');
-//require('./editor/editor.cases.js');
-//require('./storage/storage.cases.js');
-//require('./common/common.cases.js');
+require('./launcher/launcher.cases.js');
+require('./schedules/schedules.cases.js');
+require('./displays/displays.cases.js');
+require('./editor/editor.cases.js');
+require('./storage/storage.cases.js');
+require('./common/common.cases.js');
 require('./template-editor/template-editor.cases');

--- a/test/e2e/apps.scenarios.js
+++ b/test/e2e/apps.scenarios.js
@@ -1,7 +1,7 @@
-require('./launcher/launcher.cases.js');
-require('./schedules/schedules.cases.js');
-require('./displays/displays.cases.js');
-require('./editor/editor.cases.js');
-require('./storage/storage.cases.js');
-require('./common/common.cases.js');
+//require('./launcher/launcher.cases.js');
+//require('./schedules/schedules.cases.js');
+//require('./displays/displays.cases.js');
+//require('./editor/editor.cases.js');
+//require('./storage/storage.cases.js');
+//require('./common/common.cases.js');
 require('./template-editor/template-editor.cases');

--- a/test/e2e/template-editor/cases/components/financial.js
+++ b/test/e2e/template-editor/cases/components/financial.js
@@ -55,6 +55,7 @@ var FinancialComponentScenarios = function () {
 
       it('should show open the Instrument Selector', function () {
         helper.wait(financialComponentPage.getAddCurrenciesButton(), 'Add Currencies');
+        helper.waitDisappear(presentationsListPage.getTemplateEditorLoader());
         helper.clickWhenClickable(financialComponentPage.getAddCurrenciesButton(), 'Add Currencies');
         expect(financialComponentPage.getAddInstrumentButton().isPresent()).to.eventually.be.true;
       });
@@ -71,19 +72,17 @@ var FinancialComponentScenarios = function () {
 
         presentationsListPage.changePresentationName(presentationName);
 
-        //log presentaion / company URL for troubeshooting
+        //log presentation / company URL for troubeshooting
         browser.getCurrentUrl().then(function(actualUrl) {
           console.log(actualUrl);
         });
 
         helper.wait(templateEditorPage.getSavingText(), 'Financial component auto-saving');
         helper.wait(templateEditorPage.getSavedText(), 'Financial component auto-saved');
-        browser.sleep(100);
 
         presentationsListPage.loadPresentation(presentationName);
         templateEditorPage.selectComponent("Financial - ");
 
-        browser.sleep(500);
         expect(financialComponentPage.getInstrumentItems().count()).to.eventually.equal(4);
       });
     });

--- a/test/e2e/template-editor/cases/components/financial.js
+++ b/test/e2e/template-editor/cases/components/financial.js
@@ -40,6 +40,11 @@ var FinancialComponentScenarios = function () {
         expect(financialComponentPage.getInstrumentItems().count()).to.eventually.equal(3);
       });
 
+      it('should auto-save the component after the instruments are loaded', function () {
+        helper.wait(templateEditorPage.getSavingText(), 'Financial component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Financial component auto-saved');
+      });
+
       it('should show open the Instrument Selector', function () {
         helper.wait(financialComponentPage.getAddCurrenciesButton(), 'Add Currencies');
         helper.clickWhenClickable(financialComponentPage.getAddCurrenciesButton(), 'Add Currencies');
@@ -57,19 +62,20 @@ var FinancialComponentScenarios = function () {
       it('should save the Presentation, reload it, and validate changes were saved', function () {
 
         presentationsListPage.changePresentationName(presentationName);
-        presentationsListPage.savePresentation();
 
         //log presentaion / company URL for troubeshooting
         browser.getCurrentUrl().then(function(actualUrl) {
           console.log(actualUrl);
         });
-        browser.sleep(100);
 
-        expect(templateEditorPage.getSaveButton().isEnabled()).to.eventually.be.true;
+        helper.wait(templateEditorPage.getSavingText(), 'Financial component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Financial component auto-saved');
+        browser.sleep(100);
 
         presentationsListPage.loadPresentation(presentationName);
         templateEditorPage.selectComponent("Financial - ");
 
+        browser.sleep(500);
         expect(financialComponentPage.getInstrumentItems().count()).to.eventually.equal(4);
       });
     });

--- a/test/e2e/template-editor/cases/components/financial.js
+++ b/test/e2e/template-editor/cases/components/financial.js
@@ -36,7 +36,8 @@ var FinancialComponentScenarios = function () {
       });
 
       it('should auto-save the Presentation after it has been created', function () {
-        helper.wait(templateEditorPage.getSavingText(), 'Financial component auto-saving');
+        helper.waitDisappear(templateEditorPage.getDirtyText());
+        helper.waitDisappear(templateEditorPage.getSavingText());
         helper.wait(templateEditorPage.getSavedText(), 'Financial component auto-saved');
       });
 

--- a/test/e2e/template-editor/cases/components/financial.js
+++ b/test/e2e/template-editor/cases/components/financial.js
@@ -72,10 +72,11 @@ var FinancialComponentScenarios = function () {
 
         presentationsListPage.changePresentationName(presentationName);
 
-        //log presentation / company URL for troubeshooting
+        //log presentation / company URL for troubleshooting
         browser.getCurrentUrl().then(function(actualUrl) {
           console.log(actualUrl);
         });
+        browser.sleep(100);
 
         helper.wait(templateEditorPage.getSavingText(), 'Financial component auto-saving');
         helper.wait(templateEditorPage.getSavedText(), 'Financial component auto-saved');

--- a/test/e2e/template-editor/cases/components/financial.js
+++ b/test/e2e/template-editor/cases/components/financial.js
@@ -39,8 +39,8 @@ var FinancialComponentScenarios = function () {
       });
 
       it('should auto-save the Presentation after it has been created', function () {
-        helper.wait(templateEditorPage.getSavingText(), 'Component auto-saving');
-        helper.wait(templateEditorPage.getSavedText(), 'Component auto-saved');
+        helper.wait(templateEditorPage.getSavingText(), 'Financial component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Financial component auto-saved');
       });
 
       it('should show one Financial Component', function () {

--- a/test/e2e/template-editor/cases/components/financial.js
+++ b/test/e2e/template-editor/cases/components/financial.js
@@ -4,7 +4,6 @@ var expect = require('rv-common-e2e').expect;
 var PresentationListPage = require('./../../pages/presentationListPage.js');
 var TemplateEditorPage = require('./../../pages/templateEditorPage.js');
 var FinancialComponentPage = require('./../../pages/components/financialComponentPage.js');
-var AutoScheduleModalPage = require('./../../../schedules/pages/autoScheduleModalPage.js');
 var helper = require('rv-common-e2e').helper;
 
 var FinancialComponentScenarios = function () {
@@ -17,13 +16,11 @@ var FinancialComponentScenarios = function () {
     var presentationsListPage;
     var templateEditorPage;
     var financialComponentPage;
-    var autoScheduleModalPage;
 
     before(function () {
       presentationsListPage = new PresentationListPage();
       templateEditorPage = new TemplateEditorPage();
       financialComponentPage = new FinancialComponentPage();
-      autoScheduleModalPage = new AutoScheduleModalPage();
 
       presentationsListPage.loadCurrentCompanyPresentationList();
       presentationsListPage.createNewPresentationFromTemplate('"Example Financial Template V3"', 'example-financial-template-v3');

--- a/test/e2e/template-editor/cases/components/financial.js
+++ b/test/e2e/template-editor/cases/components/financial.js
@@ -38,6 +38,11 @@ var FinancialComponentScenarios = function () {
         templateEditorPage.dismissFinancialDataLicenseMessage();
       });
 
+      it('should auto-save the Presentation after it has been created', function () {
+        helper.wait(templateEditorPage.getSavingText(), 'Component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Component auto-saved');
+      });
+
       it('should show one Financial Component', function () {
         templateEditorPage.selectComponent("Financial - ");
         expect(financialComponentPage.getInstrumentItems().count()).to.eventually.equal(3);
@@ -46,11 +51,6 @@ var FinancialComponentScenarios = function () {
       it('should auto-save the component after the instruments are loaded', function () {
         helper.wait(templateEditorPage.getSavingText(), 'Financial component auto-saving');
         helper.wait(templateEditorPage.getSavedText(), 'Financial component auto-saved');
-
-        helper.wait(autoScheduleModalPage.getAutoScheduleModal());
-        autoScheduleModalPage.getCloseButton().click();
-        helper.waitDisappear(autoScheduleModalPage.getAutoScheduleModal());
-        helper.waitDisappear(presentationsListPage.getTemplateEditorLoader());
       });
 
       it('should show open the Instrument Selector', function () {
@@ -72,14 +72,14 @@ var FinancialComponentScenarios = function () {
 
         presentationsListPage.changePresentationName(presentationName);
 
+        helper.wait(templateEditorPage.getSavingText(), 'Financial component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Financial component auto-saved');
+
         //log presentation / company URL for troubleshooting
         browser.getCurrentUrl().then(function(actualUrl) {
           console.log(actualUrl);
         });
         browser.sleep(100);
-
-        helper.wait(templateEditorPage.getSavingText(), 'Financial component auto-saving');
-        helper.wait(templateEditorPage.getSavedText(), 'Financial component auto-saved');
 
         presentationsListPage.loadPresentation(presentationName);
         templateEditorPage.selectComponent("Financial - ");

--- a/test/e2e/template-editor/cases/components/financial.js
+++ b/test/e2e/template-editor/cases/components/financial.js
@@ -52,7 +52,6 @@ var FinancialComponentScenarios = function () {
 
       it('should show open the Instrument Selector', function () {
         helper.wait(financialComponentPage.getAddCurrenciesButton(), 'Add Currencies');
-        helper.waitDisappear(presentationsListPage.getTemplateEditorLoader());
         helper.clickWhenClickable(financialComponentPage.getAddCurrenciesButton(), 'Add Currencies');
         expect(financialComponentPage.getAddInstrumentButton().isPresent()).to.eventually.be.true;
       });

--- a/test/e2e/template-editor/cases/components/financial.js
+++ b/test/e2e/template-editor/cases/components/financial.js
@@ -4,6 +4,7 @@ var expect = require('rv-common-e2e').expect;
 var PresentationListPage = require('./../../pages/presentationListPage.js');
 var TemplateEditorPage = require('./../../pages/templateEditorPage.js');
 var FinancialComponentPage = require('./../../pages/components/financialComponentPage.js');
+var AutoScheduleModalPage = require('./../../../schedules/pages/autoScheduleModalPage.js');
 var helper = require('rv-common-e2e').helper;
 
 var FinancialComponentScenarios = function () {
@@ -16,11 +17,13 @@ var FinancialComponentScenarios = function () {
     var presentationsListPage;
     var templateEditorPage;
     var financialComponentPage;
+    var autoScheduleModalPage;
 
     before(function () {
       presentationsListPage = new PresentationListPage();
       templateEditorPage = new TemplateEditorPage();
       financialComponentPage = new FinancialComponentPage();
+      autoScheduleModalPage = new AutoScheduleModalPage();
 
       presentationsListPage.loadCurrentCompanyPresentationList();
       presentationsListPage.createNewPresentationFromTemplate('"Example Financial Template V3"', 'example-financial-template-v3');
@@ -43,6 +46,11 @@ var FinancialComponentScenarios = function () {
       it('should auto-save the component after the instruments are loaded', function () {
         helper.wait(templateEditorPage.getSavingText(), 'Financial component auto-saving');
         helper.wait(templateEditorPage.getSavedText(), 'Financial component auto-saved');
+
+        helper.wait(autoScheduleModalPage.getAutoScheduleModal());
+        autoScheduleModalPage.getCloseButton().click();
+        helper.waitDisappear(autoScheduleModalPage.getAutoScheduleModal());
+        helper.waitDisappear(presentationsListPage.getTemplateEditorLoader());
       });
 
       it('should show open the Instrument Selector', function () {

--- a/test/e2e/template-editor/cases/components/image.js
+++ b/test/e2e/template-editor/cases/components/image.js
@@ -28,10 +28,20 @@ var ImageComponentScenarios = function () {
     });
 
     describe('basic operations', function () {
-      it('should select the first Image Component', function () {
+      it('should auto-save the Presentation after it has been created', function () {
+        helper.wait(templateEditorPage.getSavingText(), 'Image component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Image component auto-saved');
+      });
+
+      it('should list the duration and images for the first Image Component', function () {
         templateEditorPage.selectComponent('Image - ');
         helper.wait(imageComponentPage.getListDurationComponent(), 'List Duration');
         expect(imageComponentPage.getSelectedImagesMain().count()).to.eventually.equal(4);
+      });
+
+      it('should auto-save the Presentation after loading thumbnails', function () {
+        helper.wait(templateEditorPage.getSavingText(), 'Image component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Image component auto-saved');
       });
     });
 
@@ -54,6 +64,11 @@ var ImageComponentScenarios = function () {
 
       it('should have a thumbnail', function() {
         expect(imageComponentPage.getThumbnails().count()).to.eventually.equal(1);
+      });
+
+      it('should auto-save the Presentation after updating the image list', function () {
+        helper.wait(templateEditorPage.getSavingText(), 'Image component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Image component auto-saved');
       });
     });
 
@@ -81,7 +96,7 @@ var ImageComponentScenarios = function () {
           expect(imageComponentPage.getUploadPanelStorage().isDisplayed()).to.eventually.be.false;
         });
 
-        it('should list uploaded file only, with sample files removed', function() {
+        it('should list the uploaded file', function() {
           expect(imageComponentPage.getStorageItems().count()).to.eventually.equal(2);
         });
 
@@ -93,21 +108,26 @@ var ImageComponentScenarios = function () {
           helper.wait(imageComponentPage.getListDurationComponent(), 'List Duration');
           expect(imageComponentPage.getSelectedImagesMain().count()).to.eventually.equal(2);
         });
+
+        it('should auto-save the Presentation after adding file from storage', function () {
+          helper.wait(templateEditorPage.getSavingText(), 'Image component auto-saving');
+          helper.wait(templateEditorPage.getSavedText(), 'Image component auto-saved');
+        });
       });
     });
 
     describe('save and validations', function () {
       it('should save the Presentation, reload it, and validate changes were saved', function () {
         presentationsListPage.changePresentationName(presentationName);
-        presentationsListPage.savePresentation();
+
+        helper.wait(templateEditorPage.getSavingText(), 'Image component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Image component auto-saved');
 
         //log presentation / company URL for troubleshooting
         browser.getCurrentUrl().then(function(actualUrl) {
           console.log(actualUrl);
         });
         browser.sleep(100);
-
-        expect(templateEditorPage.getSaveButton().isEnabled()).to.eventually.be.true;
 
         presentationsListPage.loadPresentation(presentationName);
         templateEditorPage.selectComponent('Image - ');
@@ -122,9 +142,15 @@ var ImageComponentScenarios = function () {
         presentationsListPage.createNewPresentationFromTemplate('"Example Financial Template V3"', 'example-financial-template-v3');
         templateEditorPage.dismissFinancialDataLicenseMessage();
 
+        helper.wait(templateEditorPage.getSavingText(), 'Image component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Image component auto-saved');
+
         templateEditorPage.selectComponent('Image - ');
         helper.wait(imageComponentPage.getListDurationComponent(), 'List Duration');
         expect(imageComponentPage.getSelectedImagesMain().count()).to.eventually.equal(4);
+
+        helper.wait(templateEditorPage.getSavingText(), 'Image component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Image component auto-saved');
       });
 
       it('should display image titles', function () {
@@ -158,12 +184,9 @@ var ImageComponentScenarios = function () {
         expect(imageComponentPage.getSelectedImagesMain().count()).to.eventually.equal(3);
       });
 
-      it('should save the Presentation', function () {
-        presentationsListPage.savePresentation();
-
-        browser.sleep(100);
-
-        expect(templateEditorPage.getSaveButton().isEnabled()).to.eventually.be.true;
+      it('should auto-save the Presentation after removing a row', function () {
+        helper.wait(templateEditorPage.getSavingText(), 'Image component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Image component auto-saved');
       });
     });
 

--- a/test/e2e/template-editor/cases/components/image.js
+++ b/test/e2e/template-editor/cases/components/image.js
@@ -29,7 +29,8 @@ var ImageComponentScenarios = function () {
 
     describe('basic operations', function () {
       it('should auto-save the Presentation after it has been created', function () {
-        helper.wait(templateEditorPage.getSavingText(), 'Image component auto-saving');
+        helper.waitDisappear(templateEditorPage.getDirtyText());
+        helper.waitDisappear(templateEditorPage.getSavingText());
         helper.wait(templateEditorPage.getSavedText(), 'Image component auto-saved');
       });
 
@@ -77,7 +78,7 @@ var ImageComponentScenarios = function () {
         it('should load Storage page', function () {
           helper.wait(imageComponentPage.getStorageButtonMain(), 'Storage Button Main');
           helper.clickWhenClickable(imageComponentPage.getStorageButtonMain(), 'Storage Button Main');
-          browser.sleep(500);
+          browser.sleep(1000);
           helper.waitDisappear(imageComponentPage.getStorageSpinner(), 'Storage Spinner');
           expect(imageComponentPage.getStorageItems().count()).to.eventually.equal(1);
         });
@@ -142,7 +143,8 @@ var ImageComponentScenarios = function () {
         presentationsListPage.createNewPresentationFromTemplate('"Example Financial Template V3"', 'example-financial-template-v3');
         templateEditorPage.dismissFinancialDataLicenseMessage();
 
-        helper.wait(templateEditorPage.getSavingText(), 'Image component auto-saving');
+        helper.waitDisappear(templateEditorPage.getDirtyText());
+        helper.waitDisappear(templateEditorPage.getSavingText());
         helper.wait(templateEditorPage.getSavedText(), 'Image component auto-saved');
 
         templateEditorPage.selectComponent('Image - ');

--- a/test/e2e/template-editor/cases/components/text.js
+++ b/test/e2e/template-editor/cases/components/text.js
@@ -48,7 +48,7 @@ var TextComponentScenarios = function () {
       it('should auto-save the Presentation after it has been created', function () {
         helper.waitDisappear(templateEditorPage.getDirtyText());
         helper.waitDisappear(templateEditorPage.getSavingText());
-        helper.wait(templateEditorPage.getSavedText(), 'Component auto-saved');
+        helper.wait(templateEditorPage.getSavedText(), 'Text component auto-saved');
       });
 
       it('should open properties of Text Component', function () {

--- a/test/e2e/template-editor/cases/components/text.js
+++ b/test/e2e/template-editor/cases/components/text.js
@@ -4,6 +4,7 @@ var expect = require('rv-common-e2e').expect;
 var PresentationListPage = require('./../../pages/presentationListPage.js');
 var TemplateEditorPage = require('./../../pages/templateEditorPage.js');
 var TextComponentPage = require('./../../pages/components/textComponentPage.js');
+var helper = require('rv-common-e2e').helper;
 
 var TextComponentScenarios = function () {
 
@@ -34,23 +35,38 @@ var TextComponentScenarios = function () {
         expect(textComponentPage.getTextInput().getAttribute('value')).to.eventually.equal("Financial Literacy");
       });
 
-      it('should save the Presentation, reload it, and validate changes were saved', function () {
+      it('should auto-save the Presentation after a text change', function () {
 
         //change text
         expect(textComponentPage.getTextInput().isEnabled()).to.eventually.be.true;
         textComponentPage.getTextInput().clear();
         textComponentPage.getTextInput().sendKeys("Changed Text" + protractor.Key.ENTER);
-    
-        //save presentation
-        presentationsListPage.changePresentationName(presentationName);
-        presentationsListPage.savePresentation();
-        expect(templateEditorPage.getSaveButton().isEnabled()).to.eventually.be.true;
 
-        //log URL for troubeshooting 
+        //save presentation
+        helper.wait(templateEditorPage.getSavingText(), 'Text component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Text component auto-saved');
+
+        //wait for lagging auto-saves
+        browser.sleep(10000);
+        helper.wait(templateEditorPage.getSavedText(), 'Text component auto-saved');
+      });
+
+      it('should auto-save the Presentation, reload it, and validate changes were saved', function () {
+
+        //change presentation name
+        browser.sleep(1000);
+        presentationsListPage.changePresentationName(presentationName);
+
+        //save presentation
+        helper.waitDisappear(templateEditorPage.getDirtyText());
+        helper.wait(templateEditorPage.getSavingText(), 'Text component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Text component auto-saved');
+        browser.sleep(1000);
+
+        //log URL for troubeshooting
         browser.getCurrentUrl().then(function(actualUrl) {
           console.log(actualUrl);
         });
-        browser.sleep(100);
 
         //load presentation
         presentationsListPage.loadPresentation(presentationName);

--- a/test/e2e/template-editor/cases/components/text.js
+++ b/test/e2e/template-editor/cases/components/text.js
@@ -67,10 +67,11 @@ var TextComponentScenarios = function () {
         helper.wait(templateEditorPage.getSavingText(), 'Text component auto-saving');
         helper.wait(templateEditorPage.getSavedText(), 'Text component auto-saved');
 
-        //log URL for troubeshooting
+        //log URL for troubleshooting
         browser.getCurrentUrl().then(function(actualUrl) {
           console.log(actualUrl);
         });
+        browser.sleep(100);
 
         //load presentation
         presentationsListPage.loadPresentation(presentationName);

--- a/test/e2e/template-editor/cases/components/text.js
+++ b/test/e2e/template-editor/cases/components/text.js
@@ -55,10 +55,6 @@ var TextComponentScenarios = function () {
         //save presentation
         helper.wait(templateEditorPage.getSavingText(), 'Text component auto-saving');
         helper.wait(templateEditorPage.getSavedText(), 'Text component auto-saved');
-
-        //wait for lagging auto-saves
-        browser.sleep(10000);
-        helper.wait(templateEditorPage.getSavedText(), 'Text component auto-saved');
       });
 
       it('should auto-save the Presentation, reload it, and validate changes were saved', function () {

--- a/test/e2e/template-editor/cases/components/text.js
+++ b/test/e2e/template-editor/cases/components/text.js
@@ -4,6 +4,7 @@ var expect = require('rv-common-e2e').expect;
 var PresentationListPage = require('./../../pages/presentationListPage.js');
 var TemplateEditorPage = require('./../../pages/templateEditorPage.js');
 var TextComponentPage = require('./../../pages/components/textComponentPage.js');
+var AutoScheduleModalPage = require('./../../../schedules/pages/autoScheduleModalPage.js');
 var helper = require('rv-common-e2e').helper;
 
 var TextComponentScenarios = function () {
@@ -16,11 +17,13 @@ var TextComponentScenarios = function () {
     var presentationsListPage;
     var templateEditorPage;
     var textComponentPage;
+    var autoScheduleModalPage;
 
     before(function () {
       presentationsListPage = new PresentationListPage();
       templateEditorPage = new TemplateEditorPage();
       textComponentPage = new TextComponentPage();
+      autoScheduleModalPage = new AutoScheduleModalPage();
 
       presentationsListPage.loadCurrentCompanyPresentationList();
 
@@ -28,6 +31,25 @@ var TextComponentScenarios = function () {
     });
 
     describe('basic operations', function () {
+
+      it('should auto create Schedule when saving Presentation', function () {
+        browser.sleep(500);
+
+        helper.wait(autoScheduleModalPage.getAutoScheduleModal(), 'Auto Schedule Modal');
+
+        expect(autoScheduleModalPage.getAutoScheduleModal().isDisplayed()).to.eventually.be.true;
+
+        helper.clickWhenClickable(autoScheduleModalPage.getCloseButton(), 'Auto Schedule Modal - Close Button');
+
+        helper.waitDisappear(autoScheduleModalPage.getAutoScheduleModal(), 'Auto Schedule Modal');
+        helper.waitDisappear(presentationsListPage.getTemplateEditorLoader());
+      });
+
+      it('should auto-save the Presentation after it has been created', function () {
+        helper.waitDisappear(templateEditorPage.getDirtyText());
+        helper.waitDisappear(templateEditorPage.getSavingText());
+        helper.wait(templateEditorPage.getSavedText(), 'Component auto-saved');
+      });
 
       it('should open properties of Text Component', function () {
         templateEditorPage.selectComponent("Text - Title");
@@ -37,19 +59,9 @@ var TextComponentScenarios = function () {
 
       it('should auto-save the Presentation after a text change', function () {
 
-        //clear text
+        //change text
         expect(textComponentPage.getTextInput().isEnabled()).to.eventually.be.true;
         textComponentPage.getTextInput().clear();
-
-        //save presentation
-        helper.wait(templateEditorPage.getSavingText(), 'Text component auto-saving');
-        helper.wait(templateEditorPage.getSavedText(), 'Text component auto-saved');
-
-        //wait for lagging auto-saves
-        browser.sleep(10000);
-        helper.wait(templateEditorPage.getSavedText(), 'Text component auto-saved');
-
-        //change text
         textComponentPage.getTextInput().sendKeys("Changed Text" + protractor.Key.ENTER);
 
         //save presentation

--- a/test/e2e/template-editor/cases/components/text.js
+++ b/test/e2e/template-editor/cases/components/text.js
@@ -37,9 +37,19 @@ var TextComponentScenarios = function () {
 
       it('should auto-save the Presentation after a text change', function () {
 
-        //change text
+        //clear text
         expect(textComponentPage.getTextInput().isEnabled()).to.eventually.be.true;
         textComponentPage.getTextInput().clear();
+
+        //save presentation
+        helper.wait(templateEditorPage.getSavingText(), 'Text component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Text component auto-saved');
+
+        //wait for lagging auto-saves
+        browser.sleep(10000);
+        helper.wait(templateEditorPage.getSavedText(), 'Text component auto-saved');
+
+        //change text
         textComponentPage.getTextInput().sendKeys("Changed Text" + protractor.Key.ENTER);
 
         //save presentation
@@ -54,14 +64,12 @@ var TextComponentScenarios = function () {
       it('should auto-save the Presentation, reload it, and validate changes were saved', function () {
 
         //change presentation name
-        browser.sleep(1000);
         presentationsListPage.changePresentationName(presentationName);
 
         //save presentation
         helper.waitDisappear(templateEditorPage.getDirtyText());
         helper.wait(templateEditorPage.getSavingText(), 'Text component auto-saving');
         helper.wait(templateEditorPage.getSavedText(), 'Text component auto-saved');
-        browser.sleep(1000);
 
         //log URL for troubeshooting
         browser.getCurrentUrl().then(function(actualUrl) {

--- a/test/e2e/template-editor/cases/components/weather.js
+++ b/test/e2e/template-editor/cases/components/weather.js
@@ -30,7 +30,8 @@ var WeatherComponentScenarios = function () {
     describe('basic operations', function () {
 
       it('should auto-save the Presentation after it has been created', function () {
-        helper.wait(templateEditorPage.getSavingText(), 'Weather component auto-saving');
+        helper.waitDisappear(templateEditorPage.getDirtyText());
+        helper.waitDisappear(templateEditorPage.getSavingText());
         helper.wait(templateEditorPage.getSavedText(), 'Weather component auto-saved');
       });
 

--- a/test/e2e/template-editor/cases/components/weather.js
+++ b/test/e2e/template-editor/cases/components/weather.js
@@ -4,6 +4,7 @@ var expect = require('rv-common-e2e').expect;
 var PresentationListPage = require('./../../pages/presentationListPage.js');
 var TemplateEditorPage = require('./../../pages/templateEditorPage.js');
 var WeatherComponentPage = require('./../../pages/components/weatherComponentPage.js');
+var helper = require('rv-common-e2e').helper;
 
 var WeatherComponentScenarios = function () {
 
@@ -28,26 +29,36 @@ var WeatherComponentScenarios = function () {
 
     describe('basic operations', function () {
 
+      it('should auto-save the Presentation after it has been created', function () {
+        helper.wait(templateEditorPage.getSavingText(), 'Weather component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Weather component auto-saved');
+      });
+
       it('should open properties of Weather Component', function () {
         templateEditorPage.selectComponent("Weather - Weather Forecast");
         expect(weatherComponentPage.getFarenheitOption().isSelected()).to.eventually.not.be.true;
         expect(weatherComponentPage.getCelsiusOption().isSelected()).to.eventually.be.true;
       });
 
-      it('should save the Presentation, reload it, and validate changes were saved', function () {
-
+      it('should change the weather unit and auto-save after', function () {
         //change weather
         weatherComponentPage.getFarenheitLabel().click();
-    
+
         expect(weatherComponentPage.getFarenheitOption().isSelected()).to.eventually.be.true;
         expect(weatherComponentPage.getCelsiusOption().isSelected()).to.eventually.not.be.true;
 
-        //save presentation
-        presentationsListPage.changePresentationName(presentationName);
-        presentationsListPage.savePresentation();
-        expect(templateEditorPage.getSaveButton().isEnabled()).to.eventually.be.true;
+        helper.wait(templateEditorPage.getSavingText(), 'Weather component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Weather component auto-saved');
+      });
 
-        //log URL for troubeshooting 
+      it('should save the Presentation, reload it, and validate changes were saved', function () {
+
+        //change name and save presentation
+        presentationsListPage.changePresentationName(presentationName);
+        helper.wait(templateEditorPage.getSavingText(), 'Weather component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Weather component auto-saved');
+
+        //log URL for troubleshooting
         browser.getCurrentUrl().then(function(actualUrl) {
           console.log(actualUrl);
         });

--- a/test/e2e/template-editor/cases/template-editor-add.js
+++ b/test/e2e/template-editor/cases/template-editor-add.js
@@ -2,7 +2,6 @@
 var expect = require('rv-common-e2e').expect;
 var PresentationListPage = require('./../pages/presentationListPage.js');
 var TemplateEditorPage = require('./../pages/templateEditorPage.js');
-var AutoScheduleModalPage = require('./../../schedules/pages/autoScheduleModalPage.js');
 var helper = require('rv-common-e2e').helper;
 
 var TemplateAddScenarios = function() {
@@ -14,12 +13,10 @@ var TemplateAddScenarios = function() {
     var presentationName = 'Example Presentation - ' + testStartTime;
     var presentationsListPage;
     var templateEditorPage;
-    var autoScheduleModalPage;
 
     before(function () {
       presentationsListPage = new PresentationListPage();
       templateEditorPage = new TemplateEditorPage();
-      autoScheduleModalPage = new AutoScheduleModalPage();
 
       presentationsListPage.loadCurrentCompanyPresentationList();
       presentationsListPage.createNewPresentationFromTemplate('"Example Financial Template V3"', 'example-financial-template-v3');

--- a/test/e2e/template-editor/cases/template-editor-add.js
+++ b/test/e2e/template-editor/cases/template-editor-add.js
@@ -12,7 +12,6 @@ var TemplateAddScenarios = function() {
   describe('Template Editor Add', function () {
     var testStartTime = Date.now();
     var presentationName = 'Example Presentation - ' + testStartTime;
-    var presentationName2 = 'Example Presentation 2 - ' + testStartTime;
     var presentationsListPage;
     var templateEditorPage;
     var autoScheduleModalPage;
@@ -22,6 +21,7 @@ var TemplateAddScenarios = function() {
       templateEditorPage = new TemplateEditorPage();
       autoScheduleModalPage = new AutoScheduleModalPage();
 
+      presentationsListPage.loadCurrentCompanyPresentationList();
       presentationsListPage.createNewPresentationFromTemplate('"Example Financial Template V3"', 'example-financial-template-v3');
       templateEditorPage.dismissFinancialDataLicenseMessage();
     });
@@ -32,34 +32,17 @@ var TemplateAddScenarios = function() {
         expect(templateEditorPage.getComponentItems().count()).to.eventually.be.above(1);
       });
 
+      it('should auto-save the Presentation after it has been created', function () {
+        helper.wait(templateEditorPage.getSavingText(), 'Component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Component auto-saved');
+      });
+
       it('should edit the Presentation name', function () {
         presentationsListPage.changePresentationName(presentationName);
         expect(templateEditorPage.getPresentationName().getAttribute('value')).to.eventually.equal(presentationName);
       });
 
-      it('should auto-save the Presentation', function () {
-        helper.wait(templateEditorPage.getSavingText(), 'Component auto-saving');
-        helper.wait(templateEditorPage.getSavedText(), 'Component auto-saved');
-      });
-
-      it('should auto create Schedule when saving Presentation', function () {
-        browser.sleep(500);
-
-        helper.wait(autoScheduleModalPage.getAutoScheduleModal(), 'Auto Schedule Modal');
-
-        expect(autoScheduleModalPage.getAutoScheduleModal().isDisplayed()).to.eventually.be.true;
-
-        helper.clickWhenClickable(autoScheduleModalPage.getCloseButton(), 'Auto Schedule Modal - Close Button');
-
-        helper.waitDisappear(autoScheduleModalPage.getAutoScheduleModal(), 'Auto Schedule Modal');
-        helper.waitDisappear(presentationsListPage.getTemplateEditorLoader());
-      });
-
-      it('should edit the Presentation name again', function () {
-        // Since the first time a Presentation is saved it's also Published, to later test the publish button an additional Save is needed
-        presentationsListPage.changePresentationName(presentationName2);
-        expect(templateEditorPage.getPresentationName().getAttribute('value')).to.eventually.equal(presentationName2);
-
+      it('should auto-save the Presentation after the name has changed', function () {
         helper.wait(templateEditorPage.getSavingText(), 'Component auto-saving');
         helper.wait(templateEditorPage.getSavedText(), 'Component auto-saved');
       });
@@ -72,7 +55,7 @@ var TemplateAddScenarios = function() {
       });
 
       it('should load the newly created Presentation', function () {
-        presentationsListPage.loadPresentation(presentationName2);
+        presentationsListPage.loadPresentation(presentationName);
 
         expect(templateEditorPage.getComponentItems().count()).to.eventually.be.above(1);
         expect(templateEditorPage.getImageComponentEdit().isPresent()).to.eventually.be.true;

--- a/test/e2e/template-editor/cases/template-editor-add.js
+++ b/test/e2e/template-editor/cases/template-editor-add.js
@@ -12,6 +12,7 @@ var TemplateAddScenarios = function() {
   describe('Template Editor Add', function () {
     var testStartTime = Date.now();
     var presentationName = 'Example Presentation - ' + testStartTime;
+    var presentationName2 = 'Example Presentation 2 - ' + testStartTime;
     var presentationsListPage;
     var templateEditorPage;
     var autoScheduleModalPage;
@@ -36,10 +37,9 @@ var TemplateAddScenarios = function() {
         expect(templateEditorPage.getPresentationName().getAttribute('value')).to.eventually.equal(presentationName);
       });
 
-      it('should save the Presentation', function () {
-        presentationsListPage.savePresentation();
-
-        expect(templateEditorPage.getSaveButton().isEnabled()).to.eventually.be.true;
+      it('should auto-save the Presentation', function () {
+        helper.wait(templateEditorPage.getSavingText(), 'Component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Component auto-saved');
       });
 
       it('should auto create Schedule when saving Presentation', function () {
@@ -52,20 +52,27 @@ var TemplateAddScenarios = function() {
         helper.clickWhenClickable(autoScheduleModalPage.getCloseButton(), 'Auto Schedule Modal - Close Button');
 
         helper.waitDisappear(autoScheduleModalPage.getAutoScheduleModal(), 'Auto Schedule Modal');
+        helper.waitDisappear(presentationsListPage.getTemplateEditorLoader());
+      });
+
+      it('should edit the Presentation name again', function () {
+        // Since the first time a Presentation is saved it's also Published, to later test the publish button an additional Save is needed
+        presentationsListPage.changePresentationName(presentationName2);
+        expect(templateEditorPage.getPresentationName().getAttribute('value')).to.eventually.equal(presentationName2);
+
+        helper.wait(templateEditorPage.getSavingText(), 'Component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Component auto-saved');
       });
 
       it('should publish the Presentation', function () {
-        // Since the first time a Presentation is saved it's also Published, to test the button an additional Save is needed
-        presentationsListPage.savePresentation();
-        presentationsListPage.savePresentation();
-
         helper.clickWhenClickable(templateEditorPage.getPublishButton(), 'Publish Button');
-        helper.wait(templateEditorPage.getSaveButton(), 'Save Button (after Publish)');
-        expect(templateEditorPage.getSaveButton().isEnabled()).to.eventually.be.true;
+
+        helper.wait(templateEditorPage.getSavingText(), 'Component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'Component auto-saved');
       });
 
       it('should load the newly created Presentation', function () {
-        presentationsListPage.loadPresentation(presentationName);
+        presentationsListPage.loadPresentation(presentationName2);
 
         expect(templateEditorPage.getComponentItems().count()).to.eventually.be.above(1);
         expect(templateEditorPage.getImageComponentEdit().isPresent()).to.eventually.be.true;

--- a/test/e2e/template-editor/cases/template-editor-add.js
+++ b/test/e2e/template-editor/cases/template-editor-add.js
@@ -25,7 +25,9 @@ var TemplateAddScenarios = function() {
 
     describe('basic operations', function () {
       it('should auto-save the Presentation after it has been created', function () {
-        helper.wait(templateEditorPage.getSavingText(), 'Component auto-saving');
+        browser.sleep(3000);
+        helper.waitDisappear(templateEditorPage.getDirtyText());
+        helper.waitDisappear(templateEditorPage.getSavingText());
         helper.wait(templateEditorPage.getSavedText(), 'Component auto-saved');
       });
 

--- a/test/e2e/template-editor/cases/template-editor-add.js
+++ b/test/e2e/template-editor/cases/template-editor-add.js
@@ -27,14 +27,14 @@ var TemplateAddScenarios = function() {
     });
 
     describe('basic operations', function () {
-      it('should show more than one component', function () {
-        helper.wait(templateEditorPage.getAttributeList(), 'Attribute List');
-        expect(templateEditorPage.getComponentItems().count()).to.eventually.be.above(1);
-      });
-
       it('should auto-save the Presentation after it has been created', function () {
         helper.wait(templateEditorPage.getSavingText(), 'Component auto-saving');
         helper.wait(templateEditorPage.getSavedText(), 'Component auto-saved');
+      });
+
+      it('should show more than one component', function () {
+        helper.wait(templateEditorPage.getAttributeList(), 'Attribute List');
+        expect(templateEditorPage.getComponentItems().count()).to.eventually.be.above(1);
       });
 
       it('should edit the Presentation name', function () {

--- a/test/e2e/template-editor/pages/presentationListPage.js
+++ b/test/e2e/template-editor/pages/presentationListPage.js
@@ -14,6 +14,7 @@ var PresentationListPage = function() {
   var presentationItems = element.all(by.repeater('presentation in presentations.list'));
 
   var presentationsLoader = element(by.xpath('//div[@spinner-key="presentation-list-loader"]'));
+  var spinner = element(by.xpath('//div[@spinner-key="template-editor-loader"]'));
 
   var homepage = new HomePage();
   var signInPage = new SignInPage();
@@ -63,6 +64,7 @@ var PresentationListPage = function() {
 
   this.changePresentationName = function(presentationName) {
     expect(templateEditorPage.getPresentationName().isEnabled()).to.eventually.be.false;
+    helper.waitDisappear(spinner, 'Spinner');
     templateEditorPage.getEditNameButton().click();
     expect(templateEditorPage.getPresentationName().isEnabled()).to.eventually.be.true;
     templateEditorPage.getPresentationName().sendKeys(presentationName + protractor.Key.ENTER);

--- a/test/e2e/template-editor/pages/presentationListPage.js
+++ b/test/e2e/template-editor/pages/presentationListPage.js
@@ -14,7 +14,7 @@ var PresentationListPage = function() {
   var presentationItems = element.all(by.repeater('presentation in presentations.list'));
 
   var presentationsLoader = element(by.xpath('//div[@spinner-key="presentation-list-loader"]'));
-  var spinner = element(by.xpath('//div[@spinner-key="template-editor-loader"]'));
+  var templateEditorLoader = element(by.xpath('//div[@spinner-key="template-editor-loader"]'));
 
   var homepage = new HomePage();
   var signInPage = new SignInPage();
@@ -64,11 +64,11 @@ var PresentationListPage = function() {
 
   this.changePresentationName = function(presentationName) {
     expect(templateEditorPage.getPresentationName().isEnabled()).to.eventually.be.false;
-    helper.waitDisappear(spinner, 'Spinner');
+    helper.waitDisappear(this.getTemplateEditorLoader());
     templateEditorPage.getEditNameButton().click();
     expect(templateEditorPage.getPresentationName().isEnabled()).to.eventually.be.true;
     templateEditorPage.getPresentationName().sendKeys(presentationName + protractor.Key.ENTER);
-}
+  }
 
   this.getPresentationAddButton = function() {
     return presentationAddButton;
@@ -84,6 +84,10 @@ var PresentationListPage = function() {
 
   this.getPresentationsLoader = function() {
     return presentationsLoader;
+  }
+
+  this.getTemplateEditorLoader = function() {
+    return templateEditorLoader;
   }
 };
 

--- a/test/e2e/template-editor/pages/presentationListPage.js
+++ b/test/e2e/template-editor/pages/presentationListPage.js
@@ -55,13 +55,6 @@ var PresentationListPage = function() {
     browser.sleep(500); // Wait for transition to finish
   }
 
-  this.savePresentation = function() {
-    helper.wait(templateEditorPage.getSaveButton(), 'Save Button');
-    helper.clickWhenClickable(templateEditorPage.getSaveButton(), 'Save Button');
-    expect(templateEditorPage.getSaveButton().getText()).to.eventually.equal('Saving');
-    helper.wait(templateEditorPage.getSaveButton(), 'Save Button');
-  }
-
   this.changePresentationName = function(presentationName) {
     expect(templateEditorPage.getPresentationName().isEnabled()).to.eventually.be.false;
     helper.waitDisappear(this.getTemplateEditorLoader());

--- a/test/e2e/template-editor/pages/templateEditorPage.js
+++ b/test/e2e/template-editor/pages/templateEditorPage.js
@@ -68,6 +68,10 @@ var TemplateEditorPage = function() {
     return savingText;
   };
 
+  this.getDirtyText = function () {
+    return dirtyText;
+  };
+
   this.getPublishButton = function () {
     return publishButton;
   };

--- a/test/e2e/template-editor/pages/templateEditorPage.js
+++ b/test/e2e/template-editor/pages/templateEditorPage.js
@@ -20,6 +20,11 @@ var TemplateEditorPage = function() {
   var financialDataLicenseMessage = element(by.css('.financial-data-license-message'));
   var financialDataLicenseCloseButton = element(by.css('#confirmForm .close'));
 
+  var autoSaveXPath = '//div[@id="saveButtonDesktop"]/strong[contains(text(), "TEXT")]';
+  var dirtyText = element(by.xpath(autoSaveXPath.replace('TEXT', 'Dirty')));
+  var savedText = element(by.xpath(autoSaveXPath.replace('TEXT', 'Saved')));
+  var savingText = element(by.xpath(autoSaveXPath.replace('TEXT', 'Saving')));
+
   this.seePlansLink = function () {
     return seePlansLink;
   };

--- a/test/e2e/template-editor/pages/templateEditorPage.js
+++ b/test/e2e/template-editor/pages/templateEditorPage.js
@@ -20,10 +20,10 @@ var TemplateEditorPage = function() {
   var financialDataLicenseMessage = element(by.css('.financial-data-license-message'));
   var financialDataLicenseCloseButton = element(by.css('#confirmForm .close'));
 
-  var autoSaveXPath = '//div[@id="saveButtonDesktop"]/strong[contains(text(), "TEXT")]';
-  var dirtyText = element(by.xpath(autoSaveXPath.replace('TEXT', 'Dirty')));
-  var savedText = element(by.xpath(autoSaveXPath.replace('TEXT', 'Saved')));
-  var savingText = element(by.xpath(autoSaveXPath.replace('TEXT', 'Saving')));
+  var autoSaveXPath = '//div[@id="autoSavingDesktop"]//div[contains(text(), "TEXT")]';
+  var dirtyText = element(by.xpath(autoSaveXPath.replace('TEXT', 'Unsaved changes')));
+  var savedText = element(by.xpath(autoSaveXPath.replace('TEXT', 'All changes saved')));
+  var savingText = element(by.xpath(autoSaveXPath.replace('TEXT', 'Saving changes')));
 
   this.seePlansLink = function () {
     return seePlansLink;

--- a/test/e2e/template-editor/pages/templateEditorPage.js
+++ b/test/e2e/template-editor/pages/templateEditorPage.js
@@ -11,7 +11,6 @@ var TemplateEditorPage = function() {
   var presentationName = element(by.id('presentationName'));
   var editNameButton = element(by.id('editNameButton'));
   var deleteButton = element(by.id('deleteButton'));
-  var saveButton = element(by.id('saveButtonDesktop'));
   var publishButton = element(by.id('publishButtonDesktop'));
   var imageComponentSelector = '//div[div/span[contains(text(), "Image - ")]]';
   var imageComponent = element(by.xpath('(' + imageComponentSelector + ')[1]'));
@@ -59,10 +58,6 @@ var TemplateEditorPage = function() {
 
   this.getDeleteButton = function () {
     return deleteButton;
-  };
-
-  this.getSaveButton = function () {
-    return saveButton;
   };
 
   this.getSavedText = function () {

--- a/test/e2e/template-editor/pages/templateEditorPage.js
+++ b/test/e2e/template-editor/pages/templateEditorPage.js
@@ -60,6 +60,14 @@ var TemplateEditorPage = function() {
     return saveButton;
   };
 
+  this.getSavedText = function () {
+    return savedText;
+  };
+
+  this.getSavingText = function () {
+    return savingText;
+  };
+
   this.getPublishButton = function () {
     return publishButton;
   };

--- a/test/e2e/template-editor/template-editor.cases.js
+++ b/test/e2e/template-editor/template-editor.cases.js
@@ -59,7 +59,7 @@
 
     //var templateEditorAddScenarios = new TemplateEditorAddScenarios();
     var financialComponentScenarios = new FinancialComponentScenarios();
-    //var textComponentScenarios = new TextComponentScenarios();
+    var textComponentScenarios = new TextComponentScenarios();
     //var weatherComponentScenarios = new WeatherComponentScenarios();
     //var imageComponentScenarios = new ImageComponentScenarios();
 

--- a/test/e2e/template-editor/template-editor.cases.js
+++ b/test/e2e/template-editor/template-editor.cases.js
@@ -59,9 +59,9 @@
 
     // Text component scenarios deal with the auto schedule modal, so they always should come first.
     var textComponentScenarios = new TextComponentScenarios();
-    //var templateEditorAddScenarios = new TemplateEditorAddScenarios();
-    //var financialComponentScenarios = new FinancialComponentScenarios();
-    //var weatherComponentScenarios = new WeatherComponentScenarios();
+    var templateEditorAddScenarios = new TemplateEditorAddScenarios();
+    var financialComponentScenarios = new FinancialComponentScenarios();
+    var weatherComponentScenarios = new WeatherComponentScenarios();
     var imageComponentScenarios = new ImageComponentScenarios();
 
     after(function() {

--- a/test/e2e/template-editor/template-editor.cases.js
+++ b/test/e2e/template-editor/template-editor.cases.js
@@ -57,9 +57,10 @@
       _selectSubCompany();
     });
 
+    // Text component scenarios deal with the auto schedule modal, so they always should come first.
+    var textComponentScenarios = new TextComponentScenarios();
     var templateEditorAddScenarios = new TemplateEditorAddScenarios();
     //var financialComponentScenarios = new FinancialComponentScenarios();
-    //var textComponentScenarios = new TextComponentScenarios();
     //var weatherComponentScenarios = new WeatherComponentScenarios();
     //var imageComponentScenarios = new ImageComponentScenarios();
 

--- a/test/e2e/template-editor/template-editor.cases.js
+++ b/test/e2e/template-editor/template-editor.cases.js
@@ -57,9 +57,9 @@
       _selectSubCompany();
     });
 
-    //var templateEditorAddScenarios = new TemplateEditorAddScenarios();
-    var financialComponentScenarios = new FinancialComponentScenarios();
-    var textComponentScenarios = new TextComponentScenarios();
+    var templateEditorAddScenarios = new TemplateEditorAddScenarios();
+    //var financialComponentScenarios = new FinancialComponentScenarios();
+    //var textComponentScenarios = new TextComponentScenarios();
     //var weatherComponentScenarios = new WeatherComponentScenarios();
     //var imageComponentScenarios = new ImageComponentScenarios();
 

--- a/test/e2e/template-editor/template-editor.cases.js
+++ b/test/e2e/template-editor/template-editor.cases.js
@@ -60,7 +60,7 @@
     // Text component scenarios deal with the auto schedule modal, so they always should come first.
     var textComponentScenarios = new TextComponentScenarios();
     var templateEditorAddScenarios = new TemplateEditorAddScenarios();
-    //var financialComponentScenarios = new FinancialComponentScenarios();
+    var financialComponentScenarios = new FinancialComponentScenarios();
     //var weatherComponentScenarios = new WeatherComponentScenarios();
     //var imageComponentScenarios = new ImageComponentScenarios();
 

--- a/test/e2e/template-editor/template-editor.cases.js
+++ b/test/e2e/template-editor/template-editor.cases.js
@@ -59,10 +59,10 @@
 
     // Text component scenarios deal with the auto schedule modal, so they always should come first.
     var textComponentScenarios = new TextComponentScenarios();
-    var templateEditorAddScenarios = new TemplateEditorAddScenarios();
-    var financialComponentScenarios = new FinancialComponentScenarios();
+    //var templateEditorAddScenarios = new TemplateEditorAddScenarios();
+    //var financialComponentScenarios = new FinancialComponentScenarios();
     //var weatherComponentScenarios = new WeatherComponentScenarios();
-    //var imageComponentScenarios = new ImageComponentScenarios();
+    var imageComponentScenarios = new ImageComponentScenarios();
 
     after(function() {
       // Loading the Presentation List is a workaround to a Chrome Driver issue that has it fail to click on elements over the Preview iframe

--- a/test/e2e/template-editor/template-editor.cases.js
+++ b/test/e2e/template-editor/template-editor.cases.js
@@ -6,7 +6,7 @@
   var PresentationListPage = require('./pages/presentationListPage.js');
   var TemplateEditorPage = require('./pages/templateEditorPage.js');
   var helper = require('rv-common-e2e').helper;
-  
+
   var TemplateEditorAddScenarios = require('./cases/template-editor-add.js');
   var FinancialComponentScenarios = require('./cases/components/financial.js');
   var TextComponentScenarios = require('./cases/components/text.js');
@@ -57,11 +57,11 @@
       _selectSubCompany();
     });
 
-    var templateEditorAddScenarios = new TemplateEditorAddScenarios();
+    //var templateEditorAddScenarios = new TemplateEditorAddScenarios();
     var financialComponentScenarios = new FinancialComponentScenarios();
-    var textComponentScenarios = new TextComponentScenarios();
-    var weatherComponentScenarios = new WeatherComponentScenarios();
-    var imageComponentScenarios = new ImageComponentScenarios();
+    //var textComponentScenarios = new TextComponentScenarios();
+    //var weatherComponentScenarios = new WeatherComponentScenarios();
+    //var imageComponentScenarios = new ImageComponentScenarios();
 
     after(function() {
       // Loading the Presentation List is a workaround to a Chrome Driver issue that has it fail to click on elements over the Preview iframe

--- a/test/unit/template-editor/controllers/ctr-template-editor.tests.js
+++ b/test/unit/template-editor/controllers/ctr-template-editor.tests.js
@@ -33,7 +33,10 @@ describe('controller: TemplateEditor', function() {
   var $rootScope, $scope, $modal, $timeout, $window, factory;
 
   beforeEach(function() {
-    factory = { presentation: { templateAttributeData: {} } };
+    factory = {
+      presentation: { templateAttributeData: {} },
+      save: function() {}
+    };
   });
 
   beforeEach(module('risevision.template-editor.controllers'));

--- a/test/unit/template-editor/controllers/ctr-template-editor.tests.js
+++ b/test/unit/template-editor/controllers/ctr-template-editor.tests.js
@@ -190,6 +190,7 @@ describe('controller: TemplateEditor', function() {
   describe('unsaved changes', function () {
     it('should flag unsaved changes to presentation', function () {
       expect($scope.hasUnsavedChanges).to.be.false;
+      factory.presentation.id = '1234';
       factory.presentation.name = 'New Name';
       $scope.$apply();
       $timeout.flush();
@@ -198,6 +199,7 @@ describe('controller: TemplateEditor', function() {
     });
 
     it('should clear unsaved changes flag after saving presentation', function () {
+      factory.presentation.id = '1234';
       factory.presentation.name = 'New Name';
       $scope.$apply();
       $rootScope.$broadcast('presentationUpdated');
@@ -207,6 +209,7 @@ describe('controller: TemplateEditor', function() {
     });
 
     it('should clear unsaved changes when deleting the presentation', function () {
+      factory.presentation.id = '1234';
       factory.presentation.name = 'New Name';
       $scope.$apply();
       $rootScope.$broadcast('presentationDeleted');
@@ -215,6 +218,7 @@ describe('controller: TemplateEditor', function() {
     });
 
     it('should not flag unsaved changes when publishing', function () {
+      factory.presentation.id = '1234';
       factory.presentation.revisionStatusName = 'Published';
       factory.presentation.changeDate = new Date();
       factory.presentation.changedBy = 'newUsername';
@@ -224,6 +228,7 @@ describe('controller: TemplateEditor', function() {
     });
 
     it('should notify unsaved changes when changing URL', function () {
+      factory.presentation.id = '1234';
       factory.presentation.name = 'New Name';
       $scope.$apply();
       $timeout.flush();
@@ -257,6 +262,7 @@ describe('controller: TemplateEditor', function() {
     });
 
     it('should not notify unsaved changes when changing URL if state is in Template Editor', function () {
+      factory.presentation.id = '1234';
       factory.presentation.name = 'New Name';
       $scope.$apply();
       var modalOpenStub = sinon.stub($modal, 'open', function() {
@@ -274,6 +280,7 @@ describe('controller: TemplateEditor', function() {
     });
 
     it('should notify unsaved changes when closing window', function () {
+      factory.presentation.id = '1234';
       factory.presentation.name = 'New Name';
       $scope.$apply();
       $timeout.flush();

--- a/test/unit/template-editor/services/svc-template-editor-factory.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-factory.tests.js
@@ -26,7 +26,7 @@ describe('service: templateEditorFactory:', function() {
 
     $provide.service('$state',function() {
       return {
-        go: sandbox.stub().resolves()
+        go: sinon.stub().returns(Q.resolve())
       };
     });
 
@@ -62,6 +62,11 @@ describe('service: templateEditorFactory:', function() {
       };
     });
 
+    $provide.service('$timeout', function() {
+      return function(callback, duration) {
+      };
+    });
+
     $provide.factory('$modal', function() {
       return {
         open: function(params){
@@ -84,7 +89,9 @@ describe('service: templateEditorFactory:', function() {
     needsFinancialDataLicense;
 
   beforeEach(function() {
+    console.log('D');
     inject(function($injector, checkTemplateAccess) {
+      console.log('A');
       $state = $injector.get('$state');
       $httpBackend = $injector.get('$httpBackend');
       $modal = $injector.get('$modal');
@@ -266,7 +273,7 @@ describe('service: templateEditorFactory:', function() {
       expect(templateEditorFactory.presentation.productCode).to.equal('test-id');
       expect(templateEditorFactory.presentation.templateAttributeData).to.deep.equal({});
 
-      templateEditorFactory.addPresentation()        
+      templateEditorFactory.addPresentation()
         .then(function() {
 
           setTimeout(function(){

--- a/test/unit/template-editor/services/svc-template-editor-factory.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-factory.tests.js
@@ -126,15 +126,6 @@ describe('service: templateEditorFactory:', function() {
   });
 
   describe('addFromProduct:', function() {
-    beforeEach(function() {
-      sandbox.stub(presentation, 'add').returns(Q.resolve({
-        item: {
-          name: 'Test Presentation',
-          id: 'presentationId'
-        }
-      }));
-    });
-
     it('should create a new presentation', function(done) {
       $httpBackend.when('GET', blueprintUrl).respond(200, {
         components: [
@@ -157,21 +148,7 @@ describe('service: templateEditorFactory:', function() {
         expect(templateEditorFactory.presentation.presentationType).to.equal(HTML_PRESENTATION_TYPE);
         expect(templateEditorFactory.blueprintData.components.length).to.equal(1);
 
-        expect(templateEditorUtils.showMessageWindow).to.not.have.been.called;
-        expect(templateEditorFactory.savingPresentation).to.be.true;
-        expect(templateEditorFactory.loadingPresentation).to.be.true;
-
-        setTimeout(function(){
-          expect($state.go).to.have.been.calledWith('apps.editor.templates.edit');
-          expect(presentation.add.getCall(0).args[0].templateAttributeData).to.equal('{}');
-          expect(templateEditorFactory.presentation.templateAttributeData).to.deep.equal({});
-          expect(templateEditorFactory.savingPresentation).to.be.false;
-          expect(templateEditorFactory.loadingPresentation).to.be.false;
-          expect(templateEditorFactory.errorMessage).to.not.be.ok;
-          expect(templateEditorFactory.apiError).to.not.be.ok;
-
-          done();
-        },10);
+        done();
       });
     });
 
@@ -312,6 +289,47 @@ describe('service: templateEditorFactory:', function() {
   });
 
   describe('updatePresentation:',function(){
+    it('should update the presentation',function(done){
+      sandbox.stub(presentation, 'update').returns(Q.resolve({
+        item: {
+          name: 'Test Presentation',
+          id: 'presentationId'
+        }
+      }));
+
+      $httpBackend.when('GET', blueprintUrl).respond(200, {});
+      setTimeout(function() {
+        $httpBackend.flush();
+      });
+
+      templateEditorFactory.addFromProduct({ productCode: 'test-id', name: 'Test HTML Template' });
+      expect(templateEditorFactory.presentation.id).to.be.undefined;
+      expect(templateEditorFactory.presentation.productCode).to.equal('test-id');
+      expect(templateEditorFactory.presentation.templateAttributeData).to.deep.equal({});
+
+      templateEditorFactory.updatePresentation()
+        .then(function() {
+          expect(templateEditorUtils.showMessageWindow).to.not.have.been.called;
+          expect(templateEditorFactory.savingPresentation).to.be.true;
+          expect(templateEditorFactory.loadingPresentation).to.be.true;
+
+          setTimeout(function(){
+            expect(presentation.update.getCall(0).args[1].templateAttributeData).to.equal('{}');
+            expect(templateEditorFactory.presentation.templateAttributeData).to.deep.equal({});
+            expect(templateEditorFactory.savingPresentation).to.be.false;
+            expect(templateEditorFactory.loadingPresentation).to.be.false;
+            expect(templateEditorFactory.errorMessage).to.not.be.ok;
+            expect(templateEditorFactory.apiError).to.not.be.ok;
+
+            done();
+          },10);
+        })
+        .then(null, function(err) {
+          done(err);
+        })
+        .then(null, done);
+    });
+
     it('should show an error if fails to update presentation',function(done){
       sandbox.stub(presentation, 'update').returns(Q.reject({ name: 'Test Presentation' }));
 

--- a/test/unit/template-editor/services/svc-template-editor-factory.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-factory.tests.js
@@ -89,9 +89,7 @@ describe('service: templateEditorFactory:', function() {
     needsFinancialDataLicense;
 
   beforeEach(function() {
-    console.log('D');
     inject(function($injector, checkTemplateAccess) {
-      console.log('A');
       $state = $injector.get('$state');
       $httpBackend = $injector.get('$httpBackend');
       $modal = $injector.get('$modal');
@@ -128,6 +126,15 @@ describe('service: templateEditorFactory:', function() {
   });
 
   describe('addFromProduct:', function() {
+    beforeEach(function() {
+      sandbox.stub(presentation, 'add').returns(Q.resolve({
+        item: {
+          name: 'Test Presentation',
+          id: 'presentationId'
+        }
+      }));
+    });
+
     it('should create a new presentation', function(done) {
       $httpBackend.when('GET', blueprintUrl).respond(200, {
         components: [
@@ -150,7 +157,21 @@ describe('service: templateEditorFactory:', function() {
         expect(templateEditorFactory.presentation.presentationType).to.equal(HTML_PRESENTATION_TYPE);
         expect(templateEditorFactory.blueprintData.components.length).to.equal(1);
 
-        done();
+        expect(templateEditorUtils.showMessageWindow).to.not.have.been.called;
+        expect(templateEditorFactory.savingPresentation).to.be.true;
+        expect(templateEditorFactory.loadingPresentation).to.be.true;
+
+        setTimeout(function(){
+          expect($state.go).to.have.been.calledWith('apps.editor.templates.edit');
+          expect(presentation.add.getCall(0).args[0].templateAttributeData).to.equal('{}');
+          expect(templateEditorFactory.presentation.templateAttributeData).to.deep.equal({});
+          expect(templateEditorFactory.savingPresentation).to.be.false;
+          expect(templateEditorFactory.loadingPresentation).to.be.false;
+          expect(templateEditorFactory.errorMessage).to.not.be.ok;
+          expect(templateEditorFactory.apiError).to.not.be.ok;
+
+          done();
+        },10);
       });
     });
 
@@ -291,47 +312,6 @@ describe('service: templateEditorFactory:', function() {
   });
 
   describe('updatePresentation:',function(){
-    it('should update the presentation',function(done){
-      sandbox.stub(presentation, 'update').returns(Q.resolve({
-        item: {
-          name: 'Test Presentation',
-          id: 'presentationId'
-        }
-      }));
-
-      $httpBackend.when('GET', blueprintUrl).respond(200, {});
-      setTimeout(function() {
-        $httpBackend.flush();
-      });
-
-      templateEditorFactory.addFromProduct({ productCode: 'test-id', name: 'Test HTML Template' });
-      expect(templateEditorFactory.presentation.id).to.be.undefined;
-      expect(templateEditorFactory.presentation.productCode).to.equal('test-id');
-      expect(templateEditorFactory.presentation.templateAttributeData).to.deep.equal({});
-
-      templateEditorFactory.updatePresentation()
-        .then(function() {
-          expect(templateEditorUtils.showMessageWindow).to.not.have.been.called;
-          expect(templateEditorFactory.savingPresentation).to.be.true;
-          expect(templateEditorFactory.loadingPresentation).to.be.true;
-
-          setTimeout(function(){
-            expect(presentation.update.getCall(0).args[1].templateAttributeData).to.equal('{}');
-            expect(templateEditorFactory.presentation.templateAttributeData).to.deep.equal({});
-            expect(templateEditorFactory.savingPresentation).to.be.false;
-            expect(templateEditorFactory.loadingPresentation).to.be.false;
-            expect(templateEditorFactory.errorMessage).to.not.be.ok;
-            expect(templateEditorFactory.apiError).to.not.be.ok;
-
-            done();
-          },10);
-        })
-        .then(null, function(err) {
-          done(err);
-        })
-        .then(null, done);
-    });
-
     it('should show an error if fails to update presentation',function(done){
       sandbox.stub(presentation, 'update').returns(Q.reject({ name: 'Test Presentation' }));
 

--- a/web/partials/template-editor/footer.html
+++ b/web/partials/template-editor/footer.html
@@ -1,13 +1,17 @@
 <div>
-  <button id="saveButton" require-role="ce cp" class="btn btn-primary btn-block"
-          ng-disabled="factory.savingPresentation"
-          ng-click="factory.save()">
-    <strong>
-      {{ factory.savingPresentation ?
-        ( 'common.saving' | translate ) : ( 'common.save' | translate )
-      }}
-    </strong>
-  </button>
+  <div class="auto-saving-changes">
+    <div ng-show="!factory.savingPresentation && hasUnsavedChanges">
+      Unsaved changes
+    </div>
+    <div ng-show="factory.savingPresentation">
+      Saving changes...
+    </div>
+    <div class="all-changes-saved-message"
+         ng-show="!factory.savingPresentation && !hasUnsavedChanges">
+      All changes saved
+      <streamline-icon name="checkmark" width="12" height="12"></streamline-icon>
+    </div>
+  </div>
 
   <button id="publishButton" require-role="cp" class="btn btn-primary btn-block"
           ng-disabled="hasUnsavedChanges || !factory.isRevised() || factory.savingPresentation"

--- a/web/partials/template-editor/toolbar.html
+++ b/web/partials/template-editor/toolbar.html
@@ -12,13 +12,14 @@
 
 <div class="toolbar-right">
   <div id="saveButtonDesktop" require-role="ce cp"
-          class="btn btn-primary btn-fixed-width u_margin-right hidden-xs"
+          class="btn-primary btn-fixed-width u_margin-right hidden-xs"
           ng-disabled="factory.savingPresentation"
           ng-click="factory.save()">
     <strong>
       {{
-        factory.savingPresentation ? 'Saving': 'Save'
-      }} {{ hasUnsavedChanges ? 'dirty' : 'clean' }}
+        factory.savingPresentation ? 'Saving' :
+        hasUnsavedChanges ? 'Dirty' : 'Saved'
+      }}
     </strong>
   </div>
 

--- a/web/partials/template-editor/toolbar.html
+++ b/web/partials/template-editor/toolbar.html
@@ -11,18 +11,19 @@
 </div>
 
 <div class="toolbar-right">
-  <div id="saveButtonDesktop" require-role="ce cp"
-          class="btn-primary btn-fixed-width u_margin-right hidden-xs"
-          ng-disabled="factory.savingPresentation"
-          ng-click="factory.save()">
-    <strong>
-      {{
-        factory.savingPresentation ? 'Saving' :
-        hasUnsavedChanges ? 'Dirty' : 'Saved'
-      }}
-    </strong>
+  <div id="autoSavingDesktop" class="auto-saving-changes hidden-xs">
+    <div ng-show="!factory.savingPresentation && hasUnsavedChanges">
+      Unsaved changes
+    </div>
+    <div ng-show="factory.savingPresentation">
+      Saving changes...
+    </div>
+    <div ng-show="!factory.savingPresentation && !hasUnsavedChanges">
+      <div>
+        All changes saved <streamline-icon name="checkmark" width="12" height="12"></streamline-icon>
+      </div>
+    </div>
   </div>
-
   <button id="publishButtonDesktop" require-role="cp" class="btn btn-primary btn-fixed-width hidden-xs"
           ng-disabled="hasUnsavedChanges || !factory.isRevised() || factory.savingPresentation"
           ng-click="factory.publishPresentation()">

--- a/web/partials/template-editor/toolbar.html
+++ b/web/partials/template-editor/toolbar.html
@@ -11,16 +11,16 @@
 </div>
 
 <div class="toolbar-right">
-  <button id="saveButtonDesktop" require-role="ce cp"
+  <div id="saveButtonDesktop" require-role="ce cp"
           class="btn btn-primary btn-fixed-width u_margin-right hidden-xs"
           ng-disabled="factory.savingPresentation"
           ng-click="factory.save()">
     <strong>
-      {{ factory.savingPresentation ?
-        ( 'common.saving' | translate ) : ( 'common.save' | translate )
-      }}
+      {{
+        factory.savingPresentation ? 'Saving': 'Save'
+      }} {{ hasUnsavedChanges ? 'dirty' : 'clean' }}
     </strong>
-  </button>
+  </div>
 
   <button id="publishButtonDesktop" require-role="cp" class="btn btn-primary btn-fixed-width hidden-xs"
           ng-disabled="hasUnsavedChanges || !factory.isRevised() || factory.savingPresentation"

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -92,7 +92,7 @@ angular.module('risevision.template-editor.controllers')
             _programSave();
           } else {
             _lastSavedTimestamp = _getCurrentTimestamp();
-            console.log('Saving' + _lastSavedTimestamp);
+            console.log('Saving: ' + _lastSavedTimestamp);
 
             $scope.factory.save();
           }

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -146,9 +146,14 @@ angular.module('risevision.template-editor.controllers')
       $scope.$watch('factory.presentation', function (newValue, oldValue) {
         var ignoredFields = ['id', 'revisionStatusName', 'changeDate', 'changedBy'];
 
+        if (!newValue.id) {
+          $scope.factory.save();
+          return;
+        }
         if ($scope.hasUnsavedChanges) {
           return;
         }
+
         if (_initializing) {
           $timeout(function () {
             _initializing = false;

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -1,10 +1,13 @@
 'use strict';
 
 angular.module('risevision.template-editor.controllers')
+  .constant('MINIMUM_INTERVAL_BETWEEN_SAVES', 5000)
+  .constant('MAXIMUM_INTERVAL_BETWEEN_SAVES', 20000)
   .controller('TemplateEditorController', ['$scope', '$filter', '$loading', '$modal', '$state', '$timeout', '$window',
-    'templateEditorFactory', 'userState', 'presentationUtils',
+    'templateEditorFactory', 'userState', 'presentationUtils', 'MINIMUM_INTERVAL_BETWEEN_SAVES',
+    'MAXIMUM_INTERVAL_BETWEEN_SAVES',
     function ($scope, $filter, $loading, $modal, $state, $timeout, $window, templateEditorFactory, userState,
-      presentationUtils) {
+      presentationUtils, MINIMUM_INTERVAL_BETWEEN_SAVES, MAXIMUM_INTERVAL_BETWEEN_SAVES) {
       $scope.factory = templateEditorFactory;
       $scope.isSubcompanySelected = userState.isSubcompanySelected;
       $scope.isTestCompanySelected = userState.isTestCompanySelected;

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -8,6 +8,9 @@ angular.module('risevision.template-editor.controllers')
     'MAXIMUM_INTERVAL_BETWEEN_SAVES',
     function ($scope, $filter, $loading, $modal, $state, $timeout, $window, templateEditorFactory, userState,
       presentationUtils, MINIMUM_INTERVAL_BETWEEN_SAVES, MAXIMUM_INTERVAL_BETWEEN_SAVES) {
+      var _lastSavedTimestamp = 0,
+        _saveTimeout = null;
+
       $scope.factory = templateEditorFactory;
       $scope.isSubcompanySelected = userState.isSubcompanySelected;
       $scope.isTestCompanySelected = userState.isTestCompanySelected;
@@ -76,10 +79,54 @@ angular.module('risevision.template-editor.controllers')
         return component;
       }
 
+      function _getCurrentTimestamp() {
+        return new Date().getTime();
+      }
+
+      function _programSave() {
+        _saveTimeout = $timeout(function () {
+          _saveTimeout = null;
+
+          // if a previous save hasn't finished, give more time
+          if ($scope.factory.savingPresentation) {
+            _programSave();
+          } else {
+            _lastSavedTimestamp = _getCurrentTimestamp();
+            console.log('Saving' + _lastSavedTimestamp);
+
+            $scope.factory.save();
+          }
+        }, MINIMUM_INTERVAL_BETWEEN_SAVES);
+      }
+
+      function _clearSaveTimeout() {
+        if (_saveTimeout) {
+          $timeout.cancel(_saveTimeout);
+          _saveTimeout = null;
+        }
+      }
+
+      function _reprogramSave() {
+        _clearSaveTimeout();
+        _programSave();
+      }
+
       var _bypassUnsaved = false,
         _initializing = false;
       var _setUnsavedChanges = function (state) {
         $scope.hasUnsavedChanges = state;
+
+        if ($scope.hasUnsavedChanges) {
+          if (_saveTimeout) {
+            var elapsed = _getCurrentTimestamp() - _lastSavedTimestamp;
+
+            if (elapsed < MAXIMUM_INTERVAL_BETWEEN_SAVES) {
+              _reprogramSave();
+            }
+          } else {
+            _programSave();
+          }
+        }
       };
 
       var _setUnsavedChangesAsync = function (state) {

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -92,7 +92,6 @@ angular.module('risevision.template-editor.controllers')
             _programSave();
           } else {
             _lastSavedTimestamp = _getCurrentTimestamp();
-            console.log('Saving: ' + _lastSavedTimestamp);
 
             $scope.factory.save();
           }

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -143,7 +143,10 @@ angular.module('risevision.template-editor.controllers')
       }
 
       $scope.$watch('factory.presentation', function (newValue, oldValue) {
-        var ignoredFields = ['id', 'revisionStatusName', 'changeDate', 'changedBy'];
+        var ignoredFields = [
+          'id', 'companyId', 'revisionStatus', 'revisionStatusName',
+          'changeDate', 'changedBy', 'creationDate', 'publish', 'layout'
+        ];
 
         if (!newValue.id) {
           $scope.factory.save();

--- a/web/scripts/template-editor/directives/dtv-attribute-editor.js
+++ b/web/scripts/template-editor/directives/dtv-attribute-editor.js
@@ -13,11 +13,6 @@ angular.module('risevision.template-editor.directives')
           $scope.panels = [];
           $scope.factory.selected = null;
 
-          $scope.$watch('factory.presentation', function () {
-            $scope.showAttributeList = true;
-            $scope.panels = [];
-          });
-
           $scope.registerDirective = function (directive) {
             directive.element.hide();
             $scope.directives[directive.type] = directive;

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -17,7 +17,10 @@ angular.module('risevision.template-editor.services')
 
         if (isUpdate) {
           factory.presentation.id = presentation.id;
+          factory.presentation.companyId = presentation.companyId;
+          factory.presentation.revisionStatus = presentation.revisionStatus;
           factory.presentation.revisionStatusName = presentation.revisionStatusName;
+          factory.presentation.creationDate = presentation.creationDate;
           factory.presentation.changeDate = presentation.changeDate;
           factory.presentation.changedBy = presentation.changedBy;
         } else {

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -14,6 +14,7 @@ angular.module('risevision.template-editor.services')
       var factory = {};
 
       var _setPresentation = function (presentation, isUpdate) {
+
         if (isUpdate) {
           factory.presentation.id = presentation.id;
           factory.presentation.revisionStatusName = presentation.revisionStatusName;

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -13,12 +13,15 @@ angular.module('risevision.template-editor.services')
       HTML_PRESENTATION_TYPE, BLUEPRINT_URL, REVISION_STATUS_REVISED, REVISION_STATUS_PUBLISHED) {
       var factory = {};
 
-      var _setPresentation = function (presentation) {
+      var _setPresentation = function (presentation, isUpdate) {
         presentation.templateAttributeData =
           _parseJSON(presentation.templateAttributeData) || {};
 
         factory.presentation = presentation;
-        factory.selected = null;
+
+        if (!isUpdate) {
+          factory.selected = null;
+        }
 
         $rootScope.$broadcast('presentationUpdated');
       };
@@ -150,7 +153,7 @@ angular.module('risevision.template-editor.services')
 
         presentation.update(presentationVal.id, presentationVal)
           .then(function (resp) {
-            _setPresentation(resp.item);
+            _setPresentation(resp.item, true);
 
             deferred.resolve(resp.item.id);
           })

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -14,12 +14,16 @@ angular.module('risevision.template-editor.services')
       var factory = {};
 
       var _setPresentation = function (presentation, isUpdate) {
-        presentation.templateAttributeData =
-          _parseJSON(presentation.templateAttributeData) || {};
+        if (isUpdate) {
+          factory.presentation.id = presentation.id;
+          factory.presentation.revisionStatusName = presentation.revisionStatusName;
+          factory.presentation.changeDate = presentation.changeDate;
+          factory.presentation.changedBy = presentation.changedBy;
+        } else {
+          presentation.templateAttributeData =
+            _parseJSON(presentation.templateAttributeData) || {};
 
-        factory.presentation = presentation;
-
-        if (!isUpdate) {
+          factory.presentation = presentation;
           factory.selected = null;
         }
 

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -97,6 +97,8 @@ angular.module('risevision.template-editor.services')
             factory.blueprintData = blueprintData.data;
 
             _checkFinancialDataLicenseMessage(factory.blueprintData);
+
+            return factory.addPresentation();
           })
           .then(null, function (e) {
             _showErrorMessage('add', e);
@@ -175,11 +177,11 @@ angular.module('risevision.template-editor.services')
       };
 
       factory.save = function () {
-        if (factory.presentation.id) {
-          return factory.updatePresentation();
-        } else {
-          return factory.addPresentation();
+        if (!factory.presentation.id) {
+          $log.error('presentation should already have an id');
         }
+
+        return factory.updatePresentation();
       };
 
       factory.getPresentation = function (presentationId) {

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -98,7 +98,7 @@ angular.module('risevision.template-editor.services')
 
             _checkFinancialDataLicenseMessage(factory.blueprintData);
 
-            return factory.addPresentation();
+            //return factory.addPresentation();
           })
           .then(null, function (e) {
             _showErrorMessage('add', e);

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -97,8 +97,6 @@ angular.module('risevision.template-editor.services')
             factory.blueprintData = blueprintData.data;
 
             _checkFinancialDataLicenseMessage(factory.blueprintData);
-
-            //return factory.addPresentation();
           })
           .then(null, function (e) {
             _showErrorMessage('add', e);
@@ -177,11 +175,11 @@ angular.module('risevision.template-editor.services')
       };
 
       factory.save = function () {
-        if (!factory.presentation.id) {
-          $log.error('presentation should already have an id');
+        if (factory.presentation.id) {
+          return factory.updatePresentation();
+        } else {
+          return factory.addPresentation();
         }
-
-        return factory.updatePresentation();
       };
 
       factory.getPresentation = function (presentationId) {

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -25,7 +25,6 @@ angular.module('risevision.template-editor.services')
             _parseJSON(presentation.templateAttributeData) || {};
 
           factory.presentation = presentation;
-          factory.selected = null;
         }
 
         $rootScope.$broadcast('presentationUpdated');


### PR DESCRIPTION
This is a big one, sorry ! But code changes aren't hard to follow, hopefully !

Implementation of auto-save:
- Auto-saves after changes to HTML template presentation
- Auto-saves when a new HTML template presentation is created
- Includes auto-save UI changes from @fjvallarino 
- Updates to unit and all template editor E2E tests

Two minor side effects remain that will need to be fixed in a following PR.

Validate - open one of the first presentations, and/or create a new one from example template or Indices:

https://apps-stage-9.risevision.com/editor/list?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c
