### PR TITLE
Fix double validation in Slides component when user hits Enter [stage-3]

### DIFF
--- a/web/partials/template-editor/components/component-slides.html
+++ b/web/partials/template-editor/components/component-slides.html
@@ -1,19 +1,23 @@
 <div class="attribute-editor-component" rv-spinner rv-spinner-key="slides-editor-loader" rv-spinner-start-active="1">
   <div class="row attribute-row-first">
-    <div class="form-group has-feedback" ng-class="{ 'has-error': validationResult && validationResult !== 'VALID', 'has-success': validationResult === 'VALID' }">
-      <label class="control-label" for="urlInput">Google Slides URL</label>
-      <input type="text" class="form-control" id="urlInput" ng-model="src" placeholder="Enter URL" ng-keypress="handleKeyPressSrc($event)" ng-model-options="{ debounce: 1000 }" ng-change="saveSrc()" >
-      <streamline-icon class="overlay-icon form-control-feedback" aria-hidden="true" name="{{validationResult && validationResult !== 'VALID' ? 'exclamation' : 'checkmark'}}" width="14" height="12"></streamline-icon>
-      <p class="help-block" ng-switch on="validationResult">
-        <span ng-switch-when="DELETED">Your Google Slideshow is no longer accessible, please check if it’s been deleted.</span>
-        <span ng-switch-when="NOT_PUBLIC">To use this Google Slideshow it must be publicly accessible.</span>
-        <span ng-switch-when="INVALID">Invalid URL</span>
-      </p>
-      <p ng-show="validationResult === 'NOT_PUBLIC'">
-        <streamline-icon class="icon-help" aria-hidden="true" name="help" width="15" height="15"></streamline-icon>
-        <a href="https://support.google.com/docs/answer/183965?co=GENIE.Platform%3DDesktop&hl=en" target="_blank">How to make your Google Slideshow public.</a>
-      </p>
-    </div>
+    <!-- Use the <form> tag in order to handle "debounce" option correctly for the <input ng-model="src">.
+         That way the model value is processed immeditly on Form submit and saveSrc() is called only once. -->
+    <form>
+      <div class="form-group has-feedback" ng-class="{ 'has-error': validationResult && validationResult !== 'VALID', 'has-success': validationResult === 'VALID' }">
+        <label class="control-label" for="urlInput">Google Slides URL</label>
+        <input type="text" class="form-control" id="urlInput" ng-model="src" placeholder="Enter URL" ng-model-options="{ debounce: 1000 }" ng-change="saveSrc()" >
+        <streamline-icon class="overlay-icon form-control-feedback" aria-hidden="true" name="{{validationResult && validationResult !== 'VALID' ? 'exclamation' : 'checkmark'}}" width="14" height="12"></streamline-icon>
+        <p class="help-block" ng-switch on="validationResult">
+          <span ng-switch-when="DELETED">Your Google Slideshow is no longer accessible, please check if it’s been deleted.</span>
+          <span ng-switch-when="NOT_PUBLIC">To use this Google Slideshow it must be publicly accessible.</span>
+          <span ng-switch-when="INVALID">Invalid URL</span>
+        </p>
+        <p ng-show="validationResult === 'NOT_PUBLIC'">
+          <streamline-icon class="icon-help" aria-hidden="true" name="help" width="15" height="15"></streamline-icon>
+          <a href="https://support.google.com/docs/answer/183965?co=GENIE.Platform%3DDesktop&hl=en" target="_blank">How to make your Google Slideshow public.</a>
+        </p>
+      </div>
+    </form>
   </div>
   <div class="attribute-row-last">
     <label class="control-label">Show each slide for</label>

--- a/web/partials/template-editor/components/component-slides.html
+++ b/web/partials/template-editor/components/component-slides.html
@@ -22,7 +22,7 @@
   <div class="attribute-row-last">
     <label class="control-label">Show each slide for</label>
     <div class="input-group input-duration">
-      <input type="number" class="form-control" ng-model="duration" placeholder="Enter duration" ng-change="saveDuration()">
+      <input type="number" class="form-control" ng-model="duration" placeholder="10" ng-change="saveDuration()">
       <span class="input-group-addon">seconds</span>
     </div>
   </div>

--- a/web/scripts/template-editor/components/directives/dtv-component-slides.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-slides.js
@@ -40,13 +40,6 @@ angular.module('risevision.template-editor.directives')
             $scope.setAttributeData($scope.componentId, 'duration', $scope.duration);
           };
 
-          $scope.handleKeyPressSrc = function (event) {
-            //handle Enter key only
-            if (event.which === 13) {
-              $scope.saveSrc();
-            }
-          };
-
           $scope.saveSrc = function () {
             if (_validateSrcLocally()) {
 


### PR DESCRIPTION
The `<form>` tag [commits view value](https://docs.angularjs.org/api/ng/type/ngModel.NgModelController#$commitViewValue) immediately on form submit event (i.e. on Enter) which in turn calls onChange event for the input field right away instead of waiting 1 second as defined by `debounce` option.
