### PR TITLE
Fix/issue 1042 race condition in rise image settings

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-image.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.tests.js
@@ -7,7 +7,7 @@ describe('directive: TemplateComponentImage', function() {
       timeout;
 
   beforeEach(function() {
-    factory = { selected: { id: "TEST-ID" } };
+    factory = { selected: { id: 'TEST-ID' } };
   });
 
   beforeEach(module('risevision.template-editor.directives'));
@@ -176,6 +176,131 @@ describe('directive: TemplateComponentImage', function() {
 
       done();
     }, 100);
+  });
+
+  describe('updateImageMetadata', function() {
+
+    var sampleImages;
+
+    beforeEach(function() {
+      sampleImages = [
+        { "file": "image.png", exists: true, "thumbnail-url": "http://image" },
+        { "file": "image2.png", exists: false, "thumbnail-url": "http://image2" }
+      ];
+
+      $scope.componentId = 'TEST-ID';
+    });
+
+    it('should directly set metadata if it\'s not already loaded', function()
+    {
+      $scope.getAttributeData = function() {
+        return null;
+      };
+
+      $scope.updateImageMetadata(sampleImages);
+
+      expect($scope.isDefaultImageList).to.be.false;
+      expect($scope.selectedImages).to.deep.equal(sampleImages);
+
+      expect($scope.setAttributeData).to.have.been.called.twice;
+
+      expect($scope.setAttributeData.calledWith(
+        'TEST-ID', 'metadata', sampleImages
+      ), 'set metadata attribute').to.be.true;
+
+      expect($scope.setAttributeData.calledWith(
+        'TEST-ID', 'files', 'image.png|image2.png'
+      ), 'set files attribute').to.be.true;
+    });
+
+    it('should combine metadata if it\'s already loaded', function()
+    {
+      var updatedImages = [
+        { "file": "image.png", exists: false, "thumbnail-url": "http://image5" },
+        { "file": "image2.png", exists: false, "thumbnail-url": "http://image6" }
+      ];
+
+      $scope.getAttributeData = function() {
+        return sampleImages;
+      };
+
+      $scope.updateImageMetadata(updatedImages);
+
+      expect($scope.isDefaultImageList).to.be.false;
+      expect($scope.selectedImages).to.deep.equal(updatedImages);
+
+      expect($scope.setAttributeData).to.have.been.called.twice;
+
+      expect($scope.setAttributeData.calledWith(
+        'TEST-ID', 'metadata', updatedImages
+      ), 'set metadata attribute').to.be.true;
+
+      expect($scope.setAttributeData.calledWith(
+        'TEST-ID', 'files', 'image.png|image2.png'
+      ), 'set files attribute').to.be.true;
+    });
+
+    it('should only update the provided images', function()
+    {
+      var updatedImages = [
+        { "file": "image.png", exists: false, "thumbnail-url": "http://image5" }
+      ];
+      var expectedImages = [
+        { "file": "image.png", exists: false, "thumbnail-url": "http://image5" },
+        { "file": "image2.png", exists: false, "thumbnail-url": "http://image2" }
+      ];
+
+      $scope.getAttributeData = function() {
+        return sampleImages;
+      };
+
+      $scope.updateImageMetadata(updatedImages);
+
+      expect($scope.isDefaultImageList).to.be.false;
+      expect($scope.selectedImages).to.deep.equal(expectedImages);
+
+      expect($scope.setAttributeData).to.have.been.called.twice;
+
+      expect($scope.setAttributeData.calledWith(
+        'TEST-ID', 'metadata', expectedImages
+      ), 'set metadata attribute').to.be.true;
+
+      expect($scope.setAttributeData.calledWith(
+        'TEST-ID', 'files', 'image.png|image2.png'
+      ), 'set files attribute').to.be.true;
+    });
+
+    it('should not update images that are not already present', function()
+    {
+      var updatedImages = [
+        { "file": "image.png", exists: false, "thumbnail-url": "http://image5" },
+        { "file": "imageNew.png", exists: false, "thumbnail-url": "http://imageN" }
+      ];
+      var expectedImages = [
+        { "file": "image.png", exists: false, "thumbnail-url": "http://image5" },
+        { "file": "image2.png", exists: false, "thumbnail-url": "http://image2" }
+      ];
+
+      $scope.getAttributeData = function() {
+        return sampleImages;
+      };
+
+      $scope.updateImageMetadata(updatedImages);
+
+      expect($scope.isDefaultImageList).to.be.false;
+      expect($scope.selectedImages).to.deep.equal(expectedImages);
+
+      expect($scope.setAttributeData).to.have.been.called.twice;
+
+      expect($scope.setAttributeData.calledWith(
+        'TEST-ID', 'metadata', expectedImages
+      ), 'set metadata attribute').to.be.true;
+
+      expect($scope.setAttributeData.calledWith(
+        'TEST-ID', 'files', 'image.png|image2.png'
+      ), 'set files attribute').to.be.true;
+    });
+
   });
 
 });

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -104,6 +104,10 @@ angular.module('risevision.template-editor.directives')
             return $scope.getAttributeData($scope.componentId, key);
           }
 
+          function _setAttribute(key, value) {
+            $scope.setAttributeData($scope.componentId, key, value);
+          }
+
           function _getDefaultFilesAttribute() {
             return $scope.getBlueprintData($scope.componentId, 'files');
           }
@@ -164,7 +168,7 @@ angular.module('risevision.template-editor.directives')
 
           function _buildListRecursive(metadata, fileNames) {
             if (fileNames.length === 0) {
-              _setMetadata(metadata);
+              $scope.updateImageMetadata(metadata);
               $scope.factory.loadingPresentation = false;
 
               return;
@@ -196,14 +200,39 @@ angular.module('risevision.template-editor.directives')
             }).join('|');
           }
 
+          $scope.updateImageMetadata = function(metadata) {
+            var currentMetadata = _getAttribute('metadata');
+
+            if(!currentMetadata) {
+              _setMetadata(metadata);
+            } else {
+              var atLeastOneOriginalEntryIsStillSelected = false;
+              var metadataCopy = angular.copy(currentMetadata);
+
+              _.each(metadata, function(entry) {
+                var currentEntry = _.find(metadataCopy, {file: entry.file});
+
+                if(currentEntry) {
+                  atLeastOneOriginalEntryIsStillSelected = true;
+                  currentEntry.exists = entry.exists;
+                  currentEntry['thumbnail-url'] = entry['thumbnail-url'];
+                }
+              });
+
+              if(atLeastOneOriginalEntryIsStillSelected) {
+                _setMetadata(metadataCopy);
+              }
+            }
+          }
+
           function _setMetadata(metadata) {
             var selectedImages = angular.copy(metadata);
             var filesAttribute = _filesAttributeFor(selectedImages);
 
             _setSelectedImages(selectedImages);
 
-            $scope.setAttributeData($scope.componentId, 'metadata', selectedImages);
-            $scope.setAttributeData($scope.componentId, 'files', filesAttribute);
+            _setAttribute('metadata', selectedImages);
+            _setAttribute('files', filesAttribute);
           }
 
           function _setSelectedImages(selectedImages) {
@@ -216,7 +245,7 @@ angular.module('risevision.template-editor.directives')
           _reset();
 
           $scope.saveDuration = function () {
-            $scope.setAttributeData($scope.componentId, 'duration', $scope.values.duration);
+            _setAttribute('duration', $scope.values.duration);
           };
 
           $scope.registerDirective({

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -200,30 +200,32 @@ angular.module('risevision.template-editor.directives')
             }).join('|');
           }
 
-          $scope.updateImageMetadata = function(metadata) {
+          $scope.updateImageMetadata = function (metadata) {
             var currentMetadata = _getAttribute('metadata');
 
-            if(!currentMetadata) {
+            if (!currentMetadata) {
               _setMetadata(metadata);
             } else {
               var atLeastOneOriginalEntryIsStillSelected = false;
               var metadataCopy = angular.copy(currentMetadata);
 
-              _.each(metadata, function(entry) {
-                var currentEntry = _.find(metadataCopy, {file: entry.file});
+              _.each(metadata, function (entry) {
+                var currentEntry = _.find(metadataCopy, {
+                  file: entry.file
+                });
 
-                if(currentEntry) {
+                if (currentEntry) {
                   atLeastOneOriginalEntryIsStillSelected = true;
                   currentEntry.exists = entry.exists;
                   currentEntry['thumbnail-url'] = entry['thumbnail-url'];
                 }
               });
 
-              if(atLeastOneOriginalEntryIsStillSelected) {
+              if (atLeastOneOriginalEntryIsStillSelected) {
                 _setMetadata(metadataCopy);
               }
             }
-          }
+          };
 
           function _setMetadata(metadata) {
             var selectedImages = angular.copy(metadata);


### PR DESCRIPTION
This reads the attribute data before updating thumbnail information, so deleted images are not re-added again.

Validation: open any presentation in the link below, and quickly remove images from it, they shouldn't reappear when thumbnail data is read again.
https://apps-stage-9.risevision.com/editor/list?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c