### PR TITLE
Stop spinner when image list is empty [stage-7]

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-image.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.tests.js
@@ -162,6 +162,7 @@ describe('directive: TemplateComponentImage', function() {
         }
       ];
 
+      timeout.flush();
       expect($scope.selectedImages).to.deep.equal(expectedMetadata);
 
       expect($scope.setAttributeData).to.have.been.called.twice;

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -2,9 +2,9 @@
 
 angular.module('risevision.template-editor.directives')
   .constant('SUPPORTED_IMAGE_TYPES', '.bmp, .gif, .jpeg, .jpg, .png, .svg, .webp')
-  .directive('templateComponentImage', ['$log', 'templateEditorFactory', 'templateEditorUtils', 'storageAPILoader',
+  .directive('templateComponentImage', ['$log', '$q', '$timeout', 'templateEditorFactory', 'templateEditorUtils', 'storageAPILoader',
     'DEFAULT_IMAGE_THUMBNAIL', 'SUPPORTED_IMAGE_TYPES',
-    function ($log, templateEditorFactory, templateEditorUtils, storageAPILoader, DEFAULT_IMAGE_THUMBNAIL,
+    function ($log, $q, $timeout, templateEditorFactory, templateEditorUtils, storageAPILoader, DEFAULT_IMAGE_THUMBNAIL,
       SUPPORTED_IMAGE_TYPES) {
       return {
         restrict: 'E',
@@ -132,7 +132,7 @@ angular.module('risevision.template-editor.directives')
             if (!match) {
               $log.error('Filename is not a valid Rise Storage path: ' + fileName);
 
-              return Promise.resolve('');
+              return $q.resolve('');
             }
 
             return _requestFileData(match[1], match[2])
@@ -168,10 +168,10 @@ angular.module('risevision.template-editor.directives')
 
           function _buildListRecursive(metadata, fileNames) {
             if (fileNames.length === 0) {
-              $scope.updateImageMetadata(metadata);
-              $scope.factory.loadingPresentation = false;
-
-              return;
+              return $timeout(function () {
+                $scope.updateImageMetadata(metadata);
+                $scope.factory.loadingPresentation = false;
+              });
             }
 
             var fileName = fileNames.shift();


### PR DESCRIPTION
This fixes https://github.com/Rise-Vision/rise-vision-apps/issues/1048

You can test it here: https://apps-stage-7.risevision.com/templates/edit/2e3473c4-704a-4ce6-9e38-45a1a09bb883/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

@santiagonoguez please review