### PR TITLE
Fix/issue 1057 editor preview resize

### DIFF
--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -3,8 +3,7 @@
 angular.module('risevision.template-editor.directives')
   .constant('SUPPORTED_IMAGE_TYPES', '.bmp, .gif, .jpeg, .jpg, .png, .svg, .webp')
   .directive('templateComponentImage', ['$log', '$q', '$timeout', 'templateEditorFactory', 'templateEditorUtils',
-    'storageAPILoader',
-    'DEFAULT_IMAGE_THUMBNAIL', 'SUPPORTED_IMAGE_TYPES',
+    'storageAPILoader', 'DEFAULT_IMAGE_THUMBNAIL', 'SUPPORTED_IMAGE_TYPES',
     function ($log, $q, $timeout, templateEditorFactory, templateEditorUtils, storageAPILoader,
       DEFAULT_IMAGE_THUMBNAIL,
       SUPPORTED_IMAGE_TYPES) {

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -5,8 +5,7 @@ angular.module('risevision.template-editor.directives')
   .directive('templateComponentImage', ['$log', '$q', '$timeout', 'templateEditorFactory', 'templateEditorUtils',
     'storageAPILoader', 'DEFAULT_IMAGE_THUMBNAIL', 'SUPPORTED_IMAGE_TYPES',
     function ($log, $q, $timeout, templateEditorFactory, templateEditorUtils, storageAPILoader,
-      DEFAULT_IMAGE_THUMBNAIL,
-      SUPPORTED_IMAGE_TYPES) {
+      DEFAULT_IMAGE_THUMBNAIL, SUPPORTED_IMAGE_TYPES) {
       return {
         restrict: 'E',
         scope: true,

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -2,9 +2,11 @@
 
 angular.module('risevision.template-editor.directives')
   .constant('SUPPORTED_IMAGE_TYPES', '.bmp, .gif, .jpeg, .jpg, .png, .svg, .webp')
-  .directive('templateComponentImage', ['$log', '$q', '$timeout', 'templateEditorFactory', 'templateEditorUtils', 'storageAPILoader',
+  .directive('templateComponentImage', ['$log', '$q', '$timeout', 'templateEditorFactory', 'templateEditorUtils',
+    'storageAPILoader',
     'DEFAULT_IMAGE_THUMBNAIL', 'SUPPORTED_IMAGE_TYPES',
-    function ($log, $q, $timeout, templateEditorFactory, templateEditorUtils, storageAPILoader, DEFAULT_IMAGE_THUMBNAIL,
+    function ($log, $q, $timeout, templateEditorFactory, templateEditorUtils, storageAPILoader,
+      DEFAULT_IMAGE_THUMBNAIL,
       SUPPORTED_IMAGE_TYPES) {
       return {
         restrict: 'E',

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -141,6 +141,7 @@ angular.module('risevision.template-editor.directives')
           });
 
           function _onResize() {
+            console.log('resize:' + previewHolder.clientWidth + ':' + previewHolder.clientHeight);
             _applyAspectRatio();
 
             $scope.$digest();

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -150,9 +150,7 @@ angular.module('risevision.template-editor.directives')
 
           function _onResize() {
             console.log('resize:' + previewHolder.clientWidth + ':' + previewHolder.clientHeight);
-            console.log('offset:' + previewHolder.offsetWidth + ':' + previewHolder.offsetHeight);
-            console.log('scroll:' + previewHolder.scrollWidth + ':' + previewHolder.scrollHeight);
-            //console.log('calculated:' + _getPreviewAreaWidth() + ':' + _getPreviewAreaHeight());
+            console.log('calculated:' + _getPreviewAreaWidth() + ':' + _getPreviewAreaHeight());
             _applyAspectRatio();
 
             $scope.$digest();
@@ -161,6 +159,12 @@ angular.module('risevision.template-editor.directives')
           angular.element($window).on('resize', _onResize);
           $scope.$on('$destroy', function () {
             angular.element($window).off('resize', _onResize);
+          });
+
+          $scope.$watch('factory.selected', function (selected) {
+            if (!selected) {
+              _applyAspectRatio();
+            }
           });
 
           $scope.$watch('factory.presentation.templateAttributeData', function (value) {

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -1,9 +1,9 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
-  .directive('templateEditorPreviewHolder', ['$window', '$sce', 'templateEditorFactory', 'HTML_TEMPLATE_DOMAIN',
-    'HTML_TEMPLATE_URL', 'userState',
-    function ($window, $sce, templateEditorFactory, HTML_TEMPLATE_DOMAIN, HTML_TEMPLATE_URL, userState) {
+  .directive('templateEditorPreviewHolder', ['$window', '$timeout', '$sce', 'templateEditorFactory',
+    'HTML_TEMPLATE_DOMAIN', 'HTML_TEMPLATE_URL', 'userState',
+    function ($window, $timeout, $sce, templateEditorFactory, HTML_TEMPLATE_DOMAIN, HTML_TEMPLATE_URL, userState) {
       return {
         restrict: 'E',
         templateUrl: 'partials/template-editor/preview-holder.html',
@@ -145,7 +145,7 @@ angular.module('risevision.template-editor.directives')
           ], function () {
             _applyAspectRatio();
 
-            setTimeout(_applyAspectRatio, PREVIEW_INITIAL_DELAY_MILLIS);
+            $timeout(_applyAspectRatio, PREVIEW_INITIAL_DELAY_MILLIS);
           });
 
           function _onResize() {
@@ -164,7 +164,7 @@ angular.module('risevision.template-editor.directives')
             console.log('selected:' + selected + ':' + _getPreviewAreaWidth() + ':' + _getPreviewAreaHeight());
 
             if (!selected) {
-              _applyAspectRatio();
+              $timeout(_onResize);
             }
           });
 

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -149,7 +149,6 @@ angular.module('risevision.template-editor.directives')
           });
 
           function _onResize() {
-            console.log('resize:' + previewHolder.clientWidth + ':' + previewHolder.clientHeight);
             console.log('calculated:' + _getPreviewAreaWidth() + ':' + _getPreviewAreaHeight());
             _applyAspectRatio();
 
@@ -162,6 +161,8 @@ angular.module('risevision.template-editor.directives')
           });
 
           $scope.$watch('factory.selected', function (selected) {
+            console.log('selected:' + selected + ':' + _getPreviewAreaWidth() + ':' + _getPreviewAreaHeight());
+
             if (!selected) {
               _applyAspectRatio();
             }

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -56,7 +56,7 @@ angular.module('risevision.template-editor.directives')
             return previewHolder.clientWidth;
           }
 
-          return _getPreviewAreaHeight() {
+          function _getPreviewAreaHeight() {
             return previewHolder.clientHeight;
           }
 

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -149,7 +149,6 @@ angular.module('risevision.template-editor.directives')
           });
 
           function _onResize() {
-            console.log('calculated:' + _getPreviewAreaWidth() + ':' + _getPreviewAreaHeight());
             _applyAspectRatio();
 
             $scope.$digest();
@@ -161,8 +160,6 @@ angular.module('risevision.template-editor.directives')
           });
 
           $scope.$watch('factory.selected', function (selected) {
-            console.log('selected:' + selected + ':' + _getPreviewAreaWidth() + ':' + _getPreviewAreaHeight());
-
             if (!selected) {
               $timeout(_onResize);
             }

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -52,6 +52,14 @@ angular.module('risevision.template-editor.directives')
             return height ? parseInt(height) : DEFAULT_TEMPLATE_HEIGHT;
           }
 
+          function _getPreviewAreaWidth() {
+            return previewHolder.clientWidth;
+          }
+
+          return _getPreviewAreaHeight() {
+            return previewHolder.clientHeight;
+          }
+
           function _getHeightDividedByWidth() {
             return _getTemplateHeight() / _getTemplateWidth();
           }
@@ -59,9 +67,9 @@ angular.module('risevision.template-editor.directives')
           function _useFullWidth() {
             var offset = 2 * DESKTOP_MARGIN;
             var aspectRatio = _getHeightDividedByWidth();
-            var projectedHeight = (previewHolder.clientWidth - offset) * aspectRatio;
+            var projectedHeight = (_getPreviewAreaWidth() - offset) * aspectRatio;
 
-            return projectedHeight < previewHolder.clientHeight - offset;
+            return projectedHeight < _getPreviewAreaHeight() - offset;
           }
 
           function _getWidthFor(height) {
@@ -84,7 +92,7 @@ angular.module('risevision.template-editor.directives')
           };
 
           $scope.getDesktopWidth = function () {
-            var height = previewHolder.clientHeight;
+            var height = _getPreviewAreaHeight();
 
             return _getWidthFor(height).toFixed(0);
           };
@@ -111,17 +119,17 @@ angular.module('risevision.template-editor.directives')
             var offset = (isMobile ? MOBILE_MARGIN : DESKTOP_MARGIN) * 2;
 
             if (isMobile) {
-              viewHeight = previewHolder.clientHeight - offset;
+              viewHeight = _getPreviewAreaHeight() - offset;
               parentStyle = 'width: ' + $scope.getMobileWidth() + 'px';
               frameStyle = _getFrameStyle(viewHeight, _getTemplateHeight());
             } else if (_useFullWidth()) {
-              var viewWidth = previewHolder.clientWidth - offset;
+              var viewWidth = _getPreviewAreaWidth() - offset;
               var aspectRatio = $scope.getTemplateAspectRatio() + '%';
 
               parentStyle = 'padding-bottom: ' + aspectRatio + ';';
               frameStyle = _getFrameStyle(viewWidth, _getTemplateWidth());
             } else {
-              viewHeight = previewHolder.clientHeight - offset;
+              viewHeight = _getPreviewAreaHeight() - offset;
 
               parentStyle = 'height: 100%; width: ' + $scope.getDesktopWidth() + 'px';
               frameStyle = _getFrameStyle(viewHeight, _getTemplateHeight());
@@ -142,6 +150,9 @@ angular.module('risevision.template-editor.directives')
 
           function _onResize() {
             console.log('resize:' + previewHolder.clientWidth + ':' + previewHolder.clientHeight);
+            console.log('offset:' + previewHolder.offsetWidth + ':' + previewHolder.offsetHeight);
+            console.log('scroll:' + previewHolder.scrollWidth + ':' + previewHolder.scrollHeight);
+            //console.log('calculated:' + _getPreviewAreaWidth() + ':' + _getPreviewAreaHeight());
             _applyAspectRatio();
 
             $scope.$digest();


### PR DESCRIPTION
This fixes the issue in both desktop and mobile platforms ( at least is not appearing consistently anymore in iOS Safari anymore ).

Basically it recalculates the preview area when going back to component list.

Validate: follow the procedure described in [the issue](https://github.com/Rise-Vision/rise-vision-apps/issues/1057) here:

https://apps-stage-9.risevision.com/templates/edit/2956beeb-884b-484e-9588-a5aaf624db2d/?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c

