### PR TITLE
Hide non-editable components, per blueprint.json update

### DIFF
--- a/test/unit/template-editor/directives/dtv-attribute-list.tests.js
+++ b/test/unit/template-editor/directives/dtv-attribute-list.tests.js
@@ -1,0 +1,43 @@
+'use strict';
+
+describe('directive: attribute-list', function() {
+  var element, $scope;
+  var components = [
+    {id: 'cp1', nonEditable: true},
+    {id: 'cp2', nonEditable: false},
+    {id: 'cp3'},
+  ];
+
+  beforeEach(module('risevision.template-editor.directives'));
+  beforeEach(module(mockTranlate()));
+    beforeEach(module(function ($provide) {
+    $provide.service('templateEditorFactory', function() {
+      return {
+        blueprintData: {
+          components: components
+        }
+      };
+    });
+  }));
+
+  beforeEach(inject(function($compile, $rootScope, $templateCache){
+    $templateCache.put('partials/template-editor/attribute-list.html', '<p>mock</p>');
+    element = $compile('<template-attribute-list></template-attribute-list>')($rootScope.$new());
+    $scope = element.scope();
+    $scope.$digest();
+  }));
+
+  it('should exist', function() {
+    expect($scope).to.be.ok;
+    expect($scope.factory).to.be.ok;
+    expect($scope.components).to.be.ok;
+  });
+
+  it('should not list non-editable components', function() {
+    expect($scope.components.length).to.equal(2);
+    expect($scope.components).to.not.contain(components[0]);
+    expect($scope.components).to.contain(components[1]);
+    expect($scope.components).to.contain(components[2]);
+  });
+
+});

--- a/web/scripts/billing/controllers/ctr-billing.js
+++ b/web/scripts/billing/controllers/ctr-billing.js
@@ -6,7 +6,7 @@ angular.module('risevision.apps.billing.controllers')
   .controller('BillingCtrl', ['$rootScope', '$scope', '$loading', '$window', '$timeout',
     'ScrollingListService', 'userState', 'currentPlanFactory', 'ChargebeeFactory', 'billing',
     'STORE_URL', 'PAST_INVOICES_PATH', 'UNPAID_INVOICES_PATH', 'companySettingsFactory',
-    function ($rootScope, $scope, $loading, $window, $timeout, ScrollingListService, userState, 
+    function ($rootScope, $scope, $loading, $window, $timeout, ScrollingListService, userState,
       currentPlanFactory, ChargebeeFactory, billing, STORE_URL, PAST_INVOICES_PATH, UNPAID_INVOICES_PATH,
       companySettingsFactory) {
 

--- a/web/scripts/template-editor/directives/dtv-attribute-list.js
+++ b/web/scripts/template-editor/directives/dtv-attribute-list.js
@@ -10,7 +10,10 @@ angular.module('risevision.template-editor.directives')
         link: function ($scope) {
           $scope.factory = templateEditorFactory;
 
-          $scope.components = templateEditorFactory.blueprintData.components;
+          $scope.components = templateEditorFactory.blueprintData.components
+            .filter(function (c) {
+              return !c.nonEditable;
+            });
         }
       };
     }

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -4,7 +4,7 @@ angular.module('risevision.template-editor.directives')
   .directive('templateEditorPreviewHolder', ['$window', '$timeout', '$sce', 'templateEditorFactory',
     'HTML_TEMPLATE_DOMAIN', 'HTML_TEMPLATE_URL', 'userState', '$rootScope',
     function ($window, $timeout, $sce, templateEditorFactory, HTML_TEMPLATE_DOMAIN, HTML_TEMPLATE_URL, userState,
-    $rootScope) {
+      $rootScope) {
       return {
         restrict: 'E',
         templateUrl: 'partials/template-editor/preview-holder.html',

--- a/web/scripts/template-editor/services/svc-template-editor-utils.js
+++ b/web/scripts/template-editor/services/svc-template-editor-utils.js
@@ -110,7 +110,9 @@ angular.module('risevision.template-editor.services')
             confirmationButton: function () {
               return 'Contact Us';
             },
-            cancelButton: null
+            cancelButton: function () {
+              return 'Close';
+            }
           }
         });
 


### PR DESCRIPTION
Part of fixing https://github.com/Rise-Vision/rise-vision-apps/issues/1046, prepare the editor to hide non-editable elements that are going to be added to blueprint files.
It is backwards compatible with blueprints not having the non-editable attribute listed and you can test by proxying a blueprint call from [stable](https://widgets.risevision.com/stable/templates/a2b5f32baf5a4d0e557bb34e8cc32ed9c3c21866/blueprint.json) to [this staged blueprint](https://widgets.risevision.com/staging/templates/single-world-markets/2019.07.11.15.37/blueprint.json) and opening [this sample Template](https://apps-stage-1.risevision.com/templates/edit/07941854-2762-4f96-ba1d-5d1c92a90c36/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443).

Also, I changed the label for dismissing Financial Data message from Cancel to Close for clarity. Another suggestion was to have single 'Contact Us' button, but it turned out to be much more complicated to implement.
[stage-1]

@alex-deaconu Please review. Thanks!