### PR TITLE
Save Image files value as Array and support backwards compatibility of String value

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-image.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.tests.js
@@ -2,9 +2,9 @@
 
 describe('directive: TemplateComponentImage', function() {
   var $scope,
-      element,
-      factory,
-      timeout;
+    element,
+    factory,
+    timeout;
 
   beforeEach(function() {
     factory = { selected: { id: 'TEST-ID' } };
@@ -172,7 +172,7 @@ describe('directive: TemplateComponentImage', function() {
       )).to.be.true;
 
       expect($scope.setAttributeData.calledWith(
-        'TEST-ID', 'files', TEST_FILE
+        'TEST-ID', 'files', [TEST_FILE]
       )).to.be.true;
 
       done();
@@ -210,7 +210,7 @@ describe('directive: TemplateComponentImage', function() {
       ), 'set metadata attribute').to.be.true;
 
       expect($scope.setAttributeData.calledWith(
-        'TEST-ID', 'files', 'image.png|image2.png'
+        'TEST-ID', 'files', ['image.png','image2.png']
       ), 'set files attribute').to.be.true;
     });
 
@@ -237,7 +237,7 @@ describe('directive: TemplateComponentImage', function() {
       ), 'set metadata attribute').to.be.true;
 
       expect($scope.setAttributeData.calledWith(
-        'TEST-ID', 'files', 'image.png|image2.png'
+        'TEST-ID', 'files', ['image.png', 'image2.png']
       ), 'set files attribute').to.be.true;
     });
 
@@ -267,7 +267,7 @@ describe('directive: TemplateComponentImage', function() {
       ), 'set metadata attribute').to.be.true;
 
       expect($scope.setAttributeData.calledWith(
-        'TEST-ID', 'files', 'image.png|image2.png'
+        'TEST-ID', 'files', ['image.png', 'image2.png']
       ), 'set files attribute').to.be.true;
     });
 
@@ -298,7 +298,7 @@ describe('directive: TemplateComponentImage', function() {
       ), 'set metadata attribute').to.be.true;
 
       expect($scope.setAttributeData.calledWith(
-        'TEST-ID', 'files', 'image.png|image2.png'
+        'TEST-ID', 'files', ['image.png', 'image2.png']
       ), 'set files attribute').to.be.true;
     });
 

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -111,9 +111,12 @@ angular.module('risevision.template-editor.directives')
           function _getDefaultFilesAttribute() {
             var defaultFiles = $scope.getBlueprintData($scope.componentId, 'files');
 
-            console.log('_getDefaultFilesAttribute', defaultFiles);
+            // backwards compatible with legacy 'files' attribute, covert to array
+            if ( defaultFiles && !Array.isArray(defaultFiles) ) {
+              defaultFiles = defaultFiles.split('|');
+            }
 
-            return defaultFiles && !Array.isArray(defaultFiles) ? defaultFiles.split('|') : defaultFiles;
+            return defaultFiles;
           }
 
           function _getDefaultDurationAttribute() {

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -111,9 +111,21 @@ angular.module('risevision.template-editor.directives')
           function _getDefaultFilesAttribute() {
             var defaultFiles = $scope.getBlueprintData($scope.componentId, 'files');
 
-            // backwards compatible with legacy 'files' attribute, covert to array
-            if ( defaultFiles && !Array.isArray(defaultFiles) ) {
-              defaultFiles = defaultFiles.split('|');
+            if (defaultFiles) {
+              // new 'files' attribute value is an Array, but generated in Blueprint as a String
+              // example value "["test1.jpg", "test2.jpg"]"
+              if (defaultFiles.charAt(0) === "[" && defaultFiles.charAt(defaultFiles.length-1) === "]") {
+                try {
+                  defaultFiles = JSON.parse("'" + defaultFiles + "'");
+                } catch (err) {
+                  $log.error('Invalid default files value: ' + err);
+                  return null;
+                }
+              } else {
+                // old'files' attribute value is String containing | separated values
+                // example value "test1.jpg|test2.jpg"
+                defaultFiles = defaultFiles.split('|');
+              }
             }
 
             return defaultFiles;

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -111,6 +111,8 @@ angular.module('risevision.template-editor.directives')
           function _getDefaultFilesAttribute() {
             var defaultFiles = $scope.getBlueprintData($scope.componentId, 'files');
 
+            console.log("_getDefaultFilesAttribute", defaultFiles);
+
             return defaultFiles && !Array.isArray( defaultFiles ) ? defaultFiles.split('|') : defaultFiles;
           }
 

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -111,9 +111,9 @@ angular.module('risevision.template-editor.directives')
           function _getDefaultFilesAttribute() {
             var defaultFiles = $scope.getBlueprintData($scope.componentId, 'files');
 
-            console.log("_getDefaultFilesAttribute", defaultFiles);
+            console.log('_getDefaultFilesAttribute', defaultFiles);
 
-            return defaultFiles && !Array.isArray( defaultFiles ) ? defaultFiles.split('|') : defaultFiles;
+            return defaultFiles && !Array.isArray(defaultFiles) ? defaultFiles.split('|') : defaultFiles;
           }
 
           function _getDefaultDurationAttribute() {
@@ -126,8 +126,8 @@ angular.module('risevision.template-editor.directives')
             var metadata = [];
             var fileNames = [];
 
-            if ( files ) {
-              fileNames = !Array.isArray( files ) ? files.split('|') : files;
+            if (files) {
+              fileNames = !Array.isArray(files) ? files.split('|') : files;
             }
 
             _buildListRecursive(metadata, fileNames);

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -111,7 +111,7 @@ angular.module('risevision.template-editor.directives')
           function _getDefaultFilesAttribute() {
             var defaultFiles = $scope.getBlueprintData($scope.componentId, 'files');
 
-            return !Array.isArray( defaultFiles ) ? defaultFiles.split('|') : defaultFiles;
+            return defaultFiles && !Array.isArray( defaultFiles ) ? defaultFiles.split('|') : defaultFiles;
           }
 
           function _getDefaultDurationAttribute() {
@@ -247,7 +247,7 @@ angular.module('risevision.template-editor.directives')
             var filesAttribute = _filesAttributeFor(selectedImages);
 
             $scope.selectedImages = selectedImages;
-            $scope.isDefaultImageList = filesAttribute === _getDefaultFilesAttribute();
+            $scope.isDefaultImageList = JSON.stringify(filesAttribute) === JSON.stringify(_getDefaultFilesAttribute());
           }
 
           _reset();

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -114,9 +114,9 @@ angular.module('risevision.template-editor.directives')
             if (defaultFiles) {
               // new 'files' attribute value is an Array, but generated in Blueprint as a String
               // example value "["test1.jpg", "test2.jpg"]"
-              if (defaultFiles.charAt(0) === "[" && defaultFiles.charAt(defaultFiles.length-1) === "]") {
+              if (defaultFiles.charAt(0) === '[' && defaultFiles.charAt(defaultFiles.length - 1) === ']') {
                 try {
-                  defaultFiles = JSON.parse("'" + defaultFiles + "'");
+                  defaultFiles = JSON.parse('\'' + defaultFiles + '\'');
                 } catch (err) {
                   $log.error('Invalid default files value: ' + err);
                   return null;

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -264,6 +264,7 @@ angular.module('risevision.template-editor.directives')
             var filesAttribute = _filesAttributeFor(selectedImages);
 
             $scope.selectedImages = selectedImages;
+            // need to compare two Arrays
             $scope.isDefaultImageList = JSON.stringify(filesAttribute) === JSON.stringify(_getDefaultFilesAttribute());
           }
 

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -109,7 +109,9 @@ angular.module('risevision.template-editor.directives')
           }
 
           function _getDefaultFilesAttribute() {
-            return $scope.getBlueprintData($scope.componentId, 'files');
+            var defaultFiles = $scope.getBlueprintData($scope.componentId, 'files');
+
+            return !Array.isArray( defaultFiles ) ? defaultFiles.split('|') : defaultFiles;
           }
 
           function _getDefaultDurationAttribute() {
@@ -120,7 +122,11 @@ angular.module('risevision.template-editor.directives')
             $scope.factory.loadingPresentation = true;
 
             var metadata = [];
-            var fileNames = files ? files.split('|') : [];
+            var fileNames = [];
+
+            if ( files ) {
+              fileNames = !Array.isArray( files ) ? files.split('|') : files;
+            }
 
             _buildListRecursive(metadata, fileNames);
           }
@@ -197,7 +203,7 @@ angular.module('risevision.template-editor.directives')
           function _filesAttributeFor(metadata) {
             return _.map(metadata, function (entry) {
               return entry.file;
-            }).join('|');
+            });
           }
 
           $scope.updateImageMetadata = function (metadata) {

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -142,7 +142,7 @@ angular.module('risevision.template-editor.directives')
             var fileNames = [];
 
             if (files) {
-              fileNames = !Array.isArray(files) ? files.split('|') : files;
+              fileNames = !Array.isArray(files) ? files.split('|') : JSON.parse(JSON.stringify(files));
             }
 
             _buildListRecursive(metadata, fileNames);

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -116,7 +116,7 @@ angular.module('risevision.template-editor.directives')
               // example value "["test1.jpg", "test2.jpg"]"
               if (defaultFiles.charAt(0) === '[' && defaultFiles.charAt(defaultFiles.length - 1) === ']') {
                 try {
-                  defaultFiles = JSON.parse('\'' + defaultFiles + '\'');
+                  defaultFiles = JSON.parse(defaultFiles);
                 } catch (err) {
                   $log.error('Invalid default files value: ' + err);
                   return null;


### PR DESCRIPTION
- Fix for issue #1063 
- `files` will be an Array data type in the component, see https://github.com/Rise-Vision/rise-image/pull/24 for those changes. This is to allow file path values to include any special character, i.e. `|`
- Changes in this PR support legacy implementation of String `files` value with | separator. The legacy value is converted to Array for saving to attribute data. 

Validated with a staged version of the component in _example-financial-template_.  Tested both old `files` | based value and also having revised JSON Array value. Also tested a file with all special characters in name and also files residing in a folder with all special characters in name  - https://apps-stage-8.risevision.com/templates/edit/55d88832-c75d-4512-b165-50773322e5c4/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443