### PR TITLE
Pass a copy of 'files' to '_buildListRecursive'

### DIFF
--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -142,7 +142,7 @@ angular.module('risevision.template-editor.directives')
             var fileNames = [];
 
             if (files) {
-              fileNames = !Array.isArray(files) ? files.split('|') : files;
+              fileNames = !Array.isArray(files) ? files.split('|') : JSON.parse(JSON.stringify(files));
             }
 
             _buildListRecursive(metadata, fileNames);


### PR DESCRIPTION
The call to `_buildListRecursive` modifies its argument. Since we were passing `files`, which comes from the metadata object, the watch for `factory.presentation` was being called and that caused the failed comparison. This was really hard to pin down.

@stulees please review
