### PR TITLE
Track presentation events on template editor

### DIFF
--- a/test/unit/template-editor/services/svc-template-editor-factory.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-factory.tests.js
@@ -2,6 +2,7 @@
 
 describe('service: templateEditorFactory:', function() {
   var sandbox = sinon.sandbox.create();
+  var presentationTracker = sandbox.spy();
 
   beforeEach(module('risevision.template-editor.services'));
 
@@ -56,6 +57,11 @@ describe('service: templateEditorFactory:', function() {
         showMessageWindow: sandbox.stub()
       };
     });
+
+    $provide.factory('presentationTracker', function() {
+      return presentationTracker;
+    });
+
     $provide.service('scheduleFactory', function() {
       return {
         createFirstSchedule: sinon.stub()
@@ -216,6 +222,7 @@ describe('service: templateEditorFactory:', function() {
             expect(templateEditorFactory.loadingPresentation).to.be.false;
             expect(templateEditorFactory.errorMessage).to.not.be.ok;
             expect(templateEditorFactory.apiError).to.not.be.ok;
+            expect(presentationTracker).to.have.been.calledWith('Presentation Created', 'presentationId', 'Test Presentation');
 
             done();
           },10);
@@ -286,6 +293,7 @@ describe('service: templateEditorFactory:', function() {
             expect(templateEditorFactory.loadingPresentation).to.be.false;
             expect(templateEditorFactory.errorMessage).to.not.be.ok;
             expect(templateEditorFactory.apiError).to.not.be.ok;
+            expect(presentationTracker).to.have.been.calledWith('Presentation Updated', 'presentationId', 'Test Presentation');
 
             done();
           },10);
@@ -546,6 +554,7 @@ describe('service: templateEditorFactory:', function() {
             expect(templateEditorFactory.loadingPresentation).to.be.false;
             expect(templateEditorFactory.errorMessage).to.not.be.ok;
             expect(templateEditorFactory.apiError).to.not.be.ok;
+            expect(presentationTracker).to.have.been.calledWith('Presentation Deleted', 'presentationId', 'Test Presentation');
 
             done();
           },10);
@@ -638,6 +647,7 @@ describe('service: templateEditorFactory:', function() {
             expect(templateEditorFactory.loadingPresentation).to.be.false;
             expect(templateEditorFactory.errorMessage).to.not.be.ok;
             expect(templateEditorFactory.apiError).to.not.be.ok;
+            expect(presentationTracker).to.have.been.calledWith('Presentation Published', 'presentationId', 'Test Presentation');
 
             done();
           },10);

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -5,10 +5,10 @@ angular.module('risevision.template-editor.services')
   .constant('HTML_TEMPLATE_DOMAIN', 'https://widgets.risevision.com')
   .factory('templateEditorFactory', ['$q', '$log', '$state', '$rootScope', 'presentation',
     'processErrorCode', 'userState', 'checkTemplateAccess', '$modal', 'scheduleFactory', 'plansFactory',
-    'templateEditorUtils',
+    'templateEditorUtils', 'presentationTracker',
     'HTML_PRESENTATION_TYPE', 'template', 'REVISION_STATUS_REVISED', 'REVISION_STATUS_PUBLISHED',
     function ($q, $log, $state, $rootScope, presentation, processErrorCode, userState,
-      checkTemplateAccess, $modal, scheduleFactory, plansFactory, templateEditorUtils,
+      checkTemplateAccess, $modal, scheduleFactory, plansFactory, templateEditorUtils, presentationTracker,
       HTML_PRESENTATION_TYPE, template, REVISION_STATUS_REVISED, REVISION_STATUS_PUBLISHED) {
       var factory = {};
 
@@ -121,6 +121,8 @@ angular.module('risevision.template-editor.services')
             if (resp && resp.item && resp.item.id) {
               $rootScope.$broadcast('presentationCreated');
 
+              presentationTracker('Presentation Created', resp.item.id, resp.item.name);
+
               $state.go('apps.editor.templates.edit', {
                 presentationId: resp.item.id,
                 productId: undefined
@@ -157,6 +159,8 @@ angular.module('risevision.template-editor.services')
 
         presentation.update(presentationVal.id, presentationVal)
           .then(function (resp) {
+            presentationTracker('Presentation Updated', resp.item.id, resp.item.name);
+
             _setPresentation(resp.item, true);
 
             deferred.resolve(resp.item.id);
@@ -227,8 +231,11 @@ angular.module('risevision.template-editor.services')
 
         presentation.delete(factory.presentation.id)
           .then(function () {
-            factory.presentation = {};
+            presentationTracker('Presentation Deleted', factory.presentation.id, factory.presentation.name);
+
             $rootScope.$broadcast('presentationDeleted');
+
+            factory.presentation = {};
 
             $state.go('apps.editor.list');
             deferred.resolve();
@@ -260,6 +267,8 @@ angular.module('risevision.template-editor.services')
 
         presentation.publish(factory.presentation.id)
           .then(function () {
+            presentationTracker('Presentation Published', factory.presentation.id, factory.presentation.name);
+
             factory.presentation.revisionStatusName = REVISION_STATUS_PUBLISHED;
             factory.presentation.changeDate = new Date();
             factory.presentation.changedBy = userState.getUsername();


### PR DESCRIPTION
## Description
Fix to defect https://github.com/Rise-Vision/rise-vision-apps/issues/1101

## Motivation and Context
Add missing tracking information to the new template editor

## How Has This Been Tested?
1. Go to https://apps-stage-4.risevision.com/
1. Open WebTools
1. Create a new presentation
1. Edit, Save and Publish it
1. Observe the network requests to BQ for each event on WebTools

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed