### PR TITLE
Open Account & Billing from "Get More" link

### DIFF
--- a/web/partials/displays/display-details.html
+++ b/web/partials/displays/display-details.html
@@ -45,7 +45,7 @@
           {{ getProAvailableLicenseCount() }}
         </span>
         Available Licenses
-        <a href="#" class="ml-2" ng-show="areAllProLicensesUsed() && !currentPlanFactory.currentPlan.isPurchasedByParent" ng-click="showPlansModal('displays-app.details.additional-license-warning')" aria-label="Get More Display Licenses" translate>displays-app.details.get-more</a>
+        <a ui-sref="apps.billing.home" class="ml-2" ng-show="areAllProLicensesUsed() && !currentPlanFactory.currentPlan.isPurchasedByParent" aria-label="Get More Display Licenses" translate>displays-app.details.get-more</a>
       </li>
     </ul>
 


### PR DESCRIPTION
If an account already has some licensed displays "Get More" should not
open the plans modal since getting more licenses is accomplished by
editing the existing subscription (from Account & Billing).

Addresses https://github.com/Rise-Vision/rise-vision-apps/issues/1117