### PR TITLE
Fix various issues with Stretchy

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "angular-slugify": "^1.0.1",
     "common-header": "https://github.com/Rise-Vision/common-header.git#v3.9.11",
     "oauthio-web": "0.6.2",
-    "stretchy": "https://github.com/Rise-Vision/stretchy.git#fix/elipsis"
+    "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
   "devDependencies": {
     "q": "1.0.1",

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "angular-slugify": "^1.0.1",
     "common-header": "https://github.com/Rise-Vision/common-header.git#v3.9.11",
     "oauthio-web": "0.6.2",
-    "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
+    "stretchy": "https://github.com/Rise-Vision/stretchy.git#fix/elipsis"
   },
   "devDependencies": {
     "q": "1.0.1",

--- a/web/scripts/template-editor/directives/dtv-toolbar.js
+++ b/web/scripts/template-editor/directives/dtv-toolbar.js
@@ -2,7 +2,8 @@
 
 angular.module('risevision.template-editor.directives')
   .directive('templateEditorToolbar', ['templateEditorFactory', '$templateCache', '$modal',
-    function (templateEditorFactory, $templateCache, $modal) {
+    '$window', '$timeout',
+    function (templateEditorFactory, $templateCache, $modal, $window, $timeout) {
       return {
         restrict: 'E',
         templateUrl: 'partials/template-editor/toolbar.html',
@@ -16,13 +17,21 @@ angular.module('risevision.template-editor.directives')
             $scope.isEditingName = false;
           };
 
-          $scope.$watch('isEditingName', function (editing) {
+          var _initStretchy = function() {
             var templateNameInput = element.find('input.presentation-name');
+
+            $window.Stretchy.resize(templateNameInput[0]);
 
             if (!$scope.defaultNameWidth) {
               // first time editing, store the width of the field when default name is displayed
-              $scope.defaultNameWidth = templateNameInput[0].style.width;
+              $scope.defaultNameWidth = $window.getComputedStyle(templateNameInput[0]).getPropertyValue('width');
             }
+          };
+
+          $timeout(_initStretchy);
+
+          $scope.$watch('isEditingName', function (editing) {
+            var templateNameInput = element.find('input.presentation-name');
 
             if (editing) {
               setFocus(templateNameInput[0]);


### PR DESCRIPTION
When name is using ellipsis, the scrollLeft bulletproof
from Stretchy doesn't work. It shifts the contents of the
input field out of view and calculates a much larger width.
Fixed by PR from the forked repo.

In Safari, stretchy initializes the element before the
text field value is updated. This causes a very short input to
be rendered. Fixing this by forcing stretchy initialization after
directive is rendered.

defaultNameWidth variable is initialized incorrectly. Using element.style
does not obtain the correct width. Using getComputedStyle instead.

[stage-2]