### PR TITLE
Fix issue where dragging outside the modal content closes the modal

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/modal-drag",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.9.14",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -36,7 +36,6 @@
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
     "jquery": "^2",
-    "font-awesome": "~4.7.0",
-    "common-header": "fix/modal-drag"
+    "font-awesome": "~4.7.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.9.13",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/modal-drag",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -36,6 +36,7 @@
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
     "jquery": "^2",
-    "font-awesome": "~4.7.0"
+    "font-awesome": "~4.7.0",
+    "common-header": "fix/modal-drag"
   }
 }


### PR DESCRIPTION
#  Description
Fix for #902
Basically, we are adding a handler that ignores click events within the modal that would otherwise close it.

## Motivation and Context
We have had back and forth on this issue for a while. Finally it was decided that we should fix. This fix applies to all Modals in the App

## How Has This Been Tested?
Validated fix by opening several modals and trying to drag the content in it and release the mouse button outside the modal. Also tested that clicking outside the modal closes it as expected.
Staged at https://apps-stage-2.risevision.com

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
Manual test completed
Automated tests updated in CH
Will monitor release by testing functionality once deployed
Will roll back via CH version in Apps
No documentation needed, the CH PR has descriptive comments and a link to the origin of the fix
Will notify support once released

- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
There is no relevant documentation to be updated other than in the code itself and the unit tests.
