### PR TITLE
Fix/issue 1077 height in samsung browser

### DIFF
--- a/test/unit/template-editor/controllers/ctr-template-editor.chrome-bar.tests.js
+++ b/test/unit/template-editor/controllers/ctr-template-editor.chrome-bar.tests.js
@@ -1,8 +1,7 @@
 'use strict';
 describe('controller: TemplateEditor : Chrome Bar', function() {
 
-  var $rootScope, $scope, $window, $state, factory, scheduleFactory,
-    originalWindowNavigator;
+  var $rootScope, $scope, $window, factory, originalWindowNavigator;
 
   function _providePresentationUtils($provide, isMobileBrowser) {
     $provide.factory('presentationUtils', function() {
@@ -24,10 +23,6 @@ describe('controller: TemplateEditor : Chrome Bar', function() {
         userAgent: userAgent,
         language: originalWindowNavigator.language
       };
-
-      $state = $injector.get('$state');
-      factory = $injector.get('templateEditorFactory');
-      scheduleFactory = $injector.get('scheduleFactory');
 
       $controller('TemplateEditorController', {
         $scope: $scope,

--- a/test/unit/template-editor/controllers/ctr-template-editor.chrome-bar.tests.js
+++ b/test/unit/template-editor/controllers/ctr-template-editor.chrome-bar.tests.js
@@ -1,0 +1,171 @@
+'use strict';
+describe('controller: TemplateEditor : Chrome Bar', function() {
+
+  var $rootScope, $scope, $window, $state, factory, scheduleFactory,
+    originalWindowNavigator;
+
+  function _providePresentationUtils($provide, isMobileBrowser) {
+    $provide.factory('presentationUtils', function() {
+      return {
+        isMobileBrowser: function () { return isMobileBrowser; }
+      };
+    });
+  }
+
+  function _injectController(userAgent) {
+    inject(function($injector, $controller) {
+      $rootScope = $injector.get('$rootScope');
+      $scope = $rootScope.$new();
+
+      $window = $injector.get('$window');
+
+      originalWindowNavigator = $window.navigator;
+      $window.navigator = {
+        userAgent: userAgent,
+        language: originalWindowNavigator.language
+      };
+
+      $state = $injector.get('$state');
+      factory = $injector.get('templateEditorFactory');
+      scheduleFactory = $injector.get('scheduleFactory');
+
+      $controller('TemplateEditorController', {
+        $scope: $scope,
+        editorFactory: $injector.get('templateEditorFactory')
+      });
+
+      $scope.$digest();
+    });
+  }
+
+  afterEach(function(){
+    $window.navigator = originalWindowNavigator;
+  })
+
+  beforeEach(function() {
+    factory = {
+      presentation: { templateAttributeData: {} },
+      save: function() {
+        return Q.resolve();
+      }
+    };
+  });
+
+  beforeEach(module('risevision.template-editor.controllers'));
+  beforeEach(module('risevision.template-editor.services'));
+  beforeEach(module('risevision.editor.services'));
+  beforeEach(module(mockTranlate()));
+  beforeEach(module(function ($provide) {
+    $provide.factory('templateEditorFactory', function() {
+      return factory;
+    });
+    $provide.factory('scheduleFactory', function() {
+      return {
+        hasSchedules: function () {}
+      };
+    });
+  }));
+
+  describe('controller: TemplateEditor : Chrome Bar : Desktop', function() {
+
+    beforeEach(module(function($provide) {
+      _providePresentationUtils($provide, false);
+    }));
+
+    beforeEach(function() {
+      _injectController();
+    });
+
+    it('should not consider chrome bar height on desktop browsers', function() {
+      expect($scope).to.be.truely;
+      expect($scope.considerChromeBarHeight).to.be.false;
+    });
+
+  });
+
+  describe('controller: TemplateEditor : Chrome Bar : Mobile', function() {
+
+    beforeEach(module(function($provide) {
+      _providePresentationUtils($provide, true);
+    }));
+
+    describe('controller: TemplateEditor : Chrome Bar : Mobile : Chrome', function() {
+      var CHROME_USER_AGENT =
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75 Mobile/14E5239e Safari/602.1';
+
+      beforeEach(function() {
+        _injectController(CHROME_USER_AGENT);
+      });
+
+      it('should consider chrome bar height on mobile Chrome browsers', function() {
+        expect($scope).to.be.truely;
+        expect($scope.considerChromeBarHeight).to.be.true;
+      });
+
+    });
+
+    describe('controller: TemplateEditor : Chrome Bar : Mobile : Chrome', function() {
+      var CHROME_USER_AGENT =
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75 Mobile/14E5239e Safari/602.1';
+
+      beforeEach(function() {
+        _injectController(CHROME_USER_AGENT);
+      });
+
+      it('should consider chrome bar height on mobile Chrome browsers', function() {
+        expect($scope).to.be.truely;
+        expect($scope.considerChromeBarHeight).to.be.true;
+      });
+
+    });
+
+    describe('controller: TemplateEditor : Chrome Bar : Mobile : Safari', function() {
+      var SAFARI_USER_AGENT =
+        'mozilla/5.0 (ipad; cpu iphone os 7_0_2 like mac os x) applewebkit/537.51.1 (khtml, like gecko) version/7.0 mobile/11a501 safari/9537.53';
+
+      beforeEach(function() {
+        _injectController(SAFARI_USER_AGENT);
+      });
+
+      it('should consider chrome bar height on mobile Safari browsers', function() {
+        expect($scope).to.be.truely;
+        expect($scope.considerChromeBarHeight).to.be.true;
+      });
+
+    });
+
+    describe('controller: TemplateEditor : Chrome Bar : Mobile Firefox', function() {
+
+      var FIREFOX_USER_AGENT =
+        'Mozilla/5.0 (Android 4.4; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0';
+
+      beforeEach(function() {
+        _injectController(FIREFOX_USER_AGENT);
+      });
+
+      it('should not consider chrome bar height on mobile Firefox browsers', function() {
+        expect($scope).to.be.truely;
+        expect($scope.considerChromeBarHeight).to.be.false;
+      });
+
+    });
+
+    describe('controller: TemplateEditor : Chrome Bar : Mobile Samsung Browser', function() {
+
+      var SAMSUNG_USER_AGENT =
+        'Mozilla/5.0 (Linux; Android $ver; $model) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/$app_ver Chrome/$engine_ver Mobile Safari/537.36 ? Current values: android_ver = 7.0 app_ver = 5.2 , engine_ver = 51.0.2704.106';
+
+      beforeEach(function() {
+        _injectController(SAMSUNG_USER_AGENT);
+      });
+
+      it('should not consider chrome bar height on mobile Samsung browsers', function() {
+        expect($scope).to.be.truely;
+        expect($scope.considerChromeBarHeight).to.be.false;
+      });
+
+    });
+
+  });
+
+});

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -151,9 +151,9 @@ angular.module('risevision.template-editor.controllers')
       function _considerChromeBarHeight() {
         var userAgent = $window.navigator.userAgent;
 
-        // Firefox requires desktop rule
+        // Firefox and Samsung browser require desktop rule
         return presentationUtils.isMobileBrowser() &&
-          !(/Firefox/i.test(userAgent));
+          !(/Firefox|SamsungBrowser/i.test(userAgent));
       }
 
       $scope.$watch('factory.presentation', function (newValue, oldValue) {


### PR DESCRIPTION
## Description
Includes Samsung browser as an exception to the chrome bar rule for mobile. 

Issue: https://github.com/Rise-Vision/rise-vision-apps/issues/1077

## Motivation and Context
Samsung browser behaves as Firefox browser in mobile

## How Has This Been Tested?
Tested in browserstack, using Samsung's browser with this presentation: https://apps-stage-9.risevision.com/templates/edit/46f2bd16-a3e2-4922-bb2b-0f52842ad0a9/?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c

Capture with fix ( compare to the ones I previously pasted on the issue page ) -
![fixed](https://user-images.githubusercontent.com/33162690/61661289-505cb880-ac91-11e9-8d70-bfbf68dc6190.png)


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     This adds unit tests for the Samsung case, and also for other cases.
     This does not affect data, so a simple rollback is required to undo the changes.
     The comment that documents the exception line was updated.

- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

  - no need to notify Support as this was raised by QA, not an end user.
