### PR TITLE
Fix/issue 1065 default icon transparency

### DIFF
--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -1,6 +1,7 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
+  .constant('DEFAULT_IMAGE_THUMBNAIL', 'https://s3.amazonaws.com/Rise-Images/UI/storage-image-icon-no-transparency%402x.png')
   .constant('SUPPORTED_IMAGE_TYPES', '.bmp, .gif, .jpeg, .jpg, .png, .svg, .webp')
   .directive('templateComponentImage', ['$log', '$q', '$timeout', 'templateEditorFactory', 'templateEditorUtils',
     'storageAPILoader', 'DEFAULT_IMAGE_THUMBNAIL', 'SUPPORTED_IMAGE_TYPES',

--- a/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
+++ b/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
@@ -1,9 +1,8 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
-  .constant('DEFAULT_IMAGE_THUMBNAIL', 'https://s3.amazonaws.com/Rise-Images/UI/storage-image-icon-no-transparency%402x.png')
-  .directive('basicStorageSelector', ['$loading', 'storage', 'templateEditorUtils', 'DEFAULT_IMAGE_THUMBNAIL',
-    function ($loading, storage, templateEditorUtils, DEFAULT_IMAGE_THUMBNAIL) {
+  .directive('basicStorageSelector', ['$loading', 'storage', 'templateEditorUtils',
+    function ($loading, storage, templateEditorUtils) {
       return {
         restrict: 'E',
         scope: {

--- a/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
+++ b/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
-  .constant('DEFAULT_IMAGE_THUMBNAIL', 'https://s3.amazonaws.com/Rise-Images/UI/storage-image-icon%402x.png')
+  .constant('DEFAULT_IMAGE_THUMBNAIL', 'https://s3.amazonaws.com/Rise-Images/UI/storage-image-icon-no-transparency%402x.png')
   .directive('basicStorageSelector', ['$loading', 'storage', 'templateEditorUtils', 'DEFAULT_IMAGE_THUMBNAIL',
     function ($loading, storage, templateEditorUtils, DEFAULT_IMAGE_THUMBNAIL) {
       return {


### PR DESCRIPTION
## Description
Use a default image icon with no transparency
https://github.com/Rise-Vision/rise-vision-apps/issues/1065

I also moved the constant declaration to the image component, where it is used.

## Motivation and Context
Instead of adding a flag to detect if this is a default icon, the icon reference was changed to a copy of the icon with transparency disabled.

## How Has This Been Tested?
Can be validated with the image component in this presentation:
https://apps-stage-8.risevision.com/templates/edit/26b3e7ed-991f-4432-8b36-78da972692ee/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

Capture with the fix below:
![fixed](https://user-images.githubusercontent.com/33162690/61726122-b64f4b80-ad36-11e9-8815-1d9587410eba.png)

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
      - manually tested
      - no monitoring issues
      - can be rolled back easily
      - the image name contains 'no-transparency' text, which auto-documents its intention

- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- No automated test, the transparency issue is not a easy catch on tests, and the fix is simple and the bug minor. That's why no test was created.
- No need to contact support, as this was internally raised.
