### PR TITLE
Improve Google Auth result matchers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/auth-result",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.9.15",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -36,7 +36,6 @@
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
     "jquery": "^2",
-    "font-awesome": "~4.7.0",
-    "common-header": "fix/auth-result"
+    "font-awesome": "~4.7.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.9.14",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/auth-result",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -36,6 +36,7 @@
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
     "jquery": "^2",
-    "font-awesome": "~4.7.0"
+    "font-awesome": "~4.7.0",
+    "common-header": "fix/auth-result"
   }
 }


### PR DESCRIPTION
## Description
Fix for https://github.com/Rise-Vision/rise-vision-apps/issues/995
Basically, after performing Authentication for the Google Account the User gets redirected back to the App. At that point the URL contains hash (`#`) parameters with the authentication result.
The Google library at that point parses the hash and removes it once it completes its operation. If the hash is parsed successfully authentication succeeds.
However, the App and more specifically `ui-router`, also parse the URL and try to match it to a known path. If there is no match, it will fallback to the default `/` path. To confirm, there are two flavours of behaviour here, hash mode and html5 mode. RVA uses a hash for its url parameters, while Apps uses html5 mode which has paths directly in the url (no hash).
That is why in the RVA, the hash from Google is matched to a path via the Regex.
However, in Apps, `ui-router` tries to convert the hash to a path, and subsequently doesn't find a matching path so it removes it.

Why was this working before? In Chrome, it seems that the Google library parses the URL quickly enough before `ui-router` gets a hold of it. In Safari that doesn't seem to be the case.

What this fix does is tell `ui-router` that the URL received from the Google Auth redirect is OK (and to leave it alone). What this does is allow the Google library to parse it and remove it. From there on, paths work as before, this is achieved by returning `false`.

Here's a link to the documentation:
https://github.com/angular-ui/ui-router/wiki/URL-Routing#when-for-redirection

## Motivation and Context
Fixes the issue as described

## How Has This Been Tested?
This is staged in Apps at:
https://apps-stage-2.risevision.com/
and RVA at:
http://rva-test.appspot.com

The indication that this code is working is the console statement `Google Auth result received` after the Google Auth redirect.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
**Manual test:** this was tested manually by myself in both RVA and Apps. However, as I was not able to replicate the issue, the fix itself was validated by Alan.
**Automated test:** Common Header and Apps e2e tests cover this scenario extensively by validating Google Authentication when the tests run. Hopefully this improvement will prevent some of the random test failures we have been experiencing.
**Monitoring:** We will validate the release in production to ensure no extra issues are introduced.
**Rollback:** RVA deployment can be rolled back through the App Engine console. Apps will have to be rolled back by decrementing the CH tag and following the regular deployment process.
**Documentation:** Extensive information regarding the cause and fix is provided in the PR description above.
**Internal Communication:** Will let Support know of the deployment after the Apps PR merge.

- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
