### PR TITLE
Feature/parameterize image labels in storage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#feature/generic-storage-styles-and-labels",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.9.16",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -35,7 +35,6 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
-    "common-header": "feature/generic-storage-styles-and-labels",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.9.15",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#feature/generic-storage-styles-and-labels",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },

--- a/bower.json
+++ b/bower.json
@@ -35,6 +35,7 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
+    "common-header": "feature/generic-storage-styles-and-labels",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }

--- a/test/unit/template-editor/directives/dtv-basic-storage-selector.tests.js
+++ b/test/unit/template-editor/directives/dtv-basic-storage-selector.tests.js
@@ -34,7 +34,7 @@ describe('directive: basicStorageSelector', function() {
     storage = $injector.get('storage');
 
     $templateCache.put('partials/template-editor/basic-storage-selector.html', '<p>mock</p>');
-    element = $compile('<basic-storage-selector storage-selector-id="test" valid-extensions="validExtensions" storage-manager="storageManager"></basic-storage-selector>')($rootScope);
+    element = $compile('<basic-storage-selector storage-selector-id="test" file-type="image" valid-extensions="validExtensions" storage-manager="storageManager"></basic-storage-selector>')($rootScope);
     $rootScope.$apply();
 
     $scope = element.isolateScope();
@@ -53,6 +53,11 @@ describe('directive: basicStorageSelector', function() {
     expect($scope.isSelected).to.be.a.function;
     expect($scope.addSelected).to.be.a.function;
     expect($scope.loadItems).to.be.a.function;
+  });
+
+  it('should receive attributes', function () {
+    expect($scope.storageSelectorId).to.equal('test');
+    expect($scope.fileType).to.equal('image');
   });
 
   describe('fileNameOf', function () {

--- a/web/partials/template-editor/basic-storage-selector.html
+++ b/web/partials/template-editor/basic-storage-selector.html
@@ -24,11 +24,11 @@
   <div class="storage-selector-list-empty" ng-show="folderItems.length === 0 && !isUploading">
     <div class="row">
       <div class="col-xs-12">
-        <h2 ng-show="!currentFolder">You have no images in Storage.</h2>
-        <h2 ng-show="currentFolder">You have no images in {{currentFolder}}.</h2>
-        <p>Upload images from your device to keep your display interesting!</p>
+        <h2 ng-show="!currentFolder">You have no {{fileType}}s in Storage.</h2>
+        <h2 ng-show="currentFolder">You have no {{fileType}}s in {{currentFolder}}.</h2>
+        <p>Upload {{fileType}}s from your device to keep your display interesting!</p>
         <div>
-          <img class="img-responsive" src="../images/image-empty-list.svg">
+          <img class="img-responsive" src="../images/{{fileType}}-empty-list.svg">
         </div>
       </div>
     </div>
@@ -42,9 +42,11 @@
 </div>
 
 <div class="storage-selector-action-button-bar">
-  <div class="upload-images">
+  <div class="upload-files">
     <label id="{{storageSelectorId}}-uploader-label" class="btn btn-primary btn-block" for="{{storageSelectorId}}-uploader" ng-disabled="isUploading">
-      <strong>Upload Images</strong>
+      <strong>
+        {{ ( 'template.' + fileType + '.upload' ) | translate }}
+      </strong>
     </label>
   </div>
   <div class="add-selected">

--- a/web/partials/template-editor/components/component-image.html
+++ b/web/partials/template-editor/components/component-image.html
@@ -5,6 +5,7 @@
 
   <div class="storage-selector-container" style="display: none">
     <basic-storage-selector storage-selector-id="image-storage"
+                            file-type="image"
                             valid-extensions="validExtensions"
                             storage-manager="storageManager">
     </basic-storage-selector>

--- a/web/partials/template-editor/components/component-image/image-list.html
+++ b/web/partials/template-editor/components/component-image/image-list.html
@@ -59,7 +59,7 @@
 </div>
 
 <div class="image-component-list-action-button-bar">
-  <div class="upload-images">
+  <div class="upload-files">
     <label id="image-list-uploader-label" class="btn btn-primary btn-block" for="image-list-uploader" ng-disabled="isUploading">
       <strong>Upload Images</strong>
     </label>

--- a/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
+++ b/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
@@ -7,6 +7,7 @@ angular.module('risevision.template-editor.directives')
         restrict: 'E',
         scope: {
           storageSelectorId: '@',
+          fileType: '@',
           validExtensions: '=?',
           storageManager: '='
         },


### PR DESCRIPTION
@stulees @fjvallarino as this is @willread first PR with rise-vision-apps, you may also want to take a look.

## Description
Parameterize image specific labels, and use generic styles on storage directive page.

## Motivation and Context
So we can use the same storage directive on rise-video settings as mentioned in storage section of design document: https://docs.google.com/document/d/1a6bfu73eze1IL2nVsMu3F17XMubluxpf_YDaD3Eet8Q/edit#heading=h.owgmg0g3sbdh

- a file-type attribute was added ( image / video ).
- images and texts were parameterized with it ( I didn't create labels in common header for most of them, but I did for the button label ). If any of you prefer everything be translated as a common-header label please let me know, but we are avoiding their use, and we aren't expecting this to be expanded beyond image and video.
- the upload-images style was renamed as upload-files

Common-header branch will be updated before merging when that other PR is approved.

## How Has This Been Tested?
Changes running in this presentation:
https://apps-stage-9.risevision.com/templates/edit/46f2bd16-a3e2-4922-bb2b-0f52842ad0a9/?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed.
     - Manual tests done
     - Simple automated test for attribute added
     - No monitoring issues
     - Easy to rollback, but time depends on CCI
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

     - No documentation update was considered necessary. 
