### PR TITLE
Show empty state on Attribute Editor's Storage Selector if files are not found

### DIFF
--- a/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
+++ b/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
@@ -75,11 +75,16 @@ angular.module('risevision.template-editor.directives')
               .then(function (items) {
                 $scope.selectedItems = [];
                 $scope.storageUploadManager.folderPath = newFolderPath;
-                $scope.folderItems = items.files && items.files.filter(function (item) {
-                  var isValid = templateEditorUtils.fileHasValidExtension(item.name, validExtensionsList);
 
-                  return item.name !== newFolderPath && ($scope.isFolder(item.name) || isValid);
-                });
+                if (items.files) {
+                  $scope.folderItems = items.files.filter(function (item) {
+                    var isValid = templateEditorUtils.fileHasValidExtension(item.name, validExtensionsList);
+
+                    return item.name !== newFolderPath && ($scope.isFolder(item.name) || isValid);
+                  });
+                } else {
+                  $scope.folderItems = [];
+                }
               })
               .catch(function (err) {
                 console.log('Failed to load files', err);


### PR DESCRIPTION
## Description
Opening Attribute Editor's Storage Selector when files/folders do not exist shows an empty section. It was reported here: https://github.com/Rise-Vision/rise-vision-apps/issues/1098

## Motivation and Context
It fixes the reported issue

## How Has This Been Tested?
You can test the fix using this presentation (please, don't upload files/create folders in this company): https://apps-stage-7.risevision.com/templates/edit/d93bc14b-8f3a-429c-8fe5-2bacbc208882/?cid=813fa5d7-1e2f-4b57-8508-0c6ab3360b4e

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
There are not specific steps needed for this deployment

@santiagonoguez @stulees please review
