### PR TITLE
Fix element not found error with modal-content

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.9.18",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/element-not-found",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -36,6 +36,7 @@
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
     "jquery": "^2",
-    "font-awesome": "~4.7.0"
+    "font-awesome": "~4.7.0",
+    "common-header": "fix/element-not-found"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/element-not-found",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.9.19",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -36,7 +36,6 @@
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
     "jquery": "^2",
-    "font-awesome": "~4.7.0",
-    "common-header": "fix/element-not-found"
+    "font-awesome": "~4.7.0"
   }
 }


### PR DESCRIPTION
## Description
Some modals don't have modal content. This is causing an error to appear sometimes:
`TypeError: Cannot read property 'addEventListener' of null`
Checking for element existence before adding listener

## Motivation and Context
Fix uncaught error

## How Has This Been Tested?
To validate, go to Storage or open a Template in Template Editor (that has an Image component). Open a modal such as the Select Company modal. Look at the console, the error should appear.

Fix staged at https://apps-stage-2.risevision.com

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 

**Manual Test**  Tested to ensure error doesn't occur
**Automated Test** No need to update
**Monitoring** Will validate the release once in Production
**Rollback** Rollback can be done by reverting the PR and following the deployment process
**Documentation** Error catcher added, no need to update documentation
**Internal Communication** Will notify interested parties of the fix being deployed

- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
