### PR TITLE
Save Image files value as Array and support backwards compatibility of String value

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-image.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.tests.js
@@ -172,7 +172,7 @@ describe('directive: TemplateComponentImage', function() {
       )).to.be.true;
 
       expect($scope.setAttributeData.calledWith(
-        'TEST-ID', 'files', TEST_FILE
+        'TEST-ID', 'files', [TEST_FILE]
       )).to.be.true;
 
       done();
@@ -210,7 +210,7 @@ describe('directive: TemplateComponentImage', function() {
       ), 'set metadata attribute').to.be.true;
 
       expect($scope.setAttributeData.calledWith(
-        'TEST-ID', 'files', 'image.png|image2.png'
+        'TEST-ID', 'files', ['image.png','image2.png']
       ), 'set files attribute').to.be.true;
     });
 
@@ -237,7 +237,7 @@ describe('directive: TemplateComponentImage', function() {
       ), 'set metadata attribute').to.be.true;
 
       expect($scope.setAttributeData.calledWith(
-        'TEST-ID', 'files', 'image.png|image2.png'
+        'TEST-ID', 'files', ['image.png', 'image2.png']
       ), 'set files attribute').to.be.true;
     });
 
@@ -267,7 +267,7 @@ describe('directive: TemplateComponentImage', function() {
       ), 'set metadata attribute').to.be.true;
 
       expect($scope.setAttributeData.calledWith(
-        'TEST-ID', 'files', 'image.png|image2.png'
+        'TEST-ID', 'files', ['image.png', 'image2.png']
       ), 'set files attribute').to.be.true;
     });
 
@@ -298,7 +298,7 @@ describe('directive: TemplateComponentImage', function() {
       ), 'set metadata attribute').to.be.true;
 
       expect($scope.setAttributeData.calledWith(
-        'TEST-ID', 'files', 'image.png|image2.png'
+        'TEST-ID', 'files', ['image.png', 'image2.png']
       ), 'set files attribute').to.be.true;
     });
 

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -109,7 +109,26 @@ angular.module('risevision.template-editor.directives')
           }
 
           function _getDefaultFilesAttribute() {
-            return $scope.getBlueprintData($scope.componentId, 'files');
+            var defaultFiles = $scope.getBlueprintData($scope.componentId, 'files');
+
+            if (defaultFiles) {
+              // new 'files' attribute value is an Array, but generated in Blueprint as a String
+              // example value "["test1.jpg", "test2.jpg"]"
+              if (defaultFiles.charAt(0) === '[' && defaultFiles.charAt(defaultFiles.length - 1) === ']') {
+                try {
+                  defaultFiles = JSON.parse(defaultFiles);
+                } catch (err) {
+                  $log.error('Invalid default files value: ' + err);
+                  return null;
+                }
+              } else {
+                // old'files' attribute value is String containing | separated values
+                // example value "test1.jpg|test2.jpg"
+                defaultFiles = defaultFiles.split('|');
+              }
+            }
+
+            return defaultFiles;
           }
 
           function _getDefaultDurationAttribute() {
@@ -120,12 +139,10 @@ angular.module('risevision.template-editor.directives')
             $scope.factory.loadingPresentation = true;
 
             var metadata = [];
-            var fileNames;
+            var fileNames = [];
 
-            if (files && Array.isArray(files)) {
-              fileNames = JSON.parse(JSON.stringify(files));
-            } else {
-              fileNames = files ? files.split('|') : [];
+            if (files) {
+              fileNames = !Array.isArray(files) ? files.split('|') : JSON.parse(JSON.stringify(files));
             }
 
             _buildListRecursive(metadata, fileNames);
@@ -203,7 +220,7 @@ angular.module('risevision.template-editor.directives')
           function _filesAttributeFor(metadata) {
             return _.map(metadata, function (entry) {
               return entry.file;
-            }).join('|');
+            });
           }
 
           $scope.updateImageMetadata = function (metadata) {
@@ -247,7 +264,8 @@ angular.module('risevision.template-editor.directives')
             var filesAttribute = _filesAttributeFor(selectedImages);
 
             $scope.selectedImages = selectedImages;
-            $scope.isDefaultImageList = filesAttribute === _getDefaultFilesAttribute();
+            // need to compare two Arrays
+            $scope.isDefaultImageList = JSON.stringify(filesAttribute) === JSON.stringify(_getDefaultFilesAttribute());
           }
 
           _reset();


### PR DESCRIPTION
## Description
Converting and saving Image component `files` attribute to Array data type to allow for supporting all special characters in Storage file and folder names, including the `|` character. 

## Motivation and Context
This change is required as a part of the overall fix for issue #1063 . The `files` attribute has up to now been String value with | separated GCS file path values. If a file name or folder name had a | in the name, then the component incorrectly parsed the value to obtain each file path. Our users should be able to use any special character in a file or folder name, so `files` should be an Array data type to support this. 

## How Has This Been Tested?
Testing has been done with a staged version of the component in staged Apps environment. The changes to template editor have been written to be backwards compatible in regards to handling String data type `files` value from default configuration and previously saved configuration. 

Scenarios that have been tested and validated:
- Apps staging environment with a new template presentation, staged component running in a template in Editor Preview
- Apps staging environment with a previously existing template presentation, staged component running in Editor Preview
- Staged component running on ChrOS display from RV test company, with attribute data saved from Apps staging environment 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed.
  - Manually tested on staging
  - Includes revised unit tests 
  - These changes will not be released until _rise-image_ has been released and latest version of the component is used on all displays using a template with rise-image. Details of _rise-image_ changes and release plan are in the [rise-image PR](https://github.com/Rise-Vision/rise-image/pull/32)
  - Upon release, will be validating no issue on Production by testing an existing Template with Image and creating a new template with Image. Will be monitoring rise-image logs and uptime. 
  - Rollback will involve 
    - Re-running previous stable deployment
    - Reverting code changes and merging to master branch
    - Isolate which presentations may have had Image instances edited. Will do so by obtaining list of companies from FullStory (who used Template Editor that day) and cross reference with companies listed from query that provides all presentation ids that have a rise-image instance, see query [here](https://github.com/Rise-Vision/bigquery-queries/blob/master/projects/client-side-events/datasets/Display_Events/ComponentPresentationUsage.bq). With a consolidated company list, and an exact presentation list, will manually check in GCS their last saved timestamp of attribute data (revised and production). If recently changed, manually download and reupload the file with `files` value reverted to String format.
  - Upon release, will notify Support to be aware of any issue
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- No documentation added, but has been specified in [rise-image PR](https://github.com/Rise-Vision/rise-image/pull/32)
