### PR TITLE
Fix/issue 29 image refresh in preview

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-image.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.tests.js
@@ -162,6 +162,7 @@ describe('directive: TemplateComponentImage', function() {
         {
           file: TEST_FILE,
           exists: true,
+          'time-created': 100,
           'thumbnail-url': 'http://thumbnail.png?_=100'
         }
       ];

--- a/web/scripts/storage/directives/dtv-upload.js
+++ b/web/scripts/storage/directives/dtv-upload.js
@@ -170,23 +170,6 @@
                   FileUploader.removeFromQueue(item);
                 });
             };
-
-            function _retrieveFileMetadata(fileName, attempt) {
-              console.log('Attempt #' + attempt + ' to get metadata for: ' + fileName);
-
-              return storage.files.get({ file: fileName })
-                .then(function (resp) {
-                  var file = resp && resp.files && resp.files[0];
-
-                  if (file && (!file.metadata || file.metadata['needs-thumbnail-update'] !== 'true')) {
-                    return $q.resolve(file);
-                  } else if (attempt > 0) {
-                    return _retrieveFileMetadata(fileName, attempt - 1);
-                  } else {
-                    return $q.reject();
-                  }
-                });
-            }
           }
         };
       }

--- a/web/scripts/storage/directives/dtv-upload.js
+++ b/web/scripts/storage/directives/dtv-upload.js
@@ -170,6 +170,23 @@
                   FileUploader.removeFromQueue(item);
                 });
             };
+
+            function _retrieveFileMetadata(fileName, attempt) {
+              console.log('Attempt #' + attempt + ' to get metadata for: ' + fileName);
+
+              return storage.files.get({ file: fileName })
+                .then(function (resp) {
+                  var file = resp && resp.files && resp.files[0];
+
+                  if (file && (!file.metadata || file.metadata['needs-thumbnail-update'] !== 'true')) {
+                    return $q.resolve(file);
+                  } else if (attempt > 0) {
+                    return _retrieveFileMetadata(fileName, attempt - 1);
+                  } else {
+                    return $q.reject();
+                  }
+                });
+            }
           }
         };
       }

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -159,7 +159,7 @@ angular.module('risevision.template-editor.directives')
           }
 
           function _getThumbnailDataFor(fileName) {
-            var invalidThumbnailData = { exists: false, url: '' };
+            var invalidThumbnailData = { exists: false, timeCreated: '', url: '' };
             var regex = /risemedialibrary-([0-9a-f-]{36})[/](.+)/g;
             var match = regex.exec(fileName);
 

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -1,7 +1,8 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
-  .constant('DEFAULT_IMAGE_THUMBNAIL', 'https://s3.amazonaws.com/Rise-Images/UI/storage-image-icon-no-transparency%402x.png')
+  .constant('DEFAULT_IMAGE_THUMBNAIL',
+    'https://s3.amazonaws.com/Rise-Images/UI/storage-image-icon-no-transparency%402x.png')
   .constant('SUPPORTED_IMAGE_TYPES', '.bmp, .gif, .jpeg, .jpg, .png, .svg, .webp')
   .directive('templateComponentImage', ['$log', '$q', '$timeout', 'templateEditorFactory', 'templateEditorUtils',
     'storageAPILoader', 'DEFAULT_IMAGE_THUMBNAIL', 'SUPPORTED_IMAGE_TYPES',
@@ -68,7 +69,7 @@ angular.module('risevision.template-editor.directives')
             var newFile = {
               file: filePath,
               exists: true,
-              'time-created': _timeCreatedFor(item),
+              'time-created': _timeCreatedFor(file),
               'thumbnail-url': _thumbnailFor(file)
             };
 
@@ -159,7 +160,11 @@ angular.module('risevision.template-editor.directives')
           }
 
           function _getThumbnailDataFor(fileName) {
-            var invalidThumbnailData = { exists: false, timeCreated: '', url: '' };
+            var invalidThumbnailData = {
+              exists: false,
+              timeCreated: '',
+              url: ''
+            };
             var regex = /risemedialibrary-([0-9a-f-]{36})[/](.+)/g;
             var match = regex.exec(fileName);
 

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -88,6 +88,14 @@ angular.module('risevision.template-editor.directives')
             }
           }
 
+          function _thumbnailFor(item) {
+            if (item.metadata && item.metadata.thumbnail) {
+              return item.metadata.thumbnail + '?_=' + (item.timeCreated && item.timeCreated.value);
+            } else {
+              return DEFAULT_IMAGE_THUMBNAIL;
+            }
+          }
+
           function _loadSelectedImages() {
             var files = _getAttribute('files') || '';
             var selectedImages = _getAttribute('metadata');

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -84,14 +84,6 @@ angular.module('risevision.template-editor.directives')
 
           function _thumbnailFor(item) {
             if (item.metadata && item.metadata.thumbnail) {
-              return item.metadata.thumbnail + '?_=' + (item.timeCreated && item.timeCreated.value);
-            } else {
-              return DEFAULT_IMAGE_THUMBNAIL;
-            }
-          }
-
-          function _thumbnailFor(item) {
-            if (item.metadata && item.metadata.thumbnail) {
               return item.metadata.thumbnail + '?_=' + _timeCreatedFor(item);
             } else {
               return DEFAULT_IMAGE_THUMBNAIL;


### PR DESCRIPTION
## Description
Includes the 'time-created' entry in the metadata, so preview can be updated when a file is replaced.

see https://github.com/Rise-Vision/rise-image/pull/33
for test and release info.
