### PR TITLE
When metadata exists use it to construct file names for thumbnails

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-image.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.tests.js
@@ -80,13 +80,14 @@ describe('directive: TemplateComponentImage', function() {
   it('should set image lists when available as attribute data', function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     var sampleImages = [
-      { "file": 'image.png', "thumbnail-url": "http://image" }
+      { "file": 'image.png', "thumbnail-url": "http://image" },
+      { "file": 'test|character.jpg', "thumbnail-url": "http://test%7Ccharacter.jpg" }
     ];
 
     $scope.getAttributeData = function(componentId, key) {
       switch(key) {
         case 'metadata': return sampleImages;
-        case 'files': return 'image.png';
+        case 'files': return 'image.png|test|character.png';
       }
     };
 

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -94,7 +94,9 @@ angular.module('risevision.template-editor.directives')
 
             if (selectedImages) {
               _setSelectedImages(selectedImages);
-              files = _filesAttributeFor(selectedImages);
+              files = _.map(selectedImages, function (entry) {
+                return entry.file;
+              });
             } else {
               files = _getDefaultFilesAttribute();
             }

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -89,7 +89,7 @@ angular.module('risevision.template-editor.directives')
           }
 
           function _loadSelectedImages() {
-            var files = _getAttribute('files') || '';
+            var files;
             var selectedImages = _getAttribute('metadata');
 
             if (selectedImages) {

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -81,6 +81,7 @@ angular.module('risevision.template-editor.directives')
 
             if (selectedImages) {
               _setSelectedImages(selectedImages);
+              files = _filesAttributeFor(selectedImages);
             } else {
               files = _getDefaultFilesAttribute();
             }


### PR DESCRIPTION
## Description
When `metadata` exists, use it to provide list of files for building/loading image thumbnails instead of `files` value

## Motivation and Context
This change is required as a part of the overall fix for issue https://github.com/Rise-Vision/rise-vision-apps/issues/1063 . It coincides with changes to the _rise-image_ component in this [PR](https://github.com/Rise-Vision/rise-image/pull/34), however they are independent of each other. 

If a file name or folder name had a | in the name, then template editor incorrectly parsed the `files` String value to obtain file name values for thumbnails since they are separated by |. By using `metadata` value (Array), this allows to correctly obtain file names for thumbnails with any special character. 

## How Has This Been Tested?
Testing has been done with a test template on Apps staging - https://apps-stage-8.risevision.com/templates/edit/944fde47-490e-48bd-a806-8c22b030d944/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manually tested on staging
  - Upon release, will be validating no issue on Production.
  - Rollback will involve re-running previous stable deployment followed by reverting code changes and merging to master branch 
  - Support will be notified regarding closing of issue 1063
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
- No documentation required
