### PR TITLE
Feature/extract metadata utilities

### DIFF
--- a/web/scripts/template-editor/components/services/svc-file-metadata-utils.js
+++ b/web/scripts/template-editor/components/services/svc-file-metadata-utils.js
@@ -60,11 +60,11 @@ angular.module('risevision.template-editor.services')
       };
 
       service.metadataWithFileRemoved = function (previousMetadata, entry) {
-        var index = previousMetadata.indexOf(entry);
+        var idx = previousMetadata.indexOf(entry);
         var metadata = _.cloneDeep(previousMetadata);
 
-        if (index >= 0) {
-          metadata.splice(index, 1);
+        if (idx >= 0) {
+          metadata.splice(idx, 1);
 
           return metadata;
         }

--- a/web/scripts/template-editor/components/services/svc-file-metadata-utils.js
+++ b/web/scripts/template-editor/components/services/svc-file-metadata-utils.js
@@ -1,20 +1,98 @@
 'use strict';
 
 angular.module('risevision.template-editor.services')
-  .service('fileMetadataUtilsService', function () {
-    var service = {};
+  .service('fileMetadataUtilsService', ['templateEditorUtils',
+    function (templateEditorUtils) {
+      var service = {};
 
-    service.thumbnailFor = function (item, defaultThumbnailUrl) {
-      if (item.metadata && item.metadata.thumbnail) {
-        return item.metadata.thumbnail + '?_=' + service.timeCreatedFor(item);
-      } else {
-        return defaultThumbnailUrl;
+      function _addFileToSet(selectedImages, defaultThumbnailUrl, file, alwaysAppend) {
+        var filePath = file.bucket + '/' + file.name;
+        var initialLength = selectedImages.length;
+        var timeCreated = service.timeCreatedFor(file);
+        var thumbnail = service.thumbnailFor(file, defaultThumbnailUrl);
+
+        var newFile = {
+          file: filePath,
+          exists: true,
+          'time-created': timeCreated,
+          'thumbnail-url': thumbnail
+        };
+
+        templateEditorUtils.addOrReplaceAll(selectedImages, {
+          file: filePath
+        }, newFile);
+
+        if (alwaysAppend && initialLength === selectedImages.length) {
+          selectedImages.push(newFile);
+        }
       }
-    };
 
-    service.timeCreatedFor = function (item) {
-      return item.timeCreated && item.timeCreated.value;
-    };
+      service.thumbnailFor = function (item, defaultThumbnailUrl) {
+        if (item.metadata && item.metadata.thumbnail) {
+          return item.metadata.thumbnail + '?_=' + service.timeCreatedFor(item);
+        } else {
+          return defaultThumbnailUrl;
+        }
+      };
 
-    return service;
-  });
+      service.timeCreatedFor = function (item) {
+        return item.timeCreated && item.timeCreated.value;
+      };
+
+      service.extractFileNamesFrom = function (metadata) {
+        return _.map(metadata, function (entry) {
+          return entry.file;
+        });
+      };
+
+      service.filesAttributeFor = function (metadata) {
+        return service.extractFileNamesFrom(metadata).join('|');
+      };
+
+      service.metadataWithFile = function (previousMetadata, defaultThumbnailUrl, files, alwaysAppend) {
+        var metadata = _.cloneDeep(previousMetadata);
+
+        files.forEach(function (file) {
+          _addFileToSet(metadata, defaultThumbnailUrl, file, alwaysAppend);
+        });
+
+        return metadata;
+      };
+
+      service.metadataWithFileRemoved = function (previousMetadata, entry) {
+        var index = previousMetadata.indexOf(entry);
+        var metadata = _.cloneDeep(previousMetadata);
+
+        if (index >= 0) {
+          metadata.splice(index, 1);
+
+          return metadata;
+        }
+      };
+
+      service.getUpdatedFileMetadata = function (currentMetadata, newMetadata) {
+        if (!currentMetadata) {
+          return newMetadata;
+        } else {
+          var atLeastOneOriginalEntryIsStillSelected = false;
+          var metadataCopy = angular.copy(currentMetadata);
+
+          _.each(newMetadata, function (entry) {
+            var currentEntry = _.find(metadataCopy, {
+              file: entry.file
+            });
+
+            if (currentEntry) {
+              atLeastOneOriginalEntryIsStillSelected = true;
+              currentEntry.exists = entry.exists;
+              currentEntry['thumbnail-url'] = entry['thumbnail-url'];
+            }
+          });
+
+          return atLeastOneOriginalEntryIsStillSelected ? metadataCopy : null;
+        }
+      };
+
+      return service;
+    }
+  ]);


### PR DESCRIPTION
## Description
Extract additional functionality that will be reused in rise-video settings.  This is just refactoring, no new functionality added.

## Motivation and Context
Why is this change required? What problem does it solve?
Avoids code duplication on rise-video settings.

## How Has This Been Tested?
Rise-image settings are working here:
https://apps-stage-9.risevision.com/templates/edit/ab175429-564c-4d24-bfa9-8490d33d0764/?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c

Unit tests were created for several functions that existed, but were not being tested before.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
      - Manual and automated tests
      - Monitoring: manual validation on production.
      - Simple rollback is enough, no data changes are applied here.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No documentation changes needed, and no need to notify support.
