### PR TITLE
Feature/videos in storage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.10.2",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#feature/show-videos-in-grid",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#feature/show-videos-in-grid",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.10.3",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -35,7 +35,6 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
-    "common-header": "feature/show-videos-in-grid",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -35,6 +35,7 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
+    "common-header": "feature/show-videos-in-grid",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }

--- a/web/partials/template-editor/basic-storage-selector.html
+++ b/web/partials/template-editor/basic-storage-selector.html
@@ -8,9 +8,15 @@
             <div class="folder-name">{{ fileNameOf(item.name) }}</div>
           </a>
         </div>
-        <div class="file-entry" ng-if="!isFolder(item.name)" ng-click="selectItem(item)">
+        <div class="file-entry" ng-if="!isFolder(item.name) && fileType != 'video'" ng-click="selectItem(item)">
           <a href="#">
             <img src="{{ thumbnailFor(item) }}"></img>
+          </a>
+        </div>
+        <div class="video-entry" ng-if="!isFolder(item.name) && fileType == 'video'" ng-click="selectItem(item)">
+          <a href="#">
+            <streamline-icon name="video"></streamline-icon>
+            <div class="video-name">{{ fileNameOf(item.name) }}</div>
           </a>
         </div>
         <div class="overlay-entry" ng-if="isSelected(item)" ng-click="selectItem(item)">


### PR DESCRIPTION
## Description

Update the storage selector with support for video files.

## Motivation and Context

Work related to [this Trello card](https://trello.com/c/rZHt2GmS).

The basic storage selector was updated to render a different ui element for video files (vs the existing ui element for image files) which does not include a thumbnail. Related styles were added in [this PR for common-header](https://github.com/Rise-Vision/common-header/pull/1026).

## How Has This Been Tested?

No unit or E2E tests were required. E2E testing will be handled in a later card.

Changes have been pushed to `stage-10` and can be viewed by browsing to `rise-video-test` in the basic storage selector for a video component, such as [this one](https://apps-stage-10.risevision.com/templates/edit/e4cc70ec-e14a-48af-9dcd-ac66f326d725/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443).

Changes have been tested in:

- Chrome 76
- Firefox 68
- Safari 12.1.2
- Mobile Safari 12.1.2 on iPhone X
- Mobile Chrome 76 on Pixel 2

## Release Plan:

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manual Test: Completed as noted above
  - Automated Test: To be completed in a later card
  - Monitoring: No monitoring should be required
  - Rollback: Revert to the previous commit (abdc375384a1c3a34bfba9e0139faea879d19c7e)
  - Documentation: No documentation updates required
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?

No automated testing was added, as noted above.