### PR TITLE
Prevents exceeding URL limit when requesting gadget data

### DIFF
--- a/test/unit/editor/services/svc-gadget-factory.tests.js
+++ b/test/unit/editor/services/svc-gadget-factory.tests.js
@@ -1,5 +1,7 @@
 'use strict';
 describe('service: gadgetFactory: ', function() {
+  var sandbox = sinon.sandbox.create();
+
   beforeEach(module('risevision.editor.services'));
   beforeEach(module(function ($provide) {
     $provide.service('$q', function() {return Q;});
@@ -57,7 +59,7 @@ describe('service: gadgetFactory: ', function() {
     });
 
   }));
-  var gadgetFactory, gadget, returnGadget, apiCalls, statusError,statusResponse, playerLicenseFactory;
+  var gadgetFactory, gadget, returnGadget, apiCalls, statusError,statusResponse, playerLicenseFactory, gadgetApi;
   beforeEach(function(){
     returnGadget = true;
     statusError = false;
@@ -66,7 +68,12 @@ describe('service: gadgetFactory: ', function() {
     
     inject(function($injector){  
       gadgetFactory = $injector.get('gadgetFactory');
+      gadgetApi = $injector.get('gadget');
     });
+  });
+
+  afterEach(function() {
+    sandbox.restore();
   });
 
   it('should exist',function(){
@@ -270,6 +277,21 @@ describe('service: gadgetFactory: ', function() {
           }, 10);
         }, 10);
       });
+
+      it('should not repeat gadgetIds on requests', function() {
+        items = [
+          { type: 'gadget', objectReference: 'gadgetId'},
+          { type: 'gadget', objectReference: 'gadgetId'},
+          { type: 'gadget', objectReference: 'gadgetId2'},
+          { type: 'gadget', objectReference: 'gadgetId2'},
+        ]; 
+
+        sandbox.spy(gadgetApi,'list');
+        gadgetFactory.updateItemsStatus(items);
+
+        gadgetApi.list.should.have.been.calledWith({ids:['gadgetId', 'gadgetId2']});
+      });
+
     });
 
     describe('Embedded Presentations: ', function() {

--- a/web/scripts/editor/services/svc-gadget-factory.js
+++ b/web/scripts/editor/services/svc-gadget-factory.js
@@ -127,7 +127,9 @@ angular.module('risevision.editor.services')
           if (cachedGadget) {
             items[i].gadget = cachedGadget;
           } else {
-            nonCachedIds.push(items[i].objectReference);
+            if (nonCachedIds.indexOf(items[i].objectReference) === -1) {
+              nonCachedIds.push(items[i].objectReference);
+            }
           }
         }
         if (nonCachedIds.length === 0) {

--- a/web/scripts/schedules/services/svc-schedule-factory.js
+++ b/web/scripts/schedules/services/svc-schedule-factory.js
@@ -111,12 +111,12 @@ angular.module('risevision.schedules.services')
 
       var _initFirstSchedule = function (presentationId, presentationName, presentationType) {
         var item = {
-            name: presentationName,
-            objectReference: presentationId,
-            duration: 10,
-            timeDefined: false,
-            type: 'presentation'
-          };
+          name: presentationName,
+          objectReference: presentationId,
+          duration: 10,
+          timeDefined: false,
+          type: 'presentation'
+        };
 
         if (presentationType) {
           item.presentationType = presentationType;

--- a/web/scripts/storage/services/svc-storage.js
+++ b/web/scripts/storage/services/svc-storage.js
@@ -295,7 +295,9 @@ angular.module('risevision.storage.services')
           function _refreshFileMetadata(fileName, remainingAttempts) {
             console.log('Attempt #' + remainingAttempts + ' to get metadata for: ' + fileName);
 
-            return service.files.get({ file: fileName })
+            return service.files.get({
+                file: fileName
+              })
               .then(function (resp) {
                 var file = resp && resp.files && resp.files[0];
 

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -295,7 +295,8 @@ angular.module('risevision.template-editor.services')
       };
 
       var _createFirstSchedule = function () {
-        return scheduleFactory.createFirstSchedule(factory.presentation.id, factory.presentation.name, factory.presentation.presentationType)
+        return scheduleFactory.createFirstSchedule(factory.presentation.id, factory.presentation.name, factory
+            .presentation.presentationType)
           .catch(function (err) {
             return err === 'Already have Schedules' ? $q.resolve() : $q.reject(err);
           });


### PR DESCRIPTION
## Description
Adds same objectReferences only once to prevent exceeding URL limit when requesting gadget data. 

## Motivation and Context
Why is this change required? What problem does it solve?
Fixes #1153 

## How Has This Been Tested?
Describe in detail how you tested your changes. Include details of your testing environment and link(s) for reviewers to validate.
Created a sample Presentation replicating the problem and validated no errors are raised.

Staged at: https://apps-stage-1.risevision.com/editor/workspace/dd1a38d8-1991-43d0-a020-e53b407a63e5?cid=554d3ef9-78b7-4726-8f46-c1ec140c166d


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
**Manual Test**  Tested with sample Presentation above
**Automated Test** Updated to represent such scenario
**Monitoring** Will validate the release once in Production
**Rollback** Rollback can be done by reverting the PR and following the deployment process
**Documentation** No need to update documentation
**Internal Communication** Minor change, no need for internal communication

- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
