### PR TITLE
Use template beta for staging [stage-2]

### DIFF
--- a/test/unit/template-editor/services/svc-template-editor-factory.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-factory.tests.js
@@ -91,7 +91,7 @@ describe('service: templateEditorFactory:', function() {
   }));
 
   var $state, $httpBackend, $modal, templateEditorFactory, templateEditorUtils, presentation, processErrorCode,
-    HTML_PRESENTATION_TYPE, blueprintUrl, storeAuthorize, checkTemplateAccessSpy, store, plansFactory, scheduleFactory,
+    HTML_PRESENTATION_TYPE, BLUEPRINT_URL, storeAuthorize, checkTemplateAccessSpy, store, plansFactory, scheduleFactory,
     needsFinancialDataLicense;
 
   beforeEach(function() {
@@ -110,8 +110,7 @@ describe('service: templateEditorFactory:', function() {
       templateEditorUtils = $injector.get('templateEditorUtils');
       processErrorCode = $injector.get('processErrorCode');
       HTML_PRESENTATION_TYPE = $injector.get('HTML_PRESENTATION_TYPE');
-
-      blueprintUrl = 'https://widgets.risevision.com/stable/templates/test-id/blueprint.json';
+      BLUEPRINT_URL = $injector.get('BLUEPRINT_URL').replace('PRODUCT_CODE', 'test-id');
     });
   });
 
@@ -133,7 +132,7 @@ describe('service: templateEditorFactory:', function() {
 
   describe('addFromProduct:', function() {
     it('should create a new presentation', function(done) {
-      $httpBackend.when('GET', blueprintUrl).respond(200, {
+      $httpBackend.when('GET', BLUEPRINT_URL).respond(200, {
         components: [
           {
             type: 'rise-image',
@@ -160,7 +159,7 @@ describe('service: templateEditorFactory:', function() {
     });
 
     it('should open Financial Data License message if Template uses rise-data-financial', function(done) {
-      $httpBackend.when('GET', blueprintUrl).respond(200, {
+      $httpBackend.when('GET', BLUEPRINT_URL).respond(200, {
         components: [
           {
             type: 'rise-data-financial',
@@ -199,7 +198,7 @@ describe('service: templateEditorFactory:', function() {
         }
       }));
 
-      $httpBackend.when('GET', blueprintUrl).respond(200, {});
+      $httpBackend.when('GET', BLUEPRINT_URL).respond(200, {});
       setTimeout(function() {
         $httpBackend.flush();
       });
@@ -271,7 +270,7 @@ describe('service: templateEditorFactory:', function() {
         }
       }));
 
-      $httpBackend.when('GET', blueprintUrl).respond(200, {});
+      $httpBackend.when('GET', BLUEPRINT_URL).respond(200, {});
       setTimeout(function() {
         $httpBackend.flush();
       });
@@ -343,7 +342,7 @@ describe('service: templateEditorFactory:', function() {
         }
       }));
 
-      $httpBackend.when('GET', blueprintUrl).respond(200, {
+      $httpBackend.when('GET', BLUEPRINT_URL).respond(200, {
         components: [
           {
             type: 'rise-image',
@@ -396,7 +395,7 @@ describe('service: templateEditorFactory:', function() {
         }
       }));
 
-      $httpBackend.when('GET', blueprintUrl).respond(200, {});
+      $httpBackend.when('GET', BLUEPRINT_URL).respond(200, {});
       setTimeout(function() {
         $httpBackend.flush();
       });
@@ -455,7 +454,7 @@ describe('service: templateEditorFactory:', function() {
         }
       }));
 
-      $httpBackend.when('GET', blueprintUrl).respond(500, {});
+      $httpBackend.when('GET', BLUEPRINT_URL).respond(500, {});
       setTimeout(function() {
         $httpBackend.flush();
       });
@@ -483,7 +482,7 @@ describe('service: templateEditorFactory:', function() {
         }
       }));
 
-      $httpBackend.when('GET', blueprintUrl).respond(200, {
+      $httpBackend.when('GET', BLUEPRINT_URL).respond(200, {
         components: [
           {
             type: 'rise-image',
@@ -532,7 +531,7 @@ describe('service: templateEditorFactory:', function() {
           productCode: 'test-id'
         }
       }));
-      $httpBackend.when('GET', blueprintUrl).respond(200, {});
+      $httpBackend.when('GET', BLUEPRINT_URL).respond(200, {});
       setTimeout(function() {
         $httpBackend.flush();
       });
@@ -620,7 +619,7 @@ describe('service: templateEditorFactory:', function() {
           productCode: 'test-id'
         }
       }));
-      $httpBackend.when('GET', blueprintUrl).respond(200, {});
+      $httpBackend.when('GET', BLUEPRINT_URL).respond(200, {});
       setTimeout(function() {
         $httpBackend.flush();
       });

--- a/web/scripts/config/beta.js
+++ b/web/scripts/config/beta.js
@@ -37,6 +37,8 @@
     .value('CHARGEBEE_TEST_SITE', 'risevision-test')
     .value('CHARGEBEE_PROD_SITE', 'risevision')
     .value('STRIPE_PROD_KEY', 'pk_live_31dWkTWQU125m2RcWpK4HQBR')
-    .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR');
+    .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
+    .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/src/template.html')
+    .value('BLUEPRINT_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/blueprint.json');
 
 })(angular);

--- a/web/scripts/config/dev.js
+++ b/web/scripts/config/dev.js
@@ -45,6 +45,8 @@
     .value('CHARGEBEE_PROD_SITE', 'risevision-test')
     .value('CHARGEBEE_PLANS_USE_PROD', 'false')
     .value('STRIPE_PROD_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
-    .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR');
+    .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
+    .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/beta/templates/PRODUCT_CODE/src/template.html')
+    .value('BLUEPRINT_URL', 'https://widgets.risevision.com/beta/templates/PRODUCT_CODE/blueprint.json');
 
 })(angular);

--- a/web/scripts/config/prod.js
+++ b/web/scripts/config/prod.js
@@ -37,6 +37,8 @@
     .value('CHARGEBEE_PROD_SITE', 'risevision')
     .value('CHARGEBEE_PLANS_USE_PROD', 'true')
     .value('STRIPE_PROD_KEY', 'pk_live_31dWkTWQU125m2RcWpK4HQBR')
-    .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR');
+    .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
+    .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/src/template.html')
+    .value('BLUEPRINT_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/blueprint.json');
 
 })(angular);

--- a/web/scripts/config/stage.js
+++ b/web/scripts/config/stage.js
@@ -43,6 +43,8 @@
     .value('CHARGEBEE_TEST_SITE', 'risevision-test')
     .value('CHARGEBEE_PROD_SITE', 'risevision-test')
     .value('STRIPE_PROD_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
-    .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR');
+    .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
+    .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/beta/templates/PRODUCT_CODE/src/template.html')
+    .value('BLUEPRINT_URL', 'https://widgets.risevision.com/beta/templates/PRODUCT_CODE/blueprint.json');
 
 })(angular);

--- a/web/scripts/config/test.js
+++ b/web/scripts/config/test.js
@@ -46,6 +46,8 @@
     .value('CHARGEBEE_PROD_SITE', 'risevision-test')
     .value('CHARGEBEE_PLANS_USE_PROD', 'false')
     .value('STRIPE_PROD_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
-    .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR');
+    .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
+    .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/beta/templates/PRODUCT_CODE/src/template.html')
+    .value('BLUEPRINT_URL', 'https://widgets.risevision.com/beta/templates/PRODUCT_CODE/blueprint.json');
 
 })(angular);

--- a/web/scripts/editor/services/svc-template.js
+++ b/web/scripts/editor/services/svc-template.js
@@ -3,7 +3,6 @@
 /*jshint camelcase: false */
 
 angular.module('risevision.editor.services')
-  .constant('BLUEPRINT_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/blueprint.json')
   .constant('TEMPLATE_SEARCH_FIELDS', [
     'name', 'id'
   ])

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -1,7 +1,6 @@
 'use strict';
 
 angular.module('risevision.template-editor.services')
-  .constant('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/src/template.html')
   .constant('HTML_TEMPLATE_DOMAIN', 'https://widgets.risevision.com')
   .factory('templateEditorFactory', ['$q', '$log', '$state', '$rootScope', 'presentation',
     'processErrorCode', 'userState', 'checkTemplateAccess', '$modal', 'scheduleFactory', 'plansFactory',


### PR DESCRIPTION
## Description
Dev, Stage and Test environments will use Template Beta
Prod and **Beta** will use Stable

## Motivation and Context
Because there's no reason why Apps staging would use Stable templates. There's no viable way to test Beta templates.

## How Has This Been Tested?
Validated that Beta is used in Dev and Stage (not Test). Validated that Stable is used in Prod (not Beta).

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
**Manual Test**  As per the above
**Automated Test** Unit tests were updated for the change
**Monitoring** Will test in Production once released and monitor that no errors are occurring
**Rollback** Rollback can be done by reverting the PR and following the deployment process
**Documentation** No documentation is needed for this
**Internal Communication** Will notify interested parties once deployed

- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
