### PR TITLE
Improve Google Slides invalid URL message

### DIFF
--- a/web/partials/template-editor/components/component-slides.html
+++ b/web/partials/template-editor/components/component-slides.html
@@ -10,7 +10,7 @@
         <p class="help-block" ng-switch on="validationResult">
           <span ng-switch-when="DELETED">Your Google Slideshow is no longer accessible, please check if it’s been deleted.</span>
           <span ng-switch-when="NOT_PUBLIC">To use this Google Slideshow it must be publicly accessible.</span>
-          <span ng-switch-when="INVALID">Invalid URL</span>
+          <span ng-switch-when="INVALID">Please provide a valid Google Slides URL.</span>
         </p>
         <p ng-show="validationResult === 'NOT_PUBLIC'">
           <streamline-icon class="icon-help" aria-hidden="true" name="help" width="15" height="15"></streamline-icon>


### PR DESCRIPTION
## Description
Change error message when the user enters an invalid Google Slides URL

## Motivation and Context
Fix to https://github.com/Rise-Vision/rise-vision-apps/issues/1140

## How Has This Been Tested?
1. Open a Slides template in https://apps-stage3.risevision.com
2. Enter any URL that is not a Google Slides URL
3. Observe the error message is:

<img width="373" alt="Screen Shot 2019-08-12 at 5 34 01 PM" src="https://user-images.githubusercontent.com/161674/62902054-c609f080-bd34-11e9-9419-8041edd8b1b8.png">


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed
