### PR TITLE
Add RSS UI settings

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -256,6 +256,8 @@
   <script src="scripts/editor/directives/dtv-rv-popover.js"></script>
 
   <!-- template-editor -->
+  <script src="scripts/template-editor/filters/ftr-encode-link.js"></script>
+
   <script src="scripts/template-editor/directives/dtv-attribute-editor.js"></script>
   <script src="scripts/template-editor/directives/dtv-attribute-list.js"></script>
   <script src="scripts/template-editor/directives/dtv-editor-preview-holder.js"></script>

--- a/web/partials/template-editor/components/component-rss.html
+++ b/web/partials/template-editor/components/component-rss.html
@@ -1,3 +1,26 @@
-<div>
-  RSS settings
+<div class="attribute-editor-component" rv-spinner rv-spinner-key="rss-editor-loader" rv-spinner-start-active="1">
+  <div class="attribute-editor-row">
+    <div class="form-group has-feedback has-success">
+      <label class="control-label" for="te-rss-feed">Enter the link to your RSS feed:</label>
+      <input type="text" id="te-rss-feed" class="form-control u_ellipsis" ng-model="src" placeholder="Enter the link to your RSS feed" >
+      <streamline-icon class="overlay-icon form-control-feedback" aria-hidden="true" name="checkmark" width="14" height="12"></streamline-icon>
+      <p class="help-block" ng-switch on="validationResult">
+        <span ng-switch-when="INVALID_URL">Please provide a valid URL.</span>
+        <span ng-switch-when="INVALID_FEED">There are errors with the RSS feed that could impact how your content appears. You can view a summary of the errors detected <a ng-href="https://validator.w3.org/feed/check.cgi?url={{src | encodeLink}}" target="_blank">here</a>.</span>
+      </p>
+    </div>
+  </div>
+  <div class="attribute-editor-row">
+    <div class="form-group">
+      <label class="control-label" for="te-rss-max-items">Max items in queue:</label>
+      <select id="te-rss-max-items" ng-model="maxItems" class="form-control">
+        <option value="1">1</option>
+        <option value="5">5</option>
+        <option value="10">10</option>
+        <option value="15">15</option>
+        <option value="20">20</option>
+        <option value="25">25</option>
+      </select>
+    </div>
+  </div>
 </div>

--- a/web/partials/template-editor/components/component-rss.html
+++ b/web/partials/template-editor/components/component-rss.html
@@ -1,12 +1,12 @@
 <div class="attribute-editor-component" rv-spinner rv-spinner-key="rss-editor-loader" rv-spinner-start-active="1">
   <div class="attribute-editor-row">
-    <div class="form-group has-feedback has-success">
+    <div class="form-group has-feedback has-error">
       <label class="control-label" for="te-rss-feed">Enter the link to your RSS feed:</label>
       <input type="text" id="te-rss-feed" class="form-control u_ellipsis" ng-model="src" placeholder="Enter the link to your RSS feed" >
-      <streamline-icon class="overlay-icon form-control-feedback" aria-hidden="true" name="checkmark" width="14" height="12"></streamline-icon>
-      <p class="help-block" ng-switch on="validationResult">
-        <span ng-switch-when="INVALID_URL">Please provide a valid URL.</span>
-        <span ng-switch-when="INVALID_FEED">There are errors with the RSS feed that could impact how your content appears. You can view a summary of the errors detected <a ng-href="https://validator.w3.org/feed/check.cgi?url={{src | encodeLink}}" target="_blank">here</a>.</span>
+      <streamline-icon class="overlay-icon form-control-feedback" aria-hidden="true" name="exclamation" width="14" height="12"></streamline-icon>
+      <p class="help-block">
+        <span>Please provide a valid URL.</span>
+        <span>There are errors with the RSS feed that could impact how your content appears. You can view a summary of the errors detected <a ng-href="https://validator.w3.org/feed/check.cgi?url={{src | encodeLink}}" target="_blank">here</a>.</span>
       </p>
     </div>
   </div>

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -597,12 +597,12 @@ angular.module('risevision.template-editor.services', [
   'risevision.editor.services',
   'risevision.schedules.services'
 ]);
+angular.module('risevision.template-editor.filters', []);
 angular.module('risevision.template-editor.directives', [
-  'risevision.template-editor.services'
+  'risevision.template-editor.services',
+  'risevision.template-editor.filters'
 ]);
-angular.module('risevision.template-editor.filters', [
-  'risevision.template-editor.services'
-]);
+
 angular.module('risevision.template-editor.controllers', [
   'risevision.template-editor.services'
 ]);

--- a/web/scripts/template-editor/components/directives/dtv-component-rss.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-rss.js
@@ -1,14 +1,26 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
-  .directive('templateComponentRss', ['templateEditorFactory',
-    function (templateEditorFactory) {
+  .directive('templateComponentRss', ['templateEditorFactory', '$loading',
+    function (templateEditorFactory, $loading) {
       return {
         restrict: 'E',
         scope: true,
         templateUrl: 'partials/template-editor/components/component-rss.html',
         link: function ($scope, element) {
           $scope.factory = templateEditorFactory;
+
+          $scope.$watch('spinner', function (loading) {
+            if (loading) {
+              $loading.start('rss-editor-loader');
+            } else {
+              $loading.stop('rss-editor-loader');
+            }
+          });
+
+          $scope.spinner = false;
+
+          $scope.maxItems = '1';
 
           $scope.registerDirective({
             type: 'rise-data-rss',

--- a/web/scripts/template-editor/components/directives/dtv-component-video.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-video.js
@@ -69,7 +69,7 @@ angular.module('risevision.template-editor.directives')
 
             _checkFileExistenceFor($scope.componentId)
               .finally(function () {
-                $timeout(function() {
+                $timeout(function () {
                   $scope.factory.loadingPresentation = false;
                 });
               });

--- a/web/scripts/template-editor/filters/ftr-encode-link.js
+++ b/web/scripts/template-editor/filters/ftr-encode-link.js
@@ -1,0 +1,6 @@
+'use strict';
+
+angular.module('risevision.template-editor.filters')
+  .filter('encodeLink', function () {
+    return window.encodeURIComponent;
+  });


### PR DESCRIPTION
## Description
Add UI and styling for RSS settings

## Motivation and Context
UI follows mockups, no logic/functionality implemented yet, coming in follow up PRs. All styling used already exists in common-header dependency. 

![image](https://user-images.githubusercontent.com/7407007/63026717-aa5c3280-be79-11e9-8295-49ccd948e4ad.png)

![image](https://user-images.githubusercontent.com/7407007/63026754-bd6f0280-be79-11e9-913e-a82322961040.png)

![image](https://user-images.githubusercontent.com/7407007/63026802-cf50a580-be79-11e9-9f2f-3fe0bf581cac.png)


## How Has This Been Tested?
Tested using https://apps-stage-8.risevision.com/templates/edit/e3dd2252-af3e-4627-92b3-dfe85eeeb0f7/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed.
  - Manually tested above
  - Will validate in production upon deployment
  - Given no users are using RSS in templates, rollback unlikely, however if needed it will require re-running previous master deployment and reverting code changes
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
- Support, documentation, and automated tests skipped as this is just UI and no users have access to templates using RSS in production. 