### PR TITLE
Feature/set volume

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#feature/set-volume",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.10.11",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -35,7 +35,6 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
-    "common-header": "feature/set-volume",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.10.10",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#feature/set-volume",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages"
   },
@@ -35,6 +35,7 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
+    "common-header": "feature/set-volume",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }

--- a/test/unit/template-editor/components/directives/dtv-component-video.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-video.tests.js
@@ -72,6 +72,9 @@ describe('directive: templateComponentVideo', function() {
     $scope.getAttributeData = function(componentId, key) {
       return testMetadata;
     };
+    $scope.getAvailableAttributeData = function(componentId, key) {
+      return "";
+    };
 
     directive.show();
 
@@ -89,6 +92,9 @@ describe('directive: templateComponentVideo', function() {
     };
     $scope.getBlueprintData = function() {
       return TEST_FILE;
+    };
+    $scope.getAvailableAttributeData = function(componentId, key) {
+      return "";
     };
 
     testMetadata = [
@@ -113,6 +119,90 @@ describe('directive: templateComponentVideo', function() {
 
       done();
     }, 100);
+  });
+
+  it('should get volume data', function() {
+    var directive = $scope.registerDirective.getCall(0).args[0];
+
+    $scope.getAttributeData = function(componentId, key) {
+      return [];
+    };
+    $scope.getAvailableAttributeData = function(componentId, key) {
+      return "10";
+    };
+
+    directive.show();
+
+    expect($scope.values).to.deep.equal({ volume: 10 });
+
+    timeout.flush();
+  });
+
+  it('should default volume data to 0', function() {
+    var directive = $scope.registerDirective.getCall(0).args[0];
+
+    $scope.getAttributeData = function(componentId, key) {
+      return [];
+    };
+    $scope.getAvailableAttributeData = function(componentId, key) {
+    };
+
+    directive.show();
+
+    expect($scope.values).to.deep.equal({ volume: 0 });
+
+    timeout.flush();
+  });
+
+  it('should set volume as 0 if it has an invalid vaue', function() {
+    var directive = $scope.registerDirective.getCall(0).args[0];
+
+    $scope.getAttributeData = function(componentId, key) {
+      return [];
+    };
+    $scope.getAvailableAttributeData = function(componentId, key) {
+      return "NOT A NUMBER !"
+    };
+
+    directive.show();
+
+    expect($scope.values).to.deep.equal({ volume: 0 });
+
+    timeout.flush();
+  });
+
+  describe('showSettingsUI', function() {
+
+    it('should not show settings UI if it is uploading', function()
+    {
+      $scope.selectedFiles = [ 'a' ];
+      $scope.isUploading = true;
+
+      var show = $scope.showSettingsUI();
+
+      expect(show).to.be.false;
+    });
+
+    it('should not show settings UI if there are no selected files', function()
+    {
+      $scope.selectedFiles = [];
+      $scope.isUploading = false;
+
+      var show = $scope.showSettingsUI();
+
+      expect(show).to.be.false;
+    });
+
+    it('should show settings UI if there are selected files and it\'s not uploading', function()
+    {
+      $scope.selectedFiles = [ 'a' ];
+      $scope.isUploading = false;
+
+      var show = $scope.showSettingsUI();
+
+      expect(show).to.be.true;
+    });
+
   });
 
   describe('updateFileMetadata', function() {
@@ -218,6 +308,20 @@ describe('directive: templateComponentVideo', function() {
       ), 'set metadata attribute').to.be.true;
     });
 
+  });
+
+  describe('showSettingsUI', function() {
+    it('should save volume', function()
+    {
+      $scope.componentId = 'TEST-ID';
+      $scope.values.volume = 100;
+
+      $scope.saveVolume();
+
+      expect($scope.setAttributeData.calledWith(
+        'TEST-ID', 'volume', 100
+      ), 'set volume attribute').to.be.true;
+    });
   });
 
 });

--- a/test/unit/template-editor/services/svc-template-editor-utils.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-utils.tests.js
@@ -26,9 +26,38 @@ describe('service: templateEditorUtils:', function() {
   it('should initialize', function() {
     expect(templateEditorUtils).to.be.truely;
 
+    expect(templateEditorUtils.intValueFor).to.be.a.function;
     expect(templateEditorUtils.fileNameOf).to.be.a.function;
     expect(templateEditorUtils.addOrRemove).to.be.a.function;
     expect(templateEditorUtils.addOrReplace).to.be.a.function;
+  });
+
+  describe('intValueFor',function() {
+
+    it('should get the int value of a string',function(){
+      var value = templateEditorUtils.intValueFor('100');
+
+      expect(value).to.equal(100);
+    });
+
+    it('should return 0',function(){
+      var value = templateEditorUtils.intValueFor('0', 10);
+
+      expect(value).to.equal(0);
+    });
+
+    it('should return the default value if the input is not a valid number',function(){
+      var value = templateEditorUtils.intValueFor('INVALID', 89);
+
+      expect(value).to.equal(89);
+    });
+
+    it('should return the default value if the input is undefined',function(){
+      var value = templateEditorUtils.intValueFor(undefined, 8);
+
+      expect(value).to.equal(8);
+    });
+
   });
 
   describe('fileNameOf', function () {
@@ -191,7 +220,7 @@ describe('service: templateEditorUtils:', function() {
       sandbox.stub($modal,'open').returns({ result: { then: sandbox.stub() } });
 
       templateEditorUtils.showFinancialDataLicenseRequiredMessage();
-      
+
       $modal.open.should.have.been.calledWithMatch({
         controller: "confirmInstance",
         windowClass: 'madero-style centered-modal financial-data-license-message'
@@ -199,7 +228,7 @@ describe('service: templateEditorUtils:', function() {
     });
 
     it('should dismiss and open Contact Us on page confirm', function(done){
-      var modalInstance = { result: Q.resolve(), dismiss: sinon.stub() };           
+      var modalInstance = { result: Q.resolve(), dismiss: sinon.stub() };
       sandbox.stub($modal,'open').returns(modalInstance);
       sandbox.stub($window,'open');
 
@@ -207,10 +236,10 @@ describe('service: templateEditorUtils:', function() {
 
       setTimeout(function(){
         modalInstance.dismiss.should.have.been.called;
-        $window.open.should.have.been.calledWith('https://www.risevision.com/contact-us', "_blank"); 
-        done() 
+        $window.open.should.have.been.calledWith('https://www.risevision.com/contact-us', "_blank");
+        done()
       },10);
     });
   });
-  
+
 });

--- a/web/partials/template-editor/components/component-video/video-list.html
+++ b/web/partials/template-editor/components/component-video/video-list.html
@@ -6,10 +6,13 @@
       <label>Volume</label>
       <div class="row">
         <div class="col-xs-12">
-          <input min="0" max="100" type="range">
+          <input min="0" max="100" type="range"
+            ng-model="values.volume"
+            ng-change="saveVolume()"
+          >
         </div>
       </div>
-      <p class="range-value">5</p>
+      <p class="range-value">{{ values.volume }}</p>
     </div>
 
     <p class="mt-3">

--- a/web/partials/template-editor/components/component-video/video-list.html
+++ b/web/partials/template-editor/components/component-video/video-list.html
@@ -1,4 +1,6 @@
-<div class="attribute-editor-component video-component-settings">
+<div class="attribute-editor-component video-component-settings"
+  ng-show="showSettingsUI()"
+>
   <div class="attribute-editor-row">
     <div class="video-component-volume">
       <label>Volume</label>
@@ -18,10 +20,12 @@
 
 <div class="video-component-list file-component-list te-scrollable-container"
      rv-spinner rv-spinner-key="template-editor-loader"
-     rv-spinner-start-active="1">
+     rv-spinner-start-active="1"
+     ng-class="{ 'not-empty': selectedFiles.length > 0 }"
+>
   <template-editor-file-entry
      ng-repeat="file in selectedFiles track by $index"
-     ng-show="selectedFiles.length > 0 && !isUploading"
+     ng-show="showSettingsUI()"
      entry="file"
      file-type="video"
      remove-action="removeFileFromList">

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -85,10 +85,8 @@ angular.module('risevision.template-editor.directives')
               duration = _getDefaultDurationAttribute();
             }
 
-            duration = parseInt(duration, 10);
-
             // default to value 10 if duration not defined
-            $scope.values.duration = (duration && !isNaN(duration)) ? duration : 10;
+            $scope.values.duration = templateEditorUtils.intValueFor(duration, 10);
           }
 
           function _getAttribute(key) {

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -85,8 +85,10 @@ angular.module('risevision.template-editor.directives')
               duration = _getDefaultDurationAttribute();
             }
 
+            duration = parseInt(duration, 10);
+
             // default to value 10 if duration not defined
-            $scope.values.duration = templateEditorUtils.intValueFor(duration, 10);
+            $scope.values.duration = (duration && !isNaN(duration)) ? duration : 10;
           }
 
           function _getAttribute(key) {

--- a/web/scripts/template-editor/components/directives/dtv-component-video.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-video.js
@@ -179,6 +179,10 @@ angular.module('risevision.template-editor.directives')
               _setMetadata(metadata);
             }
           };
+
+          $scope.showSettingsUI = function () {
+            return $scope.selectedFiles.length > 0 && !$scope.isUploading;
+          };
         }
       };
     }

--- a/web/scripts/template-editor/components/directives/dtv-component-video.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-video.js
@@ -75,12 +75,23 @@ angular.module('risevision.template-editor.directives')
               });
           }
 
+          function _loadVolume() {
+            var volume = _getAvailableAttribute('volume');
+
+            // default to value 0 if volume not defined
+            $scope.values.volume = templateEditorUtils.intValueFor(volume, 0);
+          }
+
           function _getAttribute(key) {
             return $scope.getAttributeData($scope.componentId, key);
           }
 
           function _setAttribute(key, value) {
             $scope.setAttributeData($scope.componentId, key, value);
+          }
+
+          function _getAvailableAttribute(key) {
+            return $scope.getAvailableAttributeData($scope.componentId, key);
           }
 
           function _getFilesFor(componentId) {
@@ -117,6 +128,10 @@ angular.module('risevision.template-editor.directives')
 
           _reset();
 
+          $scope.saveVolume = function () {
+            _setAttribute('volume', $scope.values.volume);
+          };
+
           $scope.registerDirective({
             type: 'rise-video',
             iconType: 'streamline',
@@ -129,6 +144,7 @@ angular.module('risevision.template-editor.directives')
               $scope.componentId = $scope.factory.selected.id;
 
               _loadSelectedFiles();
+              _loadVolume();
 
               $scope.showNextPanel('.video-component-container');
             },

--- a/web/scripts/template-editor/services/svc-template-editor-utils.js
+++ b/web/scripts/template-editor/services/svc-template-editor-utils.js
@@ -11,7 +11,7 @@ angular.module('risevision.template-editor.services')
       svc.intValueFor = function (providedValue, defaultValue) {
         var intValue = parseInt(providedValue, 10);
 
-        return (intValue && !isNaN(intValue)) ? intValue : defaultValue;
+        return isNaN(intValue) ? defaultValue : intValue;
       };
 
       svc.fileNameOf = function (path) {

--- a/web/scripts/template-editor/services/svc-template-editor-utils.js
+++ b/web/scripts/template-editor/services/svc-template-editor-utils.js
@@ -8,6 +8,12 @@ angular.module('risevision.template-editor.services')
     function (messageBox, NEED_FINANCIAL_DATA_LICENSE, $modal, $templateCache, $window, CONTACT_US_URL) {
       var svc = {};
 
+      svc.intValueFor = function (providedValue, defaultValue) {
+        var intValue = parseInt(providedValue, 10);
+
+        return (intValue && !isNaN(intValue)) ? intValue : defaultValue;
+      };
+
       svc.fileNameOf = function (path) {
         return path.split('/').pop();
       };


### PR DESCRIPTION
## Description
Show and save volume in video settings.

Related common header changes: https://github.com/Rise-Vision/common-header/pull/1034
Will point to release once those are approved.

## Motivation and Context
execution strategy task

## How Has This Been Tested?
Automated unit tests added to code.

Functionality can be tested here:
https://apps-stage-9.risevision.com/templates/edit/749cca27-e190-4126-86c6-bd392c4c99f6/?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c

Updated to the attribute data can be validated on files here:
https://console.cloud.google.com/storage/browser/risevision-company-notifications/cf85e5c4-9439-40ce-94d6-e5ea6ea2411c/template-data/749cca27-e190-4126-86c6-bd392c4c99f6/?project=avid-life-623

For example:
```
{
	"components": [{
		"id": "rise-video-01",
		"metadata": []
	}, {
		"id": "video2",
		"metadata": []
	}, {
		"id": "video1",
		"metadata": [{
			"file": "risemedialibrary-cf85e5c4-9439-40ce-94d6-e5ea6ea2411c/big-buck-bunny_trailer.webm",
			"exists": true,
			"time-created": "1565098230762",
			"thumbnail-url": "streamline:video"
		}],
		"volume": "100"
	}]
}
```

I could test also that volume applies to player using this schedule:

https://apps-stage-9.risevision.com/schedules/details/e0fc0433-ee93-4a9f-a2a3-6eadfdef52c3?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c

and because I'm in staging I used a RiseDisplayNetworkII.ini like:

``` 
displayid=Z8RSGWXE8KR8
coreurl=https://rvacore-test.appspot.com
viewerurl=https://rvaviewer-test.appspot.com/Viewer.html
messagingurl=https://display-messaging-staging.risevision.com
proxy=
rcosproxy=
```

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed.
    - Manual testing described above
    - Automated tests in the code
    - Will deploy on Thursday or Monday
    - Will automatically validate on production, to see that data updates are performing well, and will rollback immediately if there are problems. As rise-video is not being used by users in production, this change is still low risk. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify support.
