### PR TITLE
Fix/issue 1167 hide add selected button on empty storage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.10.13",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.10.14",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages",
     "xmlToJSON.js": "^1.3.2"
@@ -36,7 +36,6 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
-    "common-header": "fix/issue-1167-hide-add-selected-button-on-empty-storage",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.10.12",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/issue-1167-hide-add-selected-button-on-empty-storage",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages",
     "xmlToJSON.js": "^1.3.2"

--- a/bower.json
+++ b/bower.json
@@ -36,6 +36,7 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
+    "common-header": "fix/issue-1167-hide-add-selected-button-on-empty-storage",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }

--- a/test/unit/template-editor/services/svc-template-editor-utils.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-utils.tests.js
@@ -164,6 +164,34 @@ describe('service: templateEditorUtils:', function() {
     });
   });
 
+  describe('hasRegularFileItems', function () {
+    it('should return true for lists with regular file items', function () {
+      var items = [
+        { name: 'file.png' },
+        { name: 'folder/' }
+      ]
+      var hasFiles = templateEditorUtils.hasRegularFileItems(items);
+
+      expect(hasFiles).to.be.true;
+    });
+
+    it('should return false for lists with no regular file items', function () {
+      var items = [
+        { name: 'not-a-file/' },
+        { name: 'folder/' }
+      ]
+      var hasFiles = templateEditorUtils.hasRegularFileItems(items);
+
+      expect(hasFiles).to.be.false;
+    });
+
+    it('should return false for empty lists', function () {
+      var hasFiles = templateEditorUtils.hasRegularFileItems([]);
+
+      expect(hasFiles).to.be.false;
+    });
+  });
+
   describe('showInvalidExtensionsMessage', function () {
     it('should call the correct functions', function () {
       sandbox.stub(templateEditorUtils, 'showMessageWindow');

--- a/web/partials/template-editor/basic-storage-selector.html
+++ b/web/partials/template-editor/basic-storage-selector.html
@@ -1,4 +1,9 @@
-<div class="storage-selector-component te-scrollable-container" rv-spinner rv-spinner-key="storage-{{storageSelectorId}}-spinner" rv-spinner-start-active="1">
+<div class="storage-selector-component te-scrollable-container"
+  ng-class="{ 'no-files': !hasRegularFileItems() }"
+  rv-spinner
+  rv-spinner-key="storage-{{storageSelectorId}}-spinner"
+  rv-spinner-start-active="1"
+>
   <div class="storage-selector-list" ng-show="folderItems.length > 0 && !isUploading">
     <div class="storage-row" ng-repeat="item in folderItems track by $index">
       <div>
@@ -55,7 +60,7 @@
       </strong>
     </label>
   </div>
-  <div class="add-selected">
+  <div class="add-selected" ng-show="hasRegularFileItems()">
     <button id="{{storageSelectorId}}-add-selected" class="btn btn-block" ng-click="addSelected()" ng-disabled="isUploading || selectedItems.length === 0">
       <strong>Add Selected</strong>
     </button>

--- a/web/partials/template-editor/basic-storage-selector.html
+++ b/web/partials/template-editor/basic-storage-selector.html
@@ -52,7 +52,9 @@
   </basic-uploader>
 </div>
 
-<div class="storage-selector-action-button-bar">
+<div class="storage-selector-action-button-bar"
+  ng-class="{ 'no-files': !hasRegularFileItems() }"
+>
   <div class="upload-files">
     <label id="{{storageSelectorId}}-uploader-label" class="btn btn-primary btn-block" for="{{storageSelectorId}}-uploader" ng-disabled="isUploading">
       <strong>

--- a/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
+++ b/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
@@ -59,6 +59,10 @@ angular.module('risevision.template-editor.directives')
 
           $scope.fileNameOf = templateEditorUtils.fileNameOf;
 
+          $scope.hasRegularFileItems = function() {
+            return templateEditorUtils.hasRegularFileItems($scope.folderItems);
+          };
+
           $scope.thumbnailFor = function (item) {
             if (item.metadata && item.metadata.thumbnail) {
               return item.metadata.thumbnail + '?_=' + (item.timeCreated && item.timeCreated.value);

--- a/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
+++ b/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
@@ -59,7 +59,7 @@ angular.module('risevision.template-editor.directives')
 
           $scope.fileNameOf = templateEditorUtils.fileNameOf;
 
-          $scope.hasRegularFileItems = function() {
+          $scope.hasRegularFileItems = function () {
             return templateEditorUtils.hasRegularFileItems($scope.folderItems);
           };
 

--- a/web/scripts/template-editor/services/svc-template-editor-utils.js
+++ b/web/scripts/template-editor/services/svc-template-editor-utils.js
@@ -64,6 +64,14 @@ angular.module('risevision.template-editor.services')
         });
       };
 
+      svc.hasRegularFileItems = function (folderItems) {
+        var regularFiles = _.filter(folderItems, function(item) {
+          return !svc.isFolder(item.name);
+        });
+
+        return regularFiles.length > 0;
+      };
+
       svc.findElement = function (selector) {
         return document.querySelector(selector) && angular.element(document.querySelector(selector));
       };

--- a/web/scripts/template-editor/services/svc-template-editor-utils.js
+++ b/web/scripts/template-editor/services/svc-template-editor-utils.js
@@ -65,7 +65,7 @@ angular.module('risevision.template-editor.services')
       };
 
       svc.hasRegularFileItems = function (folderItems) {
-        var regularFiles = _.filter(folderItems, function(item) {
+        var regularFiles = _.filter(folderItems, function (item) {
           return !svc.isFolder(item.name);
         });
 


### PR DESCRIPTION
## Description
Hide 'add selected' button when there are no files that can be selected in a folder.

## Motivation and Context
See issue 1167 https://github.com/Rise-Vision/rise-vision-apps/issues/1167

## How Has This Been Tested?
See https://github.com/Rise-Vision/common-header/pull/1038
for this part and the release checklist.
