### PR TITLE
Add e2e test cases for RSS component UI

### DIFF
--- a/test/e2e/template-editor/cases/components/rss.js
+++ b/test/e2e/template-editor/cases/components/rss.js
@@ -1,0 +1,126 @@
+'use strict';
+
+var expect = require('rv-common-e2e').expect;
+var helper = require('rv-common-e2e').helper;
+var PresentationListPage = require('./../../pages/presentationListPage.js');
+var TemplateEditorPage = require('./../../pages/templateEditorPage.js');
+var RssComponentPage = require('./../../pages/components/rssComponentPage.js');
+
+var RssComponentScenarios = function () {
+
+  browser.driver.manage().window().setSize(1920, 1080);
+
+  describe('RSS Component', function () {
+    var testStartTime = Date.now();
+    var presentationName = 'RSS Component Presentation - ' + testStartTime;
+    var presentationsListPage;
+    var templateEditorPage;
+    var rssComponentPage;
+    var componentLabel = 'RSS - Test Feed';
+
+    before(function () {
+      presentationsListPage = new PresentationListPage();
+      templateEditorPage = new TemplateEditorPage();
+      rssComponentPage = new RssComponentPage();
+
+      presentationsListPage.loadCurrentCompanyPresentationList();
+
+      presentationsListPage.createNewPresentationFromTemplate('Example RSS Component', 'example-rss-component');
+    });
+
+    describe('basic operations', function () {
+
+      it('should open properties of RSS Component', function () {
+        templateEditorPage.selectComponent(componentLabel);
+        expect(rssComponentPage.getRssFeedInput().isEnabled()).to.eventually.be.true;
+        expect(rssComponentPage.getRssFeedInput().getAttribute('value')).to.eventually.equal('https://www.feedforall.com/sample.xml');
+        expect(rssComponentPage.getRssMaxItemsSelect().isEnabled()).to.eventually.be.true;
+        expect(rssComponentPage.getRssMaxItemsSelect().getAttribute('value')).to.eventually.equal('15');
+      });
+
+      function _testInvalidScenario (feedUrl, expectedMessageKey) {
+        // Change Feed URL
+        expect(rssComponentPage.getRssFeedInput().isEnabled()).to.eventually.be.true;
+        rssComponentPage.getRssFeedInput().clear();
+        rssComponentPage.getRssFeedInput().sendKeys(feedUrl + protractor.Key.ENTER);
+
+        // Wait for validation to complete
+        helper.waitDisappear(rssComponentPage.getLoader(), 'Validation spinner');
+
+        // Verify validation error, message and icon are visible
+        expect(rssComponentPage.getValidationError().isDisplayed()).to.eventually.be.true;
+        expect(rssComponentPage.getValidationIconError().isDisplayed()).to.eventually.be.true;
+        expect(rssComponentPage.getValidationMessage(expectedMessageKey).isDisplayed()).to.eventually.be.true;
+
+        // Verify validation success icon is not visible
+        expect(rssComponentPage.getValidationIconValid().isPresent()).to.eventually.be.false;
+      }
+
+      it('should show validation error for invalid URL', function () {
+        _testInvalidScenario('invalidFeedUrl', 'INVALID_URL');
+      });
+
+      it('should show validation error for invalid URL', function () {
+        _testInvalidScenario('https://www.google.com', 'NON_FEED');
+      });
+
+      it('should show validation error for Not Found URL', function () {
+        _testInvalidScenario('https://news.ycombinator.com/news-invalid-url', 'NOT_FOUND');
+      });
+
+      it('should not show a validation error if feed is empty', function () {
+
+        // Change Feed URL
+        expect(rssComponentPage.getRssFeedInput().isEnabled()).to.eventually.be.true;
+        rssComponentPage.getRssFeedInput().clear();
+        rssComponentPage.getRssFeedInput().sendKeys('' + protractor.Key.ENTER);
+
+        // Wait for validation to complete
+        helper.waitDisappear(rssComponentPage.getLoader(), 'Validation spinner');
+
+        // Verify validation error and icon is not visible
+        expect(rssComponentPage.getValidationError().isPresent()).to.eventually.be.false;
+        expect(rssComponentPage.getValidationIconError().isPresent()).to.eventually.be.false;
+
+        // Certify validation success icon is not visible
+        expect(rssComponentPage.getValidationIconValid().isDisplayed()).to.eventually.be.true;
+      });
+
+      it('should save the Presentation, reload it, and validate changes were saved', function () {
+
+        // Change Feed URL
+        expect(rssComponentPage.getRssFeedInput().isEnabled()).to.eventually.be.true;
+        rssComponentPage.getRssFeedInput().clear();
+        rssComponentPage.getRssFeedInput().sendKeys('https://hnrss.org/frontpage' + protractor.Key.ENTER);
+        rssComponentPage.getRssMaxItemsSelect().element(by.cssContainingText('option', '10')).click();
+
+        // Wait for validation to complete
+        helper.waitDisappear(rssComponentPage.getLoader(), 'Validation spinner');
+
+        // Change presentation name
+        presentationsListPage.changePresentationName(presentationName);
+
+        // Wait for presentation to be auto-saved
+        helper.waitDisappear(templateEditorPage.getDirtyText());
+        helper.wait(templateEditorPage.getSavingText(), 'RSS component auto-saving');
+        helper.wait(templateEditorPage.getSavedText(), 'RSS component auto-saved');
+
+        // Log URL for troubeshooting
+        browser.getCurrentUrl().then(function(actualUrl) {
+          console.log(actualUrl);
+        });
+        browser.sleep(100);
+
+        // Load presentation
+        presentationsListPage.loadPresentation(presentationName);
+        templateEditorPage.selectComponent(componentLabel);
+        expect(rssComponentPage.getRssFeedInput().isEnabled()).to.eventually.be.true;
+        expect(rssComponentPage.getRssFeedInput().getAttribute('value')).to.eventually.equal('https://hnrss.org/frontpage');
+        expect(rssComponentPage.getRssMaxItemsSelect().isEnabled()).to.eventually.be.true;
+        expect(rssComponentPage.getRssMaxItemsSelect().getAttribute('value')).to.eventually.equal('10');
+      });
+    });
+  });
+};
+
+module.exports = RssComponentScenarios;

--- a/test/e2e/template-editor/pages/components/rssComponentPage.js
+++ b/test/e2e/template-editor/pages/components/rssComponentPage.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var RssComponentPage = function() {
+  var rssFeedInput = element(by.id('te-rss-feed'));
+  var rssMaxItemsSelect = element(by.id('te-rss-max-items'));
+  var loader = element(by.xpath('//div[@spinner-key="rss-editor-loader"]'));
+  var validationError = element(by.xpath('//template-component-rss//p[@on="validationResult"]/span'));
+  var validationIconError = element(by.xpath('//template-component-rss//streamline-icon[@name="exclamation"]'));
+  var validationIconValid = element(by.xpath('//template-component-rss//streamline-icon[@name="checkmark"]'));
+
+  
+  this.getRssFeedInput = function () {
+    return rssFeedInput;
+  };
+
+  this.getRssMaxItemsSelect = function () {
+    return rssMaxItemsSelect;
+  };
+
+  this.getLoader = function () {
+    return loader;
+  };
+
+  this.getValidationError = function () {
+    return validationError;
+  };
+
+  this.getValidationIconError = function () {
+    return validationIconError;
+  };
+
+  this.getValidationIconValid = function () {
+    return validationIconValid;
+  };
+
+  this.getValidationMessage = function (key) {
+    return element(by.xpath('//span[@ng-switch-when="' + key + '"]'));
+  };
+};
+
+module.exports = RssComponentPage;

--- a/test/e2e/template-editor/template-editor.cases.js
+++ b/test/e2e/template-editor/template-editor.cases.js
@@ -15,6 +15,7 @@
   var ImageComponentScenarios = require('./cases/components/image.js');
   var SlidesComponentScenarios = require('./cases/components/slides.js');
   var VideoComponentScenarios = require('./cases/components/video.js');
+  var RssComponentScenarios = require('./cases/components/rss.js');
 
   describe('Template Editor', function() {
 
@@ -95,6 +96,7 @@
     var imageComponentScenarios = new ImageComponentScenarios();
     var slidesComponentScenarios = new SlidesComponentScenarios();
     var videoComponentScenarios = new VideoComponentScenarios();
+    var rssComponentScenarios = new RssComponentScenarios();
 
     after(function() {
       // Loading the Presentation List is a workaround to a Chrome Driver issue that has it fail to click on elements over the Preview iframe

--- a/web/partials/template-editor/components/component-rss.html
+++ b/web/partials/template-editor/components/component-rss.html
@@ -8,7 +8,7 @@
         <span ng-switch-when="INVALID_URL">Please provide a valid URL.</span>
         <span ng-switch-when="UNAUTHORIZED">The feed at the URL provided cannot be shown because it is protected and requires authentication.</span>
         <span ng-switch-when="NON_FEED">The URL provided is not an RSS feed.</span>
-        <span ng-switch-when="NOT_FOUND">The URL provided could not be resolved.</span>
+        <span ng-switch-when="NOT_FOUND">Provide a valid RSS URL.</span>
         <span ng-switch-when="INVALID_FEED">There are errors with the RSS feed that could impact how your content appears. You can view a summary of the errors detected <a ng-href="https://validator.w3.org/feed/check.cgi?url={{feedUrl | encodeLink}}" target="_blank">here</a>.</span>
       </p>
     </div>


### PR DESCRIPTION
## Description
This adds e2e test cases for RSS Component UI. It also fixes https://github.com/Rise-Vision/rise-vision-apps/issues/1203

## Motivation and Context
The e2e tests are part of the epic work and the text change was suggested during UI review.

## How Has This Been Tested?
The tests do not need manual testing. In order to get the new message, you can use: https://apps-stage-7.risevision.com/templates/edit/82f2346a-7548-485e-bcf6-2d8c38809af9/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

And use the following as Feed URL: https://news.ycombinator.com/news-invalid-url

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@santiagonoguez @stulees please review
