### PR TITLE
Select a single file when picking a logo from storage

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-image.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.tests.js
@@ -93,6 +93,11 @@ describe('directive: TemplateComponentImage', function() {
     expect($scope).to.be.ok;
     expect($scope.factory).to.be.ok;
     expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" } })
+    expect($scope.storageManager).to.be.ok;
+    expect($scope.storageManager.isSingleFileSelector).to.be.ok;    
+    expect($scope.storageManager.addSelectedItems).to.be.ok;
+    expect($scope.storageManager.handleNavigation).to.be.ok;    
+
     expect($scope.registerDirective).to.have.been.called;
 
     var directive = $scope.registerDirective.getCall(0).args[0];
@@ -179,11 +184,7 @@ describe('directive: TemplateComponentImage', function() {
 
       timeout.flush();
     });
-
-
-  });
-
-  
+  });  
 
   describe('updateFileMetadata', function() {
 
@@ -320,6 +321,20 @@ describe('directive: TemplateComponentImage', function() {
         expect($scope.selectedImages).to.deep.equal(expectedImages);
         done();
       },10);
+    });
+  });
+
+  describe('storageManager.isSingleFileSelector',function(){
+    it('should be a single file selector when picking logo',function(){
+      var directive = $scope.registerDirective.getCall(0).args[0];
+      $scope.factory.selected = {type:'rise-image'};
+      directive.show();
+
+      expect($scope.storageManager.isSingleFileSelector()).be.true;
+    });
+
+    it('should not be a single file selector when picking a regular image',function(){
+      expect($scope.storageManager.isSingleFileSelector()).be.false;
     });
   });
 });

--- a/test/unit/template-editor/directives/dtv-basic-storage-selector.tests.js
+++ b/test/unit/template-editor/directives/dtv-basic-storage-selector.tests.js
@@ -27,6 +27,7 @@ describe('directive: basicStorageSelector', function() {
     $rootScope.validExtensions = '.jpg, .png';
     $rootScope.storageManager = {
       addSelectedItems: sandbox.stub(),
+      isSingleFileSelector: sandbox.stub().returns(false),
       handleNavigation: sandbox.stub()
     };
 
@@ -84,6 +85,43 @@ describe('directive: basicStorageSelector', function() {
       $scope.selectItem({ name: 'test.jpg' });
       expect($scope.selectedItems).to.have.lengthOf(0);
     });
+
+    it('should select multiple items', function(){
+      expect($scope.selectedItems).to.be.empty;
+      $scope.selectItem({ name: 'test.jpg' });
+      expect($scope.selectedItems).to.have.lengthOf(1);
+      $scope.selectItem({ name: 'test2.jpg' });
+      expect($scope.selectedItems).to.have.lengthOf(2);
+    });
+
+    describe('selectItem() as single file selector',function(){
+      beforeEach(function(){
+        $scope.storageManager.isSingleFileSelector.returns(true);
+      });
+
+      it('should select an item',function(){
+        expect($scope.selectedItems).to.be.empty;
+        $scope.selectItem({ name: 'test.jpg' });
+        expect($scope.selectedItems).to.have.lengthOf(1);
+      });
+      
+      it('should unmark the item if it is selected twice', function () {
+        expect($scope.selectedItems).to.be.empty;
+        $scope.selectItem({ name: 'test.jpg' });
+        expect($scope.selectedItems).to.have.lengthOf(1);
+        $scope.selectItem({ name: 'test.jpg' });
+        expect($scope.selectedItems).to.have.lengthOf(0);
+      });
+
+      it('should not select multiple items, only the last item',function(){
+        expect($scope.selectedItems).to.be.empty;
+        $scope.selectItem({ name: 'test.jpg' });
+        expect($scope.selectedItems).to.have.lengthOf(1);        
+        $scope.selectItem({ name: 'test2.jpg' });
+        expect($scope.selectedItems).to.have.lengthOf(1);
+        expect($scope.selectedItems).to.deep.equals([{ name: 'test2.jpg' }]);
+      });
+    });    
   });
 
   describe('isSelected', function () {

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -36,6 +36,9 @@ angular.module('risevision.template-editor.directives')
               $scope.resetPanelHeader();
               $scope.showPreviousPanel();
             },
+            isSingleFileSelector: function () {
+              return imageFactory === logoImageFactory;
+            },
             handleNavigation: function (folderPath) {
               var folderName = templateEditorUtils.fileNameOf(folderPath);
 
@@ -262,7 +265,7 @@ angular.module('risevision.template-editor.directives')
           };
 
           $scope.removeImageFromList = function (image) {
-            imageFactory.removeImage(image, $scope.selectedImages).then(function(updatedMetadata){
+            imageFactory.removeImage(image, $scope.selectedImages).then(function (updatedMetadata) {
               _setSelectedImages(updatedMetadata);
             });
           };

--- a/web/scripts/template-editor/components/services/svc-base-image-factory.js
+++ b/web/scripts/template-editor/components/services/svc-base-image-factory.js
@@ -32,10 +32,10 @@ angular.module('risevision.template-editor.services')
           fileMetadataUtilsService.metadataWithFileRemoved(currentMetadata, image);
 
         if (metadata) {
-          return $q.resolve(factory.updateMetadata(metadata));  
+          return $q.resolve(factory.updateMetadata(metadata));
         } else {
-          return $q.resolve([]);  
-        }        
+          return $q.resolve([]);
+        }
       };
 
       factory.updateMetadata = function (metadata) {

--- a/web/scripts/template-editor/components/services/svc-branding-factory.js
+++ b/web/scripts/template-editor/components/services/svc-branding-factory.js
@@ -24,13 +24,14 @@ angular.module('risevision.template-editor.services')
           };
 
           if (factory.brandingSettings.logoFile) {
-            fileExistenceCheckService.requestMetadataFor([factory.brandingSettings.logoFile], DEFAULT_IMAGE_THUMBNAIL)
+            fileExistenceCheckService.requestMetadataFor([factory.brandingSettings.logoFile],
+                DEFAULT_IMAGE_THUMBNAIL)
               .then(function (metadata) {
                 factory.brandingSettings.logoFileMetadata = metadata;
               })
               .catch(function (error) {
                 console.error('Could not load metadata for: ' + factory.brandingSettings.logoFile, error);
-              });            
+              });
           } else {
             factory.brandingSettings.logoFileMetadata = [];
           }

--- a/web/scripts/template-editor/components/services/svc-logo-image-factory.js
+++ b/web/scripts/template-editor/components/services/svc-logo-image-factory.js
@@ -74,9 +74,9 @@ angular.module('risevision.template-editor.services')
       factory.removeImage = function (image, currentMetadata) {
         var deferred = $q.defer();
 
-        factory._canRemoveImage().then(function(){
+        factory._canRemoveImage().then(function () {
           deferred.resolve(factory.updateMetadata([]));
-        }).catch(function(){
+        }).catch(function () {
           deferred.resolve(currentMetadata);
         });
 

--- a/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
+++ b/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
@@ -102,9 +102,17 @@ angular.module('risevision.template-editor.directives')
           };
 
           $scope.selectItem = function (item) {
-            templateEditorUtils.addOrRemove($scope.selectedItems, {
-              name: item.name
-            }, item);
+            if ($scope.storageManager.isSingleFileSelector && $scope.storageManager.isSingleFileSelector()) {
+              if ($scope.isSelected(item)) {
+                $scope.selectedItems = [];
+              } else {
+                $scope.selectedItems = [item];
+              }
+            } else {
+              templateEditorUtils.addOrRemove($scope.selectedItems, {
+                name: item.name
+              }, item);
+            }
           };
 
           $scope.isSelected = function (item) {


### PR DESCRIPTION
## Description
Updated storage selector to pick a single file when selecting a logo

## Motivation and Context
Branding Epic JTBD

## How Has This Been Tested?
Tested manually in https://apps-stage-1.risevision.com. 
Confirmed it only allows a single file to be selected for logo and multiple files for any regular image

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

@alex-deaconu Please review. Thanks!
