### PR TITLE
Switch to streamline icon

### DIFF
--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -40,7 +40,7 @@ angular.module('risevision.template-editor.directives')
               var folderName = templateEditorUtils.fileNameOf(folderPath);
 
               if (folderName) {
-                $scope.setPanelIcon('fa-folder');
+                $scope.setPanelIcon('folder', 'streamline');
                 $scope.setPanelTitle(folderName);
               } else {
                 $scope.setPanelIcon('riseStorage', 'riseSvg');

--- a/web/scripts/template-editor/components/directives/dtv-component-video.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-video.js
@@ -35,7 +35,7 @@ angular.module('risevision.template-editor.directives')
               var folderName = templateEditorUtils.fileNameOf(folderPath);
 
               if (folderName) {
-                $scope.setPanelIcon('fa-folder');
+                $scope.setPanelIcon('folder', 'streamline');
                 $scope.setPanelTitle(folderName);
               } else {
                 $scope.setPanelIcon('riseStorage', 'riseSvg');


### PR DESCRIPTION
## Description

Additional fix for for issue 1161

## Motivation and Context

Work related to [this Trello card](https://trello.com/c/49gsYzfP).

- Switched to streamline icon for panel icon when viewing folder in storage browser in rise video and rise image template editor.

## How Has This Been Tested?

Has been pushed to [Apps Stage 10](https://apps-stage-10.risevision.com) and tested by validating that when browsing to an folder with no images/videos in a rise-image/rise-video component the correct streamline icon appears in the panel header, ie:

???

No automated test updates were needed.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manual Test: Completed as noted above
  - Automated Test: Not needed as noted above.
  - Monitoring: Changes will be manually tested after pushing to Production. Will not merge until Monday.
  - Rollback: Revert to the previous release
  - Documentation: No documentation updates required
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?

No automated tests or documentation updates were required.
