### PR TITLE
update 'time-created' after checking file existence [stage-9]

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-image.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.tests.js
@@ -183,7 +183,7 @@ describe('directive: TemplateComponentImage', function() {
 
   });
 
-  
+
 
   describe('updateFileMetadata', function() {
 
@@ -191,8 +191,18 @@ describe('directive: TemplateComponentImage', function() {
 
     beforeEach(function() {
       sampleImages = [
-        { "file": "image.png", exists: true, "thumbnail-url": "http://image" },
-        { "file": "image2.png", exists: false, "thumbnail-url": "http://image2" }
+        {
+          "file": "image.png",
+          exists: true,
+          "thumbnail-url": "http://image",
+          "time-created": "123"
+        },
+        {
+          "file": "image2.png",
+          exists: false,
+          "thumbnail-url": "http://image2",
+          "time-created": "345"
+        }
       ];
 
       baseImageFactory.componentId = 'TEST-ID';
@@ -222,8 +232,18 @@ describe('directive: TemplateComponentImage', function() {
 
     it('should combine metadata if it\'s already loaded', function(){
       var updatedImages = [
-        { "file": "image.png", exists: false, "thumbnail-url": "http://image5" },
-        { "file": "image2.png", exists: false, "thumbnail-url": "http://image6" }
+        {
+          "file": "image.png",
+          exists: false,
+          "thumbnail-url": "http://image5",
+          "time-created": "987"
+        },
+        {
+          "file": "image2.png",
+          exists: false,
+          "thumbnail-url": "http://image6",
+          "time-created": "654"
+        }
       ];
 
       $scope.getAttributeData = function() {
@@ -248,11 +268,26 @@ describe('directive: TemplateComponentImage', function() {
 
     it('should only update the provided images', function() {
       var updatedImages = [
-        { "file": "image.png", exists: false, "thumbnail-url": "http://image5" }
+        {
+          "file": "image.png",
+          exists: false,
+          "thumbnail-url": "http://image5",
+          "time-created": "876"
+        }
       ];
       var expectedImages = [
-        { "file": "image.png", exists: false, "thumbnail-url": "http://image5" },
-        { "file": "image2.png", exists: false, "thumbnail-url": "http://image2" }
+        {
+          "file": "image.png",
+          exists: false,
+          "thumbnail-url": "http://image5",
+          "time-created": "876"
+        },
+        {
+          "file": "image2.png",
+          exists: false,
+          "thumbnail-url": "http://image2",
+          "time-created": "345"
+        }
       ];
 
       $scope.getAttributeData = function() {
@@ -277,12 +312,32 @@ describe('directive: TemplateComponentImage', function() {
 
     it('should not update images that are not already present', function() {
       var updatedImages = [
-        { "file": "image.png", exists: false, "thumbnail-url": "http://image5" },
-        { "file": "imageNew.png", exists: false, "thumbnail-url": "http://imageN" }
+        {
+          "file": "image.png",
+          exists: false,
+          "thumbnail-url": "http://image5",
+          "time-created": "999"
+        },
+        {
+          "file": "imageNew.png",
+          exists: false,
+          "thumbnail-url": "http://imageN",
+          "time-created": "432"
+        }
       ];
       var expectedImages = [
-        { "file": "image.png", exists: false, "thumbnail-url": "http://image5" },
-        { "file": "image2.png", exists: false, "thumbnail-url": "http://image2" }
+        {
+          "file": "image.png",
+          exists: false,
+          "thumbnail-url": "http://image5",
+          "time-created": "999"
+        },
+        {
+          "file": "image2.png",
+          exists: false,
+          "thumbnail-url": "http://image2",
+          "time-created": "345"
+        }
       ];
 
       $scope.getAttributeData = function() {
@@ -312,7 +367,7 @@ describe('directive: TemplateComponentImage', function() {
       var image = {file:'file1'};
       var expectedImages = [{file: 'file2'}];
       baseImageFactory.removeImage.returns(Q.resolve(expectedImages));
-      
+
       $scope.removeImageFromList(image);
 
       baseImageFactory.removeImage.should.have.been.calledWith(image);

--- a/test/unit/template-editor/components/directives/dtv-component-video.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-video.tests.js
@@ -211,8 +211,18 @@ describe('directive: templateComponentVideo', function() {
 
     beforeEach(function() {
       sampleVideos = [
-        { 'file': 'video.mp4', exists: true, 'thumbnail-url': 'http://video' },
-        { 'file': 'video2.mp4', exists: false, 'thumbnail-url': 'http://video2' }
+        {
+          'file': 'video.mp4',
+          exists: true,
+          'thumbnail-url': 'http://video',
+          'time-created': '123'
+        },
+        {
+          'file': 'video2.mp4',
+          exists: false,
+          'thumbnail-url': 'http://video2',
+          'time-created': '345'
+        }
       ];
 
       $scope.componentId = 'TEST-ID';
@@ -238,8 +248,18 @@ describe('directive: templateComponentVideo', function() {
     it('should combine metadata if it\'s already loaded', function()
     {
       var updatedVideos = [
-        { 'file': 'video.mp4', exists: false, 'thumbnail-url': 'http://video5' },
-        { 'file': 'video2.mp4', exists: false, 'thumbnail-url': 'http://video6' }
+        {
+          'file': 'video.mp4',
+          exists: false,
+          'thumbnail-url': 'http://video5',
+          'time-created': '543'
+        },
+        {
+          'file': 'video2.mp4',
+          exists: false,
+          'thumbnail-url': 'http://video6',
+          'time-created': '777'
+        }
       ];
 
       $scope.getAttributeData = function() {
@@ -260,11 +280,26 @@ describe('directive: templateComponentVideo', function() {
     it('should only update the provided videos', function()
     {
       var updatedVideos = [
-        { 'file': 'video.mp4', exists: false, 'thumbnail-url': 'http://video5' }
+        {
+          'file': 'video.mp4',
+          exists: false,
+          'thumbnail-url': 'http://video5',
+          'time-created': '533'
+        }
       ];
       var expectedVideos = [
-        { 'file': 'video.mp4', exists: false, 'thumbnail-url': 'http://video5' },
-        { 'file': 'video2.mp4', exists: false, 'thumbnail-url': 'http://video2' }
+        {
+          'file': 'video.mp4',
+          exists: false,
+          'thumbnail-url': 'http://video5',
+          'time-created': '533'
+        },
+        {
+          'file': 'video2.mp4',
+          exists: false,
+          'thumbnail-url': 'http://video2',
+          'time-created': '345'
+        }
       ];
 
       $scope.getAttributeData = function() {
@@ -285,12 +320,32 @@ describe('directive: templateComponentVideo', function() {
     it('should not update videos that are not already present', function()
     {
       var updatedVideos = [
-        { 'file': 'video.mp4', exists: false, 'thumbnail-url': 'http://video5' },
-        { 'file': 'videoNew.mp4', exists: false, 'thumbnail-url': 'http://video-thumbnail' }
+        {
+          'file': 'video.mp4',
+          exists: false,
+          'thumbnail-url': 'http://video5',
+          'time-created': '765'
+        },
+        {
+          'file': 'videoNew.mp4',
+          exists: false,
+          'thumbnail-url': 'http://video-thumbnail',
+          'time-created': '544'
+        }
       ];
       var expectedVideos = [
-        { 'file': 'video.mp4', exists: false, 'thumbnail-url': 'http://video5' },
-        { 'file': 'video2.mp4', exists: false, 'thumbnail-url': 'http://video2' }
+        {
+          'file': 'video.mp4',
+          exists: false,
+          'thumbnail-url': 'http://video5',
+          'time-created': '765'
+        },
+        {
+          'file': 'video2.mp4',
+          exists: false,
+          'thumbnail-url': 'http://video2',
+          'time-created': '345'
+        }
       ];
 
       $scope.getAttributeData = function() {

--- a/test/unit/template-editor/components/services/svc-file-metadata-utils.tests.js
+++ b/test/unit/template-editor/components/services/svc-file-metadata-utils.tests.js
@@ -231,8 +231,18 @@ describe('service: fileMetadataUtilsService:', function() {
 
     beforeEach(function() {
       sampleMetadata = [
-        { "file": "image.png", exists: true, "thumbnail-url": "http://image" },
-        { "file": "image2.png", exists: false, "thumbnail-url": "http://image2" }
+        {
+          "file": "image.png",
+          exists: true,
+          "thumbnail-url": "http://image",
+          "time-created": "123"
+        },
+        {
+          "file": "image2.png",
+          exists: false,
+          "thumbnail-url": "http://image2",
+          "time-created": "345"
+        }
       ];
     });
 
@@ -247,8 +257,18 @@ describe('service: fileMetadataUtilsService:', function() {
     it('should combine metadata if it\'s already loaded', function()
     {
       var updatedImages = [
-        { "file": "image.png", exists: false, "thumbnail-url": "http://image5" },
-        { "file": "image2.png", exists: false, "thumbnail-url": "http://image6" }
+        {
+          "file": "image.png",
+          exists: false,
+          "thumbnail-url": "http://image5",
+          "time-created": "654"
+        },
+        {
+          "file": "image2.png",
+          exists: false,
+          "thumbnail-url": "http://image6",
+          "time-created": "877"
+        }
       ];
 
       var metadata =
@@ -260,11 +280,26 @@ describe('service: fileMetadataUtilsService:', function() {
     it('should only update the provided images', function()
     {
       var updatedImages = [
-        { "file": "image.png", exists: false, "thumbnail-url": "http://image5" }
+        {
+          "file": "image.png",
+          exists: false,
+          "thumbnail-url": "http://image5",
+          "time-created": "765"
+        }
       ];
       var expectedImages = [
-        { "file": "image.png", exists: false, "thumbnail-url": "http://image5" },
-        { "file": "image2.png", exists: false, "thumbnail-url": "http://image2" }
+        {
+          "file": "image.png",
+          exists: false,
+          "thumbnail-url": "http://image5",
+          "time-created": "765"
+        },
+        {
+          "file": "image2.png",
+          exists: false,
+          "thumbnail-url": "http://image2",
+          "time-created": "345"
+        }
       ];
 
       var metadata =
@@ -276,12 +311,31 @@ describe('service: fileMetadataUtilsService:', function() {
     it('should not update images that are not already present', function()
     {
       var updatedImages = [
-        { "file": "image.png", exists: false, "thumbnail-url": "http://image5" },
-        { "file": "imageNew.png", exists: false, "thumbnail-url": "http://imageN" }
+        {
+          "file": "image.png",
+          exists: false,
+          "thumbnail-url": "http://image5",
+          "time-created": "555"
+        },
+        {
+          "file": "imageNew.png",
+          exists: false, "thumbnail-url": "http://imageN",
+          "time-created": "9"
+        }
       ];
       var expectedImages = [
-        { "file": "image.png", exists: false, "thumbnail-url": "http://image5" },
-        { "file": "image2.png", exists: false, "thumbnail-url": "http://image2" }
+        {
+          "file": "image.png",
+          exists: false,
+          "thumbnail-url": "http://image5",
+          "time-created": "555"
+        },
+        {
+          "file": "image2.png",
+          exists: false,
+          "thumbnail-url": "http://image2",
+          "time-created": "345"
+        }
       ];
 
       var metadata =

--- a/web/scripts/template-editor/components/services/svc-file-metadata-utils.js
+++ b/web/scripts/template-editor/components/services/svc-file-metadata-utils.js
@@ -86,6 +86,7 @@ angular.module('risevision.template-editor.services')
               atLeastOneOriginalEntryIsStillSelected = true;
               currentEntry.exists = entry.exists;
               currentEntry['thumbnail-url'] = entry['thumbnail-url'];
+              currentEntry['time-created'] = entry['time-created'];
             }
           });
 


### PR DESCRIPTION
## Description
This fixes issue 1209 for template editor
https://github.com/Rise-Vision/rise-vision-apps/issues/1209

## Motivation and Context
For some reason, when the metadata is being updated for a file list ( image or video ), the 'time-created' is not being updated. That results in the URL to still use the old timestamp after it's updated, and the browser reads the image from cache instead of refreshing to the updated one.

## How Has This Been Tested?
Can be validated now working here:
https://apps-stage-9.risevision.com/templates/edit/6eba4d1b-bd19-435a-a2a9-eef3feeb47a0/?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c

1.- In template editor select an image from storage.
2.- Go to storage and delete the image
3.- In storage, upload a different image with the same name.
4.- Refresh the presentation, the image should update in both the file list and preview

Contrast this with behavior on production Apps.

Several manual tests were updated to consider 'time-created', and to validate that the fix works.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
    - Both manual and automated tests cover this
    - To be released on Monday
    - Will validate immediately that the fix works, and will rollback immediately if there is a problem.
    - No new fields are introduced, so risk is low.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to update documentation
No need to notify support
