### PR TITLE
Fix back button navigation for branding

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-branding-colors.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-branding-colors.tests.js
@@ -24,6 +24,7 @@ describe('directive: templateBrandingColors', function() {
 
     $scope.registerDirective = sinon.stub();
     $scope.setPanelTitle = sinon.stub();
+    $scope.setPanelIcon = sinon.stub();
     $scope.showPreviousPanel = sinon.stub();
 
     $scope.$digest();
@@ -66,6 +67,9 @@ describe('directive: templateBrandingColors', function() {
     $scope.showPreviousPanel.returns('backPanel');
 
     expect(directive.onBackHandler()).to.equal('backPanel');
+
+    $scope.setPanelTitle.should.have.been.calledWith('Brand Settings');
+    $scope.setPanelIcon.should.have.been.calledWith('ratingStar', 'streamline');
 
     $scope.showPreviousPanel.should.have.been.called;
   });

--- a/web/scripts/template-editor/components/directives/dtv-branding-colors.js
+++ b/web/scripts/template-editor/components/directives/dtv-branding-colors.js
@@ -24,6 +24,9 @@ angular.module('risevision.template-editor.directives')
               $scope.setPanelTitle('Color Settings');
             },
             onBackHandler: function () {
+              $scope.setPanelIcon('ratingStar', 'streamline');
+              $scope.setPanelTitle('Brand Settings');
+
               return $scope.showPreviousPanel();
             }
           });

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -193,6 +193,10 @@ angular.module('risevision.template-editor.directives')
             },
             onBackHandler: function () {
               if ($scope.getCurrentPanel() !== storagePanelSelector) {
+                if (_isEditingLogo()) {
+                  $scope.setPanelIcon('ratingStar', 'streamline');
+                  $scope.setPanelTitle('Brand Settings');
+                }
                 return $scope.showPreviousPanel();
               } else if (!$scope.storageManager.onBackHandler()) {
                 _updatePanelHeader();


### PR DESCRIPTION
## Description
When returning from the Image or Colors panels, the Branding title and icon are incorrect. Adding code to update them in the back handler for the specific panels.

## Motivation and Context
This fixes an issue with the back button and title text

## How Has This Been Tested?
This was tested locally to ensure the title and icon are updated correctly. A unit test has been added as well.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
