### PR TITLE
Add color picker for branding

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#feature/color-picker",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.10.23",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages",
     "xmlToJSON.js": "^1.3.2"
@@ -37,7 +37,6 @@
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
     "jquery": "^2",
-    "font-awesome": "~4.7.0",
-    "common-header": "feature/color-picker"
+    "font-awesome": "~4.7.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.10.20",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#feature/color-picker",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages",
     "xmlToJSON.js": "^1.3.2"
@@ -37,6 +37,7 @@
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
     "jquery": "^2",
-    "font-awesome": "~4.7.0"
+    "font-awesome": "~4.7.0",
+    "common-header": "feature/color-picker"
   }
 }

--- a/web/partials/template-editor/components/component-branding/branding-colors.html
+++ b/web/partials/template-editor/components/component-branding/branding-colors.html
@@ -1,8 +1,15 @@
 <div class="branding-colors-container attribute-list-container">
 
     <label class="control-label u_margin-md-top" for="branding-base-color">Base Color:</label>
-    <input id="branding-base-color" type="text" class="form-control" ng-model="brandingFactory.brandingSettings.baseColor" placeholder="Enter a hex value, eg. #00FF00" ng-blur="saveBranding()">
+    <div class="input-group" colorpicker="rgba" colorpicker-position="bottom" ng-model="brandingFactory.brandingSettings.baseColor">
+      <input id="branding-base-color" type="text" class="form-control" ng-model="brandingFactory.brandingSettings.baseColor" placeholder="Enter a hex value, eg. #00FF00" ng-blur="saveBranding()">
+      <span class="input-group-addon color-wheel"></span>
+    </div>
 
     <label class="control-label u_margin-md-top" for="branding-accent-color">Accent Color:</label>
-    <input id="branding-accent-color" type="text" class="form-control" ng-model="brandingFactory.brandingSettings.accentColor" placeholder="Enter a hex value, eg. #00FF00" ng-blur="saveBranding()">
+    <div class="input-group" colorpicker="rgba" colorpicker-position="bottom" ng-model="brandingFactory.brandingSettings.accentColor">
+      <input id="branding-accent-color" type="text" class="form-control" ng-model="brandingFactory.brandingSettings.accentColor" placeholder="Enter a hex value, eg. #00FF00" ng-blur="saveBranding()">
+      <span class="input-group-addon color-wheel"></span>
+    </div>
+
 </div>


### PR DESCRIPTION
Add color picker for branding

[stage-1]

## Description
Allows user to pick Brand Colors via the color picker

## Motivation and Context
Enables user to select colors via a color picker rather than having to input them. They do have the option to input colors as well however via the textbox.

## How Has This Been Tested?
Verified in the local environment

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
e2e tests for this will be added in a separate PR.
