### PR TITLE
Fixes for style guide issues

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.10.20",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/video-style-guide-fixes",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages",
     "xmlToJSON.js": "^1.3.2"
@@ -36,6 +36,7 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
+    "common-header": "fix/video-style-guide-fixes",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/video-style-guide-fixes",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.10.21",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages",
     "xmlToJSON.js": "^1.3.2"
@@ -36,7 +36,6 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
-    "common-header": "fix/video-style-guide-fixes",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }

--- a/web/partials/template-editor/components/component-image/image-list.html
+++ b/web/partials/template-editor/components/component-image/image-list.html
@@ -44,7 +44,7 @@
     </label>
   </div>
   <div class="select-from-storage">
-    <button id="image-list-storage-button" class="btn btn-block" ng-click="selectFromStorage()" ng-disabled="isUploading">
+    <button id="image-list-storage-button" class="btn btn-default btn-block" ng-click="selectFromStorage()" ng-disabled="isUploading">
       <strong>Select from Storage</strong>
     </button>
   </div>

--- a/web/partials/template-editor/components/component-video/video-list.html
+++ b/web/partials/template-editor/components/component-video/video-list.html
@@ -56,7 +56,7 @@
     </label>
   </div>
   <div class="select-from-storage">
-    <button id="video-list-storage-button" class="btn btn-block" ng-click="selectFromStorage()" ng-disabled="isUploading">
+    <button id="video-list-storage-button" class="btn btn-default btn-block" ng-click="selectFromStorage()" ng-disabled="isUploading">
       <strong>Select from Storage</strong>
     </button>
   </div>

--- a/web/partials/template-editor/file-entry.html
+++ b/web/partials/template-editor/file-entry.html
@@ -11,7 +11,7 @@
       ></streamline-icon>
     </div>
   </div>
-  <div class="file-entry">
+  <div class="file-entry" ng-class="{'is-error' : !entry.exists}">
     <div class="file-text">
       <div class="file-name">{{getFileName()}}</div>
       <div class="file-error" ng-hide="entry.exists">


### PR DESCRIPTION
## Description

Fixes for several small styleguide deviations found during QA of the video component.

## Motivation and Context

Work related to [this Trello card](https://trello.com/c/dHYxwePY). Related common-header work in [this PR](https://github.com/Rise-Vision/common-header/pull/1044).

- The version of common-header has been updated
- A `btn-default` class has been added to the storage buttons in the image and video components so some duplicate css could be removed from `common-header`
- A conditional `is-error` class has been added to the `file-entry` element to allow styling the filename when there is an error

## How Has This Been Tested?

Has been pushed to [Apps Stage 10](https://apps-stage-10.risevision.com) and tested as noted in the [common-header PR](https://github.com/Rise-Vision/common-header/pull/1044)

No automated test updates were needed.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manual Test: Completed as noted above
  - Automated Test: Not needed as noted above.
  - Monitoring: Changes will be manually tested after pushing to Production.
  - Rollback: Revert to the previous release
  - Documentation: No documentation updates required
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?

No automated tests or documentation updates were required.
