### PR TITLE
Update common-header

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/issue-1170-thumbnail-transparency",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.10.22",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages",
     "xmlToJSON.js": "^1.3.2"
@@ -36,7 +36,6 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
-    "common-header": "fix/issue-1170-thumbnail-transparency",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.10.20",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#fix/issue-1170-thumbnail-transparency",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages",
     "xmlToJSON.js": "^1.3.2"
@@ -36,6 +36,7 @@
     "angular-ui-router": "^0.2.18",
     "angular-sanitize": "~1.5.0",
     "angular-mocks": "~1.5.0",
+    "common-header": "fix/issue-1170-thumbnail-transparency",
     "jquery": "^2",
     "font-awesome": "~4.7.0"
   }


### PR DESCRIPTION
## Description

Fix for issue 1170.

## Motivation and Context

Work related to [this Trello card](https://trello.com/c/QQAdOqPa). Related common-header work in [this PR](https://github.com/Rise-Vision/common-header/pull/1046).

- The version of common-header has been updated

**Note:** __The `common-header` version will be updated after the other PR is merged.__

## How Has This Been Tested?

Has been pushed to [Apps Stage 10](https://apps-stage-10.risevision.com) and tested as noted in the [common-header PR](https://github.com/Rise-Vision/common-header/pull/1046)

No automated test updates were needed.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manual Test: Completed as noted above
  - Automated Test: Not needed as noted above.
  - Monitoring: Changes will be manually tested after pushing to Production. Will not be merged until Monday.
  - Rollback: Revert to the previous release
  - Documentation: No documentation updates required
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?

No automated tests or documentation updates were required.
