### PR TITLE
UI updates based on PM review

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-image.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.tests.js
@@ -92,11 +92,8 @@ describe('directive: TemplateComponentImage', function() {
   it('should exist', function() {
     expect($scope).to.be.ok;
     expect($scope.factory).to.be.ok;
-    expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" } })
-    expect($scope.storageManager).to.be.ok;
-    expect($scope.storageManager.isSingleFileSelector).to.be.ok;
-    expect($scope.storageManager.addSelectedItems).to.be.ok;
-    expect($scope.storageManager.handleNavigation).to.be.ok;
+    expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" } });
+    expect($scope.isEditingLogo).to.be.a('function');
 
     expect($scope.registerDirective).to.have.been.called;
 
@@ -107,6 +104,41 @@ describe('directive: TemplateComponentImage', function() {
     expect(directive.iconType).to.equal('streamline');
     expect(directive.show).to.be.a('function');
     expect(directive.onBackHandler).to.be.a('function');
+  });
+
+  it('uploadManager:', function() {
+    expect($scope.uploadManager).to.be.ok;
+    expect($scope.uploadManager.isSingleFileSelector).to.be.ok;
+    expect($scope.uploadManager.isSingleFileSelector).to.equal($scope.isEditingLogo);
+    expect($scope.uploadManager.onUploadStatus).to.be.ok;
+    expect($scope.uploadManager.addFile).to.be.ok;
+  });
+
+  it('storageManager:', function() {
+    expect($scope.storageManager).to.be.ok;
+    expect($scope.storageManager.isSingleFileSelector).to.be.ok;
+    expect($scope.storageManager.isSingleFileSelector).to.equal($scope.isEditingLogo);
+    expect($scope.storageManager.addSelectedItems).to.be.ok;
+    expect($scope.storageManager.handleNavigation).to.be.ok;
+  });
+
+  describe('isEditingLogo:', function() {
+    it('should not edit logo if component id is available', function() {
+      var directive = $scope.registerDirective.getCall(0).args[0];
+
+      directive.show();
+
+      expect($scope.isEditingLogo()).to.be.false;
+    });
+
+    it('should edit logo if component id is not available', function() {
+      var directive = $scope.registerDirective.getCall(0).args[0];
+      $scope.factory.selected = {};
+
+      directive.show();
+
+      expect($scope.isEditingLogo()).to.be.true;
+    });
   });
 
   describe('show',function(){

--- a/test/unit/template-editor/components/services/svc-base-image-factory.tests.js
+++ b/test/unit/template-editor/components/services/svc-base-image-factory.tests.js
@@ -175,12 +175,12 @@ describe('service: baseImageFactory', function() {
         templateEditorFactory.setAttributeData.should.have.been.calledWith('componentId', 'isLogo', false);
       });
 
-      it('should reset isLogo flag to true if no files are sent', function() {
+      it('should update isLogo flag to false if no files are sent', function() {
         var metadata = [];
         blueprintFactory.getBlueprintData.returns('true');
         var data = baseImageFactory.updateMetadata(metadata);      
 
-        templateEditorFactory.setAttributeData.should.have.been.calledWith('componentId', 'isLogo', true);
+        templateEditorFactory.setAttributeData.should.have.been.calledWith('componentId', 'isLogo', false);
       });
 
     });

--- a/test/unit/template-editor/directives/dtv-basic-uploader.tests.js
+++ b/test/unit/template-editor/directives/dtv-basic-uploader.tests.js
@@ -6,7 +6,10 @@ describe('directive: basicUploader', function () {
   beforeEach(module(function ($provide) {
     uploadManager = {
       onUploadStatus: sinon.stub(),
-      addFile: sinon.stub()
+      addFile: sinon.stub(),
+      isSingleFileSelector: function() {
+        return isSingleFileSelector;
+      }
     };
 
     $provide.constant('STORAGE_UPLOAD_CHUNK_SIZE', 1024);
@@ -50,7 +53,7 @@ describe('directive: basicUploader', function () {
   }));  
 
   var element;
-  var $scope, uploadManager, storage, templateEditorUtils;
+  var $scope, uploadManager, storage, templateEditorUtils, isSingleFileSelector;
   var FileUploader, UploadURIService;
 
   beforeEach(inject(function($injector){
@@ -61,7 +64,7 @@ describe('directive: basicUploader', function () {
 
   beforeEach(inject(function($injector, $compile, $rootScope, $templateCache) {
     $rootScope.uploadManager = uploadManager;
-    $templateCache.put('partials/template-editor/basic-uploader.html', '<p>mock</p>');
+    $templateCache.put('partials/template-editor/basic-uploader.html', '<input type="file" multiple>');
 
     templateEditorUtils = $injector.get('templateEditorUtils');
 
@@ -72,7 +75,7 @@ describe('directive: basicUploader', function () {
   }));
 
   it('should render directive', function () {
-    expect(element.html()).to.equal('<p>mock</p>');
+    expect(element.html()).to.equal('<input type="file" multiple="true">');
   });
 
   it('should add utility functions to scope', function () {
@@ -86,6 +89,14 @@ describe('directive: basicUploader', function () {
     expect(FileUploader.onCompleteItem).to.exist;
 
     expect(UploadURIService.getURI).to.exist;
+  });
+
+  it('should watch uploadManager.isSingleFileSelector value and update input multiple attribute', function() {
+    isSingleFileSelector = true;
+
+    $scope.$apply();
+
+    expect(element.html()).to.equal('<input type="file">');
   });
 
   it('should invoke onAfterAddingFile', function () {

--- a/test/unit/template-editor/directives/dtv-empty-file-list.tests.js
+++ b/test/unit/template-editor/directives/dtv-empty-file-list.tests.js
@@ -8,7 +8,7 @@ describe('directive: templateEditorEmptyFileList', function() {
 
   beforeEach(inject(function($compile, $rootScope, $templateCache){
     $templateCache.put('partials/template-editor/empty-file-list.html', '<p>mock</p>');
-    element = $compile('<template-editor-empty-file-list file-type="image"></template-editor-empty-file-list>')($rootScope.$new());
+    element = $compile('<template-editor-empty-file-list file-type="image" is-editing-logo="true"></template-editor-empty-file-list>')($rootScope.$new());
     $rootScope.$apply();
 
     $scope = element.isolateScope();
@@ -18,6 +18,7 @@ describe('directive: templateEditorEmptyFileList', function() {
   it('should exist', function() {
     expect($scope).to.be.ok;
     expect($scope.fileType).to.equal('image');
+    expect($scope.isEditingLogo).to.be.true;
   });
 
 });

--- a/web/partials/template-editor/components/component-image/image-list.html
+++ b/web/partials/template-editor/components/component-image/image-list.html
@@ -22,7 +22,7 @@
     remove-action="removeImageFromList">
   </template-editor-file-entry>
 
-  <template-editor-empty-file-list file-type="image"
+  <template-editor-empty-file-list file-type="image" is-editing-logo="isEditingLogo"
      ng-hide="isUploading || selectedImages.length !== 0 || factory.loadingPresentation">
   </template-editor-empty-file-list>
 
@@ -40,7 +40,8 @@
       for="image-list-uploader"
       ng-disabled="isUploading"
     >
-      <strong>Upload Images</strong>
+      <strong ng-if="!isEditingLogo()">Upload Images</strong>
+      <strong ng-if="isEditingLogo()">Upload A Logo</strong>
     </label>
   </div>
   <div class="select-from-storage">

--- a/web/partials/template-editor/empty-file-list.html
+++ b/web/partials/template-editor/empty-file-list.html
@@ -1,10 +1,25 @@
-<div class="item-list-empty">
+<div class="item-list-empty" ng-if="!isEditingLogo()">
   <div class="row">
     <div class="col-xs-12">
       <h2>You have no {{fileType}}s here.</h2>
       <p>
         Upload {{fileType}}s from your device
         or select {{fileType}}s from storage to keep your display interesting!
+      </p>
+      <div>
+        <img class="img-responsive" src="../images/empty-list.svg">
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="item-list-empty" ng-if="isEditingLogo()">
+  <div class="row">
+    <div class="col-xs-12">
+      <h2>You haven't selected a logo yet.</h2>
+      <p>
+        Upload a logo from your device
+        or select a logo from storage to keep your display interesting!
       </p>
       <div>
         <img class="img-responsive" src="../images/empty-list.svg">

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -21,21 +21,22 @@ angular.module('risevision.template-editor.directives')
           $scope.factory = templateEditorFactory;
           $scope.validExtensions = SUPPORTED_IMAGE_TYPES;
 
+          $scope.isEditingLogo = function () {
+            return imageFactory === logoImageFactory;
+          };
+
           $scope.uploadManager = {
             onUploadStatus: function (isUploading) {
               $scope.isUploading = isUploading;
             },
             addFile: function (file) {
               _addFilesToMetadata([file]);
-            }
-          };
-
-          var _isEditingLogo = function () {
-            return imageFactory === logoImageFactory;
+            },
+            isSingleFileSelector: $scope.isEditingLogo
           };
 
           var _updatePanelHeader = function () {
-            if (_isEditingLogo()) {
+            if ($scope.isEditingLogo()) {
               $scope.setPanelIcon('circleStar', 'streamline');
               $scope.setPanelTitle('Logo Settings');
             } else {
@@ -51,7 +52,7 @@ angular.module('risevision.template-editor.directives')
 
               $scope.showPreviousPanel();
             },
-            isSingleFileSelector: _isEditingLogo,
+            isSingleFileSelector: $scope.isEditingLogo,
             handleNavigation: function (folderPath) {
               var folderName = templateEditorUtils.fileNameOf(folderPath);
 
@@ -193,7 +194,7 @@ angular.module('risevision.template-editor.directives')
             },
             onBackHandler: function () {
               if ($scope.getCurrentPanel() !== storagePanelSelector) {
-                if (_isEditingLogo()) {
+                if ($scope.isEditingLogo()) {
                   $scope.setPanelIcon('ratingStar', 'streamline');
                   $scope.setPanelTitle('Brand Settings');
                 }

--- a/web/scripts/template-editor/components/services/svc-base-image-factory.js
+++ b/web/scripts/template-editor/components/services/svc-base-image-factory.js
@@ -46,15 +46,10 @@ angular.module('risevision.template-editor.services')
         _setAttributeData('metadata', selectedImages);
         _setAttributeData('files', filesAttribute);
 
-        // Check default isLogo value; if the user selects their own image
-        // set this component to use that image; if empty set it to use the 
-        // Company Branding logo
+        // Check default isLogo===true value; if the user makes changes to the component
+        // revert it to isLogo=false
         if (factory.getBlueprintData('is-logo') === 'true') {
-          if (selectedImages && selectedImages.length > 0) {
-            _setAttributeData('isLogo', false);
-          } else {
-            _setAttributeData('isLogo', true);
-          }
+          _setAttributeData('isLogo', false);
         }
 
         return selectedImages;

--- a/web/scripts/template-editor/directives/dtv-basic-uploader.js
+++ b/web/scripts/template-editor/directives/dtv-basic-uploader.js
@@ -24,6 +24,14 @@ angular.module('risevision.template-editor.directives')
             return $scope.activeUploadCount() > 0;
           }
 
+          $scope.$watch($scope.uploadManager.isSingleFileSelector, function(value) {
+            if (!value) {
+              inputElement[0].setAttribute('multiple', true);
+            } else {
+              inputElement[0].removeAttribute('multiple');
+            }
+          });
+
           $scope.removeItem = function (item) {
             FileUploader.removeFromQueue(item);
             $scope.uploadManager.onUploadStatus(_isUploading());

--- a/web/scripts/template-editor/directives/dtv-empty-file-list.js
+++ b/web/scripts/template-editor/directives/dtv-empty-file-list.js
@@ -6,7 +6,8 @@ angular.module('risevision.template-editor.directives')
       return {
         restrict: 'E',
         scope: {
-          fileType: '@'
+          fileType: '@',
+          isEditingLogo: '='
         },
         templateUrl: 'partials/template-editor/empty-file-list.html',
         link: function ($scope) {


### PR DESCRIPTION
UI review updates and fixes

[stage-2]

## Description
Update Empty file list and Image Component upload
button with Logo wording

Image Component upload component should only allow
single image uploads for Logo

Revert Image Component to isLogo=false if user modifies
the content within the component

## Motivation and Context
Updating the functionality based on PM review

## How Has This Been Tested?
Fixes have been tested in the local environment. Unit tests were also updated to cover the changes.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
