### PR TITLE
Update financial e2e tests to use Example Financial Template V4

### DIFF
--- a/test/e2e/template-editor/cases/components/financial.js
+++ b/test/e2e/template-editor/cases/components/financial.js
@@ -23,7 +23,7 @@ var FinancialComponentScenarios = function () {
       financialComponentPage = new FinancialComponentPage();
 
       presentationsListPage.loadCurrentCompanyPresentationList();
-      presentationsListPage.createNewPresentationFromTemplate('Example Financial Template V3', 'example-financial-template-v3');
+      presentationsListPage.createNewPresentationFromTemplate('Example Financial Template V4', 'example-financial-template-v4');
     });
 
     describe('basic operations', function () {

--- a/test/e2e/template-editor/cases/components/image.js
+++ b/test/e2e/template-editor/cases/components/image.js
@@ -23,7 +23,7 @@ var ImageComponentScenarios = function () {
       imageComponentPage = new ImageComponentPage();
 
       presentationsListPage.loadCurrentCompanyPresentationList();
-      presentationsListPage.createNewPresentationFromTemplate('Example Financial Template V3', 'example-financial-template-v3');
+      presentationsListPage.createNewPresentationFromTemplate('Example Financial Template V4', 'example-financial-template-v4');
       templateEditorPage.dismissFinancialDataLicenseMessage();
     });
 
@@ -135,7 +135,7 @@ var ImageComponentScenarios = function () {
     describe('list and remove images', function () {
       it('should create a new presentation and open it', function () {
         presentationsListPage.loadCurrentCompanyPresentationList();
-        presentationsListPage.createNewPresentationFromTemplate('Example Financial Template V3', 'example-financial-template-v3');
+        presentationsListPage.createNewPresentationFromTemplate('Example Financial Template V4', 'example-financial-template-v4');
         templateEditorPage.dismissFinancialDataLicenseMessage();
 
         helper.waitDisappear(templateEditorPage.getDirtyText());

--- a/test/e2e/template-editor/cases/template-editor-add.js
+++ b/test/e2e/template-editor/cases/template-editor-add.js
@@ -19,7 +19,7 @@ var TemplateAddScenarios = function() {
       templateEditorPage = new TemplateEditorPage();
 
       presentationsListPage.loadCurrentCompanyPresentationList();
-      presentationsListPage.createNewPresentationFromTemplate('Example Financial Template V3', 'example-financial-template-v3');
+      presentationsListPage.createNewPresentationFromTemplate('Example Financial Template V4', 'example-financial-template-v4');
       templateEditorPage.dismissFinancialDataLicenseMessage();
     });
 


### PR DESCRIPTION
## Description
Financial component e2e tests updated to use _Example Financial Template V4_ template

## Motivation and Context
V4 of the example template has been updated to add two non-editable instances configured for _historical_ type and the template is using latest release of the _rise-data-financial_ component.

## How Has This Been Tested?
Depends on e2e tests passing (template itself has already been deployed, tested, and validated)

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- All steps skipped as there are no functionality changes, just a change in which template is used for financial e2e tests. If they don't pass, fixes to the test cases will be made. 
