### PR TITLE
Fix/issue 347 stocks without symbol

### DIFF
--- a/test/unit/template-editor/components/services/svc-instrument-search.tests.js
+++ b/test/unit/template-editor/components/services/svc-instrument-search.tests.js
@@ -67,7 +67,49 @@ describe('service: instrumentSearchService:', function() {
           console.log("shouldn't be here", err);
         });
     });
-  } );
+
+    it("should filter out results with no symbols", function() {
+      var returnedStocks = {
+        items: [
+          {
+            symbol: "AAPL.O",
+            name: "APPLE INC.",
+            category: "STOCKS",
+            logo: "https://risecontentlogos.s3.amazonaws.com/financial/AAPL.svg"
+          },
+          {
+            name: "AMAZON.COM",
+            category: "STOCKS",
+            logo: "https://risecontentlogos.s3.amazonaws.com/financial/AMZN.svg"
+          },
+          {
+            name: "AUTOZONE INC",
+            category: "STOCKS",
+            logo: "https://risecontentlogos.s3.amazonaws.com/financial/AZO.svg"
+          }
+        ]
+      };
+
+      $httpBackend.when('GET', INSTRUMENT_SEARCH_BASE_URL + "instruments/common?category=stocks").respond(200, returnedStocks);
+
+      setTimeout(function() {
+        $httpBackend.flush();
+      });
+
+      return instrumentSearchService.popularSearch("stocks")
+        .then(function (results) {
+          expect(results).to.deep.equal([
+            {
+              symbol: "AAPL.O",
+              name: "APPLE INC.",
+              category: "STOCKS",
+              logo: "https://risecontentlogos.s3.amazonaws.com/financial/AAPL.svg"
+            }
+          ]);
+        });
+    });
+
+  });
 
   describe( 'keywordSearch', function() {
     var instruments = {
@@ -127,6 +169,50 @@ describe('service: instrumentSearchService:', function() {
           console.log("shouldn't be here", err);
         });
     });
-  } );
+
+    it("should filter out results with no symbols", function() {
+      var returnedInstruments = {
+        items: [
+          {
+            name: "Amazon.com Inc",
+            category: "Stocks",
+            logo: "https://risecontentlogos.s3.amazonaws.com/financial/AMZN.svg"
+          },
+          {
+            symbol: "0#AMZF:",
+            name: "Eurex Amazon Equity Future Chain Contract",
+            category: "Stocks"
+          },
+          {
+            symbol: "0#AMZNDFW:OX",
+            name: "One Chicago LLC Amazon Com No Dividend Friday Weekly Equity Future Chain Contracts",
+            category: "Stocks"
+          }
+        ]
+      };
+
+      $httpBackend.when('GET', INSTRUMENT_SEARCH_BASE_URL + "instrument/search?category=Stocks&query=Amazon").respond(200, returnedInstruments);
+      setTimeout(function() {
+        $httpBackend.flush();
+      });
+
+      return instrumentSearchService.keywordSearch("stocks", "Amazon")
+        .then(function (results) {
+          expect(results).to.deep.equal([
+            {
+              symbol: "0#AMZF:",
+              name: "Eurex Amazon Equity Future Chain Contract",
+              category: "Stocks"
+            },
+            {
+              symbol: "0#AMZNDFW:OX",
+              name: "One Chicago LLC Amazon Com No Dividend Friday Weekly Equity Future Chain Contracts",
+              category: "Stocks"
+            }
+          ]);
+        });
+    });
+
+  });
 
 });

--- a/web/scripts/template-editor/components/services/svc-instrument-search.js
+++ b/web/scripts/template-editor/components/services/svc-instrument-search.js
@@ -43,7 +43,7 @@ angular.module('risevision.template-editor.services')
         var items = resp.data.items;
 
         return _.filter(items, function (item) {
-          return !!item.symbol
+          return !!item.symbol;
         });
       }
 

--- a/web/scripts/template-editor/components/services/svc-instrument-search.js
+++ b/web/scripts/template-editor/components/services/svc-instrument-search.js
@@ -23,7 +23,7 @@ angular.module('risevision.template-editor.services')
 
         return $http.get(keywordSearchURL.replace('CATEGORY', capitalized).replace('QUERY', keyword))
           .then(function (resp) {
-            results.keyword[keywordProp] = resp.data.items;
+            results.keyword[keywordProp] = _getValidItems(resp);
             return results.keyword[keywordProp];
           });
       };
@@ -39,6 +39,14 @@ angular.module('risevision.template-editor.services')
         }).join('%20');
       }
 
+      function _getValidItems(resp) {
+        var items = resp.data.items;
+
+        return _.filter(items, function (item) {
+          return !!item.symbol
+        });
+      }
+
       factory.popularSearch = function (category) {
         if (results.popular[category]) {
           return $q.when(results.popular[category]);
@@ -46,7 +54,7 @@ angular.module('risevision.template-editor.services')
 
         return $http.get(popularSearchURL.replace('CATEGORY', category))
           .then(function (resp) {
-            results.popular[category] = resp.data.items;
+            results.popular[category] = _getValidItems(resp);
             return results.popular[category];
           });
       };


### PR DESCRIPTION
## Description
Filters out any entry returning from financial server that has no symbols.
Issue: https://github.com/Rise-Vision/html-template-library/issues/347

## Motivation and Context
Financial server is returning stocks with no symbols as described in the issue, so financial settings should filter out invalid entries.

@alexey-rise do you consider some changes to financial server are also needed to prevent it from returning stocks with no symbols ?

## How Has This Been Tested?
Running right in stage-9:
https://apps-stage-9.risevision.com/templates/edit/46841dc1-efef-4a2d-84c9-1e0a14932ff4/?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
   Manual testing above
   Automated tests created
   To be deployed before Friday or next Monday
  Will be monitored immediately after deployment, and rolled back if there is a problem
   A simple rollback is needed
  As there are no users affected with this, no manual data corrections are needed
  Will notify support once fixed.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No documentation updates needed; 
