### PR TITLE
Refresh logo metadata every time

### DIFF
--- a/web/scripts/template-editor/components/services/svc-branding-factory.js
+++ b/web/scripts/template-editor/components/services/svc-branding-factory.js
@@ -12,6 +12,21 @@ angular.module('risevision.template-editor.services')
         brandingSettings: null
       };
 
+      var _refreshMetadata = function() {
+        if (factory.brandingSettings.logoFile) {
+          fileExistenceCheckService.requestMetadataFor([factory.brandingSettings.logoFile],
+              DEFAULT_IMAGE_THUMBNAIL)
+            .then(function (metadata) {
+              factory.brandingSettings.logoFileMetadata = metadata;
+            })
+            .catch(function (error) {
+              console.error('Could not load metadata for: ' + factory.brandingSettings.logoFile, error);
+            });
+        } else {
+          factory.brandingSettings.logoFileMetadata = [];
+        }
+      };
+
       var _loadBranding = function (forceRefresh) {
         if (!factory.brandingSettings || forceRefresh) {
           var company = userState.getCopyOfSelectedCompany();
@@ -22,20 +37,9 @@ angular.module('risevision.template-editor.services')
             baseColor: settings.brandingDraftBaseColor,
             accentColor: settings.brandingDraftAccentColor
           };
-
-          if (factory.brandingSettings.logoFile) {
-            fileExistenceCheckService.requestMetadataFor([factory.brandingSettings.logoFile],
-                DEFAULT_IMAGE_THUMBNAIL)
-              .then(function (metadata) {
-                factory.brandingSettings.logoFileMetadata = metadata;
-              })
-              .catch(function (error) {
-                console.error('Could not load metadata for: ' + factory.brandingSettings.logoFile, error);
-              });
-          } else {
-            factory.brandingSettings.logoFileMetadata = [];
-          }
         }
+
+        _refreshMetadata();
       };
 
       $rootScope.$on('risevision.company.updated', function () {


### PR DESCRIPTION
## Description
Refresh logo metadata every time the template loads

[stage-2]

## Motivation and Context
No longer use old values, because logo
metadata may have been updated in Storage

## How Has This Been Tested?
Tested this via localhost; updated unit test coverage for the change

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
