### PR TITLE
Fix logo flickering on color change

### DIFF
--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -193,7 +193,7 @@ angular.module('risevision.template-editor.directives')
           });
 
           function _updateLogoData(attributeData) {
-            if (attributeData && attributeData.components && brandingFactory.brandingSettings.logoFileMetadata) {
+            if (attributeData && attributeData.components) {
               var logoComponents = blueprintFactory.getLogoComponents();
 
               angular.forEach(logoComponents, function (logoComponent) {


### PR DESCRIPTION

## Description
The removed condition caused logo component to revert to default values, loading the default image and causing the flickering.

## Motivation and Context
Branding JTBDs

## How Has This Been Tested?
Manually tested locally and on stage-1.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

@alex-deaconu Please review. Thanks