### PR TITLE
Fix/issue 1186 dont autopublish

### DIFF
--- a/test/e2e/template-editor/cases/components/text.js
+++ b/test/e2e/template-editor/cases/components/text.js
@@ -71,9 +71,7 @@ var TextComponentScenarios = function () {
         helper.waitDisappear(presentationsListPage.getTemplateEditorLoader());
       });
 
-      it('should auto-save the Presentation, reload it, and validate changes were saved', function () {
-
-        //change presentation name
+      it('should change the Presentation name and auto-save', function () {
         presentationsListPage.changePresentationName(presentationName);
 
         //wait for presentation to be auto-saved
@@ -86,12 +84,19 @@ var TextComponentScenarios = function () {
           console.log(actualUrl);
         });
         browser.sleep(100);
+      });
 
-        //load presentation
+      it('should reload the Presentation, and validate changes were saved', function () {
         presentationsListPage.loadPresentation(presentationName);
+
         templateEditorPage.selectComponent("Text - Title");
         expect(textComponentPage.getTextInput().isEnabled()).to.eventually.be.true;
         expect(textComponentPage.getTextInput().getAttribute('value')).to.eventually.equal("Changed Text");
+      });
+
+      it('should not have auto-published the Presentation when navigating', function () {
+        // prevents reoccurrence of issue 1186
+        expect(templateEditorPage.getPublishButton().isEnabled()).to.eventually.be.true;
       });
     });
   });

--- a/test/unit/template-editor/controllers/ctr-template-editor.tests.js
+++ b/test/unit/template-editor/controllers/ctr-template-editor.tests.js
@@ -243,7 +243,7 @@ describe('controller: TemplateEditor', function() {
       factory.publish.should.not.have.been.called;
     });
 
-    it('should not change URL if there are no changes but user does not have schedules', function () {
+    it('should change URL if there are no changes and user does not have schedules', function () {
       var saveStub = sinon.stub(factory, 'save');
 
       sinon.stub($state, 'go');
@@ -254,8 +254,8 @@ describe('controller: TemplateEditor', function() {
       $scope.$apply();
 
       saveStub.should.not.have.been.called;
-      $state.go.should.not.have.been.called;
-      factory.publish.should.have.been.called;
+      $state.go.should.have.been.called;
+      factory.publish.should.not.have.been.called;
     });
 
     it('should not notify unsaved changes when changing URL if state is in Template Editor', function () {

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -87,7 +87,8 @@ angular.module('risevision.template-editor.controllers')
         _programSave();
       }
 
-      var _initializing = false;
+      var _bypassUnsaved = false,
+        _initializing = false;
       var _setUnsavedChanges = function (state) {
         $scope.hasUnsavedChanges = state;
 
@@ -149,6 +150,10 @@ angular.module('risevision.template-editor.controllers')
       $scope.$on('presentationPublished', _setUnsavedChangesAsync.bind(null, false));
 
       $scope.$on('$stateChangeStart', function (event, toState, toParams) {
+        if (_bypassUnsaved) {
+          _bypassUnsaved = false;
+          return;
+        }
         if (toState.name.indexOf('apps.editor.templates') === -1) {
           event.preventDefault();
 
@@ -158,7 +163,8 @@ angular.module('risevision.template-editor.controllers')
 
           savePromise
             .finally(function () {
-                $state.go(toState, toParams);
+              _bypassUnsaved = true;
+              $state.go(toState, toParams);
             });
         }
       });

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -87,8 +87,7 @@ angular.module('risevision.template-editor.controllers')
         _programSave();
       }
 
-      var _bypassUnsaved = false,
-        _initializing = false;
+      var _initializing = false;
       var _setUnsavedChanges = function (state) {
         $scope.hasUnsavedChanges = state;
 
@@ -150,30 +149,16 @@ angular.module('risevision.template-editor.controllers')
       $scope.$on('presentationPublished', _setUnsavedChangesAsync.bind(null, false));
 
       $scope.$on('$stateChangeStart', function (event, toState, toParams) {
-        if (_bypassUnsaved) {
-          _bypassUnsaved = false;
-          return;
-        }
         if (toState.name.indexOf('apps.editor.templates') === -1) {
           event.preventDefault();
 
           _clearSaveTimeout();
 
           var savePromise = $scope.hasUnsavedChanges ? $scope.factory.save() : $q.resolve();
-          var hasSchedules = scheduleFactory.hasSchedules();
 
           savePromise
-            .then(function () {
-              if (!hasSchedules) {
-                return $scope.factory.publish();
-              }
-            })
             .finally(function () {
-              // If the modal was displayed we can't navigate away, otherwise it will be closed by apps.js' $modalStack.dismissAll
-              if (hasSchedules) {
-                _bypassUnsaved = true;
                 $state.go(toState, toParams);
-              }
             });
         }
       });


### PR DESCRIPTION
## Description
Don't auto-publish when navigating away from a presentation
https://github.com/Rise-Vision/rise-vision-apps/issues/1186 

## Motivation and Context
When navigating away from a presentation, it was auto-published, which is incorrect behavior. This implementation removes the publish() call, and adds tests to ensure it won't happen again.

## How Has This Been Tested?
Open any 'Revised' presentation here:
https://apps-stage-9.risevision.com/editor/list?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c
and then navigate back to the presentation list using the 'Presentations' link above.

It should always navigate back, and it should never auto-publish the presentation.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed.
    - Automated and manual tests completed
    - Release plan - will be tested in production right after deployment
    - Simple rollback needed if there are problems 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to update documentation
No need to notify support
