### PR TITLE
Don't save RSS attribute data with an invalid RSS feed

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-rss.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-rss.tests.js
@@ -5,20 +5,14 @@ describe('directive: templateComponentRss', function() {
     element,
     factory,
     rssFeedValidation,
-    parsableResult = true,
-    isValidResult = true,
     sandbox = sinon.sandbox.create();
-
-  function getParsableResult() {
-    return parsableResult;
-  }
 
   beforeEach(function() {
     factory = { selected: { id: "TEST-ID" } };
 
     rssFeedValidation = {
-      isParsable: sandbox.stub().returns(parsableResult ? Q.resolve('VALID') : Q.resolve('NON_FEED')),
-      isValid: sandbox.stub().returns(isValidResult ? Q.resolve('VALID') : Q.resolve('INVALID_FEED'))
+      isParsable: sandbox.stub().returns(Q.resolve('VALID')),
+      isValid: sandbox.stub().returns(Q.resolve('VALID'))
     };
   });
 
@@ -127,12 +121,13 @@ describe('directive: templateComponentRss', function() {
 
     setTimeout(function(){
       expect(rssFeedValidation.isValid).to.have.been.called;
+      expect($scope.setAttributeData).to.have.been.called;
 
       done();
     }, 200);
   });
 
-  it('should not check feed parsability if invalid URL format', function() {
+  it('should not save or check feed parsability if invalid URL format', function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     var sampleData = {};
 
@@ -148,17 +143,18 @@ describe('directive: templateComponentRss', function() {
 
     // only 1 call from initial load, no subsequent call from invalid url entry
     expect(rssFeedValidation.isParsable.callCount).to.equal(1);
+    expect($scope.setAttributeData).to.not.have.been.called;
   });
 
-  it('should not check feed validity if feed parser response is not VALID', function(done) {
+  it('should not save or check feed validity if feed parser response is not VALID', function(done) {
     var directive = $scope.registerDirective.getCall(0).args[0];
     var sampleData = {};
+
+    rssFeedValidation.isParsable = sandbox.stub().returns(Q.resolve('NON_FEED'));
 
     $scope.getAvailableAttributeData = function(componentId, attributeName) {
       return sampleData[attributeName];
     };
-
-    parsableResult = false;
 
     directive.show();
 
@@ -166,9 +162,11 @@ describe('directive: templateComponentRss', function() {
     $scope.feedUrl = invalidUrl;
     $scope.saveFeed();
 
+    // 1 call from initial load and 1 call from feed url change
     expect(rssFeedValidation.isParsable.callCount).to.equal(2);
 
     setTimeout(function(){
+      expect($scope.setAttributeData).to.not.have.been.called;
       expect(rssFeedValidation.isValid).to.not.have.been.called;
 
       done();

--- a/web/scripts/template-editor/components/directives/dtv-component-rss.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-rss.js
@@ -23,7 +23,6 @@ angular.module('risevision.template-editor.directives')
 
           $scope.saveFeed = function () {
             if (_validateFeedUrl()) {
-              $scope.setAttributeData($scope.componentId, 'feedurl', $scope.feedUrl);
               $scope.spinner = true;
 
               _isFeedParsable();
@@ -76,6 +75,8 @@ angular.module('risevision.template-editor.directives')
             rssFeedValidation.isParsable($scope.feedUrl)
               .then(function (result) {
                 if (result === 'VALID') {
+                  $scope.setAttributeData($scope.componentId, 'feedurl', $scope.feedUrl);
+
                   _isFeedValid();
                 } else {
                   $scope.validationResult = result;


### PR DESCRIPTION
## Description
Don't save RSS attribute data unless feed parsability is considered VALID 

## Motivation and Context
We have been allowing a template presentation to be saved with an RSS feed that our feed-parser server can't parse as RSS (can be various reasons, i.e. site not found - 404). 

We should only save upon parsability being considered valid

## How Has This Been Tested?
Tested on staging - https://apps-stage-8.risevision.com/templates/edit/b077b1bb-1713-49cb-b72b-77f8f7fde9a5/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Tested manually
  - Added automated unit tests
  - Will re-validate on production after deployment
  - Rollback involves re-running previous master build on CCI followed by reverting code changes and merging them to master
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- Notifying Support and documentation not required
