### PR TITLE
Add warning for Storage trash action

### DIFF
--- a/test/e2e/storage/cases/trash.js
+++ b/test/e2e/storage/cases/trash.js
@@ -61,8 +61,18 @@ var TrashScenarios = function() {
         expect(storageHomePage.getMoveToTrashButton().isEnabled()).to.eventually.be.true;
       });
 
-      it('should delete the file',function(){
+      it('should show break file link warning',function(){
         storageHomePage.getMoveToTrashButton().click();
+
+        helper.wait(storageHomePage.getConfirmBreakLinkModal(), 'Confirm Break Link Modal');
+
+        expect(storageHomePage.getConfirmBreakLinkModal().isDisplayed()).to.eventually.be.true;
+      });
+
+      it('should delete the file',function(){
+        storageHomePage.getConfirmBreakLinkButton().click();
+
+        helper.waitDisappear(storageHomePage.getConfirmBreakLinkModal(), 'Confirm Break Link Modal');
 
         helper.waitDisappear(storageHomePage.getPendingOperationsPanel(), 'Pending Operations Panel');
 
@@ -113,6 +123,11 @@ var TrashScenarios = function() {
         //delete file
         filesListPage.getFileItems().get(0).click();
         storageHomePage.getMoveToTrashButton().click();
+
+        helper.wait(storageHomePage.getConfirmBreakLinkModal(), 'Confirm Break Link Modal');
+        storageHomePage.getConfirmBreakLinkButton().click();
+        helper.waitDisappear(storageHomePage.getConfirmBreakLinkModal(), 'Confirm Break Link Modal');
+
         helper.waitDisappear(storageHomePage.getPendingOperationsPanel(), 'Pending Operations Panel');
 
         //open Trash

--- a/test/e2e/storage/pages/storageHomePage.js
+++ b/test/e2e/storage/pages/storageHomePage.js
@@ -15,6 +15,9 @@ var StorageHomePage = function() {
   var deleteForeverButton = element(by.id('deleteForeverButton'));
   var confirmDeleteButton = element(by.id('confirmForm')).element(by.buttonText('Delete Forever'));
 
+  var confirmBreakLinkModal = element(by.id('breakLinkModal'));
+  var confirmBreakLinkButton = element(by.id('breakLinkModal')).element(by.buttonText('Okay'));
+
   var breadcrumbs = element.all(by.css('.breadcrumb li a'));
 
   var pendingOperationsPanel = element(by.id('pendingOperationsPanel'));
@@ -57,24 +60,31 @@ var StorageHomePage = function() {
   
   this.getCopyUrlButton = function() {
     return copyUrlButton;
-  }
+  };
 
   this.getMoveToTrashButton = function() {
     return moveToTrashButton;
-  }
+  };
 
   this.getRestoreFromTrashButton = function() {
     return restoreFromTrashButton;
-  }
+  };
 
   this.getDeleteForeverButton = function() {
     return deleteForeverButton;
-  }
+  };
 
   this.getConfirmDeleteButton = function() {
     return confirmDeleteButton;
-  }
+  };
 
+  this.getConfirmBreakLinkModal = function() {
+    return confirmBreakLinkModal;
+  };
+
+  this.getConfirmBreakLinkButton = function() {
+    return confirmBreakLinkButton;
+  };
 };
 
 module.exports = StorageHomePage;

--- a/test/unit/storage/services/svc-file-actions-factory.tests.js
+++ b/test/unit/storage/services/svc-file-actions-factory.tests.js
@@ -7,9 +7,7 @@ describe('service: fileActionsFactory', function() {
 
   var modalOpenMock = function() {
     return {
-      result: {
-        then: function(cb){ cb(); }
-      }
+      result: Q.resolve()
     };
   };
 
@@ -109,11 +107,7 @@ describe('service: fileActionsFactory', function() {
   });
 
   it('should exist',function(){
-    expect(fileActionsFactory).to.be.truely;
-
-    expect(fileActionsFactory.statusDetails).to.be.truely;
-    expect(fileActionsFactory.pendingOperations).to.be.truely;
-    expect(fileActionsFactory.isPOCollapsed).to.be.truely;
+    expect(fileActionsFactory).to.be.ok;
     
     expect(fileActionsFactory.downloadButtonClick).to.be.a('function');
     expect(fileActionsFactory.deleteButtonClick).to.be.a('function');
@@ -143,11 +137,57 @@ describe('service: fileActionsFactory', function() {
   });
 
   describe('trashButtonClick:', function(){
-    it('should enqueue trash action',function(){
-      var stub = sinon.stub(fileActionsFactory,'processFilesAction');
+    beforeEach(function() {
+      sandbox.stub($modal, 'open').returns({
+        result: Q.resolve()
+      });
+      sandbox.stub(fileActionsFactory,'processFilesAction');
+    });
+    
+    it('should open warning modal',function(done){
+      sandbox.stub(localStorageService, "get").returns('false');
+
+      fileActionsFactory.trashButtonClick();
+      
+      setTimeout(function() {
+        $modal.open.should.have.been.called;
+        expect($modal.open.getCall(0).args[0].templateUrl).to.equal('partials/storage/break-link-warning-modal.html');
+        expect($modal.open.getCall(0).args[0].controller).to.equal('BreakLinkWarningModalCtrl');
+        expect($modal.open.getCall(0).args[0].resolve).to.be.ok;
+        expect($modal.open.getCall(0).args[0].resolve.infoLine1Key()).to.equal('storage-client.breaking-link-warning.text1');
+
+        fileActionsFactory.processFilesAction.should.have.been.calledWith(storage.trash.move, 'delete');
+        
+        done();
+      }, 10);
+    });
+
+    it('should not open warning modal',function(done){
+      sandbox.stub(localStorageService, "get").returns('true');
+
+      fileActionsFactory.trashButtonClick();
+      
+      setTimeout(function() {
+        $modal.open.should.not.have.been.called;
+
+        fileActionsFactory.processFilesAction.should.have.been.calledWith(storage.trash.move, 'delete');
+        
+        done();
+      }, 10);
+    });
+
+    it('should not enqueue trash action',function(done){
+      $modal.open.returns({
+        result: Q.reject()
+      });
+
       fileActionsFactory.trashButtonClick();
 
-      stub.should.have.been.calledWith(storage.trash.move, 'delete');
+      setTimeout(function() {
+        fileActionsFactory.processFilesAction.should.not.have.been.called;
+
+        done();
+      }, 10);
     });
   });
 

--- a/web/scripts/storage/services/svc-file-actions-factory.js
+++ b/web/scripts/storage/services/svc-file-actions-factory.js
@@ -19,7 +19,9 @@ angular.module('risevision.storage.services')
         };
 
         factory.trashButtonClick = function () {
-          factory.processFilesAction(storage.trash.move, 'delete');
+          return _showBreakLinkWarning().then(function () {
+            factory.processFilesAction(storage.trash.move, 'delete');
+          });
         };
 
         factory.restoreButtonClick = function () {


### PR DESCRIPTION
## Description
Add warning for Storage trash action

## Motivation and Context
Inform user that moving their files to Trash will break links in their Presentations

## How Has This Been Tested?
Tested in local environment, updated unit and e2e tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
