### PR TITLE
Don't show pricing message for Companies created after Jun 25

### DIFF
--- a/test/unit/common/directives/dtv-pricing-changes-message.tests.js
+++ b/test/unit/common/directives/dtv-pricing-changes-message.tests.js
@@ -1,0 +1,116 @@
+'use strict';
+describe('directive: pricingChangesMessage', function() {
+  var $compile,
+      $rootScope,
+      $scope,
+      element,
+      selectedCompany,
+      localStorageService;
+  beforeEach(module('risevision.apps.directives'));
+  beforeEach(module(function ($provide) {
+    $provide.service('userState', function() {
+      return {
+        getCopyOfSelectedCompany: function() {
+          return selectedCompany;
+        }
+      };
+    });
+    $provide.service('localStorageService', function() {
+      return localStorageService;
+    });   
+    
+  }));
+  beforeEach(inject(function(_$compile_, _$rootScope_, $templateCache){
+    selectedCompany = {};
+    localStorageService = {
+        get: sinon.stub().returns('false'),
+        set: sinon.stub()
+    };
+
+    $compile = _$compile_;
+    $rootScope = _$rootScope_;
+    $templateCache.put('partials/common/pricing-changes-message.html', '<p>mock</p>');
+  }));
+
+  function compileDirective() {
+    element = $compile('<pricing-changes-message></pricing-changes-message>')($rootScope.$new());
+    $rootScope.$digest();
+    $scope = element.isolateScope();   
+  }
+
+  describe('initialization', function() {
+    beforeEach(compileDirective);
+
+    it('should compile', function() {
+      expect(element[0].outerHTML).to.equal('<pricing-changes-message class="ng-scope ng-isolate-scope"><p>mock</p></pricing-changes-message>');
+    });
+
+    it('should initialize scope', function() {
+      expect($scope.alertVisible).to.be.a('function');
+      expect($scope.dismissAlert).to.be.a('function');
+    });
+
+    it('should check localStorage value', function() {
+      localStorageService.get.should.have.been.calledWith('pricingChangesAlert.dismissed');
+    });
+  });
+
+  describe('alertVisible:', function() {
+    it('should not show alert if company is missing',function() {
+      compileDirective();
+
+      expect($scope.alertVisible()).to.be.false;
+    });
+
+    it('should not show alert if company is missing',function() {
+      compileDirective();
+
+      expect($scope.alertVisible()).to.be.false;
+    });
+
+    it('should not show notice if company creationDate is after Jun 25', function() {
+      selectedCompany.creationDate = 'Jun 26, 2019';
+      compileDirective();
+
+      expect($scope.alertVisible()).to.be.false;      
+    });
+
+    it('should show notice if company creationDate is before Jun 25',function() {
+      selectedCompany.creationDate = 'Jun 24, 2019';
+      compileDirective();
+
+      expect($scope.alertVisible()).to.be.true;
+    });    
+
+    it('should update value when the Selected Company Changes', function() {
+      selectedCompany.creationDate = 'Jun 26, 2019';
+      compileDirective();
+
+      expect($scope.alertVisible()).to.be.false;      
+
+      selectedCompany.creationDate = 'Jun 24, 2019';
+
+      $scope.$broadcast('risevision.company.selectedCompanyChanged');
+      $scope.$digest();
+
+      expect($scope.alertVisible()).to.be.true;      
+    });
+  });
+
+  describe('dismissAlert:',function() {
+    beforeEach(compileDirective);
+
+    it('should update local storage value', function() {
+      $scope.dismissAlert();
+
+      localStorageService.set.should.have.been.calledWith('pricingChangesAlert.dismissed', 'true');
+    });
+
+    it('should no longer show the alert', function() {
+      $scope.dismissAlert();
+
+      expect($scope.alertVisible()).to.be.false;
+    });
+  });
+
+});

--- a/test/unit/common/directives/dtv-pricing-changes-message.tests.js
+++ b/test/unit/common/directives/dtv-pricing-changes-message.tests.js
@@ -62,12 +62,6 @@ describe('directive: pricingChangesMessage', function() {
       expect($scope.alertVisible()).to.be.false;
     });
 
-    it('should not show alert if company is missing',function() {
-      compileDirective();
-
-      expect($scope.alertVisible()).to.be.false;
-    });
-
     it('should not show notice if company creationDate is after Jun 25', function() {
       selectedCompany.creationDate = 'Jun 26, 2019';
       compileDirective();

--- a/web/partials/common/pricing-changes-message.html
+++ b/web/partials/common/pricing-changes-message.html
@@ -1,4 +1,4 @@
-<div class="alert alert-info mt-4" ng-show="alertVisible">
+<div class="alert alert-info mt-4" ng-show="alertVisible()">
   <div class="fa fa-times pull-right u_clickable" ng-click="dismissAlert()"></div>
 
   We are making changes to our pricing.

--- a/web/scripts/common/directives/dtv-pricing-changes-message.js
+++ b/web/scripts/common/directives/dtv-pricing-changes-message.js
@@ -2,35 +2,37 @@
 
 angular.module('risevision.apps.directives')
   .directive('pricingChangesMessage', ['localStorageService', 'userState',
-  function (localStorageService, userState) {
-    return {
-      restrict: 'E',
-      scope: {},
-      templateUrl: 'partials/common/pricing-changes-message.html',
-      link: function ($scope) {
-        var alertDismissedKey = 'pricingChangesAlert.dismissed';
-        var alertDismissed = localStorageService.get(alertDismissedKey) === 'true';
-        var isPastCreationDate = false;
+    function (localStorageService, userState) {
+      return {
+        restrict: 'E',
+        scope: {},
+        templateUrl: 'partials/common/pricing-changes-message.html',
+        link: function ($scope) {
+          var alertDismissedKey = 'pricingChangesAlert.dismissed';
+          var alertDismissed = localStorageService.get(alertDismissedKey) === 'true';
+          var isPastCreationDate = false;
 
-        var _checkCreationDate = function() {
-          var company = userState.getCopyOfSelectedCompany();
-          var creationDate = ((company && company.creationDate) ? (new Date(company.creationDate)) : (new Date()));
+          var _checkCreationDate = function () {
+            var company = userState.getCopyOfSelectedCompany();
+            var creationDate = ((company && company.creationDate) ? (new Date(company.creationDate)) : (
+            new Date()));
 
-          isPastCreationDate = creationDate < new Date('June 25, 2019');
-        };
+            isPastCreationDate = creationDate < new Date('June 25, 2019');
+          };
 
-        _checkCreationDate();
+          _checkCreationDate();
 
-        $scope.$on('risevision.company.selectedCompanyChanged', _checkCreationDate);
+          $scope.$on('risevision.company.selectedCompanyChanged', _checkCreationDate);
 
-        $scope.alertVisible = function() {
-          return !alertDismissed && isPastCreationDate;
-        };
+          $scope.alertVisible = function () {
+            return !alertDismissed && isPastCreationDate;
+          };
 
-        $scope.dismissAlert = function () {
-          alertDismissed = true;
-          localStorageService.set(alertDismissedKey, 'true');
-        };
-      }
-    };
-  }]);
+          $scope.dismissAlert = function () {
+            alertDismissed = true;
+            localStorageService.set(alertDismissedKey, 'true');
+          };
+        }
+      };
+    }
+  ]);

--- a/web/scripts/common/directives/dtv-pricing-changes-message.js
+++ b/web/scripts/common/directives/dtv-pricing-changes-message.js
@@ -1,17 +1,34 @@
 'use strict';
 
 angular.module('risevision.apps.directives')
-  .directive('pricingChangesMessage', ['localStorageService', function (localStorageService) {
+  .directive('pricingChangesMessage', ['localStorageService', 'userState',
+  function (localStorageService, userState) {
     return {
       restrict: 'E',
+      scope: {},
       templateUrl: 'partials/common/pricing-changes-message.html',
       link: function ($scope) {
         var alertDismissedKey = 'pricingChangesAlert.dismissed';
+        var alertDismissed = localStorageService.get(alertDismissedKey) === 'true';
+        var isPastCreationDate = false;
 
-        $scope.alertVisible = localStorageService.get(alertDismissedKey) !== 'true';
+        var _checkCreationDate = function() {
+          var company = userState.getCopyOfSelectedCompany();
+          var creationDate = ((company && company.creationDate) ? (new Date(company.creationDate)) : (new Date()));
+
+          isPastCreationDate = creationDate < new Date('June 25, 2019');
+        };
+
+        _checkCreationDate();
+
+        $scope.$on('risevision.company.selectedCompanyChanged', _checkCreationDate);
+
+        $scope.alertVisible = function() {
+          return !alertDismissed && isPastCreationDate;
+        };
 
         $scope.dismissAlert = function () {
-          $scope.alertVisible = false;
+          alertDismissed = true;
           localStorageService.set(alertDismissedKey, 'true');
         };
       }

--- a/web/scripts/template-editor/components/services/svc-branding-factory.js
+++ b/web/scripts/template-editor/components/services/svc-branding-factory.js
@@ -12,7 +12,7 @@ angular.module('risevision.template-editor.services')
         brandingSettings: null
       };
 
-      var _refreshMetadata = function() {
+      var _refreshMetadata = function () {
         if (factory.brandingSettings.logoFile) {
           fileExistenceCheckService.requestMetadataFor([factory.brandingSettings.logoFile],
               DEFAULT_IMAGE_THUMBNAIL)

--- a/web/scripts/template-editor/directives/dtv-basic-uploader.js
+++ b/web/scripts/template-editor/directives/dtv-basic-uploader.js
@@ -2,9 +2,11 @@
 
 angular.module('risevision.template-editor.directives')
   .constant('ALLOWED_VALID_TYPES', ['video', 'image'])
-  .directive('basicUploader', ['storage', 'fileUploaderFactory', 'UploadURIService', 'templateEditorUtils', 'presentationUtils',
+  .directive('basicUploader', ['storage', 'fileUploaderFactory', 'UploadURIService', 'templateEditorUtils',
+    'presentationUtils',
     'STORAGE_UPLOAD_CHUNK_SIZE', 'ALLOWED_VALID_TYPES',
-    function (storage, fileUploaderFactory, UploadURIService, templateEditorUtils, presentationUtils, STORAGE_UPLOAD_CHUNK_SIZE, ALLOWED_VALID_TYPES) {
+    function (storage, fileUploaderFactory, UploadURIService, templateEditorUtils, presentationUtils,
+      STORAGE_UPLOAD_CHUNK_SIZE, ALLOWED_VALID_TYPES) {
       return {
         restrict: 'E',
         scope: {


### PR DESCRIPTION
## Description
Check companyCreation date for pricing changes message
Do not show message if Company was created after Jun 25, 2019

## Motivation and Context
Those Companies were already on-boarded with the new pricing

## How Has This Been Tested?
Tested in the local environment and added unit tests for the directive

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
