### PR TITLE
Watch branding factory colors directly

### DIFF
--- a/test/unit/template-editor/components/services/svc-branding-factory.tests.js
+++ b/test/unit/template-editor/components/services/svc-branding-factory.tests.js
@@ -111,49 +111,6 @@ describe('service: brandingFactory', function() {
 
   });
 
-  describe('risevision.company.updated: ', function() {
-    it('should load branding settings on event', function() {
-      userState.getCopyOfSelectedCompany.returns({
-        settings: {}
-      });
-
-      $rootScope.$emit('risevision.company.updated');
-      $rootScope.$digest();
-
-      expect(brandingFactory.brandingSettings).to.deep.equal({
-        baseColor: undefined,
-        accentColor: undefined,
-        logoFile: undefined,
-        logoFileMetadata: []
-      });
-    });
-
-    it('should update branding settings on subsequent events', function() {
-      userState.getCopyOfSelectedCompany.returns({
-        settings: {}
-      });
-
-      $rootScope.$emit('risevision.company.updated');
-      $rootScope.$digest();
-
-      userState.getCopyOfSelectedCompany.returns({
-        settings: {
-          brandingDraftLogoFile: 'logoFile'
-        }
-      });
-
-      $rootScope.$emit('risevision.company.updated');
-      $rootScope.$digest();
-
-      expect(brandingFactory.brandingSettings).to.deep.equal({
-        baseColor: undefined,
-        accentColor: undefined,
-        logoFile: 'logoFile'
-      });
-    });
-
-  });
-
   describe('risevision.company.selectedCompanyChanged: ', function() {
     it('should update branding settings on event', function() {
       brandingFactory.brandingSettings = 'previousBranding';
@@ -170,6 +127,30 @@ describe('service: brandingFactory', function() {
         accentColor: undefined,
         logoFile: undefined,
         logoFileMetadata: []
+      });
+    });
+
+    it('should update branding settings on subsequent events', function() {
+      userState.getCopyOfSelectedCompany.returns({
+        settings: {}
+      });
+
+      $rootScope.$emit('risevision.company.selectedCompanyChanged');
+      $rootScope.$digest();
+
+      userState.getCopyOfSelectedCompany.returns({
+        settings: {
+          brandingDraftLogoFile: 'logoFile'
+        }
+      });
+
+      $rootScope.$emit('risevision.company.selectedCompanyChanged');
+      $rootScope.$digest();
+
+      expect(brandingFactory.brandingSettings).to.deep.equal({
+        baseColor: undefined,
+        accentColor: undefined,
+        logoFile: 'logoFile'
       });
     });
 

--- a/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
+++ b/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
@@ -131,6 +131,22 @@ describe('directive: TemplateEditorPreviewHolder', function() {
         done();
       },10);
     });    
+
+    it('posts display data when branding colors have changed', function(done) {
+      iframe.onload();
+      iframe.contentWindow.postMessage.reset();
+      brandingFactory.brandingSettings.baseColor = "newBaseColor";
+      brandingFactory.brandingSettings.accentColor = "newAccentColor";
+      $scope.$digest();
+      $timeout.flush();
+
+      setTimeout(function(){
+        iframe.contentWindow.postMessage.should.have.been.called;
+        expect(iframe.contentWindow.postMessage.getCall(0).args).to.deep.equal(['{"type":"displayData","value":{"displayAddress":{},"companyBranding":{"baseColor":"newBaseColor","accentColor":"newAccentColor"}}}', 'https://widgets.risevision.com']);
+
+        done();
+      },10);
+    });    
   });
 
   describe('_updateLogoData', function() {

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -86,6 +86,12 @@ angular.module('risevision.template-editor.directives')
           function _loadSelectedImages() {
             var selectedImages = imageFactory.getImagesAsMetadata();
 
+            // Show logo in the image list if component is set to use logo and a logo is available 
+            var logoAsMetadata = logoImageFactory.getImagesAsMetadata();
+            if (!$scope.isEditingLogo() && imageFactory.isSetAsLogo() && logoAsMetadata.length > 0) {
+              selectedImages = logoAsMetadata;
+            }
+
             if (selectedImages) {
               _setSelectedImages(selectedImages);
             }
@@ -160,12 +166,6 @@ angular.module('risevision.template-editor.directives')
           function _setSelectedImages(selectedImages) {
             var filesAttribute =
               fileMetadataUtilsService.filesAttributeFor(selectedImages);
-
-            // Show logo in the image list if component is set to use logo and a logo is available 
-            var logoAsMetadata = logoImageFactory.getImagesAsMetadata();
-            if (!$scope.isEditingLogo() && imageFactory.isSetAsLogo() && logoAsMetadata.length > 0) {
-              selectedImages = logoAsMetadata;
-            }
 
             $scope.selectedImages = selectedImages;
             $scope.isDefaultImageList = filesAttribute === _getDefaultFilesAttribute();

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -86,12 +86,6 @@ angular.module('risevision.template-editor.directives')
           function _loadSelectedImages() {
             var selectedImages = imageFactory.getImagesAsMetadata();
 
-            // Show logo in the image list if component is set to use logo and a logo is available 
-            var logoAsMetadata = logoImageFactory.getImagesAsMetadata();
-            if (!$scope.isEditingLogo() && imageFactory.isSetAsLogo() && logoAsMetadata.length > 0) {
-              selectedImages = logoAsMetadata;
-            }
-
             if (selectedImages) {
               _setSelectedImages(selectedImages);
             }
@@ -166,6 +160,12 @@ angular.module('risevision.template-editor.directives')
           function _setSelectedImages(selectedImages) {
             var filesAttribute =
               fileMetadataUtilsService.filesAttributeFor(selectedImages);
+
+            // Show logo in the image list if component is set to use logo and a logo is available 
+            var logoAsMetadata = logoImageFactory.getImagesAsMetadata();
+            if (!$scope.isEditingLogo() && imageFactory.isSetAsLogo() && logoAsMetadata.length > 0) {
+              selectedImages = logoAsMetadata;
+            }
 
             $scope.selectedImages = selectedImages;
             $scope.isDefaultImageList = filesAttribute === _getDefaultFilesAttribute();

--- a/web/scripts/template-editor/components/services/svc-branding-factory.js
+++ b/web/scripts/template-editor/components/services/svc-branding-factory.js
@@ -42,10 +42,6 @@ angular.module('risevision.template-editor.services')
         _refreshMetadata();
       };
 
-      $rootScope.$on('risevision.company.updated', function () {
-        _loadBranding(true);
-      });
-
       $rootScope.$on('risevision.company.selectedCompanyChanged', function () {
         _loadBranding(true);
       });

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -176,11 +176,19 @@ angular.module('risevision.template-editor.directives')
             _postAttributeData();
           }, true);
 
+          $scope.$watchGroup([
+            'brandingFactory.brandingSettings.baseColor',
+            'brandingFactory.brandingSettings.accentColor'
+          ], function () {
+            $timeout(function () {
+              _postDisplayData();
+            });
+          });
+
           $scope.$on('risevision.company.updated', function () {
             // ensure branding factory updates branding via the same handler
             $timeout(function () {
               _postDisplayData();
-              _postAttributeData();
             });
           });
 
@@ -188,7 +196,6 @@ angular.module('risevision.template-editor.directives')
             // ensure branding factory updates branding via the same handler
             $timeout(function () {
               _postDisplayData();
-              _postAttributeData();
             });
           });
 


### PR DESCRIPTION
## Description
Preview holder watches colors directly linked to text boxes
so that preview updates on every color change

Remove watch for company.updated message

Only perform logo check on show function for image component

[stage-18]


## Motivation and Context
Fix #1249 

## How Has This Been Tested?
This was tested in the local environment using the preview holder workaround for a *.risevision.com domain.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
