### PR TITLE
Swap template-editor confirm buttons

### DIFF
--- a/web/partials/template-editor/confirm-modal.html
+++ b/web/partials/template-editor/confirm-modal.html
@@ -11,13 +11,13 @@
   <div class="modal-footer">
     <div class="row">
       <div class="col-xs-6">
-        <button class="btn btn-default w-100" ng-click="cancel()">
-          <span translate="{{cancelButton}}"></span>
+        <button id="confirm-primary" class="btn btn-primary w-100" ng-click="ok()">
+          <span translate="{{confirmationButton}}"></span>
         </button>
       </div>
       <div class="col-xs-6">
-        <button id="confirm-primary" class="btn btn-primary w-100" ng-click="ok()">
-          <span translate="{{confirmationButton}}"></span>
+        <button class="btn btn-default w-100" ng-click="cancel()">
+          <span translate="{{cancelButton}}"></span>
         </button>
       </div>
     </div>

--- a/web/partials/template-editor/more-info-modal.html
+++ b/web/partials/template-editor/more-info-modal.html
@@ -1,0 +1,25 @@
+<form id="confirmForm">
+  <div class="modal-header">
+    <button type="button" class="close" ng-click="dismiss()" data-dismiss="modal" aria-hidden="true">
+      <streamline-icon name="close" width="12" height="12"></streamline-icon>
+    </button>
+  </div>
+  <div class="modal-body" stop-event="touchend">
+    <h4 ng-if="confirmationTitle" translate>{{confirmationTitle}}</h4>
+    <p translate>{{confirmationMessage}}</p>
+  </div>
+  <div class="modal-footer">
+    <div class="row">
+      <div class="col-xs-6">
+        <button class="btn btn-default w-100" ng-click="cancel()">
+          <span translate="{{cancelButton}}"></span>
+        </button>
+      </div>
+      <div class="col-xs-6">
+        <button id="confirm-primary" class="btn btn-primary w-100" ng-click="ok()">
+          <span translate="{{confirmationButton}}"></span>
+        </button>
+      </div>
+    </div>
+  </div>
+</form>

--- a/web/scripts/template-editor/services/svc-financial-license-factory.js
+++ b/web/scripts/template-editor/services/svc-financial-license-factory.js
@@ -20,7 +20,7 @@ angular.module('risevision.template-editor.services')
 
       var _showFinancialDataLicenseRequiredMessage = function () {
         var modalInstance = $modal.open({
-          template: $templateCache.get('partials/template-editor/confirm-modal.html'),
+          template: $templateCache.get('partials/template-editor/more-info-modal.html'),
           controller: 'confirmInstance',
           windowClass: 'madero-style centered-modal financial-data-license-message',
           resolve: {

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -43,7 +43,7 @@ angular.module('risevision.template-editor.services')
 
       var _openExpiredModal = function () {
         var modalInstance = $modal.open({
-          templateUrl: 'partials/template-editor/confirm-modal.html',
+          templateUrl: 'partials/template-editor/more-info-modal.html',
           controller: 'confirmInstance',
           windowClass: 'madero-style centered-modal',
           resolve: {


### PR DESCRIPTION
## Description
Swap template-editor confirm buttons
Confirm action first followed by Cancel second

As this is a shared partial, the following modals are affected:
- Remove Logo
- Delete Template

The following modals are **not** affected, ie. have been moved to a different partial:
- Financial License notification
- Expired Subscription notification

## Motivation and Context
Fix #1248 

## How Has This Been Tested?
Validated button order for all 4 modals in the local environment.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
