### PR TITLE
Add helper function to wait for spinners

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "rollup-plugin-node-resolve": "^5.0.3",
     "rollup-plugin-terser": "^5.0.0",
     "run-sequence": "^1.1.1",
-    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git",
+    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git#feature/spinner-wait",
     "terser": "^4.0.0",
     "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "rollup-plugin-node-resolve": "^5.0.3",
     "rollup-plugin-terser": "^5.0.0",
     "run-sequence": "^1.1.1",
-    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git#feature/spinner-wait",
+    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git",
     "terser": "^4.0.0",
     "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
   },

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -111,6 +111,9 @@ var FirstSigninScenarios = function() {
       it('should show last step after reload',function(){
         browser.refresh();
         helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+
+        // wait for transition
+        browser.sleep(1000);
         
         expect(getStartedPage.getWizardStep4().isDisplayed()).to.eventually.be.true;
         

--- a/test/e2e/common/pages/purchaseFlowModalPage.js
+++ b/test/e2e/common/pages/purchaseFlowModalPage.js
@@ -71,9 +71,9 @@ var PurchaseFlowModalPage = function() {
     browser.sleep(1000);
     helper.clickWhenClickable(this.getContinueButton(), 'Purchase flow Payment');
     helper.wait(this.getPayButton(), 'Purchase flow Payment');
-    browser.sleep(3000);
+    helper.waitForSpinner();
     helper.clickWhenClickable(this.getPayButton(), 'Purchase flow Review');
-    helper.waitDisappear(this.getPayButton(), 'Purchase flow Complete');
+    helper.waitForSpinner();
 
     console.log('Purchase complete');
 

--- a/test/e2e/template-editor/template-editor.cases.js
+++ b/test/e2e/template-editor/template-editor.cases.js
@@ -30,7 +30,7 @@
     }
 
     function _purchaseSubscription() {
-      helper.waitDisappear(presentationsListPage.getPresentationsLoader(), 'Presentation loader');
+      helper.waitForSpinner();
       helper.wait(templateEditorPage.seePlansLink(), 'See Plans Link');
       helper.clickWhenClickable(templateEditorPage.seePlansLink(), 'See Plans Link');
 


### PR DESCRIPTION
## Description
Add helper function to wait for spinners
Update in rv-common-e2e repo
Fix purchase flow spinner issue
Add wait for transition

## Motivation and Context
This helper function will allow waiting for spinner code to be much simpler. `id`s will no longer be needed for spinners, no additional element defined, etc. If there's a spinner showing, it will wait for it to hide based on the CSS classes specific to the spinner library.

## How Has This Been Tested?
Updated some sample e2e tests to validate.

There are no code changes in this PR, just e2e related changes.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
