### PR TITLE
Branding should not be revised if Template is not branded

### DIFF
--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -64,6 +64,8 @@ var FirstSigninScenarios = function() {
         _waitFullPageLoad();
 
         commonHeaderPage.createSubCompany(subCompanyName);
+        helper.waitForSpinner();
+
         commonHeaderPage.selectSubCompany(subCompanyName);
         _waitFullPageLoad();
       });

--- a/test/e2e/common/pages/purchaseFlowModalPage.js
+++ b/test/e2e/common/pages/purchaseFlowModalPage.js
@@ -43,6 +43,7 @@ var PurchaseFlowModalPage = function() {
   }
 
   this.purchase = function(useCreditCard) {
+    helper.waitForSpinner();
     helper.wait(this.getContinueButton(), 'Purchase flow Billing');
     browser.sleep(1000);
     helper.clickWhenClickable(this.getContinueButton(), 'Purchase flow Billing');
@@ -56,7 +57,8 @@ var PurchaseFlowModalPage = function() {
     this.getPC().sendKeys('M6P 1Z2');
     browser.sleep(1000);
     helper.clickWhenClickable(this.getContinueButton(), 'Purchase flow Shipping');
-    helper.waitDisappear(this.getCompanyNameField(), 'Purchase flow Shipping');
+    helper.waitForSpinner();
+    helper.wait(this.getCardName(), 'Purchase flow Payment');
     if (useCreditCard) {
       console.log('Purchase using Credit Card');
       this.getCardName().sendKeys('AAA');

--- a/test/unit/template-editor/components/services/svc-branding-factory.tests.js
+++ b/test/unit/template-editor/components/services/svc-branding-factory.tests.js
@@ -370,6 +370,10 @@ describe('service: brandingFactory', function() {
   });
 
   describe('isRevised', function() {
+    beforeEach(function() {
+      blueprintFactory.hasBranding.returns(true);
+    });
+
     it('should be false if settings does not exist', function() {
       expect(brandingFactory.isRevised()).to.be.false;
     });
@@ -378,6 +382,19 @@ describe('service: brandingFactory', function() {
       userState.getCopyOfSelectedCompany.returns({
         settings: {
           brandingLogoFile: 'logoFile',
+        }
+      });
+
+      expect(brandingFactory.isRevised()).to.be.false;
+    });
+
+    it('should be false if Template is not branded', function() {
+      blueprintFactory.hasBranding.returns(false);
+
+      userState.getCopyOfSelectedCompany.returns({
+        settings: {
+          brandingDraftLogoFile: 'draftLogoFile',
+          brandingRevisionStatusName: 'Revised'
         }
       });
 
@@ -395,7 +412,7 @@ describe('service: brandingFactory', function() {
       expect(brandingFactory.isRevised()).to.be.true;
     });
 
-    it('should be falsed otherwise', function() {
+    it('should be false otherwise', function() {
       userState.getCopyOfSelectedCompany.returns({
         settings: {
           brandingDraftAccentColor: 'draftAccentColor',

--- a/web/scripts/template-editor/components/services/svc-branding-factory.js
+++ b/web/scripts/template-editor/components/services/svc-branding-factory.js
@@ -94,6 +94,10 @@ angular.module('risevision.template-editor.services')
       };
 
       factory.isRevised = function () {
+        if (!blueprintFactory.hasBranding()) {
+          return false;
+        }
+
         var company = userState.getCopyOfSelectedCompany();
 
         return !!(company.settings && company.settings.brandingRevisionStatusName === REVISION_STATUS_REVISED);


### PR DESCRIPTION
## Description
Branding should not be revised if Template is not branded
Disables Publish button for non Branded templates

Various e2e test improvements, some from the other branch

[stage-2]

## Motivation and Context
Fixes issue where Branding settings are mistakenly published in non Branded templates

## How Has This Been Tested?
Verified in the local environment. The Publish button is disabled if the Template is not in the revised state. Also, if the Publish button is clicked (when the Template is in revised state), the unpublished Branding settings are not published.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
