### PR TITLE
Update RSS e2e tests to grab the first matching element

### DIFF
--- a/test/e2e/template-editor/cases/components/rss.js
+++ b/test/e2e/template-editor/cases/components/rss.js
@@ -16,7 +16,7 @@ var RssComponentScenarios = function () {
     var presentationsListPage;
     var templateEditorPage;
     var rssComponentPage;
-    var componentLabel = 'RSS - Test Feed';
+    var componentLabel = 'RSS - Top left';
 
     before(function () {
       presentationsListPage = new PresentationListPage();

--- a/test/e2e/template-editor/cases/components/rss.js
+++ b/test/e2e/template-editor/cases/components/rss.js
@@ -35,7 +35,7 @@ var RssComponentScenarios = function () {
         expect(rssComponentPage.getRssFeedInput().isEnabled()).to.eventually.be.true;
         expect(rssComponentPage.getRssFeedInput().getAttribute('value')).to.eventually.equal('https://www.feedforall.com/sample.xml');
         expect(rssComponentPage.getRssMaxItemsSelect().isEnabled()).to.eventually.be.true;
-        expect(rssComponentPage.getRssMaxItemsSelect().getAttribute('value')).to.eventually.equal('15');
+        expect(rssComponentPage.getRssMaxItemsSelect().getAttribute('value')).to.eventually.equal('1');
       });
 
       function _testInvalidScenario (feedUrl, expectedMessageKey) {

--- a/test/e2e/template-editor/pages/components/rssComponentPage.js
+++ b/test/e2e/template-editor/pages/components/rssComponentPage.js
@@ -1,12 +1,13 @@
 'use strict';
 
 var RssComponentPage = function() {
-  var rssFeedInput = element.all(by.id('te-rss-feed')).get(0);
-  var rssMaxItemsSelect = element.all(by.id('te-rss-max-items')).get(0);
+  var rssFeedInput = element(by.id('te-rss-feed'));
+  var rssMaxItemsSelect = element(by.id('te-rss-max-items'));
   var loader = element(by.xpath('//div[@spinner-key="rss-editor-loader"]'));
   var validationError = element(by.xpath('//template-component-rss//p[@on="validationResult"]/span'));
   var validationIconError = element(by.xpath('//template-component-rss//streamline-icon[@name="exclamation"]'));
   var validationIconValid = element(by.xpath('//template-component-rss//streamline-icon[@name="checkmark"]'));
+
   
   this.getRssFeedInput = function () {
     return rssFeedInput;

--- a/test/e2e/template-editor/pages/components/rssComponentPage.js
+++ b/test/e2e/template-editor/pages/components/rssComponentPage.js
@@ -1,13 +1,12 @@
 'use strict';
 
 var RssComponentPage = function() {
-  var rssFeedInput = element(by.id('te-rss-feed'));
-  var rssMaxItemsSelect = element(by.id('te-rss-max-items'));
+  var rssFeedInput = element.all(by.id('te-rss-feed')).get(0);
+  var rssMaxItemsSelect = element.all(by.id('te-rss-max-items')).get(0);
   var loader = element(by.xpath('//div[@spinner-key="rss-editor-loader"]'));
   var validationError = element(by.xpath('//template-component-rss//p[@on="validationResult"]/span'));
   var validationIconError = element(by.xpath('//template-component-rss//streamline-icon[@name="exclamation"]'));
   var validationIconValid = element(by.xpath('//template-component-rss//streamline-icon[@name="checkmark"]'));
-
   
   this.getRssFeedInput = function () {
     return rssFeedInput;


### PR DESCRIPTION
## Description
Fixes RSS component Editor e2e tests 

## Motivation and Context
Updates to the example RSS template, made to provide for a better example and stress test the component, had broken the e2e tests in Apps

## How Has This Been Tested?
Successful build on CCI

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@alex-deaconu @stulees please review
