### PR TITLE
Do not show links to Company Settings if user does not have required role

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-weather.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-weather.tests.js
@@ -6,7 +6,8 @@ describe('directive: templateComponentWeather', function() {
       factory,
       company,
       rootScope,
-      compile;
+      compile,
+      hasRole = true;
 
   beforeEach(function() {
     factory = { selected: { id: "TEST-ID" } };
@@ -32,6 +33,9 @@ describe('directive: templateComponentWeather', function() {
         _restoreState: function(){},
         getCopyOfSelectedCompany: function() { 
           return company;
+        },
+        hasRole: function(){
+          return hasRole;
         }
       };
     });
@@ -64,6 +68,7 @@ describe('directive: templateComponentWeather', function() {
     expect($scope.registerDirective).to.have.been.called;
     expect($scope.companySettingsFactory).to.be.ok;
     expect($scope.hasValidAddress).to.be.ok;
+    expect($scope.canEditCompany).to.be.true;
 
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
@@ -122,6 +127,22 @@ describe('directive: templateComponentWeather', function() {
     expect($scope.setAttributeData.calledWith(
       "TEST-ID", "scale", "updated weather"
     )).to.be.true;
+  });
+
+  describe('canEditCompany:',function(){
+    it('should be true if user has required role',function(){
+      hasRole = true;
+      compileDirective();
+      
+      expect($scope.canEditCompany).to.be.true;
+    });
+
+    it('should be false if user does not have required role',function(){
+      hasRole = false;
+      compileDirective();
+      
+      expect($scope.canEditCompany).to.be.false;
+    });
   });
 
   describe('hasValidAddress:',function(){

--- a/web/partials/billing/app-billing.html
+++ b/web/partials/billing/app-billing.html
@@ -87,7 +87,7 @@
       </div>
     </div><!--panel-->
 
-    <div class="panel panel-default">
+    <div class="panel panel-default" require-role="ua">
       <div class="panel-heading">
         <h3 class="panel-title">Account Information</h3>
       </div>

--- a/web/partials/template-editor/components/component-weather.html
+++ b/web/partials/template-editor/components/component-weather.html
@@ -1,7 +1,8 @@
 <div class="attribute-editor-component">
   <div class="attribute-editor-row">
-    <p ng-hide="hasValidAddress">Set an address to see the weather. Navigate to <a href="" ng-click="companySettingsFactory.openCompanySettings()">Company Settings</a>, enter your address and click Save.</p>
-    <p ng-show="hasValidAddress">This Template will show the weather for the Address of the Display it is playing on.</p>
+    <p ng-show="!hasValidAddress && !canEditCompany">Set an address to see the weather. Please contact your System Administrator to set an address to your company.</p>
+    <p ng-show="!hasValidAddress && canEditCompany">Set an address to see the weather. Navigate to <a href="" ng-click="companySettingsFactory.openCompanySettings()">Company Settings</a>, enter your address and click Save.</p>
+    <p ng-show="hasValidAddress">This Template will show the weather for the Address of the Display it is playing on.</p>    
     <label class="u_margin-sm-top">Display weather in:</label>
     <div class="radio">
       <input type="radio" ng-model="scale" value="F" id="farenheit" name="farenheit" ng-change="save()" aria-required="true" tabindex="1" required>

--- a/web/scripts/template-editor/components/directives/dtv-component-weather.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-weather.js
@@ -10,6 +10,7 @@ angular.module('risevision.template-editor.directives')
         link: function ($scope, element) {
           $scope.factory = templateEditorFactory;
           $scope.companySettingsFactory = companySettingsFactory;
+          $scope.canEditCompany = userState.hasRole('ua');
 
           var company = userState.getCopyOfSelectedCompany(true);
           $scope.hasValidAddress = !!(company.postalCode || (company.city && company.country));


### PR DESCRIPTION
## Description
Do not show links to Company Settings if user does not have required role.
Links were accessible from Billing page and Weather Component attributes editor.

## Motivation and Context
Fixes #1181.

## How Has This Been Tested?
Manually tested on stage-1

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

@alex-deaconu Please review. Thanks