### PR TITLE
Added error message when alert key cannot be reset

### DIFF
--- a/web/partials/displays/alerts.html
+++ b/web/partials/displays/alerts.html
@@ -31,6 +31,11 @@
 				<p class="u_remove-bottom"><i class="fa fa-warning icon-left"></i><span translate>displays-app.alerts.turnedOffWarning</span> <a href="" ng-click="$parent.alertsOn = true" translate>displays-app.alerts.turnOnShort</a></p>
 			</div>
 		</div><!--warning-->
+		
+		
+	    <div id="errorBox" ng-show="factory.apiError" class="alert alert-danger" role="alert">
+            <strong>{{factory.errorMessage}}</strong> {{factory.apiError}}
+        </div>
 
 		<div class="form-group">
 			<label class="control-label" translate>displays-app.alerts.webServiceURL</label>

--- a/web/scripts/displays/services/svc-alerts-factory.js
+++ b/web/scripts/displays/services/svc-alerts-factory.js
@@ -194,7 +194,7 @@ angular.module('risevision.displays.services')
           factory.savingAlerts = false;
           factory.errorSaving = true;
           factory.errorMessage = 'Failed to update Alerts.';
-          factory.apiError = humanReadableError(error.result?error.result:error);
+          factory.apiError = humanReadableError(error && error.result || error);
           $log.error(factory.errorMessage, error);
         });
       };

--- a/web/scripts/displays/services/svc-alerts-factory.js
+++ b/web/scripts/displays/services/svc-alerts-factory.js
@@ -2,12 +2,18 @@
 
 angular.module('risevision.displays.services')
   .factory('alertsFactory', ['$modal', 'companyService', 'userState', 'company',
-    '$log', 'regenerateCompanyField', '$filter',
+    '$log', 'regenerateCompanyField', '$filter','humanReadableError',
     function ($modal, companyService, userState, company, $log,
-      regenerateCompanyField, $filter) {
+      regenerateCompanyField, $filter, humanReadableError) {
       var factory = {};
 
       var _company = null;
+      
+      var _clearMessages = function () {
+
+          factory.errorMessage = '';
+          factory.apiError = '';
+        };
 
       var _updateSettings = function (company) {
         _company = company;
@@ -172,12 +178,12 @@ angular.module('risevision.displays.services')
         });
         modalInstance.result.then(function (presentationDetails) {
           factory.alertSettings.presentationId = presentationDetails[0];
-          factory.alertSettings.presentationName = presentationDetails[
-            1];
+          factory.alertSettings.presentationName = presentationDetails[1];
         });
       };
 
       factory.save = function () {
+    	_clearMessages();
         factory.savingAlerts = true;
         factory.errorSaving = false;
         company.updateAlerts(_company.id, _company).then(function (result) {
@@ -187,16 +193,21 @@ angular.module('risevision.displays.services')
         }, function (error) {
           factory.savingAlerts = false;
           factory.errorSaving = true;
-          console.error('Error updating Alerts', error);
+          factory.errorMessage = 'Failed to update Alerts.';
+          factory.apiError = humanReadableError(error.result?error.result:error);
+          $log.error(factory.errorMessage, error);
         });
       };
 
       factory.regenerateAlertKey = function () {
-        regenerateCompanyField(_company.id, 'alertKey').then(function (
-          result) {
+    	 _clearMessages(); 
+    	  
+        regenerateCompanyField(_company.id, 'alertKey').then(function (result) {
           factory.alertKey = result.item;
         }, function (error) {
-          console.error('Error regenerating alertKey', error);
+            factory.errorMessage = 'Failed to reset Web Service URL.';
+            factory.apiError = humanReadableError(error);
+            $log.error(factory.errorMessage, error);
         });
       };
 


### PR DESCRIPTION
## Description
Added error message when alert key cannot be reset. 

## Motivation and Context
As per vulnerability report Core allows a non-privileged user to reset the “Authentication Key” and “Claim ID” utilized by the company, move other companies under their company, which gives the attacker control over the victim’s company (specifically access to content, photos, etc).

## How Has This Been Tested?
Tested locally and using staged environment (stage-6).

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
Documentation was not updated because none exists for this functionality.