### PR TITLE
Use version of CH that moves credentials to request body

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "Sortable": "^1.4.2",
     "angular-truncate": "*",
     "angular-slugify": "^1.0.1",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.11.0",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.11.1",
     "oauthio-web": "0.6.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages",
     "xmlToJSON.js": "^1.3.2"


### PR DESCRIPTION
## Description
Use version of CH that moves credentials to request body. 

## Motivation and Context
As per vulnerability report the application exposes the user’s username and password used for authentication when logging into the application and when a user resets their password. Although both requests are using POST, the credentials are passed through the URL query rather than through the body. This allows the credentials to be stored in a multitude of unintended locations such as server logs, third-party sites (through the referrer header), proxies, and in the browser history. Attackers may also be able to obtain the credentials by sniffing the traffic of the victim through a Man-in-the-Middle (MitM) attack. This change eliminates this vulnerability.

## How Has This Been Tested?
Tested locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
N/A
