### PR TITLE
Update branding to use template-editor autosave

### DIFF
--- a/test/e2e/template-editor/cases/components/branding.js
+++ b/test/e2e/template-editor/cases/components/branding.js
@@ -98,6 +98,7 @@ var WeatherComponentScenarios = function () {
         helper.clickWhenClickable(templateEditorPage.getBackToComponentsButton(),'Back to Branding Settings');
         browser.sleep(1000);
       });
+
     });
 
     describe('Edit Branding Logo',function(){
@@ -128,6 +129,12 @@ var WeatherComponentScenarios = function () {
         it('should have a thumbnail', function() {
           expect(imageComponentPage.getThumbnails().count()).to.eventually.equal(1);
         });
+
+        it('should auto-save the Branding after adding file from storage', function () {
+          helper.wait(templateEditorPage.getSavingText(), 'Branding component auto-saving');
+          helper.wait(templateEditorPage.getSavedText(), 'Branding component auto-saved');
+        });
+
       });
 
       describe('subsequent upload - should list a single file', function () {
@@ -146,6 +153,12 @@ var WeatherComponentScenarios = function () {
         it('should list only the uploaded file', function() {
           expect(imageComponentPage.getSelectedImagesMain().count()).to.eventually.equal(1);
         });
+
+        it('should auto-save the Branding after adding file from storage', function () {
+          helper.wait(templateEditorPage.getSavingText(), 'Branding component auto-saving');
+          helper.wait(templateEditorPage.getSavedText(), 'Branding component auto-saved');
+        });
+
       });
 
       describe('storage',function(){
@@ -164,7 +177,13 @@ var WeatherComponentScenarios = function () {
           browser.sleep(1000);
           expect(imageComponentPage.getSelectedImagesMain().count()).to.eventually.equal(1);
         });
-      })
+
+        it('should auto-save the Branding after adding file from storage', function () {
+          helper.wait(templateEditorPage.getSavingText(), 'Branding component auto-saving');
+          helper.wait(templateEditorPage.getSavedText(), 'Branding component auto-saved');
+        });
+
+      });
     });
 
     describe('remove',function(){
@@ -174,7 +193,7 @@ var WeatherComponentScenarios = function () {
         browser.driver.manage().window().setSize(500, 800); 
       });
 
-      it('should aks for confirmation before removing logo', function () {
+      it('should asks for confirmation before removing logo', function () {
         var removeLink = imageComponentPage.getRemoveLinkFor('e2e-upload-image-2.png');
         helper.wait(removeLink, 'Image Row Remove');
         helper.clickWhenClickable(removeLink, 'Image Row Remove');

--- a/test/unit/template-editor/components/directives/dtv-branding-colors.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-branding-colors.tests.js
@@ -10,7 +10,7 @@ describe('directive: templateBrandingColors', function() {
   beforeEach(module(function ($provide) {
     $provide.service('brandingFactory', function() {
       return factory = {
-        updateDraftColors: sinon.spy()
+        setUnsavedChanges: sinon.spy()
       };
     });
   }));
@@ -51,7 +51,14 @@ describe('directive: templateBrandingColors', function() {
   it('saveBranding: ', function() {
     $scope.saveBranding();
 
-    factory.updateDraftColors.should.have.been.called;
+    factory.setUnsavedChanges.should.have.been.called;
+  });
+
+  it('colorpicker-selected event: ', function() {
+    $scope.$emit('colorpicker-selected');
+    $scope.$digest();
+
+    factory.setUnsavedChanges.should.have.been.called;
   });
 
   it('directive.show: ', function() {

--- a/test/unit/template-editor/components/services/svc-logo-image-factory.tests.js
+++ b/test/unit/template-editor/components/services/svc-logo-image-factory.tests.js
@@ -10,7 +10,7 @@ describe('service: logoImageFactory', function() {
     $provide.service('brandingFactory', function() {
       return {
         brandingSettings: {},
-        updateDraftLogo: sandbox.stub()
+        setUnsavedChanges: sandbox.stub()
       };
     });
     $provide.service('$q', function() {
@@ -144,7 +144,7 @@ describe('service: logoImageFactory', function() {
       expect(brandingFactory.brandingSettings.logoFile).to.equal('logo1');
       expect(brandingFactory.brandingSettings.logoFileMetadata).to.deep.equals(metadata);
       
-      brandingFactory.updateDraftLogo.should.have.been.called;
+      brandingFactory.setUnsavedChanges.should.have.been.called;
     });
 
     it('should set branding attributes with last metadata item and ignore the rest', function() {
@@ -156,7 +156,7 @@ describe('service: logoImageFactory', function() {
       expect(brandingFactory.brandingSettings.logoFile).to.equal('logo3');
       expect(brandingFactory.brandingSettings.logoFileMetadata).to.deep.equals([lastFile]);
       
-      brandingFactory.updateDraftLogo.should.have.been.called;
+      brandingFactory.setUnsavedChanges.should.have.been.called;
     });
 
     it('should clear branding attributes if no metadata items', function() {
@@ -167,7 +167,7 @@ describe('service: logoImageFactory', function() {
       expect(brandingFactory.brandingSettings.logoFile).to.equal('');
       expect(brandingFactory.brandingSettings.logoFileMetadata).to.deep.equals([]);
       
-      brandingFactory.updateDraftLogo.should.have.been.called;
+      brandingFactory.setUnsavedChanges.should.have.been.called;
     });
   });
 

--- a/test/unit/template-editor/controllers/ctr-template-editor.tests.js
+++ b/test/unit/template-editor/controllers/ctr-template-editor.tests.js
@@ -38,6 +38,9 @@ describe('controller: TemplateEditor', function() {
       presentation: { templateAttributeData: {} },
       getAttributeData: sandbox.stub().returns('data'),
       setAttributeData: sandbox.stub(),
+      isUnsaved: function() {
+        return factory.hasUnsavedChanges
+      },
       save: function() {
         return Q.resolve();
       },
@@ -109,8 +112,8 @@ describe('controller: TemplateEditor', function() {
   });
 
   it('should exist', function() {
-    expect($scope).to.be.truely;
-    expect($scope.factory).to.be.truely;
+    expect($scope).to.be.ok;
+    expect($scope.factory).to.be.ok;
     expect($scope.factory.presentation).to.be.ok;
     expect($scope.factory.presentation.templateAttributeData).to.deep.equal({});
   });
@@ -175,13 +178,13 @@ describe('controller: TemplateEditor', function() {
 
   describe('unsaved changes', function () {
     it('should flag unsaved changes to presentation', function () {
-      expect($scope.hasUnsavedChanges).to.be.false;
+      expect($scope.factory.hasUnsavedChanges).to.be.false;
       factory.presentation.id = '1234';
       factory.presentation.name = 'New Name';
       $scope.$apply();
       $timeout.flush();
 
-      expect($scope.hasUnsavedChanges).to.be.true;
+      expect($scope.factory.hasUnsavedChanges).to.be.true;
     });
 
     it('should clear unsaved changes flag after saving presentation', function () {
@@ -191,7 +194,7 @@ describe('controller: TemplateEditor', function() {
       $rootScope.$broadcast('presentationUpdated');
       $scope.$apply();
       $timeout.flush();
-      expect($scope.hasUnsavedChanges).to.be.false;
+      expect($scope.factory.hasUnsavedChanges).to.be.false;
     });
 
     it('should clear unsaved changes when deleting the presentation', function () {
@@ -200,7 +203,7 @@ describe('controller: TemplateEditor', function() {
       $scope.$apply();
       $rootScope.$broadcast('presentationDeleted');
       $scope.$apply();
-      expect($scope.hasUnsavedChanges).to.be.false;
+      expect($scope.factory.hasUnsavedChanges).to.be.false;
     });
 
     it('should not flag unsaved changes when publishing', function () {
@@ -210,7 +213,7 @@ describe('controller: TemplateEditor', function() {
       factory.presentation.changedBy = 'newUsername';
       $scope.$apply();
 
-      expect($scope.hasUnsavedChanges).to.be.false;
+      expect($scope.factory.hasUnsavedChanges).to.be.false;
     });
 
     it('should notify unsaved changes when changing URL', function () {
@@ -226,36 +229,6 @@ describe('controller: TemplateEditor', function() {
       $scope.$apply();
 
       saveStub.should.have.been.called;
-    });
-
-    it('should not notify unsaved changes when changing URL if there are no changes and user has schedules', function () {
-      var saveStub = sinon.stub(factory, 'save');
-
-      sinon.stub($state, 'go');
-      sinon.stub(factory, 'publish');
-      sinon.stub(scheduleFactory, 'hasSchedules').returns(true);
-
-      $rootScope.$broadcast('$stateChangeStart', { name: 'newState' });
-      $scope.$apply();
-
-      saveStub.should.not.have.been.called;
-      $state.go.should.have.been.called;
-      factory.publish.should.not.have.been.called;
-    });
-
-    it('should change URL if there are no changes and user does not have schedules', function () {
-      var saveStub = sinon.stub(factory, 'save');
-
-      sinon.stub($state, 'go');
-      sinon.stub(factory, 'publish');
-      sinon.stub(scheduleFactory, 'hasSchedules').returns(false);
-
-      $rootScope.$broadcast('$stateChangeStart', { name: 'newState' });
-      $scope.$apply();
-
-      saveStub.should.not.have.been.called;
-      $state.go.should.have.been.called;
-      factory.publish.should.not.have.been.called;
     });
 
     it('should not notify unsaved changes when changing URL if state is in Template Editor', function () {

--- a/test/unit/template-editor/services/svc-auto-save-service.tests.js
+++ b/test/unit/template-editor/services/svc-auto-save-service.tests.js
@@ -1,0 +1,139 @@
+'use strict';
+
+describe('service: auto save service', function() {
+  beforeEach(module('risevision.template-editor.services'));
+  beforeEach(module(mockTranlate()));
+
+  var autoSaveService, saveFunction, clock, $timeout, MINIMUM_INTERVAL_BETWEEN_SAVES, MAXIMUM_INTERVAL_BETWEEN_SAVES;
+  beforeEach(function(){
+    saveFunction = sinon.stub().returns(Q.resolve());
+    
+    inject(function($injector){
+      $timeout = $injector.get('$timeout');
+
+      MINIMUM_INTERVAL_BETWEEN_SAVES = $injector.get('MINIMUM_INTERVAL_BETWEEN_SAVES');
+      MAXIMUM_INTERVAL_BETWEEN_SAVES = $injector.get('MAXIMUM_INTERVAL_BETWEEN_SAVES');
+
+      var AutoSaveService = $injector.get('AutoSaveService');
+      autoSaveService = new AutoSaveService(saveFunction);
+    });
+  });
+
+  it('should exist',function(){
+    expect(autoSaveService).to.be.ok;
+    
+    expect(autoSaveService.save).to.be.a('function');
+    expect(autoSaveService.clearSaveTimeout).to.be.a('function');
+    expect(MINIMUM_INTERVAL_BETWEEN_SAVES).to.equal(5000);
+  });
+
+  describe('save: ',function(){
+    beforeEach(function(){
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('should save after minimum interval', function() {
+      autoSaveService.save();
+
+      saveFunction.should.not.have.been.called;
+
+      $timeout.flush(MINIMUM_INTERVAL_BETWEEN_SAVES / 2);
+
+      saveFunction.should.not.have.been.called;
+
+      $timeout.flush(MINIMUM_INTERVAL_BETWEEN_SAVES / 2);
+
+      saveFunction.should.have.been.calledOnce;
+    });
+
+    it('should reprogram save and save after minimum interval', function() {
+      autoSaveService.save();
+
+      saveFunction.should.not.have.been.called;
+
+      $timeout.flush(MINIMUM_INTERVAL_BETWEEN_SAVES / 2);
+
+      autoSaveService.save();
+
+      $timeout.flush(MINIMUM_INTERVAL_BETWEEN_SAVES / 2);
+
+      saveFunction.should.not.have.been.called;
+
+      $timeout.flush();
+
+      saveFunction.should.have.been.calledOnce;
+    });
+
+    it('should not reprogram save if we reach maximum interval', function() {
+      autoSaveService.save();
+
+      saveFunction.should.not.have.been.called;
+
+      $timeout.flush(MINIMUM_INTERVAL_BETWEEN_SAVES / 2);
+      clock.tick(MAXIMUM_INTERVAL_BETWEEN_SAVES);
+
+      autoSaveService.save();
+
+      $timeout.flush(MINIMUM_INTERVAL_BETWEEN_SAVES / 2);
+
+      saveFunction.should.have.been.calledOnce;
+
+      $timeout.flush(MINIMUM_INTERVAL_BETWEEN_SAVES / 2);
+
+      saveFunction.should.have.been.calledOnce;
+    });
+
+  });
+
+  describe('_saving: ', function() {
+    var saveDeferred;
+
+    beforeEach(function() {
+      saveDeferred = Q.defer();
+      saveFunction.returns(saveDeferred.promise);
+    });
+
+    it('should reprogram save if previous save is in progress', function(done) {
+      autoSaveService.save();
+
+      $timeout.flush();
+
+      saveFunction.should.have.been.called;
+
+      autoSaveService.save();
+
+      $timeout.flush();
+
+      saveFunction.should.have.been.calledOnce;
+
+      saveDeferred.resolve();
+
+      setTimeout(function() {
+        $timeout.flush();
+
+        saveFunction.should.have.been.calledTwice;          
+
+        done();
+      });
+    });
+  });
+
+  it('clearSaveTimeout: ', function() {
+    autoSaveService.save();
+
+    saveFunction.should.not.have.been.called;
+
+    $timeout.flush(MINIMUM_INTERVAL_BETWEEN_SAVES / 2);
+
+    autoSaveService.clearSaveTimeout();
+
+    $timeout.flush(MINIMUM_INTERVAL_BETWEEN_SAVES);
+
+    saveFunction.should.not.have.been.called;
+  });
+
+});

--- a/test/unit/template-editor/services/svc-template-editor-factory.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-factory.tests.js
@@ -298,8 +298,6 @@ describe('service: templateEditorFactory:', function() {
       });
 
       it('should save the presentation', function(done) {
-        var timeBeforePublish = new Date();
-
         templateEditorFactory.save()
           .then(function() {
             presentation.add.should.have.been.called;

--- a/test/unit/template-editor/services/svc-template-editor-factory.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-factory.tests.js
@@ -67,7 +67,8 @@ describe('service: templateEditorFactory:', function() {
 
     $provide.factory('brandingFactory', function() {
       return {
-        publishBranding: sandbox.stub()
+        publishBranding: sandbox.stub(),
+        saveBranding: sandbox.stub()
       };
     });
 
@@ -130,12 +131,12 @@ describe('service: templateEditorFactory:', function() {
   });
 
   it('should initialize', function() {
-    expect(templateEditorFactory).to.be.truely;
+    expect(templateEditorFactory).to.be.ok;
 
-    expect(templateEditorFactory.presentation).to.be.truely;
+    expect(templateEditorFactory.presentation).to.be.a('object');
     expect(templateEditorFactory.loadingPresentation).to.be.false;
     expect(templateEditorFactory.savingPresentation).to.be.false;
-    expect(templateEditorFactory.apiError).to.not.be.truely;
+    expect(templateEditorFactory.apiError).to.not.be.ok;
 
     expect(templateEditorFactory.getPresentation).to.be.a('function');
     expect(templateEditorFactory.addPresentation).to.be.a('function');
@@ -184,8 +185,33 @@ describe('service: templateEditorFactory:', function() {
     });
   });
 
-  describe('addPresentation:',function(){
-    it('should add the presentation',function(done){
+  describe('isUnsaved: ', function() {
+    it('should return false if neither factory hasUnsavedChanges', function() {
+      expect(templateEditorFactory.isUnsaved()).to.be.false;
+    });
+
+    it('should return true if this factory hasUnsavedChanges', function() {
+      templateEditorFactory.hasUnsavedChanges = true;
+
+      expect(templateEditorFactory.isUnsaved()).to.be.true;
+    });
+
+    it('should return true if branding hasUnsavedChanges', function() {
+      brandingFactory.hasUnsavedChanges = true;
+
+      expect(templateEditorFactory.isUnsaved()).to.be.true;
+    });
+
+    it('should return true if both factories have UnsavedChanges', function() {
+      templateEditorFactory.hasUnsavedChanges = true;
+      brandingFactory.hasUnsavedChanges = true;
+
+      expect(templateEditorFactory.isUnsaved()).to.be.true;
+    });
+  });
+
+  describe('save: ', function() {
+    beforeEach(function() {
       sandbox.stub(presentation, 'add').returns(Q.resolve({
         item: {
           name: 'Test Presentation',
@@ -193,66 +219,6 @@ describe('service: templateEditorFactory:', function() {
         }
       }));
 
-      templateEditorFactory.addFromProduct({ productCode: 'test-id', name: 'Test HTML Template' });
-      expect(templateEditorFactory.presentation.id).to.be.undefined;
-      expect(templateEditorFactory.presentation.productCode).to.equal('test-id');
-      expect(templateEditorFactory.presentation.templateAttributeData).to.deep.equal({});
-
-      templateEditorFactory.addPresentation()
-        .then(function() {
-          expect(templateEditorUtils.showMessageWindow).to.not.have.been.called;
-          expect(templateEditorFactory.savingPresentation).to.be.true;
-          expect(templateEditorFactory.loadingPresentation).to.be.true;
-
-          setTimeout(function(){
-            expect($state.go).to.have.been.calledWith('apps.editor.templates.edit');
-            expect(presentation.add.getCall(0).args[0].templateAttributeData).to.equal('{}');
-            expect(templateEditorFactory.presentation.templateAttributeData).to.deep.equal({});
-            expect(templateEditorFactory.savingPresentation).to.be.false;
-            expect(templateEditorFactory.loadingPresentation).to.be.false;
-            expect(templateEditorFactory.errorMessage).to.not.be.ok;
-            expect(templateEditorFactory.apiError).to.not.be.ok;
-            expect(presentationTracker).to.have.been.calledWith('Presentation Created', 'presentationId', 'Test Presentation');
-
-            done();
-          },10);
-        })
-        .then(null, function(err) {
-          done(err);
-        })
-        .then(null, done);
-    });
-
-    it('should show an error if fails to add presentation',function(done){
-      sandbox.stub(presentation, 'add').returns(Q.reject({ name: 'Test Presentation' }));
-
-      templateEditorFactory.addPresentation()
-        .then(function(result) {
-          done(result);
-        })
-        .then(null, function(e) {
-          expect(e).to.be.ok;
-          expect(templateEditorFactory.errorMessage).to.be.ok;
-          expect(templateEditorFactory.errorMessage).to.equal('Failed to add Presentation.');
-
-          processErrorCode.should.have.been.calledWith('Presentation', 'add', e);
-          expect(templateEditorFactory.apiError).to.be.ok;
-          expect(templateEditorUtils.showMessageWindow).to.have.been.called;
-
-          setTimeout(function() {
-            expect(templateEditorFactory.loadingPresentation).to.be.false;
-            expect(templateEditorFactory.savingPresentation).to.be.false;
-            expect($state.go).to.not.have.been.called;
-
-            done();
-          }, 10);
-        })
-        .then(null, done);
-    });
-  });
-
-  describe('updatePresentation:',function(){
-    it('should update the presentation',function(done){
       sandbox.stub(presentation, 'update').returns(Q.resolve({
         item: {
           name: 'Test Presentation',
@@ -264,57 +230,225 @@ describe('service: templateEditorFactory:', function() {
       expect(templateEditorFactory.presentation.id).to.be.undefined;
       expect(templateEditorFactory.presentation.productCode).to.equal('test-id');
       expect(templateEditorFactory.presentation.templateAttributeData).to.deep.equal({});
+    });
 
-      templateEditorFactory.updatePresentation()
-        .then(function() {
+    it('should wait for both promises to resolve', function(done) {
+      var addTemplateDeferred = Q.defer();
+      var saveBrandingDeferred = Q.defer();
+      presentation.add.returns(addTemplateDeferred.promise);
+      brandingFactory.saveBranding.returns(saveBrandingDeferred.promise);
+
+      templateEditorFactory.save();
+
+      presentation.add.should.have.been.called;
+      brandingFactory.saveBranding.should.have.been.called;
+
+      expect(templateEditorFactory.savingPresentation).to.be.true;
+
+      addTemplateDeferred.resolve({
+        item: {
+          name: 'Test Presentation',
+          id: 'presentationId'
+        }
+      });
+
+      setTimeout(function() {
+        expect(templateEditorFactory.savingPresentation).to.be.true;  
+
+        saveBrandingDeferred.resolve();
+        
+        setTimeout(function() {
+          expect(templateEditorFactory.savingPresentation).to.be.false;  
+
+          done();
+        });
+      });
+    });
+
+    describe('save Template: ', function() {
+      it('should add the presentation if it is new', function(done) {
+        templateEditorFactory.save()
+          .then(function() {
+            presentation.add.should.have.been.called;
+            presentation.update.should.not.have.been.called;
+
+            done();
+          })
+          .then(null, function(err) {
+            done(err);
+          })
+          .then(null, done);
+      });
+
+      it('should update the presentation if it is existing', function(done) {
+        templateEditorFactory.presentation.id = 'presentationId';
+        templateEditorFactory.hasUnsavedChanges = true;
+
+        templateEditorFactory.save()
+          .then(function() {
+            presentation.add.should.not.have.been.called;
+            presentation.update.should.have.been.called;
+
+            done();
+          })
+          .then(null, function(err) {
+            done(err);
+          })
+          .then(null, done);
+      });
+
+      it('should save the presentation', function(done) {
+        var timeBeforePublish = new Date();
+
+        templateEditorFactory.save()
+          .then(function() {
+            presentation.add.should.have.been.called;
+
+            setTimeout(function() {
+              expect(templateEditorFactory.savingPresentation).to.be.false;
+              expect(templateEditorFactory.loadingPresentation).to.be.false;
+              expect(templateEditorFactory.errorMessage).to.not.be.ok;
+              expect(templateEditorFactory.apiError).to.not.be.ok;
+
+              done();
+            },10);
+          })
+          .then(null, function(err) {
+            done(err);
+          })
+          .then(null, done);
+
           expect(templateEditorUtils.showMessageWindow).to.not.have.been.called;
           expect(templateEditorFactory.savingPresentation).to.be.true;
           expect(templateEditorFactory.loadingPresentation).to.be.true;
+      });
 
-          setTimeout(function(){
+      it('should show an error if fails to add the presentation', function(done) {
+        presentation.add.returns(Q.reject());
+
+        templateEditorFactory.save()
+          .then(null, function(e) {
+            expect(templateEditorFactory.errorMessage).to.be.ok;
+            expect(templateEditorFactory.apiError).to.be.ok;
+            expect(templateEditorUtils.showMessageWindow).to.have.been.called;
+
+            setTimeout(function() {
+              expect(templateEditorFactory.savingPresentation).to.be.false;
+              expect(templateEditorFactory.loadingPresentation).to.be.false;
+
+              done();
+            }, 10);
+          });
+      });
+
+      it('should show an error if fails to update the presentation', function(done) {
+        templateEditorFactory.presentation.id = 'presentationId';
+        templateEditorFactory.hasUnsavedChanges = true;
+
+        presentation.update.returns(Q.reject());
+
+        templateEditorFactory.save()
+          .then(null, function(e) {
+            expect(templateEditorFactory.errorMessage).to.be.ok;
+            expect(templateEditorFactory.apiError).to.be.ok;
+            expect(templateEditorUtils.showMessageWindow).to.have.been.called;
+
+            setTimeout(function() {
+              expect(templateEditorFactory.savingPresentation).to.be.false;
+              expect(templateEditorFactory.loadingPresentation).to.be.false;
+
+              done();
+            }, 10);
+          });
+      });
+
+    });
+
+    describe('addPresentation:',function(){
+      it('should add the presentation',function(done){
+        templateEditorFactory.addPresentation()
+          .then(function() {
+            expect($state.go).to.have.been.calledWith('apps.editor.templates.edit');
+            expect(presentation.add.getCall(0).args[0].templateAttributeData).to.equal('{}');
+            expect(templateEditorFactory.presentation.templateAttributeData).to.deep.equal({});
+            expect(presentationTracker).to.have.been.calledWith('Presentation Created', 'presentationId', 'Test Presentation');
+
+            done();
+          })
+          .then(null, function(err) {
+            done(err);
+          })
+          .then(null, done);
+      });
+
+    });
+
+    describe('updatePresentation:',function(){
+      it('should not update the presentation if it does not have unsaved changes',function(){
+        templateEditorFactory.updatePresentation();
+        
+        presentation.update.should.not.have.been.called;
+      });
+
+      it('should still resolve it does not have unsaved changes',function(done){
+        templateEditorFactory.updatePresentation().then(function() {
+          presentation.update.should.not.have.been.called;
+
+          done();
+        });      
+      });
+
+      it('should update the presentation if it has unsaved changes',function(){
+        templateEditorFactory.hasUnsavedChanges = true;
+        templateEditorFactory.updatePresentation();
+        
+        presentation.update.should.have.been.called;
+      });
+
+      it('should update the presentation',function(done){
+        templateEditorFactory.hasUnsavedChanges = true;
+        templateEditorFactory.updatePresentation()
+          .then(function() {
             expect(presentation.update.getCall(0).args[1].templateAttributeData).to.equal('{}');
             expect(templateEditorFactory.presentation.templateAttributeData).to.deep.equal({});
-            expect(templateEditorFactory.savingPresentation).to.be.false;
-            expect(templateEditorFactory.loadingPresentation).to.be.false;
-            expect(templateEditorFactory.errorMessage).to.not.be.ok;
-            expect(templateEditorFactory.apiError).to.not.be.ok;
             expect(presentationTracker).to.have.been.calledWith('Presentation Updated', 'presentationId', 'Test Presentation');
 
             done();
-          },10);
-        })
-        .then(null, function(err) {
-          done(err);
-        })
-        .then(null, done);
+          })
+          .then(null, function(err) {
+            done(err);
+          })
+          .then(null, done);
+      });
+
     });
 
-    it('should show an error if fails to update presentation',function(done){
-      sandbox.stub(presentation, 'update').returns(Q.reject({ name: 'Test Presentation' }));
+    describe('saveBranding: ', function() {
+      it('should save the branding settings', function() {
+        templateEditorFactory.save();
 
-      templateEditorFactory.updatePresentation()
-        .then(function(result) {
-          done(result);
-        })
-        .then(null, function(e) {
-          expect(e).to.be.ok;
-          expect(templateEditorFactory.errorMessage).to.be.ok;
-          expect(templateEditorFactory.errorMessage).to.equal('Failed to update Presentation.');
+        brandingFactory.saveBranding.should.have.been.called;
+      });
 
-          processErrorCode.should.have.been.calledWith('Presentation', 'update', e);
-          expect(templateEditorFactory.apiError).to.be.ok;
-          expect(templateEditorUtils.showMessageWindow).to.have.been.called;
+      it('should show an error if fails to save the branding', function(done) {
+        brandingFactory.saveBranding.returns(Q.reject());
 
-          setTimeout(function() {
-            expect(templateEditorFactory.loadingPresentation).to.be.false;
-            expect(templateEditorFactory.savingPresentation).to.be.false;
-            expect($state.go).to.not.have.been.called;
+        templateEditorFactory.save()
+          .then(null, function(e) {
+            expect(templateEditorFactory.errorMessage).to.be.ok;
+            expect(templateEditorFactory.apiError).to.be.ok;
+            expect(templateEditorUtils.showMessageWindow).to.have.been.called;
 
-            done();
-          }, 10);
-        })
-        .then(null, done);
-    });
+            setTimeout(function() {
+              expect(templateEditorFactory.savingPresentation).to.be.false;
+              expect(templateEditorFactory.loadingPresentation).to.be.false;
+
+              done();
+            }, 10);
+          });
+      });
+    });    
+
   });
 
   describe('getPresentation:', function() {

--- a/web/index.html
+++ b/web/index.html
@@ -207,21 +207,6 @@
   <script src="scripts/editor/controllers/ctr-widget-item-modal.js"></script>
   <script src="scripts/editor/controllers/ctr-playlist-item-modal.js"></script>
 
-  <script src="scripts/template-editor/services/svc-template-editor-factory.js"></script>
-  <script src="scripts/template-editor/services/svc-template-editor-utils.js"></script>
-  <script src="scripts/template-editor/services/svc-blueprint-factory.js"></script>
-  <script src="scripts/template-editor/services/svc-financial-license-factory.js"></script>
-  <script src="scripts/template-editor/components/services/svc-branding-factory.js"></script>
-  <script src="scripts/template-editor/components/services/svc-instrument-search.js"></script>
-  <script src="scripts/template-editor/components/services/svc-logo-image-factory.js"></script>
-  <script src="scripts/template-editor/components/services/svc-base-image-factory.js"></script>
-  <script src="scripts/template-editor/components/services/svc-slides-url-validation.js"></script>
-  <script src="scripts/template-editor/components/services/svc-rss-feed-validation.js"></script>
-  <script src="scripts/template-editor/components/services/svc-file-existence-check.js"></script>
-  <script src="scripts/template-editor/components/services/svc-file-metadata-utils.js"></script>
-  <script src="scripts/template-editor/components/services/svc-component-utils.js"></script>
-  <script src="scripts/template-editor/controllers/ctr-template-editor.js"></script>
-
   <script src="scripts/editor/services/svc-gadget.js"></script>
   <script src="scripts/editor/services/svc-gadget-factory.js"></script>
   <script src="scripts/editor/services/svc-store.js"></script>
@@ -262,6 +247,22 @@
   <script src="scripts/editor/directives/dtv-rv-popover.js"></script>
 
   <!-- template-editor -->
+  <script src="scripts/template-editor/services/svc-template-editor-factory.js"></script>
+  <script src="scripts/template-editor/services/svc-template-editor-utils.js"></script>
+  <script src="scripts/template-editor/services/svc-auto-save-service.js"></script>
+  <script src="scripts/template-editor/services/svc-blueprint-factory.js"></script>
+  <script src="scripts/template-editor/services/svc-financial-license-factory.js"></script>
+  <script src="scripts/template-editor/components/services/svc-branding-factory.js"></script>
+  <script src="scripts/template-editor/components/services/svc-instrument-search.js"></script>
+  <script src="scripts/template-editor/components/services/svc-logo-image-factory.js"></script>
+  <script src="scripts/template-editor/components/services/svc-base-image-factory.js"></script>
+  <script src="scripts/template-editor/components/services/svc-slides-url-validation.js"></script>
+  <script src="scripts/template-editor/components/services/svc-rss-feed-validation.js"></script>
+  <script src="scripts/template-editor/components/services/svc-file-existence-check.js"></script>
+  <script src="scripts/template-editor/components/services/svc-file-metadata-utils.js"></script>
+  <script src="scripts/template-editor/components/services/svc-component-utils.js"></script>
+  <script src="scripts/template-editor/controllers/ctr-template-editor.js"></script>
+
   <script src="scripts/template-editor/filters/ftr-encode-link.js"></script>
 
   <script src="scripts/template-editor/directives/dtv-attribute-editor.js"></script>

--- a/web/partials/template-editor/footer.html
+++ b/web/partials/template-editor/footer.html
@@ -1,13 +1,13 @@
 <div>
   <div class="auto-saving-changes">
-    <div ng-show="!factory.savingPresentation && hasUnsavedChanges">
+    <div ng-show="!factory.savingPresentation && factory.isUnsaved()">
       Unsaved changes
     </div>
     <div ng-show="factory.savingPresentation">
       Saving changes...
     </div>
     <div class="all-changes-saved-message"
-         ng-show="!factory.savingPresentation && !hasUnsavedChanges">
+         ng-show="!factory.savingPresentation && !factory.isUnsaved()">
       All changes saved
       <streamline-icon name="checkmark" width="12" height="12"></streamline-icon>
     </div>

--- a/web/partials/template-editor/toolbar.html
+++ b/web/partials/template-editor/toolbar.html
@@ -12,13 +12,13 @@
 
 <div class="toolbar-right">
   <div id="autoSavingDesktop" class="auto-saving-changes hidden-xs">
-    <div ng-show="!factory.savingPresentation && hasUnsavedChanges">
+    <div ng-show="!factory.savingPresentation && factory.isUnsaved()">
       Unsaved changes
     </div>
     <div ng-show="factory.savingPresentation">
       Saving changes...
     </div>
-    <div ng-show="!factory.savingPresentation && !hasUnsavedChanges">
+    <div ng-show="!factory.savingPresentation && !factory.isUnsaved()">
       <div>
         All changes saved <streamline-icon name="checkmark" width="12" height="12"></streamline-icon>
       </div>

--- a/web/scripts/template-editor/components/directives/dtv-branding-colors.js
+++ b/web/scripts/template-editor/components/directives/dtv-branding-colors.js
@@ -11,8 +11,10 @@ angular.module('risevision.template-editor.directives')
           $scope.brandingFactory = brandingFactory;
 
           $scope.saveBranding = function () {
-            brandingFactory.updateDraftColors();
+            brandingFactory.setUnsavedChanges();
           };
+
+          $scope.$on('colorpicker-selected', $scope.saveBranding);
 
           $scope.registerDirective({
             type: 'rise-branding-colors',

--- a/web/scripts/template-editor/components/services/svc-branding-factory.js
+++ b/web/scripts/template-editor/components/services/svc-branding-factory.js
@@ -9,7 +9,8 @@ angular.module('risevision.template-editor.services')
         type: 'rise-branding'
       };
       var factory = {
-        brandingSettings: null
+        brandingSettings: null,
+        hasUnsavedChanges: false
       };
 
       var _refreshMetadata = function () {
@@ -37,6 +38,7 @@ angular.module('risevision.template-editor.services')
             baseColor: settings.brandingDraftBaseColor,
             accentColor: settings.brandingDraftAccentColor
           };
+          factory.hasUnsavedChanges = false;
         }
 
         _refreshMetadata();
@@ -78,19 +80,25 @@ angular.module('risevision.template-editor.services')
         });
       };
 
-      factory.updateDraftColors = function () {
+      factory.saveBranding = function () {
+        if (!factory.hasUnsavedChanges || !blueprintFactory.hasBranding()) {
+          return $q.resolve();
+        }
+
         return _updateCompanySettings({
           brandingDraftBaseColor: factory.brandingSettings.baseColor,
           brandingDraftAccentColor: factory.brandingSettings.accentColor,
+          brandingDraftLogoFile: factory.brandingSettings.logoFile,
           brandingRevisionStatusName: REVISION_STATUS_REVISED
+        }).then(function () {
+          factory.hasUnsavedChanges = false;
         });
       };
 
-      factory.updateDraftLogo = function () {
-        return _updateCompanySettings({
-          brandingDraftLogoFile: factory.brandingSettings.logoFile,
-          brandingRevisionStatusName: REVISION_STATUS_REVISED
-        });
+      factory.setUnsavedChanges = function () {
+        $rootScope.$broadcast('risevision.template-editor.brandingUnsavedChanges');
+
+        this.hasUnsavedChanges = true;
       };
 
       factory.isRevised = function () {

--- a/web/scripts/template-editor/components/services/svc-logo-image-factory.js
+++ b/web/scripts/template-editor/components/services/svc-logo-image-factory.js
@@ -36,7 +36,7 @@ angular.module('risevision.template-editor.services')
           brandingFactory.brandingSettings.logoFileMetadata = [];
           brandingFactory.brandingSettings.logoFile = '';
         }
-        brandingFactory.updateDraftLogo();
+        brandingFactory.setUnsavedChanges();
         return brandingFactory.brandingSettings.logoFileMetadata;
       };
 

--- a/web/scripts/template-editor/services/svc-auto-save-service.js
+++ b/web/scripts/template-editor/services/svc-auto-save-service.js
@@ -1,0 +1,62 @@
+'use strict';
+
+angular.module('risevision.template-editor.services')
+  .constant('MINIMUM_INTERVAL_BETWEEN_SAVES', 5000)
+  .constant('MAXIMUM_INTERVAL_BETWEEN_SAVES', 20000)
+  .factory('AutoSaveService', ['$timeout', 'MINIMUM_INTERVAL_BETWEEN_SAVES', 'MAXIMUM_INTERVAL_BETWEEN_SAVES',
+    function ($timeout, MINIMUM_INTERVAL_BETWEEN_SAVES, MAXIMUM_INTERVAL_BETWEEN_SAVES) {
+      return function (saveFunction) {
+        var factory = {},
+          _lastSavedTimestamp = 0,
+          _saveTimeout = null,
+          _saving = false;
+
+        var _getCurrentTimestamp = function () {
+          return new Date().getTime();
+        };
+
+        var _programSave = function () {
+          _saveTimeout = $timeout(function () {
+            _saveTimeout = null;
+
+            // if a previous save hasn't finished, give more time
+            if (_saving) {
+              _programSave();
+            } else {
+              _lastSavedTimestamp = _getCurrentTimestamp();
+
+              saveFunction().finally(function () {
+                _saving = false;
+              });
+            }
+          }, MINIMUM_INTERVAL_BETWEEN_SAVES);
+        };
+
+        var _reprogramSave = function () {
+          factory.clearSaveTimeout();
+          _programSave();
+        };
+
+        factory.clearSaveTimeout = function () {
+          if (_saveTimeout) {
+            $timeout.cancel(_saveTimeout);
+            _saveTimeout = null;
+          }
+        };
+
+        factory.save = function () {
+          if (_saveTimeout) {
+            var elapsed = _getCurrentTimestamp() - _lastSavedTimestamp;
+
+            if (elapsed < MAXIMUM_INTERVAL_BETWEEN_SAVES) {
+              _reprogramSave();
+            }
+          } else {
+            _programSave();
+          }
+        };
+
+        return factory;
+      };
+    }
+  ]);

--- a/web/scripts/template-editor/services/svc-auto-save-service.js
+++ b/web/scripts/template-editor/services/svc-auto-save-service.js
@@ -24,6 +24,7 @@ angular.module('risevision.template-editor.services')
               _programSave();
             } else {
               _lastSavedTimestamp = _getCurrentTimestamp();
+              _saving = true;
 
               saveFunction().finally(function () {
                 _saving = false;


### PR DESCRIPTION
## Description
Branding saves with the same mechanism as the Template
Split out auto-save factory

Save Brand Colors on selection from color picker

[stage-2]

## Motivation and Context
Fixes https://github.com/Rise-Vision/html-template-library/issues/522

To confirm, we will now use the same Auto Save mechanism to update Branding when the User leaves the page or navigates away from the Template Editor.

In addition, we are going to be saving Branding settings on color selection via the color picker.

## How Has This Been Tested?
Tested the various scenarios locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No