### PR TITLE
Don't purchase a plan for Template Editor tests

### DIFF
--- a/test/e2e/common-header/cases/company-subcompanies.js
+++ b/test/e2e/common-header/cases/company-subcompanies.js
@@ -43,6 +43,9 @@
 
         homepage.get();
         signInPage.signIn();
+
+        // In case move succeeded and deletion failed
+        commonHeaderPage.deleteSubCompanyIfExists(subSubCompanyName);
       });
       
       describe("Add subcompany", function () {
@@ -55,7 +58,7 @@
         });
         
         it("Add new company", function() {
-          commonHeaderPage.createSubCompany(subCompanyName);
+          commonHeaderPage.createUnsubscribedSubCompany(subCompanyName);
         });
       });
 
@@ -106,7 +109,7 @@
         var subCompanyClaimId;
         
         it("Add another sub company", function() {
-          commonHeaderPage.createSubCompany(subSubCompanyName);
+          commonHeaderPage.createUnsubscribedSubCompany(subSubCompanyName);
         });
         
         it("Switch to sub-sub-company", function() {

--- a/test/e2e/common-header/cases/company-users.js
+++ b/test/e2e/common-header/cases/company-users.js
@@ -66,8 +66,8 @@
         userSettingsModalPage.getLastNameField().sendKeys("test");
         userSettingsModalPage.getPhoneField().sendKeys("000-000-0000");
 
-       userSettingsModalPage.getCeCheckbox().click();
-       userSettingsModalPage.getDaCheckbox().click();
+        userSettingsModalPage.getCeCheckbox().click();
+        userSettingsModalPage.getDaCheckbox().click();
 
         userSettingsModalPage.getEmailField().sendKeys(initialUsername);
         userSettingsModalPage.getSaveButton().click();

--- a/test/e2e/common-header/pages/companyUsersModalPage.js
+++ b/test/e2e/common-header/pages/companyUsersModalPage.js
@@ -53,6 +53,7 @@
     };
 
     this.searchUser = function(username) {
+      helper.waitDisappear(this.getLoader(), "Company Users Loaded");
       this.getUsersModalFilter().clear();
       this.getUsersModalFilter().sendKeys(username);
       helper.wait(this.getLoader(), "Load Company Users");

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -57,7 +57,7 @@ var FirstSigninScenarios = function() {
         signInPage.signIn();
         _waitFullPageLoad();
 
-        commonHeaderPage.createSubCompany(subCompanyName);
+        commonHeaderPage.createUnsubscribedSubCompany(subCompanyName);
         helper.waitForSpinner();
 
         commonHeaderPage.selectSubCompany(subCompanyName);

--- a/test/e2e/editor/cases/professional-widgets.js
+++ b/test/e2e/editor/cases/professional-widgets.js
@@ -38,14 +38,6 @@ var ProfessionalWidgetsScenarios = function() {
       signInPage.signIn();
     }
 
-    function createSubCompany() {
-      commonHeaderPage.createSubCompany(subCompanyName);
-    }
-
-    function selectSubCompany() {
-      commonHeaderPage.selectSubCompany(subCompanyName);
-    }
-
     before(function () {
       homepage = new HomePage();
       signInPage = new SignInPage();
@@ -61,8 +53,8 @@ var ProfessionalWidgetsScenarios = function() {
       autoScheduleModalPage = new AutoScheduleModalPage();
 
       loadEditor();
-      createSubCompany();
-      selectSubCompany();
+      commonHeaderPage.createUnsubscribedSubCompany(subCompanyName);
+      commonHeaderPage.selectSubCompany(subCompanyName);
     });
 
     after(function() {

--- a/test/e2e/editor/cases/template-add.js
+++ b/test/e2e/editor/cases/template-add.js
@@ -55,10 +55,6 @@ var TemplateAddScenarios = function() {
       helper.waitDisappear(storeProductsModalPage.getStoreProductsLoader(), 'Store products loader');
     }
 
-    function createSubCompany() {
-      commonHeaderPage.createSubCompany(subCompanyName, 'PRIMARY_SECONDARY_EDUCATION');
-    }
-
     function selectSubCompany() {
       commonHeaderPage.selectSubCompany(subCompanyName);
     }
@@ -76,7 +72,7 @@ var TemplateAddScenarios = function() {
       purchaseFlowModalPage = new PurchaseFlowModalPage();
 
       loadEditor();
-      createSubCompany();
+      commonHeaderPage.createUnsubscribedSubCompany(subCompanyName, 'PRIMARY_SECONDARY_EDUCATION');
       selectSubCompany();
       openContentModal();
     });

--- a/test/e2e/launcher/cases/weekly-templates.js
+++ b/test/e2e/launcher/cases/weekly-templates.js
@@ -39,7 +39,7 @@ var WeeklyTemplatesScenarios = function() {
     it('should show Weekly Templates for Education Customers',function(){
       //creates an Education sub-company
       var subCompanyName = 'E2E TEST EDUCATION SUBCOMPANY';
-      commonHeaderPage.createSubCompany(subCompanyName,'PRIMARY_SECONDARY_EDUCATION');
+      commonHeaderPage.createUnsubscribedSubCompany(subCompanyName,'PRIMARY_SECONDARY_EDUCATION');
       commonHeaderPage.selectSubCompany(subCompanyName);
       helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
       

--- a/test/e2e/storage/cases/trial.js
+++ b/test/e2e/storage/cases/trial.js
@@ -42,7 +42,7 @@ var StorageTrialScenarios = function() {
         homepage.getStorage();
         signInPage.signIn();
         var subCompanyName = 'E2E TEST SUBCOMPANY - STORAGE TRIAL';
-        commonHeaderPage.createSubCompany(subCompanyName);
+        commonHeaderPage.createUnsubscribedSubCompany(subCompanyName);
         commonHeaderPage.selectSubCompany(subCompanyName);   
       });
 

--- a/test/e2e/template-editor/template-editor.cases.js
+++ b/test/e2e/template-editor/template-editor.cases.js
@@ -2,11 +2,7 @@
   'use strict';
 
   var CommonHeaderPage = require('./../common-header/pages/commonHeaderPage.js');
-  var PricingComponentModalPage = require('./../common/pages/pricingComponentModalPage.js');
-  var PurchaseFlowModalPage = require('./../common/pages/purchaseFlowModalPage.js');
   var PresentationListPage = require('./pages/presentationListPage.js');
-  var TemplateEditorPage = require('./pages/templateEditorPage.js');
-  var helper = require('rv-common-e2e').helper;
 
   var TemplateEditorAddScenarios = require('./cases/template-editor-add.js');
   var FinancialComponentScenarios = require('./cases/components/financial.js');
@@ -16,48 +12,15 @@
 
     var subCompanyName = 'E2E TEST SUBCOMPANY - TEMPLATE EDITOR';
     var commonHeaderPage;
-    var pricingComponentModalPage;
-    var purchaseFlowModalPage;
     var presentationsListPage;
-    var templateEditorPage;
-
-    function _createSubCompany() {
-      commonHeaderPage.createSubCompany(subCompanyName);
-    }
-
-    function _selectSubCompany() {
-      commonHeaderPage.selectSubCompany(subCompanyName);
-    }
-
-    function _purchaseSubscription() {
-      helper.waitForSpinner();
-      helper.wait(templateEditorPage.seePlansLink(), 'See Plans Link');
-      helper.clickWhenClickable(templateEditorPage.seePlansLink(), 'See Plans Link');
-
-      helper.wait(pricingComponentModalPage.getSubscribeButton(), 'Subscribe Button');
-      helper.clickWhenClickable(pricingComponentModalPage.getSubscribeButton(), 'Subscribe Button');
-
-      helper.waitDisappear(pricingComponentModalPage.getSubscribeButton(), 'Subscribe Button Disappear');
-
-      purchaseFlowModalPage.purchase();
-    }
 
     before(function () {
       commonHeaderPage = new CommonHeaderPage();
       presentationsListPage = new PresentationListPage();
-      pricingComponentModalPage = new PricingComponentModalPage();
-      purchaseFlowModalPage = new PurchaseFlowModalPage();
-      templateEditorPage = new TemplateEditorPage();
 
       presentationsListPage.loadPresentationsList();
-      _createSubCompany();
-      _selectSubCompany();
-      _purchaseSubscription();
-      // Sometimes the trial does not start in time; this section tries to reduce the number of times this step fails
-      browser.sleep(5000);
-      presentationsListPage.loadPresentationsList();
-
-      _selectSubCompany();
+      commonHeaderPage.createSubscribedSubCompany(subCompanyName);
+      commonHeaderPage.selectSubCompany(subCompanyName);
     });
 
     // Text component scenarios deal with the auto schedule modal, so they always should come first.
@@ -68,7 +31,7 @@
     after(function() {
       // Loading the Presentation List is a workaround to a Chrome Driver issue that has it fail to click on elements over the Preview iframe
       presentationsListPage.loadCurrentCompanyPresentationList();
-      commonHeaderPage.deleteCurrentCompany();
+      commonHeaderPage.deleteCurrentCompany(subCompanyName);
     });
   });
 })();

--- a/test/e2e/template-editor/template-editor2.cases.js
+++ b/test/e2e/template-editor/template-editor2.cases.js
@@ -2,11 +2,7 @@
   'use strict';
 
   var CommonHeaderPage = require('./../common-header/pages/commonHeaderPage.js');
-  var PricingComponentModalPage = require('./../common/pages/pricingComponentModalPage.js');
-  var PurchaseFlowModalPage = require('./../common/pages/purchaseFlowModalPage.js');
   var PresentationListPage = require('./pages/presentationListPage.js');
-  var TemplateEditorPage = require('./pages/templateEditorPage.js');
-  var helper = require('rv-common-e2e').helper;
 
   var WeatherComponentScenarios = require('./cases/components/weather.js');
   var ImageComponentScenarios = require('./cases/components/image.js');
@@ -16,48 +12,15 @@
 
     var subCompanyName = 'E2E TEST SUBCOMPANY - TEMPLATE EDITOR 2';
     var commonHeaderPage;
-    var pricingComponentModalPage;
-    var purchaseFlowModalPage;
     var presentationsListPage;
-    var templateEditorPage;
-
-    function _createSubCompany() {
-      commonHeaderPage.createSubCompany(subCompanyName);
-    }
-
-    function _selectSubCompany() {
-      commonHeaderPage.selectSubCompany(subCompanyName);
-    }
-
-    function _purchaseSubscription() {
-      helper.waitDisappear(presentationsListPage.getPresentationsLoader(), 'Presentation loader');
-      helper.wait(templateEditorPage.seePlansLink(), 'See Plans Link');
-      helper.clickWhenClickable(templateEditorPage.seePlansLink(), 'See Plans Link');
-
-      helper.wait(pricingComponentModalPage.getSubscribeButton(), 'Subscribe Button');
-      helper.clickWhenClickable(pricingComponentModalPage.getSubscribeButton(), 'Subscribe Button');
-
-      helper.waitDisappear(pricingComponentModalPage.getSubscribeButton(), 'Subscribe Button Disappear');
-
-      purchaseFlowModalPage.purchase();
-    }
 
     before(function () {
       commonHeaderPage = new CommonHeaderPage();
       presentationsListPage = new PresentationListPage();
-      pricingComponentModalPage = new PricingComponentModalPage();
-      purchaseFlowModalPage = new PurchaseFlowModalPage();
-      templateEditorPage = new TemplateEditorPage();
 
       presentationsListPage.loadPresentationsList();
-      _createSubCompany();
-      _selectSubCompany();
-      _purchaseSubscription();
-      // Sometimes the trial does not start in time; this section tries to reduce the number of times this step fails
-      browser.sleep(5000);
-      presentationsListPage.loadPresentationsList();
-
-      _selectSubCompany();
+      commonHeaderPage.createSubscribedSubCompany(subCompanyName);
+      commonHeaderPage.selectSubCompany(subCompanyName);
     });
 
     var weatherComponentScenarios = new WeatherComponentScenarios();
@@ -67,7 +30,7 @@
     after(function() {
       // Loading the Presentation List is a workaround to a Chrome Driver issue that has it fail to click on elements over the Preview iframe
       presentationsListPage.loadCurrentCompanyPresentationList();
-      commonHeaderPage.deleteCurrentCompany();
+      commonHeaderPage.deleteCurrentCompany(subCompanyName);
     });
   });
 })();

--- a/test/e2e/template-editor/template-editor3.cases.js
+++ b/test/e2e/template-editor/template-editor3.cases.js
@@ -2,11 +2,7 @@
   'use strict';
 
   var CommonHeaderPage = require('./../common-header/pages/commonHeaderPage.js');
-  var PricingComponentModalPage = require('./../common/pages/pricingComponentModalPage.js');
-  var PurchaseFlowModalPage = require('./../common/pages/purchaseFlowModalPage.js');
   var PresentationListPage = require('./pages/presentationListPage.js');
-  var TemplateEditorPage = require('./pages/templateEditorPage.js');
-  var helper = require('rv-common-e2e').helper;
 
   var VideoComponentScenarios = require('./cases/components/video.js');
   var RssComponentScenarios = require('./cases/components/rss.js');
@@ -16,48 +12,15 @@
 
     var subCompanyName = 'E2E TEST SUBCOMPANY - TEMPLATE EDITOR 3';
     var commonHeaderPage;
-    var pricingComponentModalPage;
-    var purchaseFlowModalPage;
     var presentationsListPage;
-    var templateEditorPage;
-
-    function _createSubCompany() {
-      commonHeaderPage.createSubCompany(subCompanyName);
-    }
-
-    function _selectSubCompany() {
-      commonHeaderPage.selectSubCompany(subCompanyName);
-    }
-
-    function _purchaseSubscription() {
-      helper.waitDisappear(presentationsListPage.getPresentationsLoader(), 'Presentation loader');
-      helper.wait(templateEditorPage.seePlansLink(), 'See Plans Link');
-      helper.clickWhenClickable(templateEditorPage.seePlansLink(), 'See Plans Link');
-
-      helper.wait(pricingComponentModalPage.getSubscribeButton(), 'Subscribe Button');
-      helper.clickWhenClickable(pricingComponentModalPage.getSubscribeButton(), 'Subscribe Button');
-
-      helper.waitDisappear(pricingComponentModalPage.getSubscribeButton(), 'Subscribe Button Disappear');
-
-      purchaseFlowModalPage.purchase();
-    }
 
     before(function () {
       commonHeaderPage = new CommonHeaderPage();
       presentationsListPage = new PresentationListPage();
-      pricingComponentModalPage = new PricingComponentModalPage();
-      purchaseFlowModalPage = new PurchaseFlowModalPage();
-      templateEditorPage = new TemplateEditorPage();
 
       presentationsListPage.loadPresentationsList();
-      _createSubCompany();
-      _selectSubCompany();
-      _purchaseSubscription();
-      // Sometimes the trial does not start in time; this section tries to reduce the number of times this step fails
-      browser.sleep(5000);
-      presentationsListPage.loadPresentationsList();
-
-      _selectSubCompany();
+      commonHeaderPage.createSubscribedSubCompany(subCompanyName);
+      commonHeaderPage.selectSubCompany(subCompanyName);
     });
 
     var videoComponentScenarios = new VideoComponentScenarios();
@@ -67,7 +30,7 @@
     after(function() {
       // Loading the Presentation List is a workaround to a Chrome Driver issue that has it fail to click on elements over the Preview iframe
       presentationsListPage.loadCurrentCompanyPresentationList();
-      commonHeaderPage.deleteCurrentCompany();
+      commonHeaderPage.deleteCurrentCompany(subCompanyName);
     });
   });
 })();


### PR DESCRIPTION
## Description
Created a separate sub-company with a plan
Template Editor will create sub-companies of that company
and inherit the plan

Add 2 separate createSubcompany steps

Check deleted company
Don't use suffix for some subcompany selections

## Motivation and Context
No need to test purchase on all Template editor tests

## How Has This Been Tested?
No actual code/functionality changes

e2e tests pass

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
N/A
