### PR TITLE
Allow parallel registration e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gulp-usemin": "0.3.28",
     "gulp-util": "^3.0.8",
     "jshint-stylish": "^2.0.1",
+    "mail-listener2-updated": "^0.3.3",
     "rollup": "^1.15.6",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-node-resolve": "^5.0.3",

--- a/test/e2e/common-header/cases/account-removal.js
+++ b/test/e2e/common-header/cases/account-removal.js
@@ -27,9 +27,9 @@
         safeDeleteModalPage = new SafeDeleteModalPage();
         signInPage = new SignInPage();
 
+        homepage.get();
 
-        homepage.get();        
-        signInPage.signIn(browser.params.login.user1, browser.params.login.pass1);
+        signInPage.customAuthSignIn(commonHeaderPage.getStageEmailAddress(), commonHeaderPage.getPassword());
       });
 
       it("Deletes company", function() {
@@ -40,7 +40,7 @@
         helper.waitDisappear(companySettingsModalPage.getLoader(), "Load Company Settings");
         
         // Ensure the right Company is being deleted
-        expect(companySettingsModalPage.getNameField().getAttribute("value")).to.eventually.equal("Public School #5");
+        expect(companySettingsModalPage.getNameField().getAttribute("value")).to.eventually.equal(commonHeaderPage.addStageSuffix("Public School"));
 
         companySettingsModalPage.getDeleteButton().click();
     

--- a/test/e2e/common-header/cases/account-removal.js
+++ b/test/e2e/common-header/cases/account-removal.js
@@ -33,7 +33,7 @@
       });
 
       it("Deletes company", function() {
-        commonHeaderPage.getProfilePic().click();
+        commonHeaderPage.openProfileMenu();
         homepage.getCompanySettingsButton().click();        
         
         helper.wait(companySettingsModalPage.getCompanySettingsModal(), "Comapny Settings Modal");

--- a/test/e2e/common-header/cases/registration-existing-company.js
+++ b/test/e2e/common-header/cases/registration-existing-company.js
@@ -114,7 +114,7 @@
 
         it('should register user',function(){
           signUpPage.get();
-          
+
           helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
 
           signUpPage.getUsernameTextBox().sendKeys(EMAIL_ADDRESS);
@@ -122,8 +122,9 @@
           signUpPage.getConfirmPasswordTextBox().sendKeys(PASSWORD);
 
           signUpPage.getSignupButton().click();
-
           helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+
+          expect(signUpPage.getConfirmEmailNotice().isDisplayed()).to.eventually.be.true;
         });
 
         it('should wait for confirmation email', function() {        
@@ -145,24 +146,16 @@
 
           expect(signInPage.getUsernameTextBox().isPresent()).to.eventually.be.true;
           expect(signInPage.getPasswordTextBox().isPresent()).to.eventually.be.true;
-          
           expect(signInPage.getSigninButton().isPresent()).to.eventually.be.true;
+
+          expect(signUpPage.getEmailConfirmedNotice().isDisplayed()).to.eventually.be.true;
         });
 
-        it('should sign in user', function() {
-          signInPage.getUsernameTextBox().sendKeys(EMAIL_ADDRESS);
-
-          var enter = "\ue007";
-          signInPage.getPasswordTextBox().clear();
-          signInPage.getPasswordTextBox().sendKeys(PASSWORD + enter);
-        });
-
-        it("should show T&C Dialog on new Account", function() {
-          helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+        it('should sign in user and show T&C Dialog on new Account', function() {
+          signInPage.customAuthSignIn(EMAIL_ADDRESS,PASSWORD);
           
           helper.wait(registrationModalPage.getRegistrationModal(), "Registration Modal");
-          
-          //dialog shows
+
           expect(registrationModalPage.getRegistrationModal().isPresent()).to.eventually.be.true;
         });
 

--- a/test/e2e/common-header/cases/registration-existing-company.js
+++ b/test/e2e/common-header/cases/registration-existing-company.js
@@ -115,47 +115,27 @@
         it('should register user',function(){
           signUpPage.get();
 
-          helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
-
-          signUpPage.getUsernameTextBox().sendKeys(EMAIL_ADDRESS);
-          signUpPage.getPasswordTextBox().sendKeys(PASSWORD);
-          signUpPage.getConfirmPasswordTextBox().sendKeys(PASSWORD);
-
-          signUpPage.getSignupButton().click();
-          helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+          signUpPage.customAuthSignUp(EMAIL_ADDRESS, PASSWORD);
 
           expect(signUpPage.getConfirmEmailNotice().isDisplayed()).to.eventually.be.true;
         });
 
         it('should wait for confirmation email', function() {        
-          browser.controlFlow().wait(mailListener.getLastEmail(), 45000).then(function (email) {
-
-            expect(email.subject).to.equal("Confirm account");
-
-            var pattern = /href="(https:\/\/apps-stage-0\.risevision\.com\/confirmaccount\/.*?)"/g;
-            confirmationLink = pattern.exec(email.html)[1];
-            console.log("Confirmation link: "+confirmationLink);
-
+          browser.controlFlow().wait(signUpPage.getConfirmationLink(mailListener), 45000).then(function(link){
+            confirmationLink = link;
             expect(confirmationLink).to.contain("https://apps-stage-0.risevision.com/confirmaccount/"+EMAIL_ADDRESS);
-          });        
+          });
         });
 
         it('should confirm email address',function(){
           browser.get(confirmationLink);
           helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
-
-          expect(signInPage.getUsernameTextBox().isPresent()).to.eventually.be.true;
-          expect(signInPage.getPasswordTextBox().isPresent()).to.eventually.be.true;
-          expect(signInPage.getSigninButton().isPresent()).to.eventually.be.true;
-
           expect(signUpPage.getEmailConfirmedNotice().isDisplayed()).to.eventually.be.true;
         });
 
         it('should sign in user and show T&C Dialog on new Account', function() {
-          signInPage.customAuthSignIn(EMAIL_ADDRESS,PASSWORD);
-          
+          signInPage.customAuthSignIn(EMAIL_ADDRESS,PASSWORD);         
           helper.wait(registrationModalPage.getRegistrationModal(), "Registration Modal");
-
           expect(registrationModalPage.getRegistrationModal().isPresent()).to.eventually.be.true;
         });
 

--- a/test/e2e/common-header/cases/registration-existing-company.js
+++ b/test/e2e/common-header/cases/registration-existing-company.js
@@ -123,7 +123,7 @@
         it('should wait for confirmation email', function() {        
           browser.controlFlow().wait(signUpPage.getConfirmationLink(mailListener), 45000).then(function(link){
             confirmationLink = link;
-            expect(confirmationLink).to.contain("https://apps-stage-0.risevision.com/confirmaccount/"+EMAIL_ADDRESS);
+            expect(confirmationLink).to.contain("http://localhost:8099/confirmaccount/"+EMAIL_ADDRESS);
           });
         });
 
@@ -171,8 +171,6 @@
       describe("New User Deletes Themselves", function() {
 
         it("Opens User Settings Dialog", function() {
-          helper.waitDisappear(commonHeaderPage.getLoader(), "CH spinner loader");
-
           commonHeaderPage.openProfileMenu();
 
           expect(homepage.getUserSettingsButton().isDisplayed()).to.eventually.be.true;

--- a/test/e2e/common-header/cases/registration-existing-company.js
+++ b/test/e2e/common-header/cases/registration-existing-company.js
@@ -10,6 +10,8 @@
   var CompanyUsersModalPage = require("./../pages/companyUsersModalPage.js");
   var UserSettingsModalPage = require("./../pages/userSettingsModalPage.js");
   var SignInPage = require('./../../launcher/pages/signInPage.js');
+  var SignUpPage = require('./../../launcher/pages/signUpPage.js');
+  var MailListener = require('./../utils/mailListener.js');
 
   var RegistrationExistingCompanyScenarios = function() {
 
@@ -21,6 +23,10 @@
       var companyUsersModalPage;
       var userSettingsModalPage;
       var signInPage;
+      var signUpPage;
+      var EMAIL_ADDRESS;
+      var PASSWORD;
+      var mailListener;
 
       before(function (){
         commonHeaderPage = new CommonHeaderPage();
@@ -29,6 +35,13 @@
         companyUsersModalPage = new CompanyUsersModalPage();
         userSettingsModalPage = new UserSettingsModalPage();
         signInPage = new SignInPage();
+        signUpPage = new SignUpPage();
+
+        EMAIL_ADDRESS = commonHeaderPage.getStageEmailAddress();
+        PASSWORD = commonHeaderPage.getPassword();
+
+        mailListener = new MailListener(EMAIL_ADDRESS,PASSWORD);
+        mailListener.start();
 
         homepage.get();
         signInPage.signIn();
@@ -50,10 +63,10 @@
         });
 
         it("adds a user", function () {
-          userSettingsModalPage.getUsernameField().sendKeys("jenkins1@risevision.com");
-          userSettingsModalPage.getFirstNameField().sendKeys("Jenkins");
-          userSettingsModalPage.getLastNameField().sendKeys("1");
-          userSettingsModalPage.getEmailField().sendKeys("jenkins1@risevision.com");
+          userSettingsModalPage.getUsernameField().sendKeys(EMAIL_ADDRESS);
+          userSettingsModalPage.getFirstNameField().sendKeys("Added");
+          userSettingsModalPage.getLastNameField().sendKeys("User");
+          userSettingsModalPage.getEmailField().sendKeys(EMAIL_ADDRESS);
           // Set as User Administrator so they can delete themselves
           userSettingsModalPage.getUaCheckbox().click();
           userSettingsModalPage.getSaveButton().click();
@@ -61,6 +74,12 @@
           helper.waitDisappear(userSettingsModalPage.getUserSettingsModal(), "User Settings Modal");        
 
           expect(userSettingsModalPage.getUserSettingsModal().isPresent()).to.eventually.be.false;
+        });
+
+        it('should send an email to the added user',function(){
+          browser.controlFlow().wait(mailListener.getLastEmail(), 45000).then(function (email) {
+            expect(email.subject).to.equal("You've been added to a Rise Vision account!");
+          }); 
         });
         
         it("Company Users Dialog Should Close", function () {
@@ -81,25 +100,70 @@
           helper.wait(commonHeaderPage.getSignOutModal(), "Sign Out Modal");
           
           expect(commonHeaderPage.getSignOutModal().isDisplayed()).to.eventually.be.true;
-          commonHeaderPage.getSignOutRvOnlyButton().click();
+          commonHeaderPage.getSignOutGoogleButton().click();
 
           //signed out; google sign-in button shows
           expect(signInPage.getSignInGoogleLink().isDisplayed()).to.eventually.be.true;
+          helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
         });
 
       });
 
       describe("New User Logs in and Registers", function() {
-        it("should show T&C Dialog on new Google Account", function() {
-          //sign in, wait for spinner to go away
-          signInPage.signIn(browser.params.login.user1, browser.params.login.pass1);
+        var confirmationLink;
+
+        it('should register user',function(){
+          signUpPage.get();
+          
+          helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+
+          signUpPage.getUsernameTextBox().sendKeys(EMAIL_ADDRESS);
+          signUpPage.getPasswordTextBox().sendKeys(PASSWORD);
+          signUpPage.getConfirmPasswordTextBox().sendKeys(PASSWORD);
+
+          signUpPage.getSignupButton().click();
+
+          helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+        });
+
+        it('should wait for confirmation email', function() {        
+          browser.controlFlow().wait(mailListener.getLastEmail(), 45000).then(function (email) {
+
+            expect(email.subject).to.equal("Confirm account");
+
+            var pattern = /href="(https:\/\/apps-stage-0\.risevision\.com\/confirmaccount\/.*?)"/g;
+            confirmationLink = pattern.exec(email.html)[1];
+            console.log("Confirmation link: "+confirmationLink);
+
+            expect(confirmationLink).to.contain("https://apps-stage-0.risevision.com/confirmaccount/"+EMAIL_ADDRESS);
+          });        
+        });
+
+        it('should confirm email address',function(){
+          browser.get(confirmationLink);
+          helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+
+          expect(signInPage.getUsernameTextBox().isPresent()).to.eventually.be.true;
+          expect(signInPage.getPasswordTextBox().isPresent()).to.eventually.be.true;
+          
+          expect(signInPage.getSigninButton().isPresent()).to.eventually.be.true;
+        });
+
+        it('should sign in user', function() {
+          signInPage.getUsernameTextBox().sendKeys(EMAIL_ADDRESS);
+
+          var enter = "\ue007";
+          signInPage.getPasswordTextBox().clear();
+          signInPage.getPasswordTextBox().sendKeys(PASSWORD + enter);
+        });
+
+        it("should show T&C Dialog on new Account", function() {
+          helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
           
           helper.wait(registrationModalPage.getRegistrationModal(), "Registration Modal");
           
           //dialog shows
           expect(registrationModalPage.getRegistrationModal().isPresent()).to.eventually.be.true;
-
-          //fill in email address
         });
 
         it("should show only relevant Registration fields", function() {
@@ -118,8 +182,6 @@
           //click authorize
           registrationModalPage.getTermsCheckbox().click();
           
-          // No need to sign up for newsletter
-          // registrationModalPage.getNewsletterCheckbox().click();
           registrationModalPage.getSaveButton().click();
           
           helper.waitRemoved(registrationModalPage.getRegistrationModal(), "Registration Modal");
@@ -134,14 +196,11 @@
       });
 
       describe("New User Deletes Themselves", function() {
-        before(function() {
-          homepage.get();
-
-          helper.waitDisappear(commonHeaderPage.getLoader(), "CH spinner loader");
-        });
 
         it("Opens User Settings Dialog", function() {
-          commonHeaderPage.getProfilePic().click();
+          helper.waitDisappear(commonHeaderPage.getLoader(), "CH spinner loader");
+
+          commonHeaderPage.openProfileMenu();
 
           expect(homepage.getUserSettingsButton().isDisplayed()).to.eventually.be.true;
           homepage.getUserSettingsButton().click();
@@ -153,7 +212,7 @@
 
         it("deletes a user", function() {
           // Ensure the right User is being deleted
-          expect(userSettingsModalPage.getUsernameLabel().getText()).to.eventually.equal("jenkins1@risevision.com");
+          expect(userSettingsModalPage.getUsernameLabel().getText()).to.eventually.equal(EMAIL_ADDRESS);
 
           userSettingsModalPage.getDeleteButton().click();
           
@@ -162,6 +221,10 @@
           helper.waitDisappear(userSettingsModalPage.getLoader(), "User Settings Modal");
         });
         
+      });
+
+      after(function(){
+        mailListener.stop();
       });
 
     });

--- a/test/e2e/common-header/cases/registration.js
+++ b/test/e2e/common-header/cases/registration.js
@@ -58,6 +58,7 @@
         helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
 
         expect(signUpPage.getAlreadyRegisteredError().isDisplayed()).to.eventually.be.false;
+        expect(signUpPage.getConfirmEmailNotice().isDisplayed()).to.eventually.be.true;
       });
 
       it('should wait for confirmation email', function() {        
@@ -78,24 +79,17 @@
         helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
 
         expect(signInPage.getUsernameTextBox().isPresent()).to.eventually.be.true;
-        expect(signInPage.getPasswordTextBox().isPresent()).to.eventually.be.true;
-        
+        expect(signInPage.getPasswordTextBox().isPresent()).to.eventually.be.true;        
         expect(signInPage.getSigninButton().isPresent()).to.eventually.be.true;
+
+        expect(signUpPage.getEmailConfirmedNotice().isDisplayed()).to.eventually.be.true;
       });
 
-      it('should sign in user', function() {
-        signInPage.getUsernameTextBox().sendKeys(EMAIL_ADDRESS);
-
-        var enter = "\ue007";
-        signInPage.getPasswordTextBox().clear();
-        signInPage.getPasswordTextBox().sendKeys(PASSWORD + enter);
-      });
-      
-      it("should show T&C Dialog on new Google Account", function() {
-        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
-        helper.wait(registrationModalPage.getRegistrationModal(), "Registration Modal");
+      it('should sign in user and show T&C Dialog on new Account', function() {
+        signInPage.customAuthSignIn(EMAIL_ADDRESS,PASSWORD);
         
-        //dialog shows
+        helper.wait(registrationModalPage.getRegistrationModal(), "Registration Modal");
+
         expect(registrationModalPage.getRegistrationModal().isPresent()).to.eventually.be.true;
       });
 

--- a/test/e2e/common-header/cases/registration.js
+++ b/test/e2e/common-header/cases/registration.js
@@ -49,29 +49,17 @@
       });
 
       it('should register user', function() {
-        signUpPage.getUsernameTextBox().sendKeys(EMAIL_ADDRESS);
-        signUpPage.getPasswordTextBox().sendKeys(PASSWORD);
-        signUpPage.getConfirmPasswordTextBox().sendKeys(PASSWORD);
-
-        signUpPage.getSignupButton().click();
-
-        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
-
+        signUpPage.customAuthSignUp(EMAIL_ADDRESS, PASSWORD);
+        
         expect(signUpPage.getAlreadyRegisteredError().isDisplayed()).to.eventually.be.false;
         expect(signUpPage.getConfirmEmailNotice().isDisplayed()).to.eventually.be.true;
       });
 
-      it('should wait for confirmation email', function() {        
-        browser.controlFlow().wait(mailListener.getLastEmail(), 45000).then(function (email) {
-
-          expect(email.subject).to.equal("Confirm account");
-
-          var pattern = /href="(https:\/\/apps-stage-0\.risevision\.com\/confirmaccount\/.*?)"/g;
-          confirmationLink = pattern.exec(email.html)[1];
-          console.log("Confirmation link: "+confirmationLink);
-
+      it('should wait for confirmation email', function() {
+        browser.controlFlow().wait(signUpPage.getConfirmationLink(mailListener), 45000).then(function(link){
+          confirmationLink = link;
           expect(confirmationLink).to.contain("https://apps-stage-0.risevision.com/confirmaccount/"+EMAIL_ADDRESS);
-        });        
+        });             
       });
 
       it('should confirm email address',function(){
@@ -86,7 +74,7 @@
       });
 
       it('should sign in user and show T&C Dialog on new Account', function() {
-        signInPage.customAuthSignIn(EMAIL_ADDRESS,PASSWORD);
+        signInPage.customAuthSignIn(EMAIL_ADDRESS, PASSWORD);
         
         helper.wait(registrationModalPage.getRegistrationModal(), "Registration Modal");
 

--- a/test/e2e/common-header/cases/registration.js
+++ b/test/e2e/common-header/cases/registration.js
@@ -58,7 +58,7 @@
       it('should wait for confirmation email', function() {
         browser.controlFlow().wait(signUpPage.getConfirmationLink(mailListener), 45000).then(function(link){
           confirmationLink = link;
-          expect(confirmationLink).to.contain("https://apps-stage-0.risevision.com/confirmaccount/"+EMAIL_ADDRESS);
+          expect(confirmationLink).to.contain("http://localhost:8099/confirmaccount/"+EMAIL_ADDRESS);
         });             
       });
 
@@ -120,6 +120,17 @@
 
       it("should update auth button", function () {
         expect(commonHeaderPage.getProfilePic().isDisplayed()).to.eventually.be.true;
+      });
+
+      it("should sign out", function() {
+        commonHeaderPage.openProfileMenu();
+
+        expect(commonHeaderPage.getSignOutButton().isDisplayed()).to.eventually.be.true;
+
+        commonHeaderPage.getSignOutButton().click();       
+        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+
+        expect(signInPage.getSignInGoogleLink().isDisplayed()).to.eventually.be.true;
       });
 
       after(function(){

--- a/test/e2e/common-header/cases/registration.js
+++ b/test/e2e/common-header/cases/registration.js
@@ -9,26 +9,127 @@
   var HomePage = require('./../pages/homepage.js');
   var RegistrationModalPage = require('./../pages/registrationModalPage.js');
   var SignInPage = require('./../../launcher/pages/signInPage.js');
+  var SignUpPage = require('./../../launcher/pages/signUpPage.js');
+
+  var MailListener = require("mail-listener2-updated");
 
   var RegistrationScenarios = function() {
 
     describe("Registration", function() {
-      var commonHeaderPage, 
+      var EMAIL_ADDRESS, 
+        PASSWORD,
+        commonHeaderPage, 
         homepage, 
         registrationModalPage,
-        signInPage;
+        signInPage,
+        signUpPage,
+        mailListener,
+        confirmationLink;
+
+
+      function getLastEmail() {
+        var deferred = protractor.promise.defer();
+        console.log("Waiting for an email...");
+
+        mailListener.on("mail", function(mail, seqno, attributes){
+          console.log("Mail received: " + mail.subject);
+
+          mailListener.imap.addFlags(attributes.uid, '\\Seen', function(err) {
+            if (err) {
+              console.log('error marking message read/SEEN');
+            } else {
+              console.log('marked message as SEEN');
+            }
+          });          
+          deferred.fulfill(mail);
+        });
+        return deferred.promise;
+      };
         
       before(function (){
         commonHeaderPage = new CommonHeaderPage();
         homepage = new HomePage();
         registrationModalPage = new RegistrationModalPage();
         signInPage = new SignInPage();
+        signUpPage = new SignUpPage();
 
-        homepage.get();
-        signInPage.signIn(browser.params.login.user1, browser.params.login.pass1);
+        EMAIL_ADDRESS = commonHeaderPage.getStageEmailAddress();
+        PASSWORD = commonHeaderPage.getPassword();
+
+        console.log('Username: '+EMAIL_ADDRESS);
+        mailListener = new MailListener({
+          username: "jenkins.rise@gmail.com",
+          password: PASSWORD, 
+          host: "imap.gmail.com",
+          port: 993,
+          searchFilter: ["UNSEEN",['TO', EMAIL_ADDRESS]],
+          tls: true,
+          fetchUnreadOnStart: true
+        });
+        mailListener.on("server:connected", function(){
+          console.log("Mail listener connected");
+        });
+
+        mailListener.on("server:disconnected", function(){
+          console.log("Mail listener disconnected");
+        });
+        mailListener.start();
+
+        signUpPage.get();
       });
 
+      it('should show create account page', function() {
+        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+
+        expect(signUpPage.getSignUpPageContainer().isPresent()).to.eventually.be.true;
+        expect(signUpPage.getSignUpCTA().isPresent()).to.eventually.be.true;
+      });
+
+      it('should register user', function() {
+        signUpPage.getUsernameTextBox().sendKeys(EMAIL_ADDRESS);
+        signUpPage.getPasswordTextBox().sendKeys(PASSWORD);
+        signUpPage.getConfirmPasswordTextBox().sendKeys(PASSWORD);
+
+        signUpPage.getSignupButton().click();
+
+        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+
+        expect(signUpPage.getAlreadyRegisteredError().isDisplayed()).to.eventually.be.false;
+      });
+
+      it('should wait for confirmation email', function() {        
+        browser.controlFlow().wait(getLastEmail(), 45000).then(function (email) {
+
+          expect(email.subject).to.equal("Confirm account");
+
+          var pattern = /href="(https:\/\/apps-stage-0\.risevision\.com\/confirmaccount\/.*?)"/g;
+          confirmationLink = pattern.exec(email.html)[1];
+          console.log("Confirmation link: "+confirmationLink);
+
+          expect(confirmationLink).to.contain("https://apps-stage-0.risevision.com/confirmaccount/"+EMAIL_ADDRESS);
+        });        
+      });
+
+      it('should confirm email address',function(){
+        browser.get(confirmationLink);
+        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+
+        expect(signInPage.getUsernameTextBox().isPresent()).to.eventually.be.true;
+        expect(signInPage.getPasswordTextBox().isPresent()).to.eventually.be.true;
+        
+        expect(signInPage.getSigninButton().isPresent()).to.eventually.be.true;
+      });
+
+      it('should sign in user', function() {
+        signInPage.getUsernameTextBox().sendKeys(EMAIL_ADDRESS);
+
+        var enter = "\ue007";
+        signInPage.getPasswordTextBox().clear();
+        signInPage.getPasswordTextBox().sendKeys(PASSWORD + enter);
+      });
+      
       it("should show T&C Dialog on new Google Account", function() {
+        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
         helper.wait(registrationModalPage.getRegistrationModal(), "Registration Modal");
         
         //dialog shows
@@ -41,26 +142,6 @@
         expect(registrationModalPage.getCompanyNameField().isDisplayed()).to.eventually.be.true;
         expect(registrationModalPage.getCompanyIndustryDropdown().isDisplayed()).to.eventually.be.true;
         expect(registrationModalPage.getTermsCheckbox().isDisplayed()).to.eventually.be.true;
-      });
-
-      xit("should not bug me again when I click 'cancel', even after a refresh (limbo state)", function() {
-        registrationModalPage.getCancelButton().click();
-        browser.refresh();
-        
-        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
-        
-        expect(commonHeaderPage.getSignInButton().isDisplayed()).to.eventually.be.false;
-        expect(registrationModalPage.getRegistrationModal().isPresent()).to.eventually.be.false;
-      });
-
-      xit("allow me to register when I've changed my mind", function() {
-        expect(homepage.getRegisterUserButton().isDisplayed(), "Create Account button should show").to.eventually.be.true;
-        homepage.getRegisterUserButton().click();
-        
-        helper.wait(registrationModalPage.getRegistrationModal(), "Registration Modal");
-        
-        //dialog shows
-        expect(registrationModalPage.getRegistrationModal().isPresent()).to.eventually.be.true;
       });
 
       it("should show validation errors if i have not agreed to terms and entered a first and last name", function () {
@@ -76,7 +157,7 @@
       it("should complete the registration process", function () {
         registrationModalPage.getFirstNameField().sendKeys("John");
         registrationModalPage.getLastNameField().sendKeys("Doe");
-        registrationModalPage.getCompanyNameField().sendKeys("Public School #5");
+        registrationModalPage.getCompanyNameField().sendKeys(commonHeaderPage.addStageSuffix("Public School"));
         registrationModalPage.getCompanyIndustryOptions().then(function(options){
           options[2].click(); //select random option
         }); 
@@ -95,6 +176,11 @@
       it("should update auth button", function () {
         expect(commonHeaderPage.getProfilePic().isDisplayed()).to.eventually.be.true;
       });
+
+      after(function(){
+        console.log("Stopping Mail listener");
+        mailListener.stop();
+      })
 
     });
   };

--- a/test/e2e/common-header/pages/commonHeaderPage.js
+++ b/test/e2e/common-header/pages/commonHeaderPage.js
@@ -112,11 +112,19 @@
 
     this.getStageEnv = function () {
       return browser.params.login.stageEnv.split('-').join('');
-    }
+    };
 
     this.addStageSuffix = function (name) {
       return name + " - " + this.getStageEnv();
-    }
+    };
+
+    this.getStageEmailAddress = function () {
+      return 'jenkins.rise+'+this.getStageEnv()+'@gmail.com';
+    };
+
+    this.getPassword = function () {
+      return browser.params.login.pass;
+    };
 
     this.searchSubCompany = function (subCompanyName) {
       this.openProfileMenu();

--- a/test/e2e/common-header/utils/mailListener.js
+++ b/test/e2e/common-header/utils/mailListener.js
@@ -1,0 +1,54 @@
+(function(module) {
+  'use strict';
+
+  var MailListener2 = require("mail-listener2-updated");
+
+  var MailListener = function (emailAddressToFilter, password) {
+    var mailListener2 = new MailListener2({
+      username: "jenkins.rise@gmail.com",
+      password: password, 
+      host: "imap.gmail.com",
+      port: 993,
+      searchFilter: ["UNSEEN",['TO', emailAddressToFilter]],
+      tls: true,
+      fetchUnreadOnStart: true
+    });
+      
+    this.start = function() {
+      mailListener2.on("server:connected", function(){
+        console.log("Mail listener connected");
+      });
+      mailListener2.on("server:disconnected", function(){
+        console.log("Mail listener disconnected");
+      });
+      console.log('Starting MailListener for ' + emailAddressToFilter);
+      mailListener2.start();      
+    };
+
+    this.stop = function() {
+      console.log('Stopping MailListener');
+      mailListener2.stop();
+    };
+
+    this.getLastEmail = function() {
+      var deferred = protractor.promise.defer();
+      console.log("Waiting for an email...");
+
+      mailListener2.once("mail", function(mail, seqno, attributes){
+        console.log("Mail received: " + mail.subject);
+
+        mailListener2.imap.addFlags(attributes.uid, '\\Seen', function(err) {
+          if (err) {
+            console.log('Error marking message read/SEEN');
+          } else {
+            console.log('Marked message as SEEN');
+          }
+        });          
+        deferred.fulfill(mail);
+      });
+      return deferred.promise;
+    };   
+  };
+
+  module.exports = MailListener;
+})(module);

--- a/test/e2e/launcher/pages/signInPage.js
+++ b/test/e2e/launcher/pages/signInPage.js
@@ -60,6 +60,20 @@ var SignInPage = function() {
     return incorrectCredentialsError;
   };
 
+  this.customAuthSignIn = function(username,password) {
+    //wait for spinner to go away.
+    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - Before Custom Sign In');
+
+    this.getUsernameTextBox().clear();
+    this.getUsernameTextBox().sendKeys(username);
+
+    var enter = "\ue007";
+    this.getPasswordTextBox().clear();
+    this.getPasswordTextBox().sendKeys(password + enter);
+    
+    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - After Custom Sign In');    
+  };
+
   this.getGoogleLogin = function() {
     helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - Get Google Login');
     helper.wait(signInGoogleLink, 'Sign In Google Link', 1000);

--- a/test/e2e/launcher/pages/signUpPage.js
+++ b/test/e2e/launcher/pages/signUpPage.js
@@ -21,6 +21,8 @@ var SignUpPage = function() {
   var passwordStrengthWarning = element(by.cssContainingText('.text-warning', 'strong password'));
   var matchingPasswordsError = element(by.cssContainingText('.text-danger', 'must match'));
   var alreadyRegisteredError = element(by.id('already-registered-warning'));
+  var confirmEmailNotice = element(by.cssContainingText('.panel-body', 'check your inbox to complete your account registration'));
+  var emailConfirmedNotice = element(by.cssContainingText('.panel-body', 'Account successfully confirmed'));
 
   var modalDialog = element(by.css('.modal-dialog'));
   var modalTitle = element(by.css('.modal-title'));
@@ -75,6 +77,14 @@ var SignUpPage = function() {
 
   this.getAlreadyRegisteredError = function() {
     return alreadyRegisteredError;
+  };
+
+  this.getConfirmEmailNotice = function() {
+    return confirmEmailNotice;
+  };
+
+  this.getEmailConfirmedNotice = function() {
+    return emailConfirmedNotice;
   };
 
   this.getModalDialog = function () {

--- a/test/e2e/launcher/pages/signUpPage.js
+++ b/test/e2e/launcher/pages/signUpPage.js
@@ -107,7 +107,7 @@ var SignUpPage = function() {
   this.getConfirmationLink = function(mailListener) {
     var deferred = protractor.promise.defer();
 
-    browser.controlFlow().wait(mailListener.getLastEmail(), 45000).then(function (email) {
+    mailListener.getLastEmail().then(function (email) {
       var pattern = /href="(https:\/\/apps-stage-0\.risevision\.com\/confirmaccount\/.*?)"/g;
       var confirmationLink = pattern.exec(email.html)[1];
       console.log("Confirmation link: "+confirmationLink);
@@ -119,7 +119,7 @@ var SignUpPage = function() {
 
   this.customAuthSignUp = function(email, password){
     helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
-    
+
     this.getUsernameTextBox().sendKeys(email);
     this.getPasswordTextBox().sendKeys(password);
     this.getConfirmPasswordTextBox().sendKeys(password);

--- a/test/e2e/launcher/pages/signUpPage.js
+++ b/test/e2e/launcher/pages/signUpPage.js
@@ -104,6 +104,31 @@ var SignUpPage = function() {
     signInPage.getSignInGoogleLink().click();
   };
 
+  this.getConfirmationLink = function(mailListener) {
+    var deferred = protractor.promise.defer();
+
+    browser.controlFlow().wait(mailListener.getLastEmail(), 45000).then(function (email) {
+      var pattern = /href="(https:\/\/apps-stage-0\.risevision\.com\/confirmaccount\/.*?)"/g;
+      var confirmationLink = pattern.exec(email.html)[1];
+      console.log("Confirmation link: "+confirmationLink);
+
+      deferred.fulfill(confirmationLink);
+    });
+    return deferred.promise;
+  };
+
+  this.customAuthSignUp = function(email, password){
+    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+    
+    this.getUsernameTextBox().sendKeys(email);
+    this.getPasswordTextBox().sendKeys(password);
+    this.getConfirmPasswordTextBox().sendKeys(password);
+
+    this.getSignupButton().click();
+
+    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+  };
+
 };
 
 module.exports = SignUpPage;

--- a/test/e2e/launcher/pages/signUpPage.js
+++ b/test/e2e/launcher/pages/signUpPage.js
@@ -110,6 +110,7 @@ var SignUpPage = function() {
     mailListener.getLastEmail().then(function (email) {
       var pattern = /href="(https:\/\/apps-stage-0\.risevision\.com\/confirmaccount\/.*?)"/g;
       var confirmationLink = pattern.exec(email.html)[1];
+      confirmationLink = confirmationLink.replace('https://apps-stage-0.risevision.com','http://localhost:8099');
       console.log("Confirmation link: "+confirmationLink);
 
       deferred.fulfill(confirmationLink);


### PR DESCRIPTION
## Description
Creates a unique custom auth user for each build/stage environment using gmail plus addressing to test Registration scenarios.
Added MailListener to validate that expected emails are sent and to grab the email confirmation link.
Miscellaneous refactorings/improvements. 

## Motivation and Context
To prevent conflicts due to parallelism and preparing to replace risevision domain accounts with regular gmail accounts.

## How Has This Been Tested?
E2E changes only. Tested locally and on staging environment.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

@alex-deaconu Please review. Thanks