### PR TITLE
Check for unsaved changes before autosaving

### DIFF
--- a/test/e2e/template-editor/cases/template-editor-add.js
+++ b/test/e2e/template-editor/cases/template-editor-add.js
@@ -59,6 +59,37 @@ var TemplateAddScenarios = function() {
         expect(templateEditorPage.getComponentItems().count()).to.eventually.be.above(1);
         expect(templateEditorPage.getImageComponentEdit().isPresent()).to.eventually.be.true;
       });
+
+      describe('remove',function(){
+        before(function(){
+          //workaround as protactor can't click on top of iframes
+          //decrease window size to hide template preview        
+          browser.driver.manage().window().setSize(500, 800); 
+        });
+
+        it('should delete the Presentation', function () {
+          browser.sleep(500);
+          helper.clickWhenClickable(templateEditorPage.getDeleteButton(), 'Template Delete Button');
+
+          browser.sleep(500);
+          helper.wait(templateEditorPage.getDeleteForeverButton(), 'Template Delete Forever Button');      
+          helper.clickWhenClickable(templateEditorPage.getDeleteForeverButton(), 'Template Delete Forever Button');
+
+          helper.wait(presentationsListPage.getTitle(), 'Presentation List');
+        });
+
+        it('should not show any errors', function() {
+          browser.sleep(3000);
+
+          expect(templateEditorPage.getErrorModal().isPresent()).to.eventually.be.false;
+        });
+
+        after(function(){
+          //revert workaround
+          browser.driver.manage().window().setSize(1920, 1080); 
+        });
+      });    
+
     });
   });
 };

--- a/test/e2e/template-editor/pages/presentationListPage.js
+++ b/test/e2e/template-editor/pages/presentationListPage.js
@@ -8,6 +8,8 @@ var StoreProductsModalPage = require('../../editor/pages/storeProductsModalPage.
 var TemplateEditorPage = require('./templateEditorPage.js');
 
 var PresentationListPage = function() {
+  var title = element(by.id('title'));
+
   var presentationAddButton = element(by.id('presentationAddButton'));
 
   var presentationListTable = element(by.id('presentationListTable'));
@@ -62,6 +64,10 @@ var PresentationListPage = function() {
     expect(templateEditorPage.getPresentationName().isEnabled()).to.eventually.be.true;
     templateEditorPage.getPresentationName().sendKeys(presentationName + protractor.Key.ENTER);
   }
+
+  this.getTitle = function() {
+    return title;
+  };
 
   this.getPresentationAddButton = function() {
     return presentationAddButton;

--- a/test/e2e/template-editor/pages/templateEditorPage.js
+++ b/test/e2e/template-editor/pages/templateEditorPage.js
@@ -11,6 +11,8 @@ var TemplateEditorPage = function() {
   var presentationName = element(by.id('presentationName'));
   var editNameButton = element(by.id('editNameButton'));
   var deleteButton = element(by.id('deleteButton'));
+  var deleteForeverButton = element(by.buttonText('Delete Forever'));
+  var errorModal = element(by.xpath('//h4[contains(text(), "Failed to")]'));
   var publishButton = element(by.id('publishButtonDesktop'));
   var imageComponentSelector = '//div[div/span[contains(text(), "Image - ")]]';
   var imageComponent = element(by.xpath('(' + imageComponentSelector + ')[1]'));
@@ -60,6 +62,14 @@ var TemplateEditorPage = function() {
 
   this.getDeleteButton = function () {
     return deleteButton;
+  };
+
+  this.getDeleteForeverButton = function () {
+    return deleteForeverButton
+  };
+
+  this.getErrorModal = function () {
+    return errorModal;
   };
 
   this.getSavedText = function () {

--- a/test/unit/template-editor/controllers/ctr-template-editor.tests.js
+++ b/test/unit/template-editor/controllers/ctr-template-editor.tests.js
@@ -231,6 +231,24 @@ describe('controller: TemplateEditor', function() {
       saveStub.should.have.been.called;
     });
 
+    it('should not notify unsaved changes when changing URL on delete', function () {
+      factory.presentation.id = '1234';
+      factory.presentation.name = 'New Name';
+      $scope.$apply();
+      $timeout.flush();
+      var saveStub = sinon.stub(factory, 'save', function(){
+        return Q.resolve();
+      });
+
+      $rootScope.$broadcast('presentationDeleted');
+      $scope.$apply();
+
+      $rootScope.$broadcast('$stateChangeStart', { name: 'newState' });
+      $scope.$apply();
+
+      saveStub.should.not.have.been.called;
+    });
+
     it('should not notify unsaved changes when changing URL if state is in Template Editor', function () {
       factory.presentation.id = '1234';
       factory.presentation.name = 'New Name';

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -118,7 +118,9 @@ angular.module('risevision.template-editor.controllers')
 
           autoSaveService.clearSaveTimeout();
 
-          $scope.factory.save()
+          var savePromise = $scope.factory.isUnsaved() ? $scope.factory.save() : $q.resolve();
+
+          savePromise
             .finally(function () {
               _bypassUnsaved = true;
               $state.go(toState, toParams);


### PR DESCRIPTION
## Description
Fixes issue where if the Presentation is deleted
the id is null and the service tries to add
template instead of update

[stage-2]

## Motivation and Context
Fix for #1287 
Introduced with #1281 

## How Has This Been Tested?
Validated fix locally and in the staging environment. Added unit and e2e test coverage for Template Delete use case.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No