### PR TITLE
Change custom auth account to hotmail

### DIFF
--- a/test/e2e/common-header/cases/registration-existing-company.js
+++ b/test/e2e/common-header/cases/registration-existing-company.js
@@ -182,6 +182,7 @@
         });
 
         it("deletes a user", function() {
+          browser.sleep(500);
           // Ensure the right User is being deleted
           expect(userSettingsModalPage.getUsernameLabel().getText()).to.eventually.equal(EMAIL_ADDRESS);
 

--- a/test/e2e/common-header/pages/commonHeaderPage.js
+++ b/test/e2e/common-header/pages/commonHeaderPage.js
@@ -122,7 +122,7 @@
     };
 
     this.getStageEmailAddress = function () {
-      return 'jenkins.rise+'+this.getStageEnv()+'@gmail.com';
+      return 'jenkins.rise+'+this.getStageEnv()+'@hotmail.com';
     };
 
     this.getPassword = function () {

--- a/test/e2e/common-header/utils/mailListener.js
+++ b/test/e2e/common-header/utils/mailListener.js
@@ -5,9 +5,9 @@
 
   var MailListener = function (emailAddressToFilter, password) {
     var mailListener2 = new MailListener2({
-      username: "jenkins.rise@gmail.com",
+      username: "jenkins.rise@hotmail.com",
       password: password, 
-      host: "imap.gmail.com",
+      host: "outlook.office365.com",
       port: 993,
       searchFilter: ["UNSEEN",['TO', emailAddressToFilter]],
       tls: true,
@@ -36,14 +36,6 @@
 
       mailListener2.once("mail", function(mail, seqno, attributes){
         console.log("Mail received: " + mail.subject);
-
-        mailListener2.imap.addFlags(attributes.uid, '\\Seen', function(err) {
-          if (err) {
-            console.log('Error marking message read/SEEN');
-          } else {
-            console.log('Marked message as SEEN');
-          }
-        });          
         deferred.fulfill(mail);
       });
       return deferred.promise;

--- a/test/e2e/launcher/pages/signUpPage.js
+++ b/test/e2e/launcher/pages/signUpPage.js
@@ -104,6 +104,12 @@ var SignUpPage = function() {
     signInPage.getSignInGoogleLink().click();
   };
 
+  function decodeHtml (str) {
+    return str.replace(/&#(\d+);/g, function(match, dec) {
+      return String.fromCharCode(dec);
+    });
+  }
+
   this.getConfirmationLink = function(mailListener) {
     var deferred = protractor.promise.defer();
 
@@ -111,6 +117,7 @@ var SignUpPage = function() {
       var pattern = /href="(https:\/\/apps-stage-0\.risevision\.com\/confirmaccount\/.*?)"/g;
       var confirmationLink = pattern.exec(email.html)[1];
       confirmationLink = confirmationLink.replace('https://apps-stage-0.risevision.com','http://localhost:8099');
+      confirmationLink = decodeHtml(confirmationLink);
       console.log("Confirmation link: "+confirmationLink);
 
       deferred.fulfill(confirmationLink);


### PR DESCRIPTION
## Description
Change custom auth account to hotmail to overcome login problems due to gmail security.

Removed unneeded call to mark email as read.
Adde a sleep to wait for modal animation.
Decoded confirmation URL as hotmail had an html entity for the plus sign.


## Motivation and Context
Multiple times mail listener could not sign in due to google blocking access from a new device. The workaround was to visit https://www.google.com/accounts/UnlockCaptcha to unblock the device, but it is not a scalable solution. 
Changing the account to hotmail as in our tests all attempts worked fine, it seems they have a less strict policy.

## How Has This Been Tested?
Describe in detail how you tested your changes. Include details of your testing environment and link(s) for reviewers to validate.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

@alex-deaconu Please review. Thanks