### PR TITLE
Send all user and company info on initial registration

### DIFF
--- a/test/unit/common-header/services/svc-account-spec.js
+++ b/test/unit/common-header/services/svc-account-spec.js
@@ -35,7 +35,7 @@ describe("Services: account", function() {
         deferred.resolve({
           account: {
             agreeToTerms: riseApiResponse,
-            add: riseApiResponse,
+            addWithDetails: riseApiResponse,
             get: riseApiResponse
           }
         });

--- a/web/scripts/common-header/controllers/ctr-registration-modal.js
+++ b/web/scripts/common-header/controllers/ctr-registration-modal.js
@@ -72,7 +72,8 @@ angular.module('risevision.common.header')
 
           var action;
           if ($scope.newUser) {
-            action = registerAccount(userState.getUsername(), $scope.profile);
+            action = registerAccount($scope.profile.firstName, $scope.profile.lastName, $scope.company.name, $scope
+              .company.companyIndustry);
           } else {
             action = agreeToTermsAndUpdateUser(userState.getUsername(),
               $scope.profile);
@@ -83,17 +84,11 @@ angular.module('risevision.common.header')
                 userState.refreshProfile()
                   .finally(function () {
                     if ($scope.newUser) {
-                      updateCompany(userState.getUserCompanyId(), $scope.company)
-                        .then(function () {
-                          plansFactory.startVolumePlanTrial();
-                        })
-                        .finally(function () {
-                          $rootScope.$broadcast(
-                            'risevision.user.authorized');
+                      plansFactory.startVolumePlanTrial();
+                      $rootScope.$broadcast('risevision.user.authorized');
 
-                          $modalInstance.close('success');
-                          $loading.stop('registration-modal');
-                        });
+                      $modalInstance.close('success');
+                      $loading.stop('registration-modal');
                     }
 
                     analyticsEvents.identify();

--- a/web/scripts/common-header/services/svc-account.js
+++ b/web/scripts/common-header/services/svc-account.js
@@ -52,17 +52,13 @@
     .factory('registerAccount', ['$q', '$log',
       'addAccount', 'updateUser',
       function ($q, $log, addAccount, updateUser) {
-        return function (username, basicProfile) {
-          $log.debug('registerAccount called.', username, basicProfile);
+        return function (userFirst, userLast, companyName, companyIndustry) {
+          $log.debug('registerAccount called.', userFirst, userLast, companyName, companyIndustry);
           var deferred = $q.defer();
-          addAccount().then().finally(function () {
-            updateUser(username, basicProfile).then(function (resp) {
-              if (resp.result) {
-                deferred.resolve();
-              } else {
-                deferred.reject();
-              }
-            }, deferred.reject).finally('registerAccount ended');
+          addAccount(userFirst, userLast, companyName, companyIndustry).then(function () {
+            deferred.resolve();
+          }).finally(function () {
+            deferred.reject();
           });
           return deferred.promise;
         };
@@ -71,11 +67,17 @@
 
     .factory('addAccount', ['$q', 'riseAPILoader', '$log',
       function ($q, riseAPILoader, $log) {
-        return function () {
+        return function (userFirst, userLast, companyName, companyIndustry) {
           $log.debug('addAccount called.');
           var deferred = $q.defer();
           riseAPILoader().then(function (riseApi) {
-            var request = riseApi.account.add();
+            var request = riseApi.account.addWithDetails({
+              userFirst: userFirst,
+              userLast: userLast,
+              companyName: companyName,
+              companyIndustry: companyIndustry
+            });
+
             request.execute(function (resp) {
               $log.debug('addAccount resp', resp);
               if (resp.result) {


### PR DESCRIPTION
Populate company and user info on first creation

Rather than creating users without first / last and companies without
industry and name, set all of these on first registration. That way
they do not have to be set in subsequent api calls.

This will remove the race condition in Hubspot that is caused by
rapid creation of company as "me@example.com's company" then rename to "my
company".

## How Has This Been Tested?
Manual tests and verification of hubspot calls and chargebee trial subscription and company.
Existing unit test updated.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
