### PR TITLE
Fix unit test that eventually fails

### DIFF
--- a/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
+++ b/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
@@ -80,8 +80,8 @@ describe('directive: TemplateEditorPreviewHolder', function() {
           setAttribute: function() {}
         }
     });
+    sandbox.stub($window, 'matchMedia').returns({ matches: false });
 
-      
     element = $compile("<template-editor-preview-holder></template-editor-preview-holder>")($scope);
     $scope.$digest();
   }));


### PR DESCRIPTION
## Description
Probably due to a race condition, `$window.matchMedia()` was sometimes returning `true` when testing mobile size. By stubbing it, we will always get the same value and unit tests will stop failing sporadically.

## Motivation and Context
99% Reliable Builds.

## How Has This Been Tested?
This could be validated by running the test with `.only()`. It would always fail, and it stopped failing after the stub was added.
[stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

@alex-deaconu Please review. Thanks