### PR TITLE
change all beta to staging

### DIFF
--- a/test/unit/template-editor/services/svc-blueprint-factory.tests.js
+++ b/test/unit/template-editor/services/svc-blueprint-factory.tests.js
@@ -52,7 +52,7 @@ describe('service: blueprint factory', function() {
   describe('load: ', function() {
 
     it('should call API and return blueprintData',function(done) {
-      $httpBackend.expect('GET', 'https://widgets.risevision.com/beta/templates/template123/blueprint.json').respond(200, 'blueprintData');
+      $httpBackend.expect('GET', 'https://widgets.risevision.com/staging/templates/template123/blueprint.json').respond(200, 'blueprintData');
 
       blueprintFactory.load(PRODUCT_CODE)
         .then(function(resp) {
@@ -64,7 +64,7 @@ describe('service: blueprint factory', function() {
     });
 
     it('should populate factory object on load',function(done) {
-      $httpBackend.expect('GET', 'https://widgets.risevision.com/beta/templates/template123/blueprint.json').respond(200, 'blueprintData');
+      $httpBackend.expect('GET', 'https://widgets.risevision.com/staging/templates/template123/blueprint.json').respond(200, 'blueprintData');
 
       blueprintFactory.load(PRODUCT_CODE)
         .then(function(resp) {
@@ -76,7 +76,7 @@ describe('service: blueprint factory', function() {
     });
 
     it('should reject on http error',function(done) {
-      $httpBackend.expect('GET', 'https://widgets.risevision.com/beta/templates/template123/blueprint.json').respond(500, { error: 'Error' });
+      $httpBackend.expect('GET', 'https://widgets.risevision.com/staging/templates/template123/blueprint.json').respond(500, { error: 'Error' });
 
       blueprintFactory.load(PRODUCT_CODE)
         .then(null,function(error) {
@@ -85,7 +85,7 @@ describe('service: blueprint factory', function() {
         });
 
       $httpBackend.flush();
-    });    
+    });
   });
 
   describe('isPlayUntilDone: ', function() {
@@ -116,7 +116,7 @@ describe('service: blueprint factory', function() {
       };
 
       expect(blueprintFactory.isPlayUntilDone()).to.be.false;
-    });    
+    });
   });
 
   describe('hasBranding: ', function() {
@@ -139,7 +139,7 @@ describe('service: blueprint factory', function() {
       };
 
       expect(blueprintFactory.hasBranding()).to.be.false;
-    });    
+    });
   });
 
   describe('getBlueprintData', function () {
@@ -198,7 +198,7 @@ describe('service: blueprint factory', function() {
       expect(blueprintFactory.getLogoComponents()).to.deep.equal([]);
     });
 
-    it('should return is-logo images',function(){      
+    it('should return is-logo images',function(){
       var logoComponent = { type: "rise-image", attributes: {'is-logo': {value:'true' } } };
       blueprintFactory.blueprintData = {
         components: [

--- a/web/scripts/config/beta.js
+++ b/web/scripts/config/beta.js
@@ -38,7 +38,7 @@
     .value('CHARGEBEE_PROD_SITE', 'risevision')
     .value('STRIPE_PROD_KEY', 'pk_live_31dWkTWQU125m2RcWpK4HQBR')
     .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
-    .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/src/template.html')
-    .value('BLUEPRINT_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/blueprint.json');
+    .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/src/template.html')
+    .value('BLUEPRINT_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/blueprint.json');
 
 })(angular);

--- a/web/scripts/config/dev.js
+++ b/web/scripts/config/dev.js
@@ -46,7 +46,7 @@
     .value('CHARGEBEE_PLANS_USE_PROD', 'false')
     .value('STRIPE_PROD_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
     .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
-    .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/beta/templates/PRODUCT_CODE/src/template.html')
-    .value('BLUEPRINT_URL', 'https://widgets.risevision.com/beta/templates/PRODUCT_CODE/blueprint.json');
+    .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/src/template.html')
+    .value('BLUEPRINT_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/blueprint.json');
 
 })(angular);

--- a/web/scripts/config/test.js
+++ b/web/scripts/config/test.js
@@ -47,7 +47,7 @@
     .value('CHARGEBEE_PLANS_USE_PROD', 'false')
     .value('STRIPE_PROD_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
     .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
-    .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/beta/templates/PRODUCT_CODE/src/template.html')
-    .value('BLUEPRINT_URL', 'https://widgets.risevision.com/beta/templates/PRODUCT_CODE/blueprint.json');
+    .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/src/template.html')
+    .value('BLUEPRINT_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/blueprint.json');
 
 })(angular);


### PR DESCRIPTION
## Description
Change beta template references to staging on apps beta, dev and test 

## Motivation and Context
Beta HTML templates will be replaced by staging level. It was previously changed for Apps staging, and this PR also changes all other non-production configurations.

## How Has This Been Tested?
Automated tests that use these levels should pass.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     To be released before Friday.
      No changes to production environment, so risk to customers is low. Simple rollback is needed to return to previous version.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to update documentation. No need to notify support.
