### PR TITLE
Check for overwrite modal when uploading

### DIFF
--- a/test/e2e/storage/cases/trash.js
+++ b/test/e2e/storage/cases/trash.js
@@ -6,6 +6,7 @@ var CommonHeaderPage = require('./../../common-header/pages/commonHeaderPage.js'
 var helper = require('rv-common-e2e').helper;
 var StorageHomePage = require('./../pages/storageHomePage.js');
 var FilesListPage = require('./../pages/filesListPage.js');
+var StorageSelectorModalPage = require('./../pages/storageSelectorModalPage.js');
 
 var TrashScenarios = function() {
 
@@ -16,6 +17,7 @@ var TrashScenarios = function() {
     var commonHeaderPage;
     var storageHomePage;
     var filesListPage;
+    var storageSelectorModalPage;
 
     before(function () {
       homepage = new HomePage();
@@ -23,6 +25,7 @@ var TrashScenarios = function() {
       commonHeaderPage = new CommonHeaderPage();
       storageHomePage = new StorageHomePage();
       filesListPage = new FilesListPage();
+      storageSelectorModalPage = new StorageSelectorModalPage();
     });
 
     describe('Given a user who wants to delete a file forever', function () {
@@ -37,6 +40,13 @@ var TrashScenarios = function() {
         //upload sample file       
         var uploadFilePath = process.cwd() + '/bower.json';
         storageHomePage.getUploadInput().sendKeys(uploadFilePath);
+
+        storageSelectorModalPage.getOverwriteConfirmationModal().isPresent().then(function(isDisplayed) {
+          if (isDisplayed) {
+            helper.clickWhenClickable(storageSelectorModalPage.getOverwriteFilesButton(),'Keep Files button');
+            helper.waitDisappear(storageSelectorModalPage.getOverwriteConfirmationModal(), 'Overwrite Confirmation');            
+          }
+        });
 
         //wait upload to finish        
         helper.waitDisappear(storageHomePage.getUploadPanel(), 'Storage Upload Panel');


### PR DESCRIPTION
## Description
File may not have been deleted correctly by previous/concurrent tests

## Motivation and Context
Directly addresses this e2e failure:
https://circleci.com/gh/Rise-Vision/rise-vision-apps/39317
Otherwise manual action is required to delete the file.

## How Has This Been Tested?
No actual code/functionality changes.
Ran e2e tests locally and on CCI. Replicated the scenario and validated the tests recover by confirming the file overwrite.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
N/A
