### PR TITLE
Remove network check from endpoint load

### DIFF
--- a/test/e2e/launcher/pages/homepage.js
+++ b/test/e2e/launcher/pages/homepage.js
@@ -39,6 +39,10 @@ var HomePage = function() {
           alert.accept();
 
           return _this.confirmGet(url);
+        })
+        .catch(function(error) {
+          // no Alert shown, proceed
+          console.log(error);
         });
       });
   };

--- a/test/unit/components/scrolling-list/svc-process-error-code.tests.js
+++ b/test/unit/components/scrolling-list/svc-process-error-code.tests.js
@@ -25,6 +25,22 @@ describe("service: process error code:", function() {
     expect(processErrorCode(itemName, action, {})).to.equal("An Error has Occurred");
   });
 
+  it("should process all flavors of errors", function() {
+    var e = { code: -1 };
+    expect(processErrorCode(itemName, action, e)).to.equal("apps-common.errors.checkConnection");
+    expect(processErrorCode(itemName, action, {
+      error: e
+    })).to.equal("apps-common.errors.checkConnection");
+    expect(processErrorCode(itemName, action, {
+      result: e
+    })).to.equal("apps-common.errors.checkConnection");
+    expect(processErrorCode(itemName, action, {
+      result: {
+        error: e
+      }
+    })).to.equal("apps-common.errors.checkConnection");
+  });
+
   it("should attempt to internationalize Storage errors", function() {
     expect(processErrorCode(itemName, action, {
       result: { error: { message: "i18n-fail" } }

--- a/test/unit/storage/services/svc-storage.tests.js
+++ b/test/unit/storage/services/svc-storage.tests.js
@@ -171,8 +171,11 @@ describe('service: storage:', function() {
       };
     });
 
+    $provide.service('processErrorCode', function() {
+      return sinon.spy(function() { return 'error'; });
+    });
   }));
-  var storage, returnResult, folderPath, filePath, folderName, storageApiRequestObj;
+  var storage, returnResult, folderPath, filePath, folderName, storageApiRequestObj, processErrorCode;
   beforeEach(function(){
     returnResult = true;
     folderPath = '';
@@ -180,6 +183,7 @@ describe('service: storage:', function() {
     
     inject(function($injector){
       storage = $injector.get('storage');
+      processErrorCode = $injector.get('processErrorCode');
     });
   });
 
@@ -252,6 +256,7 @@ describe('service: storage:', function() {
           done(result);
         })
         .then(null, function(error) {
+          expect(processErrorCode).to.have.been.calledWith('Files', 'list', 'API Failed');
           expect(error).to.deep.equal('API Failed');
           done();
         })

--- a/web/scripts/components/core-api-client/svc-user.js
+++ b/web/scripts/components/core-api-client/svc-user.js
@@ -21,9 +21,8 @@
       'status', 'companyRole', 'dataCollectionDate'
     ])
 
-    .factory('getUserProfile', ['oauth2APILoader', 'coreAPILoader', '$q',
-      '$log',
-      function (oauth2APILoader, coreAPILoader, $q, $log) {
+    .factory('getUserProfile', ['coreAPILoader', '$q', '$log',
+      function (coreAPILoader, $q, $log) {
         var _username;
         var _cachedPromises = {};
 
@@ -52,10 +51,7 @@
             }
             $log.debug('getUserProfile called', criteria);
 
-            $q.all([oauth2APILoader(), coreAPILoader()]).then(function (
-              results) {
-              var coreApi = results[1];
-              // var oauthUserInfo = results[2];
+            coreAPILoader().then(function (coreApi) {
               coreApi.user.get(criteria).execute(function (resp) {
                 if (resp.error || !resp.result) {
                   deferred.reject(resp);

--- a/web/scripts/components/scrolling-list/svc-process-error-code.js
+++ b/web/scripts/components/scrolling-list/svc-process-error-code.js
@@ -18,10 +18,28 @@ angular.module('risevision.common.components.scrolling-list')
         reboot: 'rebooted'
       };
 
+      var _getError = function(e) {
+        if (e) {
+          if (e.result) {
+            if (e.result.error) {
+              return e.result.error;
+            } else {
+              return e.result;
+            }
+          } else if (e.error) {
+            return e.error;
+          } else {
+            return e;
+          }
+        } else {
+          return {};
+        }
+      };
+
       return function (itemName, action, e) {
         var tryAgainMessage = $filter('translate')('apps-common.errors.tryAgain');
         var actionName = actionsMap[action];
-        var error = (e && e.result && e.result.error) || {};
+        var error = _getError(e);
         var errorString = error.message ? error.message : 'An Error has Occurred';
         var messagePrefix = $filter('translate')('apps-common.errors.actionFailed', {
           itemName: itemName,

--- a/web/scripts/storage/services/svc-storage.js
+++ b/web/scripts/storage/services/svc-storage.js
@@ -4,8 +4,8 @@
 
 angular.module('risevision.storage.services')
   .service('storage', ['$q', '$log', 'storageAPILoader',
-    'userState', '$window',
-    function ($q, $log, storageAPILoader, userState, $window) {
+    'userState', '$window', 'processErrorCode',
+    function ($q, $log, storageAPILoader, userState, $window, processErrorCode) {
       var service = {
         files: {
           get: function (search) {
@@ -33,7 +33,8 @@ angular.module('risevision.storage.services')
                 deferred.resolve(resp.result);
               })
               .then(null, function (e) {
-                console.error('Failed to get storage files', e);
+                var apiError = processErrorCode('Files', 'list', e);
+                console.error('Failed to get storage files', apiError);
                 deferred.reject(e);
               });
 


### PR DESCRIPTION
## Description
Network check was failing to work correctly due
to CORS issues

However by testing the library, it seems that we get
the correct error response regardless

Update gapiClientLoaderGenerator to use promises

Send error code, handle it in processErrorCode
and add sample error handling for Storage list

[stage-2]

## Motivation and Context
e2e tests were failing because of this
Users would get random login failures because of this

## How Has This Been Tested?
Functionality is removed.
Validated with local environment: gapi calls are handled correctly. Promises are interpreted properly. Using request blocking validated that Storage API failures are handled correctly and the correct message is displayed.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
N/A
