### PR TITLE
E2E tests specify expected subject when waiting for emails

### DIFF
--- a/test/e2e/common-header/cases/registration-existing-company.js
+++ b/test/e2e/common-header/cases/registration-existing-company.js
@@ -77,9 +77,10 @@
         });
 
         it('should send an email to the added user',function(){
-          browser.controlFlow().wait(mailListener.getLastEmail(), 60000).then(function (email) {
-            expect(email.subject).to.equal("You've been added to a Rise Vision account!");
-          }); 
+          browser.controlFlow().wait(mailListener.getLastEmail("You've been added to a Rise Vision account!"), 60000)
+            .then(function (email) {
+              expect(email.subject).to.equal("You've been added to a Rise Vision account!");
+            }); 
         });
         
         it("Company Users Dialog Should Close", function () {

--- a/test/e2e/common-header/utils/mailListener.js
+++ b/test/e2e/common-header/utils/mailListener.js
@@ -30,14 +30,23 @@
       mailListener2.stop();
     };
 
-    this.getLastEmail = function() {
+    this.getLastEmail = function(subjectFilter) {
       var deferred = protractor.promise.defer();
       console.log("Waiting for an email...");
-
-      mailListener2.once("mail", function(mail, seqno, attributes){
-        console.log("Mail received: " + mail.subject);
-        deferred.fulfill(mail);
-      });
+      if (!subjectFilter) {
+        mailListener2.once("mail", function(mail, seqno, attributes){
+          console.log("Mail received: " + mail.subject);
+          deferred.fulfill(mail);
+        });
+      } else {
+        mailListener2.on("mail", function(mail, seqno, attributes){
+          console.log("Mail received: " + mail.subject);
+          if (mail.subject === subjectFilter) {
+            mailListener2.removeAllListeners("mail");
+            deferred.fulfill(mail);
+          }
+        });
+      }
       return deferred.promise;
     };   
   };

--- a/test/e2e/launcher/pages/signUpPage.js
+++ b/test/e2e/launcher/pages/signUpPage.js
@@ -113,7 +113,7 @@ var SignUpPage = function() {
   this.getConfirmationLink = function(mailListener) {
     var deferred = protractor.promise.defer();
 
-    mailListener.getLastEmail().then(function (email) {
+    mailListener.getLastEmail('Confirm account').then(function (email) {
       var pattern = /href="(https:\/\/apps-stage-0\.risevision\.com\/confirmaccount\/.*?)"/g;
       var confirmationLink = pattern.exec(email.html)[1];
       confirmationLink = confirmationLink.replace('https://apps-stage-0.risevision.com','http://localhost:8099');


### PR DESCRIPTION
## Description
If a subject is specified, mail listener will wait until a received email matches that subject before resolving the promise.

## Motivation and Context
99% reliable builds. Tests were eventually failing if receiving unexpected emails.

## How Has This Been Tested?
Tested locally by manually sending non expected emails.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

@alex-deaconu Please review. Thanks