### PR TITLE
Add wait for checkout flow

### DIFF
--- a/test/e2e/common-header/cases/checkout.js
+++ b/test/e2e/common-header/cases/checkout.js
@@ -168,6 +168,10 @@
           helper.wait(purchaseFlowModalPage.getReviewPurchasePage(), 'Review Purchase Page');
 
           expect(purchaseFlowModalPage.getReviewPurchasePage().isDisplayed()).to.eventually.be.true;
+
+          // Wait for other responses to complete and update Chargebee address for the Company
+          browser.sleep(10000);
+
           expect(purchaseFlowModalPage.getPayButton().isDisplayed()).to.eventually.be.true;
 
           helper.clickWhenClickable(purchaseFlowModalPage.getPayButton(), 'Purchase flow Pay Button');


### PR DESCRIPTION
## Description
Waits for Core to update Address in Chargebee

[stage-2]

## Motivation and Context
Fixes issue where Billing Address is not updated in Chargebee when the Purchase API is called. This is causing an error with the purchase.

## How Has This Been Tested?
The Company API is being called in the background when updating the Billing Address, and may take longer to complete. The Purchase call may happen before the Company update call finishes.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
N/A
