### PR TITLE
Adjust margins to not push modals to the bottom of page on small screens

### DIFF
--- a/web/scss/sections/template-editor-layout.scss
+++ b/web/scss/sections/template-editor-layout.scss
@@ -1103,6 +1103,7 @@ $maderio-green-disabled: #a2dbb2;
     vertical-align: middle;
     content: " ";
     height: 100%;
+    margin-right: -4px; /* Adjusts for small screens by removing the space added by inline-block */
   }
 
   &.centered-modal {


### PR DESCRIPTION
## Description
Adjust margins to not push modals to the bottom of page on small screens
Ref: https://stackoverflow.com/a/21323821/427373

## Motivation and Context
Fix UI style

## How Has This Been Tested?
Tested locally and on stage-1 for multiple resolutions and modals.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

@alex-deaconu Please review.