### PR TITLE
sanitize output [stage-9]

### DIFF
--- a/web/scripts/editor/directives/dtv-presentation-name.js
+++ b/web/scripts/editor/directives/dtv-presentation-name.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.editor.directives')
-  .directive('presentationName', ['presentationFactory',
-    function (presentationFactory) {
+  .directive('presentationName', ['$sce', 'presentationFactory',
+    function ($sce, presentationFactory) {
       return {
         restrict: 'A',
         require: '?ngModel',
@@ -19,7 +19,7 @@ angular.module('risevision.editor.directives')
                     if (ngModel) {
                       $scope.ngModel = presentation.name;
                     } else {
-                      element.html(presentation.name);
+                      element.html($sce.getTrustedHtml(presentation.name));
                     }
                   }
                 });


### PR DESCRIPTION
## Description
Sanitize output in presentation name directive.

## Motivation and Context
For some reason, the presentation name directive chooses to insert HTML directly into the page [here](https://github.com/Rise-Vision/rise-vision-apps/blob/master/web/scripts/editor/directives/dtv-presentation-name.js#L22), which results in potential code injection. Here we sanitize such output so it does not represents an issue.

## How Has This Been Tested?
Tested locally and remotely in https://apps-stage-9.risevision.com/schedules/details/e0fc0433-ee93-4a9f-a2a3-6eadfdef52c3?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     - To be released before Friday.
     - It will be validated in production right after release.
     - Simple rollback is enough to undo changes, no user data is affected so this is low risk.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to update documentation or notify support.
