### PR TITLE
Fix issue with display deletion/save after opening modal

### DIFF
--- a/test/e2e/displays/cases/alerts.js
+++ b/test/e2e/displays/cases/alerts.js
@@ -132,9 +132,12 @@ var AlertsScenarios = function() {
           expect(presentationModalPage.getAddPresentationModal().isDisplayed()).to.eventually.be.true;
           expect(presentationModalPage.getModalTitle().getText()).to.eventually.equal('Select Presentation');
           presentationModalPage.getCloseButton().click();
+          helper.waitDisappear(presentationModalPage.getAddPresentationModal(), 'Add Presentation Modal');
       });
 
       it('should open the Edit Distribution Modal', function () {
+        browser.sleep(100);
+
         alertsPage.getDistributeToAllText().click();
         alertsPage.getDistributionField().click();
         helper.wait(distributionModalPage.getEditDistributionModal(), 'Edit Distribution Modal');

--- a/test/e2e/displays/cases/displayadd.js
+++ b/test/e2e/displays/cases/displayadd.js
@@ -28,6 +28,9 @@ var DisplayAddScenarios = function() {
       homepage.getDisplays();
       signInPage.signIn();
       helper.waitDisappear(displaysListPage.getDisplaysLoader(), 'Displays loader');
+
+      displaysListPage.deleteDisplayIfExists();
+
       displaysListPage.getDisplayAddButton().click();
     });
 

--- a/test/e2e/displays/cases/displaymanage.js
+++ b/test/e2e/displays/cases/displaymanage.js
@@ -8,7 +8,7 @@ var DisplayManagePage = require('./../pages/displayManagePage.js');
 var DisplayAddModalPage = require('./../pages/displayAddModalPage.js');
 var helper = require('rv-common-e2e').helper;
 
-var DisplayAddScenarios = function() {
+var DisplayManageScenarios = function() {
 
   browser.driver.manage().window().setSize(1280, 960);
   describe('Display Manage', function () {
@@ -36,174 +36,198 @@ var DisplayAddScenarios = function() {
       // Search for recently created Display
       displayName = 'TEST_E2E_DISPLAY ' + commonHeaderPage.getStageEnv();
 
-      helper.wait(displaysListPage.getSearchFilterField(), 'Search Filter Field');
-      displaysListPage.getSearchFilterField().sendKeys(displayName);
-      helper.wait(displaysListPage.getDisplaysLoader(), 'Displays loader');
-      helper.waitDisappear(displaysListPage.getDisplaysLoader(), 'Displays loader');
+      displaysListPage.searchDisplay(displayName);
+
       displaysListPage.getDisplayItems().first().element(by.tagName('td')).click();
     });
 
-    it('should load display', function () {
-      helper.waitDisappear(displayManagePage.getDisplayLoader(), 'Display loader');
-      expect(displayManagePage.getDisplayNameField().isPresent()).to.eventually.be.true;
-      expect(displayManagePage.getDisplayNameField().getAttribute('value')).to.eventually.equal(displayName);
-    });
-
-    it('should show User Company Address Checkbox', function () {
-      expect(displayManagePage.getDisplayUseCompanyAddressCheckbox().isPresent()).to.eventually.be.true;
-    });
-
-    it('should show Reboot Checkbox', function () {
-      expect(displayManagePage.getDisplayRebootCheckbox().isPresent()).to.eventually.be.true;
-    });
-
-    it('should show Time Selector', function () {
-      expect(displayManagePage.getDisplayHoursField().isPresent()).to.eventually.be.true;
-      expect(displayManagePage.getDisplayMinutesField().isPresent()).to.eventually.be.true;
-      expect(displayManagePage.getDisplayMeridianButton().isPresent()).to.eventually.be.true;
-    });
-
-    it('should show the schedule link', function() {
-      helper.wait(displayManagePage.getViewScheduleLink(), 'View Schedule Link');
-      expect(displayManagePage.getViewScheduleLink().isDisplayed()).to.eventually.be.true;
-    });
-
-    it('should show address options', function(done) {
-      displayManagePage.getDisplayUseCompanyAddressCheckbox().click();
-      displayManagePage.getDisplayTimeZoneSelect().isDisplayed().then(function (isDisplayed) {
-        if (!isDisplayed) {
-          displayManagePage.getDisplayUseCompanyAddressCheckbox().click();
-        }
-
-        expect(displayManagePage.getDisplayCountrySelect().isDisplayed()).to.eventually.be.true;
-        expect(displayManagePage.getDisplayTimeZoneSelect().isDisplayed()).to.eventually.be.true;
-
-        done();
+    describe('load', function() {
+      it('should load display', function () {
+        helper.waitDisappear(displayManagePage.getDisplayLoader(), 'Display loader');
+        expect(displayManagePage.getDisplayNameField().isPresent()).to.eventually.be.true;
+        expect(displayManagePage.getDisplayNameField().getAttribute('value')).to.eventually.equal(displayName);
       });
 
-    });
+      it('should show User Company Address Checkbox', function () {
+        expect(displayManagePage.getDisplayUseCompanyAddressCheckbox().isPresent()).to.eventually.be.true;
+      });
 
-    it('should select country',function(done){
-      browser.driver.executeScript('window.scrollTo(0,500);').then(function() {
-        displayManagePage.getDisplayCountrySelect().element(by.cssContainingText('option', 'Canada')).click();
-        expect(displayManagePage.getDisplayCountrySelect().$('option:checked').getText()).to.eventually.contain('Canada');
+      it('should show Reboot Checkbox', function () {
+        expect(displayManagePage.getDisplayRebootCheckbox().isPresent()).to.eventually.be.true;
+      });
 
-        done();
+      it('should show Time Selector', function () {
+        expect(displayManagePage.getDisplayHoursField().isPresent()).to.eventually.be.true;
+        expect(displayManagePage.getDisplayMinutesField().isPresent()).to.eventually.be.true;
+        expect(displayManagePage.getDisplayMeridianButton().isPresent()).to.eventually.be.true;
+      });
+
+      it('should show the schedule link', function() {
+        helper.wait(displayManagePage.getViewScheduleLink(), 'View Schedule Link');
+        expect(displayManagePage.getViewScheduleLink().isDisplayed()).to.eventually.be.true;
       });
     });
 
-    it('should select timezone',function(){
-      displayManagePage.getDisplayTimeZoneSelect().element(by.cssContainingText('option', 'Buenos Aires')).click();
-      expect(displayManagePage.getDisplayTimeZoneSelect().$('option:checked').getText()).to.eventually.contain('Buenos Aires');
-    });
+    describe('display address', function() {
+      it('should show address options', function(done) {
+        displayManagePage.getDisplayUseCompanyAddressCheckbox().click();
+        displayManagePage.getDisplayTimeZoneSelect().isDisplayed().then(function (isDisplayed) {
+          if (!isDisplayed) {
+            displayManagePage.getDisplayUseCompanyAddressCheckbox().click();
+          }
 
-    it('should show Save Button', function () {
-      expect(displayManagePage.getSaveButton().isPresent()).to.eventually.be.true;
-    });
+          expect(displayManagePage.getDisplayCountrySelect().isDisplayed()).to.eventually.be.true;
+          expect(displayManagePage.getDisplayTimeZoneSelect().isDisplayed()).to.eventually.be.true;
 
-    it('should show Cancel Button', function () {
-      expect(displayManagePage.getCancelButton().isPresent()).to.eventually.be.true;
-    });
+          done();
+        });
 
-    it('should fail to save the display and show validation error', function () {
-      helper.clickWhenClickable(displayManagePage.getSaveButton(), 'Save Button');
-      helper.waitDisappear(displayManagePage.getDisplayLoader(), 'Display loader');
-      expect(displayManagePage.getDisplayErrorBox().getText()).to.eventually.contain('We couldn\'t update your address.');
-    });
+      });
 
-    it('should select another country',function(){
-      displayManagePage.getDisplayCountrySelect().element(by.cssContainingText('option', 'Argentina')).click();
-      expect(displayManagePage.getDisplayCountrySelect().$('option:checked').getText()).to.eventually.contain('Argentina');
-    });
+      it('should select country',function(done){
+        browser.driver.executeScript('window.scrollTo(0,500);').then(function() {
+          displayManagePage.getDisplayCountrySelect().element(by.cssContainingText('option', 'Canada')).click();
+          expect(displayManagePage.getDisplayCountrySelect().$('option:checked').getText()).to.eventually.contain('Canada');
 
-    it('should save the display on Enter and skip address validation', function () {
-      displayManagePage.getDisplayNameField().sendKeys(protractor.Key.ENTER);
-      helper.waitDisappear(displayManagePage.getDisplayLoader(), 'Display loader');
-      expect(displayManagePage.getSaveButton().getText()).to.eventually.equal('Save');
-    });
+          done();
+        });
+      });
 
-    it('should show correct timezone after reload',function(done){
-      browser.refresh();
-      helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
-      helper.waitDisappear(displayManagePage.getDisplayLoader(), 'Display loader');
-
-      browser.driver.executeScript('window.scrollTo(0,500);').then(function() {
+      it('should select timezone',function(){
+        displayManagePage.getDisplayTimeZoneSelect().element(by.cssContainingText('option', 'Buenos Aires')).click();
         expect(displayManagePage.getDisplayTimeZoneSelect().$('option:checked').getText()).to.eventually.contain('Buenos Aires');
+      });      
+    });
 
-        done();
+    describe('update display', function() {
+      it('should show Save Button', function () {
+        expect(displayManagePage.getSaveButton().isPresent()).to.eventually.be.true;
       });
-    });
 
-    it('should show the Not Activated Display link, which opens the Display Modal', function() {
-      helper.wait(displayManagePage.getNotActivatedPlayerLink(), 'Not Activated Display link');
-      expect(displayManagePage.getNotActivatedPlayerLink().isDisplayed()).to.eventually.be.true;
+      it('should show Cancel Button', function () {
+        expect(displayManagePage.getCancelButton().isPresent()).to.eventually.be.true;
+      });
 
-      // Display modal and validate download button
-      helper.clickWhenClickable(displayManagePage.getNotActivatedPlayerLink(), 'Not Activated Display link');
+      it('should fail to save the display and show validation error', function () {
+        helper.clickWhenClickable(displayManagePage.getSaveButton(), 'Save Button');
+        helper.waitDisappear(displayManagePage.getDisplayLoader(), 'Display loader');
+        expect(displayManagePage.getDisplayErrorBox().getText()).to.eventually.contain('We couldn\'t update your address.');
+      });
 
-      helper.wait(displayAddModalPage.getDisplayAddModal(), 'Display Add Modal');
+      it('should select another country',function(){
+        displayManagePage.getDisplayCountrySelect().element(by.cssContainingText('option', 'Argentina')).click();
+        expect(displayManagePage.getDisplayCountrySelect().$('option:checked').getText()).to.eventually.contain('Argentina');
+      });
 
-      expect(displayAddModalPage.getDisplayAddModal().isDisplayed()).to.eventually.be.true;
+      it('should save the display on Enter and skip address validation', function () {
+        displayManagePage.getDisplayNameField().sendKeys(protractor.Key.ENTER);
+        helper.waitDisappear(displayManagePage.getDisplayLoader(), 'Display loader');
+        expect(displayManagePage.getSaveButton().getText()).to.eventually.equal('Save');
+      });
 
-      browser.sleep(100);
-      expect(displayAddModalPage.getTitle().getText()).to.eventually.equal('Activate your Display');
+      it('should show correct timezone after reload',function(done){
+        browser.refresh();
+        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+        helper.waitDisappear(displayManagePage.getDisplayLoader(), 'Display loader');
 
-    });
-
-    it('should show Display Id but hide the Email Instructions', function() {
-      displayAddModalPage.getPreconfiguredPlayerPanel().click();
-
-      helper.wait(displayAddModalPage.getPreconfiguredPlayerPage(), 'User Player page');
-
-      expect(displayAddModalPage.getDisplayIdField().isDisplayed()).to.eventually.be.true;
-      expect(displayAddModalPage.getDisplayIdField().getAttribute('value')).to.eventually.have.length.greaterThan(0);
-
-      expect(displayAddModalPage.getEmailedInstructions().isPresent()).to.eventually.be.false;      
-    });
-
-    it('should close the modal', function() {
-      // Close the modal
-      helper.wait(displayAddModalPage.getDismissButton(), 'Dismiss Button');
-      helper.clickWhenClickable(displayAddModalPage.getDismissButton(), 'Dismiss Button');
-
-      helper.waitDisappear(displayAddModalPage.getDisplayAddModal(), 'Display Add Modal');
-      expect(displayAddModalPage.getDisplayAddModal().isPresent()).to.eventually.be.false;
-    });
-
-    it('should show the Install Player button, which opens the Display Modal', function() {
-      helper.wait(displayManagePage.getInstallPlayerButton(), 'Install Player Button');
-      expect(displayManagePage.getInstallPlayerButton().isDisplayed()).to.eventually.be.true;
-
-      // Display modal and validate download button
-      helper.clickWhenClickable(displayManagePage.getInstallPlayerButton(), 'Install Player Button');
-
-      helper.wait(displayAddModalPage.getDisplayAddModal(), 'Display Add Modal');
-
-      expect(displayAddModalPage.getDisplayAddModal().isDisplayed()).to.eventually.be.true;
-
-      browser.sleep(100);
-      expect(displayAddModalPage.getTitle().getText()).to.eventually.equal('Activate your Display');
-    });
-
-    it('should close the modal', function() {
-      // Close the modal
-      helper.wait(displayAddModalPage.getDismissButton(), 'Dismiss Button');
-      helper.clickWhenClickable(displayAddModalPage.getDismissButton(), 'Dismiss Button');
-
-      helper.waitDisappear(displayAddModalPage.getDisplayAddModal(), 'Display Add Modal');
-      expect(displayAddModalPage.getDisplayAddModal().isPresent()).to.eventually.be.false;
-    });
-
-    it('should delete the display', function (done) {
-      helper.clickWhenClickable(displayManagePage.getDeleteButton(), 'Display Delete Button').then(function () {
-        helper.clickWhenClickable(displayManagePage.getDeleteForeverButton(), 'Display Delete Forever Button').then(function () {
-          helper.wait(displaysListPage.getDisplaysAppContainer(), 'Displays List');
+        browser.driver.executeScript('window.scrollTo(0,500);').then(function() {
+          expect(displayManagePage.getDisplayTimeZoneSelect().$('option:checked').getText()).to.eventually.contain('Buenos Aires');
 
           done();
         });
       });
     });
+
+    describe('display activation', function() {
+      it('should show the Not Activated Display link, which opens the Display Modal', function() {
+        helper.wait(displayManagePage.getNotActivatedPlayerLink(), 'Not Activated Display link');
+        expect(displayManagePage.getNotActivatedPlayerLink().isDisplayed()).to.eventually.be.true;
+
+        // Display modal and validate download button
+        helper.clickWhenClickable(displayManagePage.getNotActivatedPlayerLink(), 'Not Activated Display link');
+
+        helper.wait(displayAddModalPage.getDisplayAddModal(), 'Display Add Modal');
+
+        expect(displayAddModalPage.getDisplayAddModal().isDisplayed()).to.eventually.be.true;
+
+        browser.sleep(100);
+        expect(displayAddModalPage.getTitle().getText()).to.eventually.equal('Activate your Display');
+
+      });
+
+      it('should show Display Id but hide the Email Instructions', function() {
+        displayAddModalPage.getPreconfiguredPlayerPanel().click();
+
+        helper.wait(displayAddModalPage.getPreconfiguredPlayerPage(), 'User Player page');
+
+        expect(displayAddModalPage.getDisplayIdField().isDisplayed()).to.eventually.be.true;
+        expect(displayAddModalPage.getDisplayIdField().getAttribute('value')).to.eventually.have.length.greaterThan(0);
+
+        expect(displayAddModalPage.getEmailedInstructions().isPresent()).to.eventually.be.false;      
+      });
+
+      it('should close the modal', function() {
+        // Close the modal
+        helper.wait(displayAddModalPage.getDismissButton(), 'Dismiss Button');
+        helper.clickWhenClickable(displayAddModalPage.getDismissButton(), 'Dismiss Button');
+
+        helper.waitDisappear(displayAddModalPage.getDisplayAddModal(), 'Display Add Modal');
+        expect(displayAddModalPage.getDisplayAddModal().isPresent()).to.eventually.be.false;
+      });
+    });
+
+    describe('install player', function() {
+      it('should show the Install Player button, which opens the Display Modal', function() {
+        helper.wait(displayManagePage.getInstallPlayerButton(), 'Install Player Button');
+        expect(displayManagePage.getInstallPlayerButton().isDisplayed()).to.eventually.be.true;
+
+        // Display modal and validate download button
+        helper.clickWhenClickable(displayManagePage.getInstallPlayerButton(), 'Install Player Button');
+
+        helper.wait(displayAddModalPage.getDisplayAddModal(), 'Display Add Modal');
+
+        expect(displayAddModalPage.getDisplayAddModal().isDisplayed()).to.eventually.be.true;
+
+        browser.sleep(100);
+        expect(displayAddModalPage.getTitle().getText()).to.eventually.equal('Activate your Display');
+      });
+
+      it('should close the modal', function() {
+        // Close the modal
+        helper.wait(displayAddModalPage.getDismissButton(), 'Dismiss Button');
+        helper.clickWhenClickable(displayAddModalPage.getDismissButton(), 'Dismiss Button');
+
+        helper.waitDisappear(displayAddModalPage.getDisplayAddModal(), 'Display Add Modal');
+        expect(displayAddModalPage.getDisplayAddModal().isPresent()).to.eventually.be.false;
+      });
+    });
+
+    describe('delete', function() {
+      it('should delete the display', function () {
+        helper.waitDisappear(displayManagePage.getDisplayLoader(), 'Display loader');
+        helper.wait(displayManagePage.getDeleteButton(), 'Display Delete Button');
+
+        expect(displayManagePage.getDeleteButton().isPresent()).to.eventually.be.true;
+
+        helper.clickWhenClickable(displayManagePage.getDeleteButton(), 'Display Delete Button');
+      });
+
+      it('should confirm deletion', function () {
+        helper.wait(displayManagePage.getDeleteForeverButton(), 'Display Delete Forever Button');
+
+        expect(displayManagePage.getDeleteForeverButton().isPresent()).to.eventually.be.true;
+        helper.clickWhenClickable(displayManagePage.getDeleteForeverButton(), 'Display Delete Forever Button');
+
+        helper.waitDisappear(displayManagePage.getDeleteForeverButton(), 'Display Delete Forever Button');
+      });
+
+      it('should return to displays page', function() {
+        helper.wait(displaysListPage.getDisplaysListTable(), 'Displays List');
+
+        expect(displaysListPage.getDisplaysListTable().isPresent()).to.eventually.be.true;
+      });
+    });
   });
 };
 
-module.exports = DisplayAddScenarios;
+module.exports = DisplayManageScenarios;

--- a/test/e2e/displays/pages/displaysListPage.js
+++ b/test/e2e/displays/pages/displaysListPage.js
@@ -1,5 +1,16 @@
 'use strict';
+
+var CommonHeaderPage = require('./../../common-header/pages/commonHeaderPage.js');
+var DisplayManagePage = require('./displayManagePage.js');
+var helper = require('rv-common-e2e').helper;
+var expect = require('rv-common-e2e').expect;
+
 var DisplaysListPage = function() {
+  var _this = this;
+
+  var commonHeaderPage = new CommonHeaderPage();
+  var displayManagePage = new DisplayManagePage();
+
   var displaysAppContainer = element(by.css('.displays-app'));
   var title = element(by.id('title'));
   var searchFilter = element(by.tagName('search-filter'));
@@ -11,6 +22,65 @@ var DisplaysListPage = function() {
   var tableHeaderStatus = element(by.id('tableHeaderStatus'));
   var displayItems = element.all(by.repeater('display in displays.items.list'));
   var displaysLoader = element(by.xpath('//div[@spinner-key="displays-list-loader"]'));
+  var displayStatusError = element(by.cssContainingText('#errorBox strong', 'Failed to load displays connection status.'));
+
+  this.searchDisplay = function(displayName) {
+    helper.wait(searchFilterField, 'Search Filter Field');
+    searchFilterField.sendKeys(displayName);
+    helper.wait(displaysLoader, 'Displays loader');
+    helper.waitDisappear(displaysLoader, 'Displays loader');
+
+    displayItems.count().then(function(count) {
+      if (count > 0) {
+        helper.wait(displayStatusError, 'Connection Status Load error');
+      }
+    });
+  };
+
+  this.clearSearch = function() {
+    helper.wait(searchFilterField, 'Search Filter Field');
+    searchFilterField.clear();
+    helper.wait(displaysLoader, 'Displays loader');
+    helper.waitDisappear(displaysLoader, 'Displays loader');
+
+    displayItems.count().then(function(count) {
+      if (count > 0) {
+        helper.wait(displayStatusError, 'Connection Status Load error');
+      }
+    });
+  };
+
+  this.deleteDisplayIfExists = function() {
+    var displayName = 'TEST_E2E_DISPLAY ' + commonHeaderPage.getStageEnv();
+
+    helper.waitDisappear(displaysLoader, 'Displays loader');
+
+    this.searchDisplay(displayName);
+
+    displayItems.count().then(function(count) {
+      if (count > 0) {
+        helper.clickWhenClickable(displayItems.get(0).element(by.tagName('td')), "First matching Display");
+
+        helper.waitDisappear(displayManagePage.getDisplayLoader(), 'Display loader');
+
+        expect(displayManagePage.getDisplayNameField().getAttribute('value')).to.eventually.contain(displayName);
+
+        helper.wait(displayManagePage.getDeleteButton(), 'Display Delete Button');
+        helper.clickWhenClickable(displayManagePage.getDeleteButton(), 'Display Delete Button');
+
+        helper.wait(displayManagePage.getDeleteForeverButton(), 'Display Delete Forever Button');
+        helper.clickWhenClickable(displayManagePage.getDeleteForeverButton(), 'Display Delete Forever Button');
+        helper.waitDisappear(displayManagePage.getDeleteForeverButton(), 'Display Delete Forever Button');
+
+        helper.wait(displaysListTable, 'Displays List');
+        helper.waitDisappear(displaysLoader, 'Displays loader');
+
+        _this.deleteDisplayIfExists();
+      } else {
+        _this.clearSearch();
+      }
+    });
+  };
 
   this.getDisplaysAppContainer = function() {
     return displaysAppContainer;

--- a/test/unit/displays/services/svc-display-factory.tests.js
+++ b/test/unit/displays/services/svc-display-factory.tests.js
@@ -201,6 +201,17 @@ describe('service: displayFactory:', function() {
       });
       expect(displayFactory.displayId).to.not.be.truely;
     });
+
+    it('should set the display to parameter if it exists',function(){
+      var testDisplay = { id: 'test', name: 'test' };
+      
+      displayFactory.addDisplayModal(testDisplay);
+      
+      expect(trackerCalled).to.equal('Add Display');
+      
+      expect(displayFactory.display).to.deep.equal(testDisplay);
+    });
+
   });
     
   describe('getDisplay:',function(){

--- a/web/scripts/displays/services/svc-display-factory.js
+++ b/web/scripts/displays/services/svc-display-factory.js
@@ -37,11 +37,11 @@ angular.module('risevision.displays.services')
 
       factory.addDisplayModal = function (display) {
         displayTracker('Add Display');
-
-        _init();
-
+        
         if (display) {
           factory.display = display;
+        } else {
+          _init();  
         }
 
         $modal.open({


### PR DESCRIPTION
## Description
Fix issue with display deletion/save after opening modal

Refactor display e2e tests

## Motivation and Context
Fixes issue with Display Deletion/Save.
Fixes e2e tests so they test Display deletion correctly.
Prevents Displays from not be deleted correctly in the e2e company

## How Has This Been Tested?
Validated by manual testing and by updating e2e and unit test coverage.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No