### PR TITLE
Use mockTranslate instead of mockTranlate

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "run-sequence": "^1.1.1",
     "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git",
     "terser": "^4.0.0",
-    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
+    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git#chore/rename-i18n-test-helper"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "run-sequence": "^1.1.1",
     "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git",
     "terser": "^4.0.0",
-    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git#chore/rename-i18n-test-helper"
+    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
   },
   "repository": {
     "type": "git",

--- a/test/unit/common/services/svc-in-app-messages-factory.tests.js
+++ b/test/unit/common/services/svc-in-app-messages-factory.tests.js
@@ -4,7 +4,7 @@ describe('service: in-app-messages-factory', function() {
   var factory, selectedCompany, localStorageService, executeStub, userState, $rootScope;
 
   beforeEach(module('risevision.apps.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
 
     $provide.service('presentation', function() {

--- a/test/unit/displays/controllers/ctr-display-control-modal.tests.js
+++ b/test/unit/displays/controllers/ctr-display-control-modal.tests.js
@@ -4,7 +4,7 @@ describe('controller: display control modal', function() {
 
   beforeEach(module('risevision.displays.controllers'));
   beforeEach(module('risevision.displays.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('displayControlFactory',function() {
       return {

--- a/test/unit/displays/controllers/ctr-display-controls.tests.js
+++ b/test/unit/displays/controllers/ctr-display-controls.tests.js
@@ -3,7 +3,7 @@ describe('controller: display controls', function() {
   var displayId = 1234;
   beforeEach(module('risevision.displays.controllers'));
   beforeEach(module('risevision.displays.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('userState',userState);
     $provide.service('display',function(){

--- a/test/unit/displays/controllers/ctr-display-details.tests.js
+++ b/test/unit/displays/controllers/ctr-display-details.tests.js
@@ -6,7 +6,7 @@ describe('controller: display details', function() {
 
   beforeEach(module('risevision.displays.services'));
   beforeEach(module('risevision.displays.controllers'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('$q', function() {return Q;});
     $provide.service('displayFactory', function() {

--- a/test/unit/displays/controllers/ctr-displays-list.tests.js
+++ b/test/unit/displays/controllers/ctr-displays-list.tests.js
@@ -5,7 +5,7 @@ describe('controller: displays list', function() {
   beforeEach(module('risevision.displays.filters'));
   beforeEach(module('risevision.displays.controllers'));
   beforeEach(module('risevision.displays.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('userState',function(){
       return {

--- a/test/unit/editor/controllers/ctr-artboard.tests.js
+++ b/test/unit/editor/controllers/ctr-artboard.tests.js
@@ -2,7 +2,7 @@
 describe('controller: Artboard', function() {
   beforeEach(module('risevision.editor.controllers'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.factory('editorFactory',function(){
       return { };

--- a/test/unit/editor/controllers/ctr-html-editor.tests.js
+++ b/test/unit/editor/controllers/ctr-html-editor.tests.js
@@ -5,7 +5,7 @@ describe('controller: HtmlEditor', function() {
 	}
 	beforeEach(module('risevision.editor.controllers'));
 	beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
 	beforeEach(module(function ($provide) {
 		$provide.factory('editorFactory',function(){
 			return { 

--- a/test/unit/editor/controllers/ctr-presentation-list.tests.js
+++ b/test/unit/editor/controllers/ctr-presentation-list.tests.js
@@ -4,7 +4,7 @@ describe('controller: Presentation List', function() {
   beforeEach(module('risevision.editor.services'));
   beforeEach(module('risevision.template-editor.directives'));
   beforeEach(module('risevision.template-editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('ScrollingListService', function() {
       return function() {

--- a/test/unit/editor/controllers/ctr-store-products-modal.tests.js
+++ b/test/unit/editor/controllers/ctr-store-products-modal.tests.js
@@ -3,7 +3,7 @@
 describe('controller: Store Products Modal', function() {
   beforeEach(module('risevision.editor.controllers'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.value('STORE_AUTHORIZATION_URL','http://www.example.com/api/auth')
     $provide.service('ScrollingListService', function() {

--- a/test/unit/editor/controllers/ctr-widget-item-modal.tests.js
+++ b/test/unit/editor/controllers/ctr-widget-item-modal.tests.js
@@ -2,7 +2,7 @@
 describe('controller: Widget Items Modal', function() {
   beforeEach(module('risevision.editor.controllers'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('$modalInstance',function(){
       return {

--- a/test/unit/editor/controllers/ctr-workspace.tests.js
+++ b/test/unit/editor/controllers/ctr-workspace.tests.js
@@ -2,7 +2,7 @@
 describe('controller: Workspace', function() {
   beforeEach(module('risevision.editor.controllers'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.factory('editorFactory',function(){
       return { 

--- a/test/unit/editor/directives/dtv-artboard-placeholder.tests.js
+++ b/test/unit/editor/directives/dtv-artboard-placeholder.tests.js
@@ -23,7 +23,7 @@ describe('directive: artboard-placeholder', function() {
 
   beforeEach(module('risevision.editor.services'));
   beforeEach(module('risevision.editor.directives'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('placeholderFactory', function() {
       return {

--- a/test/unit/editor/directives/dtv-artboard-presentation.tests.js
+++ b/test/unit/editor/directives/dtv-artboard-presentation.tests.js
@@ -21,7 +21,7 @@ describe('directive: artboard-presentation', function() {
 
   beforeEach(module('risevision.editor.services'));
   beforeEach(module('risevision.editor.directives'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('editorFactory', function() {
       return {

--- a/test/unit/editor/directives/dtv-placeholder-drag.tests.js
+++ b/test/unit/editor/directives/dtv-placeholder-drag.tests.js
@@ -17,7 +17,7 @@ describe('directive: placeholder-drag', function() {
       };
     });
   }));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(inject(function(_$compile_, _$rootScope_,_$document_,_artboardFactory_){
     $compile = _$compile_;
     $rootScope = _$rootScope_;

--- a/test/unit/editor/directives/dtv-placeholder-playlist.tests.js
+++ b/test/unit/editor/directives/dtv-placeholder-playlist.tests.js
@@ -8,7 +8,7 @@ describe('directive: placeholder-playlist', function() {
   beforeEach(module('risevision.editor.controllers'));
   beforeEach(module('risevision.editor.services'));
   beforeEach(module('risevision.editor.directives'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('placeholderPlaylistFactory', function() {
       return {

--- a/test/unit/editor/directives/dtv-placeholder-settings.tests.js
+++ b/test/unit/editor/directives/dtv-placeholder-settings.tests.js
@@ -2,7 +2,7 @@
 describe('directive: placeholder settings', function() {
   beforeEach(module('risevision.editor.services'));
   beforeEach(module('risevision.editor.directives'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
 
   beforeEach(module(function ($provide) {
     placeholderFactory = {

--- a/test/unit/editor/directives/dtv-resolution-selector.tests.js
+++ b/test/unit/editor/directives/dtv-resolution-selector.tests.js
@@ -6,7 +6,7 @@ describe('directive: resolution selector', function() {
   beforeEach(module('risevision.editor.controllers'));
   beforeEach(module('risevision.editor.services'));
   beforeEach(module('risevision.editor.directives'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   var presentationProperties, element;
   beforeEach(inject(function(_$compile_, _$rootScope_, $templateCache){
     $templateCache.put('partials/editor/resolution-selector.html', '<p>mock</p>');

--- a/test/unit/editor/directives/dtv-sidebar.tests.js
+++ b/test/unit/editor/directives/dtv-sidebar.tests.js
@@ -7,7 +7,7 @@ describe('directive: sidebar', function() {
   beforeEach(module('risevision.editor.controllers'));
   beforeEach(module('risevision.editor.services'));
   beforeEach(module('risevision.editor.directives'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('placeholderFactory', function() {
       return {};

--- a/test/unit/editor/directives/dtv-toolbar.tests.js
+++ b/test/unit/editor/directives/dtv-toolbar.tests.js
@@ -11,7 +11,7 @@ describe('directive: toolbar', function() {
   beforeEach(module('risevision.editor.controllers'));
   beforeEach(module('risevision.editor.services'));
   beforeEach(module('risevision.editor.directives'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('editorFactory', function() {
       return {

--- a/test/unit/editor/services/svc-widget-modal-factory.tests.js
+++ b/test/unit/editor/services/svc-widget-modal-factory.tests.js
@@ -1,7 +1,7 @@
 'use strict';
 describe('service: widgetModalFactory:', function() {
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('$q', function() {return Q;});
     $provide.service('userState',function(){

--- a/test/unit/schedules/controllers/ctr-schedule-add.tests.js
+++ b/test/unit/schedules/controllers/ctr-schedule-add.tests.js
@@ -3,7 +3,7 @@ describe('controller: schedule add', function() {
   var scheduleId = 1234;
   beforeEach(module('risevision.schedules.controllers'));
   beforeEach(module('risevision.schedules.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('scheduleFactory',function(){
       return {

--- a/test/unit/schedules/controllers/ctr-schedule-details.tests.js
+++ b/test/unit/schedules/controllers/ctr-schedule-details.tests.js
@@ -3,7 +3,7 @@ describe('controller: schedule details', function() {
   var scheduleId = 1234;
   beforeEach(module('risevision.schedules.controllers'));
   beforeEach(module('risevision.schedules.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('scheduleFactory',function(){
       return {

--- a/test/unit/schedules/controllers/ctr-schedules-list.tests.js
+++ b/test/unit/schedules/controllers/ctr-schedules-list.tests.js
@@ -2,7 +2,7 @@
 describe('controller: schedules list', function() {
   beforeEach(module('risevision.schedules.controllers'));
   beforeEach(module('risevision.schedules.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('userState',userState);
     $provide.service('schedule',function(){

--- a/test/unit/schedules/directives/dtv-schedule-fields.tests.js
+++ b/test/unit/schedules/directives/dtv-schedule-fields.tests.js
@@ -9,7 +9,7 @@ describe('directive: scheduleFields', function() {
 
   beforeEach(module('risevision.editor.services'));
   beforeEach(module('risevision.schedules.directives'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('$modal', function() {
       return {

--- a/test/unit/template-editor/components/directives/dtv-branding-colors.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-branding-colors.tests.js
@@ -6,7 +6,7 @@ describe('directive: templateBrandingColors', function() {
       factory;
 
   beforeEach(module('risevision.template-editor.directives'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('brandingFactory', function() {
       return factory = {

--- a/test/unit/template-editor/components/directives/dtv-component-branding.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-branding.tests.js
@@ -7,7 +7,7 @@ describe('directive: templateComponentBranding', function() {
       compile;
 
   beforeEach(module('risevision.template-editor.directives'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
 
   beforeEach(inject(function($compile, $rootScope, $templateCache){
     rootScope = $rootScope;

--- a/test/unit/template-editor/components/directives/dtv-component-counter.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-counter.tests.js
@@ -13,7 +13,7 @@ describe('directive: templateComponentCounter', function() {
   beforeEach(module('risevision.template-editor.controllers'));
   beforeEach(module('risevision.template-editor.services'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
       return factory;

--- a/test/unit/template-editor/components/directives/dtv-component-financial.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-financial.tests.js
@@ -53,7 +53,7 @@ describe('directive: TemplateComponentFinancial', function() {
   beforeEach(module('risevision.template-editor.controllers'));
   beforeEach(module('risevision.template-editor.services'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
       return factory;

--- a/test/unit/template-editor/components/directives/dtv-component-image-onPresentationOpen.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image-onPresentationOpen.tests.js
@@ -17,7 +17,7 @@ describe('directive: TemplateComponentImage: onPresentationOpen', function() {
   beforeEach(module('risevision.template-editor.controllers'));
   beforeEach(module('risevision.template-editor.services'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
       return factory;

--- a/test/unit/template-editor/components/directives/dtv-component-image.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.tests.js
@@ -21,7 +21,7 @@ describe('directive: TemplateComponentImage', function() {
   beforeEach(module('risevision.template-editor.controllers'));
   beforeEach(module('risevision.template-editor.services'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
       return factory;

--- a/test/unit/template-editor/components/directives/dtv-component-rss.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-rss.tests.js
@@ -20,7 +20,7 @@ describe('directive: templateComponentRss', function() {
   beforeEach(module('risevision.template-editor.controllers'));
   beforeEach(module('risevision.template-editor.services'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
       return factory;

--- a/test/unit/template-editor/components/directives/dtv-component-slides.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-slides.tests.js
@@ -21,7 +21,7 @@ describe('directive: templateComponentSlides', function() {
   beforeEach(module('risevision.template-editor.controllers'));
   beforeEach(module('risevision.template-editor.services'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
       return factory;

--- a/test/unit/template-editor/components/directives/dtv-component-text.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-text.tests.js
@@ -13,7 +13,7 @@ describe('directive: templateComponentText', function() {
   beforeEach(module('risevision.template-editor.controllers'));
   beforeEach(module('risevision.template-editor.services'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
       return factory;

--- a/test/unit/template-editor/components/directives/dtv-component-video.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-video.tests.js
@@ -15,7 +15,7 @@ describe('directive: templateComponentVideo', function() {
   beforeEach(module('risevision.template-editor.controllers'));
   beforeEach(module('risevision.template-editor.services'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
       return factory;

--- a/test/unit/template-editor/components/directives/dtv-component-weather.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-weather.tests.js
@@ -20,7 +20,7 @@ describe('directive: templateComponentWeather', function() {
   beforeEach(module('risevision.template-editor.controllers'));
   beforeEach(module('risevision.template-editor.services'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
       return factory;

--- a/test/unit/template-editor/components/services/svc-base-image-factory.tests.js
+++ b/test/unit/template-editor/components/services/svc-base-image-factory.tests.js
@@ -4,7 +4,7 @@ describe('service: baseImageFactory', function() {
 
   beforeEach(module('risevision.template-editor.directives'));
   beforeEach(module('risevision.template-editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
 
   beforeEach(module(function($provide) {
     $provide.service('blueprintFactory', function() {

--- a/test/unit/template-editor/components/services/svc-branding-factory.tests.js
+++ b/test/unit/template-editor/components/services/svc-branding-factory.tests.js
@@ -4,7 +4,7 @@ describe('service: brandingFactory', function() {
 
   beforeEach(module('risevision.template-editor.directives'));
   beforeEach(module('risevision.template-editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
 
   beforeEach(module(function($provide) {
     $provide.service('$q', function() {return Q;});

--- a/test/unit/template-editor/components/services/svc-logo-image-factory.tests.js
+++ b/test/unit/template-editor/components/services/svc-logo-image-factory.tests.js
@@ -4,7 +4,7 @@ describe('service: logoImageFactory', function() {
 
   beforeEach(module('risevision.template-editor.directives'));
   beforeEach(module('risevision.template-editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
 
   beforeEach(module(function($provide) {
     $provide.service('brandingFactory', function() {

--- a/test/unit/template-editor/controllers/ctr-template-editor.chrome-bar.tests.js
+++ b/test/unit/template-editor/controllers/ctr-template-editor.chrome-bar.tests.js
@@ -50,7 +50,7 @@ describe('controller: TemplateEditor : Chrome Bar', function() {
   beforeEach(module('risevision.template-editor.directives'));
   beforeEach(module('risevision.template-editor.services'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.factory('templateEditorFactory', function() {
       return factory;

--- a/test/unit/template-editor/controllers/ctr-template-editor.tests.js
+++ b/test/unit/template-editor/controllers/ctr-template-editor.tests.js
@@ -57,7 +57,7 @@ describe('controller: TemplateEditor', function() {
   beforeEach(module('risevision.template-editor.directives'));
   beforeEach(module('risevision.template-editor.services'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.factory('templateEditorFactory',function() {
       return factory;

--- a/test/unit/template-editor/directives/dtv-attribute-editor.tests.js
+++ b/test/unit/template-editor/directives/dtv-attribute-editor.tests.js
@@ -14,7 +14,7 @@ describe('directive: TemplateAttributeEditor', function() {
   beforeEach(module('risevision.template-editor.controllers'));
   beforeEach(module('risevision.template-editor.services'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
       return factory;

--- a/test/unit/template-editor/directives/dtv-attribute-list.tests.js
+++ b/test/unit/template-editor/directives/dtv-attribute-list.tests.js
@@ -9,7 +9,7 @@ describe('directive: attribute-list', function() {
   ];
 
   beforeEach(module('risevision.template-editor.directives'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
     beforeEach(module(function ($provide) {
     $provide.service('blueprintFactory', function() {
       return {

--- a/test/unit/template-editor/directives/dtv-basic-storage-selector.tests.js
+++ b/test/unit/template-editor/directives/dtv-basic-storage-selector.tests.js
@@ -5,7 +5,7 @@ describe('directive: basicStorageSelector', function() {
       $scope, $loading, storage, element;
 
   beforeEach(module('risevision.template-editor.directives'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('$loading', function() {
       return {

--- a/test/unit/template-editor/directives/dtv-component-icon.tests.js
+++ b/test/unit/template-editor/directives/dtv-component-icon.tests.js
@@ -6,7 +6,7 @@ describe('directive: ComponentIcon', function () {
     elementScope;
 
   beforeEach(module('risevision.template-editor.directives'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
 
 
   beforeEach(inject(function ($compile, $rootScope) {

--- a/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
+++ b/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
@@ -33,7 +33,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
   beforeEach(module('risevision.template-editor.controllers'));
   beforeEach(module('risevision.template-editor.services'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
       return {

--- a/test/unit/template-editor/directives/dtv-empty-file-list.tests.js
+++ b/test/unit/template-editor/directives/dtv-empty-file-list.tests.js
@@ -4,7 +4,7 @@ describe('directive: templateEditorEmptyFileList', function() {
   var element, $scope;
 
   beforeEach(module('risevision.template-editor.directives'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
 
   beforeEach(inject(function($compile, $rootScope, $templateCache){
     $templateCache.put('partials/template-editor/empty-file-list.html', '<p>mock</p>');

--- a/test/unit/template-editor/directives/dtv-file-entry.tests.js
+++ b/test/unit/template-editor/directives/dtv-file-entry.tests.js
@@ -4,7 +4,7 @@ describe('directive: templateEditorFileEntry', function() {
   var sandbox = sinon.sandbox.create(), $scope, element, removeAction;
 
   beforeEach(module('risevision.template-editor.directives'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorUtils', function() {
       return {

--- a/test/unit/template-editor/directives/dtv-streamline-icon.tests.js
+++ b/test/unit/template-editor/directives/dtv-streamline-icon.tests.js
@@ -4,7 +4,7 @@ describe('directive: streamline-icon', function() {
   var element;
 
   beforeEach(module('risevision.template-editor.directives'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
 
   beforeEach(inject(function($compile, $rootScope){
     element = $compile('<streamline-icon name="checkmark" width="64" height="64"></streamline-icon>')($rootScope);

--- a/test/unit/template-editor/services/svc-auto-save-service.tests.js
+++ b/test/unit/template-editor/services/svc-auto-save-service.tests.js
@@ -2,7 +2,7 @@
 
 describe('service: auto save service', function() {
   beforeEach(module('risevision.template-editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
 
   var autoSaveService, saveFunction, clock, $timeout, MINIMUM_INTERVAL_BETWEEN_SAVES, MAXIMUM_INTERVAL_BETWEEN_SAVES;
   beforeEach(function(){

--- a/test/unit/template-editor/services/svc-blueprint-factory.tests.js
+++ b/test/unit/template-editor/services/svc-blueprint-factory.tests.js
@@ -2,7 +2,7 @@
 
 describe('service: blueprint factory', function() {
   beforeEach(module('risevision.template-editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
 
   var SAMPLE_COMPONENTS = [
     {

--- a/test/unit/widgets/image/controllers/ctr-image-settings.tests.js
+++ b/test/unit/widgets/image/controllers/ctr-image-settings.tests.js
@@ -7,7 +7,7 @@ describe('ImageSettingsController', function () {
     rootScope;
 
   beforeEach(module('risevision.widgets.image'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
 
   beforeEach(inject(function ($injector, $rootScope, $controller) {
     defaultSettings = $injector.get('defaultSettings');

--- a/test/unit/widgets/twitter/controllers/ctr-twitter-settings.tests.js
+++ b/test/unit/widgets/twitter/controllers/ctr-twitter-settings.tests.js
@@ -8,7 +8,7 @@ describe('TwitterSettingsController', function () {
     twitterOAuthService;
 
   beforeEach(module('risevision.widgets.twitter'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
 
   beforeEach(module(function ($provide) {
     $provide.service('TwitterOAuthService',function(){


### PR DESCRIPTION
## Description
Uses `mockTranslate` in unit tests setup instead of the misspelled `mockTranlate`.

## Motivation and Context
Minor improvement to a slight annoyance.

## How Has This Been Tested?
Unit tests were ran locally and the build passed in CCI.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@alex-deaconu please review
