### PR TITLE
Use custom signin for most of E2E tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -335,7 +335,7 @@ gulp.task("server-close", factory.testServerClose());
 gulp.task("test:webdrive_update", factory.webdriveUpdate());
 gulp.task("test:e2e:core", ["test:webdrive_update"],factory.testE2EAngular({
   browser: "chrome",
-  loginUser: "jenkins.rise@gmail.com",
+  loginUser: process.env.E2E_USER,
   loginPass: process.env.E2E_PASS,
   loginUser1: process.env.E2E_USER1,
   loginPass1: process.env.E2E_PASS1,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -335,8 +335,10 @@ gulp.task("server-close", factory.testServerClose());
 gulp.task("test:webdrive_update", factory.webdriveUpdate());
 gulp.task("test:e2e:core", ["test:webdrive_update"],factory.testE2EAngular({
   browser: "chrome",
-  loginUser: process.env.E2E_USER,
+  loginUser: "jenkins.rise@gmail.com",
   loginPass: process.env.E2E_PASS,
+  loginUser1: process.env.E2E_USER1,
+  loginPass1: process.env.E2E_PASS1,
   stageEnv: process.env.STAGE_ENV || os.userInfo().username || 'local',
   twitterUser: process.env.TWITTER_USER,
   twitterPass: process.env.TWITTER_PASS,

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "rollup-plugin-node-resolve": "^5.0.3",
     "rollup-plugin-terser": "^5.0.0",
     "run-sequence": "^1.1.1",
-    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git#chore/update-challenge",
+    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git",
     "terser": "^4.0.0",
     "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "rollup-plugin-node-resolve": "^5.0.3",
     "rollup-plugin-terser": "^5.0.0",
     "run-sequence": "^1.1.1",
-    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git",
+    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git#chore/update-challenge",
     "terser": "^4.0.0",
     "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
   },

--- a/test/e2e/common-header/cases/user-settings.js
+++ b/test/e2e/common-header/cases/user-settings.js
@@ -46,7 +46,7 @@
       it("should show user information", function() {
         expect(userSettingsModalPage.getFirstNameField().getAttribute('value')).to.eventually.equal("Jenkins");
         expect(userSettingsModalPage.getLastNameField().getAttribute('value')).to.eventually.equal("Rise");
-        expect(userSettingsModalPage.getEmailField().getAttribute('value')).to.eventually.equal("jenkins.rise+custom@gmail.com");
+        expect(userSettingsModalPage.getEmailField().getAttribute('value')).to.eventually.equal(browser.params.login.user1);
         expect(userSettingsModalPage.getPhoneField().getAttribute('value')).to.eventually.equal("000-000-0000");
 
         expect(userSettingsModalPage.getCeCheckbox().isSelected()).to.eventually.be.true;

--- a/test/e2e/common-header/cases/user-settings.js
+++ b/test/e2e/common-header/cases/user-settings.js
@@ -46,7 +46,7 @@
       it("should show user information", function() {
         expect(userSettingsModalPage.getFirstNameField().getAttribute('value')).to.eventually.equal("Jenkins");
         expect(userSettingsModalPage.getLastNameField().getAttribute('value')).to.eventually.equal("Rise");
-        expect(userSettingsModalPage.getEmailField().getAttribute('value')).to.eventually.equal("jenkins@risevision.com");
+        expect(userSettingsModalPage.getEmailField().getAttribute('value')).to.eventually.equal("jenkins.rise+custom@gmail.com");
         expect(userSettingsModalPage.getPhoneField().getAttribute('value')).to.eventually.equal("000-000-0000");
 
         expect(userSettingsModalPage.getCeCheckbox().isSelected()).to.eventually.be.true;

--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -161,7 +161,7 @@ var FirstSigninScenarios = function() {
       after(function() {
         commonHeaderPage.deleteCurrentCompany();
 
-        commonHeaderPage.signOut();
+        commonHeaderPage.signOut(true);
       });
 
     });

--- a/test/e2e/common/pages/signInPage.js
+++ b/test/e2e/common/pages/signInPage.js
@@ -6,6 +6,7 @@ var helper = require('rv-common-e2e').helper;
 var expect = require('rv-common-e2e').expect;
 
 var SignInPage = function() {
+  var _this = this;
   var commonHeaderPage = new CommonHeaderPage();
   var googleAuthPage = new GoogleAuthPage();
   var homepage = new HomePage();
@@ -21,6 +22,9 @@ var SignInPage = function() {
   var signinButton = element(by.cssContainingText('button.btn-primary', 'Sign In'));
   var incorrectCredentialsError = element(by.cssContainingText('.bg-danger', 'incorrect'));
   var emailNotConfirmedInfo = element(by.cssContainingText('.bg-info', 'Your email address has not been confirmed.'));
+
+  var USERNAME1 = browser.params.login.user1;
+  var PASSWORD1 = browser.params.login.pass1;
 
   this.get = function() {
     browser.get(url);
@@ -63,21 +67,27 @@ var SignInPage = function() {
   };
 
   this.customAuthSignIn = function(username,password) {
+    username = username || USERNAME1;
+    password = password || PASSWORD1;
     //wait for spinner to go away.
     helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - Before Custom Sign In');
 
-    this.getUsernameTextBox().clear();
-    this.getUsernameTextBox().sendKeys(username);
+    this.getUsernameTextBox().isPresent().then(function (state) {
+      if (state) {
+        _this.getUsernameTextBox().clear();
+        _this.getUsernameTextBox().sendKeys(username);
 
-    var enter = "\ue007";
-    this.getPasswordTextBox().clear();
-    this.getPasswordTextBox().sendKeys(password + enter);
-    
-    helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - After Custom Sign In');
+        var enter = "\ue007";
+        _this.getPasswordTextBox().clear();
+        _this.getPasswordTextBox().sendKeys(password + enter);
 
-    emailNotConfirmedInfo.isPresent().then(function (isPresent) {
-      if (isPresent) {
-        expect.fail('Email has not been not confirmed. Manual action is required. Please confirm the email or remove the account.');
+        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader - After Custom Sign In');
+
+        emailNotConfirmedInfo.isPresent().then(function (isPresent) {
+  	      if (isPresent) {
+  	        expect.fail('Email has not been not confirmed. Manual action is required. Please confirm the email or remove the account.');
+  	      }
+  	    });
       }
     });
   };
@@ -103,7 +113,7 @@ var SignInPage = function() {
     
   };
 
-  this.signIn = this.googleSignIn;
+  this.signIn = this.customAuthSignIn;
 
 };
 

--- a/test/e2e/registration/cases/registration-existing-company.js
+++ b/test/e2e/registration/cases/registration-existing-company.js
@@ -90,19 +90,7 @@
         });
 
         it("should log out", function() {
-          commonHeaderPage.getProfilePic().click();
-
-          //shows sign-out menu item
-          expect(commonHeaderPage.getSignOutButton().isDisplayed()).to.eventually.be.true;
-
-          //click sign out
-          commonHeaderPage.getSignOutButton().click();
-          
-          helper.wait(commonHeaderPage.getSignOutModal(), "Sign Out Modal");
-          
-          expect(commonHeaderPage.getSignOutModal().isDisplayed()).to.eventually.be.true;
-          commonHeaderPage.getSignOutGoogleButton().click();
-
+          commonHeaderPage.signOut(true);
           //signed out; google sign-in button shows
           expect(signInPage.getSignInGoogleLink().isDisplayed()).to.eventually.be.true;
           helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');


### PR DESCRIPTION
## Description
Handle page reload auto signin

Add user2 and use it for custom auth

[stage-2]

## Motivation and Context
Attempt to improve e2e test performance. Reduce the amount of tests that run with the Google account.

## How Has This Been Tested?
Ran e2e tests and verified various scenarios for failures.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
