### PR TITLE
Fix/issue 1319 show default images in staging

### DIFF
--- a/test/unit/template-editor/components/services/svc-file-existence-check.tests.js
+++ b/test/unit/template-editor/components/services/svc-file-existence-check.tests.js
@@ -29,7 +29,9 @@ describe('service: fileExistenceCheckService:', function() {
     });
   }));
 
-  var TEST_FILE = 'risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/file1.png';
+  var TEST_BUCKET = 'risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/';
+  var DEFAULT_TEST_FILE = TEST_BUCKET + 'Template Library/file1.png';
+  var TEST_FILE = TEST_BUCKET + 'file1.png';
   var fileExistenceCheckService;
 
   beforeEach(function() {
@@ -87,6 +89,25 @@ describe('service: fileExistenceCheckService:', function() {
             file: TEST_FILE,
             exists: true,
             'time-created': 100,
+            'thumbnail-url': 'http://default-url'
+          }
+        ]);
+
+        done();
+      })
+      .catch(function(err) {
+        expect.fail(err);
+      });
+    });
+
+    it('should mark file as existing with default thumbnail if it\'s a default file in test environment', function(done) {
+      fileExistenceCheckService.requestMetadataFor(DEFAULT_TEST_FILE, 'http://default-url')
+      .then(function(metadata) {
+        expect(metadata).to.deep.equal([
+          {
+            file: DEFAULT_TEST_FILE,
+            exists: true,
+            'time-created': '',
             'thumbnail-url': 'http://default-url'
           }
         ]);

--- a/web/scripts/template-editor/components/services/svc-file-existence-check.js
+++ b/web/scripts/template-editor/components/services/svc-file-existence-check.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.template-editor.services')
-  .service('fileExistenceCheckService', ['$q', '$log', 'storageAPILoader', 'fileMetadataUtilsService',
-    function ($q, $log, storageAPILoader, fileMetadataUtilsService) {
+  .service('fileExistenceCheckService', ['$q', '$log', 'storageAPILoader', 'fileMetadataUtilsService', 'APPS_ENV',
+    function ($q, $log, storageAPILoader, fileMetadataUtilsService, APPS_ENV) {
       var service = {};
 
       function _requestFileData(companyId, file) {
@@ -15,6 +15,16 @@ angular.module('risevision.template-editor.services')
           .then(function (storageApi) {
             return storageApi.files.get(search);
           });
+      }
+
+      function _isDefaultImageOnTestAppsEnvironment(fileName) {
+        if (APPS_ENV !== 'TEST') {
+          return false;
+        }
+
+        var regex = /^risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f[/]Template Library[/].+/;
+
+        return regex.test(fileName);
       }
 
       function _getThumbnailDataFor(fileName, defaultThumbnailUrl) {
@@ -30,6 +40,12 @@ angular.module('risevision.template-editor.services')
           $log.error('Filename is not a valid Rise Storage path: ' + fileName);
 
           return $q.resolve(invalidThumbnailData);
+        } else if (_isDefaultImageOnTestAppsEnvironment(fileName)) {
+          return $q.resolve({
+            exists: true,
+            timeCreated: '123',
+            url: defaultThumbnailUrl
+          });
         }
 
         return _requestFileData(match[1], match[2])

--- a/web/scripts/template-editor/components/services/svc-file-existence-check.js
+++ b/web/scripts/template-editor/components/services/svc-file-existence-check.js
@@ -22,6 +22,7 @@ angular.module('risevision.template-editor.services')
           return false;
         }
 
+        // all default files for Rise Vision templates are defined under this GCS bucket
         var regex = /^risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f[/]Template Library[/].+/;
 
         return regex.test(fileName);
@@ -43,7 +44,7 @@ angular.module('risevision.template-editor.services')
         } else if (_isDefaultImageOnTestAppsEnvironment(fileName)) {
           return $q.resolve({
             exists: true,
-            timeCreated: '123',
+            timeCreated: '',
             url: defaultThumbnailUrl
           });
         }


### PR DESCRIPTION
## Description
Shows default images in staging environment.

https://github.com/Rise-Vision/rise-vision-apps/issues/1319

## Motivation and Context
Production apps makes file existence checks against production storage; and staging apps makes file existence checks against staging storage. For most storage, this works well as they work with the files being created in their own environments. But default files defined for a template live always in a production bucket, but they could be referenced by a template being loaded in a staging environment.

Developers would usually are not bothered by default files being marked as not existent in the rise-image component settings, and also don't usually care about those don't being shown in preview editor. But Creative team find a friction point here, because they usually want to validate that default images are being displayed correctly.

As default images should always exist and should never be deleted, the following implementation was done. 

A default image is always put in the same bucket, failing to do so is a mistake on Creative's team side. So the file existence check service can verify if we are in a non-production environment, and the image is a default one, and bypass existence verification in that case. This will result in the default image being shown in the preview window, even if the thumbnail is not shown. From Creative's perspective, this is good enough for them to validate the template working in staging environment.

## How Has This Been Tested?

Manually validated here ( default lower images now show ):

https://apps-stage-9.risevision.com/templates/edit/7f8f515b-ed0d-45d8-b60c-6555e8347345/?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c

I also added an automated unit test for this case.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     To be released on Monday.
     I'll test production behavior to ensure it's not affected by this. I'll also push immediately to stage-0 after releasing so Creative can use it right away.
     A simple rollback is enough to revert changes, but as this just affects staging environments is low risk for produciton.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to update documentation, no need to notify support.
