### PR TITLE
HTML Templates Announcement modal

### DIFF
--- a/test/unit/common/controllers/ctr-templates-announcement-modal.tests.js
+++ b/test/unit/common/controllers/ctr-templates-announcement-modal.tests.js
@@ -1,0 +1,55 @@
+'use strict';
+describe('controller: TemplatesAnnouncementModalCtrl', function() {
+  var sandbox = sinon.sandbox.create();
+
+  beforeEach(module('risevision.apps.controllers'));
+  beforeEach(module(function ($provide) {
+    $provide.service('$modalInstance',function(){
+      return {
+        close : sandbox.stub()
+      }
+    }); 
+    $provide.service('userState',function(){
+      return {
+        getCopyOfProfile : sandbox.stub().returns({firstName:'myFirstName'})
+      }
+    });    
+  }));
+  var $scope, $modalInstance;
+
+  beforeEach(function(){
+
+    inject(function($injector,$rootScope, $controller){
+      $scope = $rootScope.$new();
+      $modalInstance = $injector.get('$modalInstance');
+      
+      $controller('TemplatesAnnouncementModalCtrl', {
+        $scope: $scope,
+        $modalInstance : $modalInstance
+      });
+      $scope.$digest();
+    });
+  });
+  
+  it('should exist',function(){
+    expect($scope).to.be.ok;
+    expect($scope.thumbsUp).to.be.a('function');
+    expect($scope.thumbsDown).to.be.a('function');
+    expect($scope.name).to.be.ok;
+  });
+
+  it('should init user first name',function(){
+    expect($scope.name).to.equal('myFirstName');
+  })
+
+  it('should close modal on thumbs up and resolve a true value',function(){
+      $scope.thumbsUp();
+      expect($modalInstance.close).to.have.been.been.calledWith(true);
+  });
+
+  it('should close modal on thumbs down and resolve a false value',function(){
+      $scope.thumbsDown();
+      expect($modalInstance.close).to.have.been.been.calledWith(false);
+  });
+  
+});

--- a/test/unit/common/directives/dtv-in-app-messages.tests.js
+++ b/test/unit/common/directives/dtv-in-app-messages.tests.js
@@ -5,6 +5,7 @@ describe('directive: in-app-messages', function() {
       $rootScope,
       $scope,
       element,
+      templatesAnnouncementFactory,
       inAppMessagesFactory;
   beforeEach(module('risevision.apps.directives'));
   beforeEach(module(function ($provide) {
@@ -13,11 +14,17 @@ describe('directive: in-app-messages', function() {
         pickMessage: sandbox.stub().returns(Q.resolve('message')),
         dismissMessage: sandbox.stub()
       };
-    });  
+    });
+    $provide.service('templatesAnnouncementFactory', function() {
+      return {
+        showAnnouncementIfNeeded: sandbox.stub()
+      };
+    });
   }));
   beforeEach(inject(function(_$compile_, _$rootScope_, $templateCache, $injector){
     $compile = _$compile_;
     $rootScope = _$rootScope_;
+    templatesAnnouncementFactory = $injector.get('templatesAnnouncementFactory');
     inAppMessagesFactory = $injector.get('inAppMessagesFactory');
     $templateCache.put('partials/common/in-app-messages.html', '<p>mock</p>');
   }));
@@ -47,6 +54,10 @@ describe('directive: in-app-messages', function() {
       expect(inAppMessagesFactory.pickMessage).to.have.been.called;
     });
 
+    it('should check and show templates announcement', function() {
+      expect(templatesAnnouncementFactory.showAnnouncementIfNeeded).to.have.been.called;
+    });
+    
   });
 
 });

--- a/test/unit/common/directives/dtv-in-app-messages.tests.js
+++ b/test/unit/common/directives/dtv-in-app-messages.tests.js
@@ -9,6 +9,7 @@ describe('directive: in-app-messages', function() {
       inAppMessagesFactory;
   beforeEach(module('risevision.apps.directives'));
   beforeEach(module(function ($provide) {
+    $provide.value('CHECK_TEMPLATES_ANNOUNCEMENT','true');
     $provide.service('inAppMessagesFactory', function() {
       return {
         pickMessage: sandbox.stub().returns(Q.resolve('message')),

--- a/test/unit/common/directives/dtv-in-app-messages.tests.js
+++ b/test/unit/common/directives/dtv-in-app-messages.tests.js
@@ -9,7 +9,6 @@ describe('directive: in-app-messages', function() {
       inAppMessagesFactory;
   beforeEach(module('risevision.apps.directives'));
   beforeEach(module(function ($provide) {
-    $provide.value('CHECK_TEMPLATES_ANNOUNCEMENT','true');
     $provide.service('inAppMessagesFactory', function() {
       return {
         pickMessage: sandbox.stub().returns(Q.resolve('message')),

--- a/test/unit/common/services/svc-templates-announcement-factory.tests.js
+++ b/test/unit/common/services/svc-templates-announcement-factory.tests.js
@@ -6,6 +6,7 @@ describe('service: templates-announcement-factory', function() {
   beforeEach(module('risevision.apps.services'));
   beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
+    $provide.value('CHECK_TEMPLATES_ANNOUNCEMENT','true');
     $provide.service('$q', function() {return Q;});
     $provide.service('presentation', function() {
       return {};
@@ -15,7 +16,7 @@ describe('service: templates-announcement-factory', function() {
         getCopyOfSelectedCompany: function() {
           return selectedCompany;
         },
-        isEducationCustomer: sandbox.stub().returns(false),
+        isEducationCustomer: sandbox.stub().returns(true),
         _restoreState: sandbox.stub(),
         getSelectedCompanyId: sandbox.stub().returns('')
       };
@@ -91,6 +92,15 @@ describe('service: templates-announcement-factory', function() {
           backdrop: 'static',
           keyboard: false
         });
+        done();
+      },10);
+    });
+
+    it('should not show announcement if customer is non Education',function(done) {
+      userState.isEducationCustomer.returns(false);
+      factory.showAnnouncementIfNeeded();
+      setTimeout(function(){
+        expect($modal.open).to.not.have.been.called;
         done();
       },10);
     });

--- a/test/unit/common/services/svc-templates-announcement-factory.tests.js
+++ b/test/unit/common/services/svc-templates-announcement-factory.tests.js
@@ -1,0 +1,208 @@
+'use strict';
+describe('service: templates-announcement-factory', function() {
+  var sandbox = sinon.sandbox.create();
+  var factory, selectedCompany, localStorageService, executeStub, userState, $modal, segmentAnalytics, bigQueryLogging;
+
+  beforeEach(module('risevision.apps.services'));
+  beforeEach(module(mockTranslate()));
+  beforeEach(module(function ($provide) {
+    $provide.service('$q', function() {return Q;});
+    $provide.service('presentation', function() {
+      return {};
+    });
+    $provide.service('userState', function() {
+      return {
+        getCopyOfSelectedCompany: function() {
+          return selectedCompany;
+        },
+        isEducationCustomer: sandbox.stub().returns(false),
+        _restoreState: sandbox.stub(),
+        getSelectedCompanyId: sandbox.stub().returns('')
+      };
+    });
+    $provide.service('localStorageService', function() {
+      return {
+        get: sandbox.stub().returns(false),
+        set: sandbox.stub(),
+        remove: sandbox.stub()
+      }
+    });
+    $provide.service('CachedRequest', function() {
+      return function(request, args) {
+        return {
+          execute: executeStub = sandbox.stub().returns(Q.resolve({items:[{changeDate: '2010-01-01'}]}))
+        }
+      }
+    });
+    $provide.service("$templateCache", function() {
+      return {
+        get: sandbox.stub().returns("template"),
+        put: sandbox.stub()
+      };
+    });
+    $provide.service('$modal', function() {
+      return {
+        open: sandbox.stub()
+      }
+    });
+    $provide.service('segmentAnalytics', function() {
+      return {
+        load: sandbox.stub(), 
+        track: sandbox.stub()
+      }
+    });
+    $provide.service('bigQueryLogging', function() {
+      return {
+        logEvent: sandbox.stub()
+      }
+    });
+  }));
+
+  beforeEach(function() {
+    inject(function($injector) {
+      factory = $injector.get('templatesAnnouncementFactory');
+      userState = $injector.get('userState');
+      localStorageService = $injector.get('localStorageService');
+      $modal = $injector.get('$modal');
+      segmentAnalytics = $injector.get('segmentAnalytics');
+      bigQueryLogging = $injector.get('bigQueryLogging');
+      selectedCompany = {
+        creationDate: '2010-01-01'
+      };
+    });
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  it('should exist',function(){
+    expect(factory.showAnnouncementIfNeeded).to.be.a('function');
+  });
+
+  describe('showAnnouncementIfNeeded:', function() {    
+    it('should show announcement',function(done){
+      factory.showAnnouncementIfNeeded();
+      setTimeout(function(){
+        expect($modal.open).to.have.been.calledWithMatch({
+          template: "template",
+          controller: "TemplatesAnnouncementModalCtrl",
+          size: "lg",
+          backdrop: 'static',
+          keyboard: false
+        });
+        done();
+      },10);
+    });
+
+    it('should not show announcement if already dismissed',function(done) {
+      localStorageService.get.returns(true);
+      factory.showAnnouncementIfNeeded();
+      setTimeout(function(){
+        expect($modal.open).to.not.have.been.called;
+        done();
+      },10);
+    });
+
+    it('should not show announcement if company is recent',function(done) {
+      selectedCompany = {creationDate: new Date()};
+      factory.showAnnouncementIfNeeded();
+      setTimeout(function(){
+        expect($modal.open).to.not.have.been.called;
+        done();
+      },10);
+    });
+
+    it('should not show announcement if company is missing',function(done) {
+      selectedCompany = undefined;
+      factory.showAnnouncementIfNeeded();
+      setTimeout(function(){
+        expect($modal.open).to.not.have.been.called;
+        done();
+      },10);
+    });
+
+    describe('added HTML Presentations in the last 30 days',function () {
+      it('should show announcement when presentations are older than 30 days',function(done) {
+        executeStub.returns(Q.resolve({items:[{changeDate: '2015-01-01'}]}));
+        factory.showAnnouncementIfNeeded();
+        setTimeout(function(){
+          expect($modal.open).to.have.been.called;
+          done();
+        },10);
+      });
+
+      it('should show announcement when no presentations are found',function(done) {
+        executeStub.returns(Q.resolve({items:[]}));
+        factory.showAnnouncementIfNeeded();
+        setTimeout(function(){
+          expect($modal.open).to.have.been.called;
+          done();
+        },10);
+      });
+
+      it('should not show announcement when there are recent html presentations',function(done) {
+        executeStub.returns(Q.resolve({items:[{changeDate: new Date()}]}));
+        factory.showAnnouncementIfNeeded();
+        setTimeout(function(){
+          expect($modal.open).to.not.have.been.called;
+          done();
+        },10);
+      });
+
+      it('should not show announcement if presentations request fail',function(done) {
+        executeStub.returns(Q.reject());
+        factory.showAnnouncementIfNeeded();
+        setTimeout(function(){
+          expect($modal.open).to.not.have.been.called;
+          done();
+        },10);
+      });
+    });
+
+    describe('handle modal result', function() {
+      it('should set as dismissed in localStorage', function(done) {
+        $modal.open.returns({result: Q.resolve()});        
+        factory.showAnnouncementIfNeeded();
+        setTimeout(function(){
+          expect(localStorageService.set).to.have.been.calledWith('templatesAnnouncement.dismissed',true);
+          done();
+        },10);
+      });
+
+      it('should log thumbsup event', function(done) {
+        $modal.open.returns({result: Q.resolve(true)});
+        factory.showAnnouncementIfNeeded();
+        setTimeout(function(){
+          expect(segmentAnalytics.track).to.have.been.calledWith('Templates Announcement Thumbs Up');
+          expect(bigQueryLogging.logEvent).to.have.been.calledWith('Templates Announcement Thumbs Up');
+          done();
+        },10);
+      });
+
+      it('should log thumbs down event', function(done) {
+        $modal.open.returns({result: Q.resolve(false)});
+        factory.showAnnouncementIfNeeded();
+        setTimeout(function(){
+          expect(segmentAnalytics.track).to.have.been.calledWith('Templates Announcement Thumbs Down');
+          expect(bigQueryLogging.logEvent).to.have.been.calledWith('Templates Announcement Thumbs Down');
+          done();
+        },10);
+      });
+
+
+      it('should not do anything on reject', function(done) {
+        $modal.open.returns({result: Q.reject()});        
+        factory.showAnnouncementIfNeeded();
+        setTimeout(function(){
+          expect(localStorageService.set).to.not.have.been.called;
+          expect(segmentAnalytics.track).to.not.have.been.called;
+          expect(bigQueryLogging.logEvent).to.not.have.been.called;
+          done();
+        },10);
+      });
+    });
+
+  });
+
+});

--- a/web/index.html
+++ b/web/index.html
@@ -319,6 +319,7 @@
   <script src="scripts/config/config.js"></script>
   <script src="scripts/app.js"></script>
   <script src="scripts/common/controllers/ctr-app.js"></script>
+  <script src="scripts/common/controllers/ctr-templates-announcement-modal.js"></script>
   <script src="scripts/common/directives/dtv-rv-sortable.js"></script>
   <script src="scripts/common/directives/dtv-guid-validator.js"></script>
   <script src="scripts/common/directives/dtv-in-app-messages.js"></script>
@@ -327,6 +328,7 @@
   <script src="scripts/common/services/svc-in-app-messages-factory.js"></script>
   <script src="scripts/common/services/svc-resource-loader.js"></script>
   <script src="scripts/common/services/svc-subscription-status.js"></script>
+  <script src="scripts/common/services/svc-templates-announcement-factory.js"></script>
 
   <!-- launcher -->
   <script src="scripts/launcher/controllers/ctr-home.js"></script>

--- a/web/partials/common/templates-announcement-modal.html
+++ b/web/partials/common/templates-announcement-modal.html
@@ -1,0 +1,24 @@
+<div id="templatesAnnouncementModal">
+  <div class="modal-header">
+    <h3 class="modal-title" translate>Save Time with Our Templates!</h3>
+  </div>
+  <div class="modal-body" stop-event="touchend">
+    <p>Hey {{name || 'there'}}! You haven’t used our time saving Templates at all. Take 1.5 minutes and learn how they could save you 16 hours.</p>
+    <h3>&#128071;&#128071;&#128071;</h3>
+    <div align="center" class="panel panel-default panel-thick-shadow embed-responsive embed-responsive-16by9">
+      <video controls class="embed-responsive-item">
+          <source src="https://storage.googleapis.com/risemedialibrary-74180546-6d57-4d62-b5f8-84eef0e53c49/in-app-template-announcement2.mp4" type="video/mp4" />
+      </video>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button class="btn btn-primary btn-fixed-width" ng-click="thumbsUp()">
+      &#128077;
+      <span translate>Awesome!</span>
+    </button>
+    <button class="btn btn-default btn-fixed-width" ng-click="thumbsDown()">
+      &#128078;
+      <span translate>I Don’t Want To Save Time</span>
+    </button>
+  </div>
+</div>

--- a/web/partials/common/templates-announcement-modal.html
+++ b/web/partials/common/templates-announcement-modal.html
@@ -7,7 +7,7 @@
     <h3>&#128071;&#128071;&#128071;</h3>
     <div align="center" class="panel panel-default panel-thick-shadow embed-responsive embed-responsive-16by9">
       <video controls class="embed-responsive-item">
-          <source src="https://storage.googleapis.com/risemedialibrary-74180546-6d57-4d62-b5f8-84eef0e53c49/in-app-template-announcement2.mp4" type="video/mp4" />
+          <source src="https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/apps/in-app-template-announcement2.mp4" type="video/mp4" />
       </video>
     </div>
   </div>

--- a/web/scripts/common/controllers/ctr-templates-announcement-modal.js
+++ b/web/scripts/common/controllers/ctr-templates-announcement-modal.js
@@ -5,7 +5,7 @@ angular.module('risevision.apps.controllers')
     function ($scope, $modalInstance, userState) {
 
       $scope.name = userState.getCopyOfProfile().firstName;
-     
+
       $scope.thumbsUp = function () {
         $modalInstance.close(true);
       };

--- a/web/scripts/common/controllers/ctr-templates-announcement-modal.js
+++ b/web/scripts/common/controllers/ctr-templates-announcement-modal.js
@@ -1,0 +1,21 @@
+'use strict';
+
+angular.module('risevision.apps.controllers')
+  .controller('TemplatesAnnouncementModalCtrl', ['$scope', '$modalInstance', 'userState',
+    function ($scope, $modalInstance, userState) {
+
+      $scope.name = userState.getCopyOfProfile().firstName;
+     
+      $scope.thumbsUp = function () {
+        $modalInstance.close(true);
+      };
+
+      $scope.thumbsDown = function () {
+        $modalInstance.close(false);
+      };
+
+      // $scope.dismiss = function () {
+      //   $modalInstance.dismiss();
+      // };
+    }
+  ]);

--- a/web/scripts/common/controllers/ctr-templates-announcement-modal.js
+++ b/web/scripts/common/controllers/ctr-templates-announcement-modal.js
@@ -13,9 +13,5 @@ angular.module('risevision.apps.controllers')
       $scope.thumbsDown = function () {
         $modalInstance.close(false);
       };
-
-      // $scope.dismiss = function () {
-      //   $modalInstance.dismiss();
-      // };
     }
   ]);

--- a/web/scripts/common/directives/dtv-in-app-messages.js
+++ b/web/scripts/common/directives/dtv-in-app-messages.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.apps.directives')
-  .directive('inAppMessages', ['inAppMessagesFactory', 'templatesAnnouncementFactory', 'CHECK_TEMPLATES_ANNOUNCEMENT',
-    function (inAppMessagesFactory, templatesAnnouncementFactory, CHECK_TEMPLATES_ANNOUNCEMENT) {
+  .directive('inAppMessages', ['inAppMessagesFactory', 'templatesAnnouncementFactory',
+    function (inAppMessagesFactory, templatesAnnouncementFactory) {
       return {
         restrict: 'E',
         scope: {},
@@ -11,9 +11,7 @@ angular.module('risevision.apps.directives')
           $scope.inAppMessagesFactory = inAppMessagesFactory;
           inAppMessagesFactory.pickMessage();
 
-          if (CHECK_TEMPLATES_ANNOUNCEMENT === 'true') {
-            templatesAnnouncementFactory.showAnnouncementIfNeeded();
-          }
+          templatesAnnouncementFactory.showAnnouncementIfNeeded();
         }
       };
     }

--- a/web/scripts/common/directives/dtv-in-app-messages.js
+++ b/web/scripts/common/directives/dtv-in-app-messages.js
@@ -11,7 +11,7 @@ angular.module('risevision.apps.directives')
           $scope.inAppMessagesFactory = inAppMessagesFactory;
           inAppMessagesFactory.pickMessage();
 
-          templatesAnnouncementFactory.showTemplatesAnnouncementIfNeeded();
+          templatesAnnouncementFactory.showAnnouncementIfNeeded();
         }
       };
     }

--- a/web/scripts/common/directives/dtv-in-app-messages.js
+++ b/web/scripts/common/directives/dtv-in-app-messages.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.apps.directives')
-  .directive('inAppMessages', ['inAppMessagesFactory',
-    function (inAppMessagesFactory) {
+  .directive('inAppMessages', ['inAppMessagesFactory', 'templatesAnnouncementFactory',
+    function (inAppMessagesFactory, templatesAnnouncementFactory) {
       return {
         restrict: 'E',
         scope: {},
@@ -10,6 +10,8 @@ angular.module('risevision.apps.directives')
         link: function ($scope) {
           $scope.inAppMessagesFactory = inAppMessagesFactory;
           inAppMessagesFactory.pickMessage();
+
+          templatesAnnouncementFactory.showTemplatesAnnouncementIfNeeded();
         }
       };
     }

--- a/web/scripts/common/directives/dtv-in-app-messages.js
+++ b/web/scripts/common/directives/dtv-in-app-messages.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.apps.directives')
-  .directive('inAppMessages', ['inAppMessagesFactory', 'templatesAnnouncementFactory',
-    function (inAppMessagesFactory, templatesAnnouncementFactory) {
+  .directive('inAppMessages', ['inAppMessagesFactory', 'templatesAnnouncementFactory', 'CHECK_TEMPLATES_ANNOUNCEMENT',
+    function (inAppMessagesFactory, templatesAnnouncementFactory, CHECK_TEMPLATES_ANNOUNCEMENT) {
       return {
         restrict: 'E',
         scope: {},
@@ -11,7 +11,9 @@ angular.module('risevision.apps.directives')
           $scope.inAppMessagesFactory = inAppMessagesFactory;
           inAppMessagesFactory.pickMessage();
 
-          templatesAnnouncementFactory.showAnnouncementIfNeeded();
+          if (CHECK_TEMPLATES_ANNOUNCEMENT === 'true') {
+            templatesAnnouncementFactory.showAnnouncementIfNeeded();
+          }
         }
       };
     }

--- a/web/scripts/common/services/svc-templates-announcement-factory.js
+++ b/web/scripts/common/services/svc-templates-announcement-factory.js
@@ -1,0 +1,43 @@
+'use strict';
+
+angular.module('risevision.apps.services')
+  .factory('templatesAnnouncementFactory', ['localStorageService', 'userState', 'CachedRequest', 'presentation', '$q',
+    '$rootScope', '$templateCache', '$modal',
+    function (localStorageService, userState, CachedRequest, presentation, $q, $rootScope, $templateCache, $modal) {
+      var presentationListReq = new CachedRequest(presentation.list, {});
+      var factory = {};
+
+      $rootScope.$on('risevision.company.selectedCompanyChanged', function () {
+        _reset();
+      });
+      $rootScope.$on('risevision.company.updated', function () {
+        _reset();
+      });
+
+      factory.showTemplatesAnnouncementIfNeeded = function() {
+        console.log('showTemplatesAnnouncementIfNeeded');
+        if(_shouldShowTemplatesAnnouncement()) {
+          var instance = $modal.open({
+            template: $templateCache.get('partials/common/templates-announcement-modal.html'),
+            controller: 'TemplatesAnnouncementModalCtrl',
+            size: 'lg',
+            backdrop: 'static', //prevent from closing modal by clicking outside
+            keyboard: false, //prevent from closing modal by pressing escape
+          });
+          instance.result.then(function (liked) {
+            console.log('liked',liked);
+          });
+        }
+      };
+
+      var _reset = function () {
+        presentationListReq = new CachedRequest(presentation.list, {});
+      };
+
+      var _shouldShowTemplatesAnnouncement = function() {
+        return true;
+      };
+
+      return factory;
+    }
+  ]);

--- a/web/scripts/common/services/svc-templates-announcement-factory.js
+++ b/web/scripts/common/services/svc-templates-announcement-factory.js
@@ -2,9 +2,9 @@
 
 angular.module('risevision.apps.services')
   .factory('templatesAnnouncementFactory', ['localStorageService', 'userState', 'CachedRequest', 'presentation', '$q',
-    '$templateCache', '$modal', 'segmentAnalytics', 'bigQueryLogging',
+    '$templateCache', '$modal', 'segmentAnalytics', 'bigQueryLogging', 'CHECK_TEMPLATES_ANNOUNCEMENT',
     function (localStorageService, userState, CachedRequest, presentation, $q, $templateCache, $modal,
-      segmentAnalytics, bigQueryLogging) {
+      segmentAnalytics, bigQueryLogging, CHECK_TEMPLATES_ANNOUNCEMENT) {
       var dismissedKey = 'templatesAnnouncement.dismissed';
       var factory = {};
       var search = {
@@ -36,7 +36,7 @@ angular.module('risevision.apps.services')
       };
 
       var _shouldShowAnnouncement = function () {
-        if (_isDismissed() || !_isOlderThan15Days()) {
+        if (CHECK_TEMPLATES_ANNOUNCEMENT !== 'true' || !userState.isEducationCustomer() || _isDismissed() || !_isOlderThan15Days()) {
           return $q.reject();
         }
 

--- a/web/scripts/common/services/svc-templates-announcement-factory.js
+++ b/web/scripts/common/services/svc-templates-announcement-factory.js
@@ -2,8 +2,8 @@
 
 angular.module('risevision.apps.services')
   .factory('templatesAnnouncementFactory', ['localStorageService', 'userState', 'CachedRequest', 'presentation', '$q',
-    '$rootScope', '$templateCache', '$modal', 'segmentAnalytics', 'bigQueryLogging',
-    function (localStorageService, userState, CachedRequest, presentation, $q, $rootScope, $templateCache, $modal,
+    '$templateCache', '$modal', 'segmentAnalytics', 'bigQueryLogging',
+    function (localStorageService, userState, CachedRequest, presentation, $q, $templateCache, $modal,
       segmentAnalytics, bigQueryLogging) {
       var dismissedKey = 'templatesAnnouncement.dismissed';
       var factory = {};
@@ -60,7 +60,7 @@ angular.module('risevision.apps.services')
 
       var _isOlderThan15Days = function () {
         var company = userState.getCopyOfSelectedCompany();
-        var creationDate = ((company && company.creationDate) ? (new Date(company.creationDate)) : (new Date()));
+        var creationDate = (company && company.creationDate) ? new Date(company.creationDate) : new Date();
         return _daysDiff(new Date(), creationDate) > 15;
       };
 

--- a/web/scripts/common/services/svc-templates-announcement-factory.js
+++ b/web/scripts/common/services/svc-templates-announcement-factory.js
@@ -3,7 +3,8 @@
 angular.module('risevision.apps.services')
   .factory('templatesAnnouncementFactory', ['localStorageService', 'userState', 'CachedRequest', 'presentation', '$q',
     '$rootScope', '$templateCache', '$modal', 'segmentAnalytics', 'bigQueryLogging',
-    function (localStorageService, userState, CachedRequest, presentation, $q, $rootScope, $templateCache, $modal, segmentAnalytics, bigQueryLogging) {
+    function (localStorageService, userState, CachedRequest, presentation, $q, $rootScope, $templateCache, $modal,
+      segmentAnalytics, bigQueryLogging) {
       var dismissedKey = 'templatesAnnouncement.dismissed';
       var factory = {};
       var search = {
@@ -14,8 +15,8 @@ angular.module('risevision.apps.services')
       };
       var presentationListReq = new CachedRequest(presentation.list, search);
 
-      factory.showAnnouncementIfNeeded = function() {
-        _shouldShowAnnouncement().then(function(){
+      factory.showAnnouncementIfNeeded = function () {
+        _shouldShowAnnouncement().then(function () {
           var instance = $modal.open({
             template: $templateCache.get('partials/common/templates-announcement-modal.html'),
             controller: 'TemplatesAnnouncementModalCtrl',
@@ -27,48 +28,48 @@ angular.module('risevision.apps.services')
             localStorageService.set(dismissedKey, true);
 
             var eventName = 'Templates Announcement';
-            eventName += liked ? ' Thumbs Up' : ' Thumbs Down'; 
+            eventName += liked ? ' Thumbs Up' : ' Thumbs Down';
             segmentAnalytics.track(eventName);
             bigQueryLogging.logEvent(eventName);
           });
         });
       };
 
-      var _shouldShowAnnouncement = function() {
-        if (_isDismissed() || !_isOlderThan15Days() ) {
+      var _shouldShowAnnouncement = function () {
+        if (_isDismissed() || !_isOlderThan15Days()) {
           return $q.reject();
         }
 
         var deferred = $q.defer();
-        
-        presentationListReq.execute().then(function(resp){
-          var hasAddedHtmlPresentationRecently = resp && resp.items && resp.items.length > 0 && _daysDiff(new Date(), new Date(resp.items[0].changeDate)) < 30;
+
+        presentationListReq.execute().then(function (resp) {
+          var hasAddedHtmlPresentationRecently = resp && resp.items && resp.items.length > 0 &&
+            _daysDiff(new Date(), new Date(resp.items[0].changeDate)) < 30;
 
           if (!hasAddedHtmlPresentationRecently) {
             deferred.resolve();
           } else {
             deferred.reject();
           }
-        }).catch(function(e){
+        }).catch(function (e) {
           deferred.reject(e);
         });
 
         return deferred.promise;
       };
 
-
-      var _isOlderThan15Days = function() {
+      var _isOlderThan15Days = function () {
         var company = userState.getCopyOfSelectedCompany();
         var creationDate = ((company && company.creationDate) ? (new Date(company.creationDate)) : (new Date()));
         return _daysDiff(new Date(), creationDate) > 15;
       };
 
-      var _isDismissed = function() {
+      var _isDismissed = function () {
         return localStorageService.get(dismissedKey) === true;
       };
 
-      var _daysDiff = function(date1,date2) {
-        return Math.abs((date1 - date2)/1000/60/60/24);
+      var _daysDiff = function (date1, date2) {
+        return Math.abs((date1 - date2) / 1000 / 60 / 60 / 24);
       };
 
       return factory;

--- a/web/scripts/config/beta.js
+++ b/web/scripts/config/beta.js
@@ -36,6 +36,7 @@
     .value('OAUTH_PUBLIC_KEY', 'EJMI-lB9hB55OYEsYmjXDNfRGoY')
     .value('CHARGEBEE_TEST_SITE', 'risevision-test')
     .value('CHARGEBEE_PROD_SITE', 'risevision')
+    .value('CHECK_TEMPLATES_ANNOUNCEMENT', 'true')
     .value('STRIPE_PROD_KEY', 'pk_live_31dWkTWQU125m2RcWpK4HQBR')
     .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
     .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/src/template.html')

--- a/web/scripts/config/dev.js
+++ b/web/scripts/config/dev.js
@@ -44,6 +44,7 @@
     .value('CHARGEBEE_TEST_SITE', 'risevision-test')
     .value('CHARGEBEE_PROD_SITE', 'risevision-test')
     .value('CHARGEBEE_PLANS_USE_PROD', 'false')
+    .value('CHECK_TEMPLATES_ANNOUNCEMENT', 'false')
     .value('STRIPE_PROD_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
     .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
     .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/src/template.html')

--- a/web/scripts/config/prod.js
+++ b/web/scripts/config/prod.js
@@ -36,6 +36,7 @@
     .value('CHARGEBEE_TEST_SITE', 'risevision-test')
     .value('CHARGEBEE_PROD_SITE', 'risevision')
     .value('CHARGEBEE_PLANS_USE_PROD', 'true')
+    .value('CHECK_TEMPLATES_ANNOUNCEMENT', 'true')
     .value('STRIPE_PROD_KEY', 'pk_live_31dWkTWQU125m2RcWpK4HQBR')
     .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
     .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/src/template.html')

--- a/web/scripts/config/stage.js
+++ b/web/scripts/config/stage.js
@@ -42,6 +42,7 @@
     .value('OAUTH_PUBLIC_KEY', 'EJMI-lB9hB55OYEsYmjXDNfRGoY')
     .value('CHARGEBEE_TEST_SITE', 'risevision-test')
     .value('CHARGEBEE_PROD_SITE', 'risevision-test')
+    .value('CHECK_TEMPLATES_ANNOUNCEMENT', 'true')
     .value('STRIPE_PROD_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
     .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
     .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/src/template.html')

--- a/web/scripts/config/test.js
+++ b/web/scripts/config/test.js
@@ -45,6 +45,7 @@
     .value('CHARGEBEE_TEST_SITE', 'risevision-test')
     .value('CHARGEBEE_PROD_SITE', 'risevision-test')
     .value('CHARGEBEE_PLANS_USE_PROD', 'false')
+    .value('CHECK_TEMPLATES_ANNOUNCEMENT', 'false')
     .value('STRIPE_PROD_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
     .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
     .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/src/template.html')

--- a/web/scripts/displays/services/svc-display-factory.js
+++ b/web/scripts/displays/services/svc-display-factory.js
@@ -37,11 +37,11 @@ angular.module('risevision.displays.services')
 
       factory.addDisplayModal = function (display) {
         displayTracker('Add Display');
-        
+
         if (display) {
           factory.display = display;
         } else {
-          _init();  
+          _init();
         }
 
         $modal.open({

--- a/web/scripts/template-editor/components/directives/dtv-component-counter.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-counter.js
@@ -9,7 +9,7 @@ angular.module('risevision.template-editor.directives')
         templateUrl: 'partials/template-editor/components/component-counter.html',
         compile: function () {
           return {
-            pre: function($scope) {
+            pre: function ($scope) {
               $scope.dateOptions = {
                 formatYear: 'yy',
                 startingDay: 1,


### PR DESCRIPTION
## Description
- Shows a modal with a video to promote HTML Templates for companies that haven't used them recently (account older than 15 days and not created an HTML Presentation in the past 30 days).
- Require user to provide  feedback to close the modal (Thumbs Up/Down) - no close button.
- Logs 'Templates Announcement Thumbs Up/Down' events to Segment and BQ.

## Motivation and Context
In-App Templates Announcement epic

## How Has This Been Tested?
Tested locally and on stage-1.

Company that shows modal: https://apps-stage-1.risevision.com/editor/list?cid=7fab085e-a773-4351-b710-a2e40da6b04e

Company that does not show modal (has recent HTML Presentation): https://apps-stage-1.risevision.com/editor/list

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
Given its impact on multiple e2e tests and conditionals, we decided to disable this functionality when running e2e tests to prevent them from failing eventually.

@alex-deaconu Please review. Thanks