### PR TITLE
Remove Connection Status error check

### DIFF
--- a/test/e2e/displays/pages/displaysListPage.js
+++ b/test/e2e/displays/pages/displaysListPage.js
@@ -22,19 +22,12 @@ var DisplaysListPage = function() {
   var tableHeaderStatus = element(by.id('tableHeaderStatus'));
   var displayItems = element.all(by.repeater('display in displays.items.list'));
   var displaysLoader = element(by.xpath('//div[@spinner-key="displays-list-loader"]'));
-  var displayStatusError = element(by.cssContainingText('#errorBox strong', 'Failed to load displays connection status.'));
 
   this.searchDisplay = function(displayName) {
     helper.wait(searchFilterField, 'Search Filter Field');
     searchFilterField.sendKeys(displayName);
     helper.wait(displaysLoader, 'Displays loader');
     helper.waitDisappear(displaysLoader, 'Displays loader');
-
-    displayItems.count().then(function(count) {
-      if (count > 0) {
-        helper.wait(displayStatusError, 'Connection Status Load error');
-      }
-    });
   };
 
   this.clearSearch = function() {
@@ -42,12 +35,6 @@ var DisplaysListPage = function() {
     searchFilterField.clear();
     helper.wait(displaysLoader, 'Displays loader');
     helper.waitDisappear(displaysLoader, 'Displays loader');
-
-    displayItems.count().then(function(count) {
-      if (count > 0) {
-        helper.wait(displayStatusError, 'Connection Status Load error');
-      }
-    });
   };
 
   this.deleteDisplayIfExists = function() {


### PR DESCRIPTION
## Description
Remove Connection Status error check

## Motivation and Context
Fix e2e test
Latest changes in widget-tester remove the CORS errors,
so this message no longer appears during e2e tests

## How Has This Been Tested?
No functionality changes
Displays e2e tests pass

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No