### PR TITLE
Use storeAuthorization rather than http call

### DIFF
--- a/test/unit/components/core-api-client/svc-store-authorization.tests.js
+++ b/test/unit/components/core-api-client/svc-store-authorization.tests.js
@@ -1,7 +1,7 @@
 "use strict";
 describe("service: storeAuthorization:", function() {
-  var STORE_SERVER_URL = "http://example.com";
-  var STORE_AUTHORIZATION_URL = STORE_SERVER_URL + "/v1/widget/auth";
+  var STORE_SERVER_URL = "http://example.com/";
+  var STORE_AUTHORIZATION_URL = STORE_SERVER_URL + "v1/widget/auth";
   
   beforeEach(module("risevision.store.authorization"));
 

--- a/test/unit/components/subscription-status/svc-subscription-status.tests.js
+++ b/test/unit/components/subscription-status/svc-subscription-status.tests.js
@@ -49,7 +49,7 @@ describe("Services: subscriptionStatusService", function() {
     storeProduct.status.should.have.been.calledWith(["1"]);
   });
 
-  it("should call not call authorization api if subscribed", function(done) {
+  it("should not call authorization api if subscribed", function(done) {
     subscriptionStatusService.get("1").then(function(data){
       storeProduct.status.should.have.been.calledWith(["1"]);
       storeAuthorization.check.should.not.have.been.called;

--- a/test/unit/components/subscription-status/svc-subscription-status.tests.js
+++ b/test/unit/components/subscription-status/svc-subscription-status.tests.js
@@ -8,9 +8,9 @@ describe("Services: subscriptionStatusService", function() {
   beforeEach(module(function ($provide) {
     $provide.service("$q", function() {return Q;});
 
-    $provide.service("$http", function() {
+    $provide.service("storeAuthorization", function() {
       return {
-        get: sinon.stub().returns(Q.resolve({ data: { authorized: false }}))
+        check: sinon.stub().returns(Q.reject(false))
       };
     });
 
@@ -22,7 +22,7 @@ describe("Services: subscriptionStatusService", function() {
 
   }));
 
-  var subscriptionStatusService, $http, storeProduct, response;
+  var subscriptionStatusService, storeAuthorization, storeProduct, response;
 
   beforeEach(function(){
     response = {
@@ -33,7 +33,7 @@ describe("Services: subscriptionStatusService", function() {
     };
 
     inject(function($injector){
-      $http = $injector.get('$http');
+      storeAuthorization = $injector.get('storeAuthorization');
       storeProduct = $injector.get('storeProduct');
       subscriptionStatusService = $injector.get('subscriptionStatusService');
     });
@@ -44,15 +44,15 @@ describe("Services: subscriptionStatusService", function() {
   });
 
   it("should call product status api", function() {
-    subscriptionStatusService.get("1", "12345");
+    subscriptionStatusService.get("1");
 
     storeProduct.status.should.have.been.calledWith(["1"]);
   });
 
   it("should call not call authorization api if subscribed", function(done) {
-    subscriptionStatusService.get("1", "12345").then(function(data){
+    subscriptionStatusService.get("1").then(function(data){
       storeProduct.status.should.have.been.calledWith(["1"]);
-      $http.get.should.not.have.been.called;
+      storeAuthorization.check.should.not.have.been.called;
 
       done();
     });
@@ -61,7 +61,7 @@ describe("Services: subscriptionStatusService", function() {
   it("should handle blank responses", function(done) {
     response.items = undefined;
 
-    subscriptionStatusService.get("1", "12345").then(function(){
+    subscriptionStatusService.get("1").then(function(){
       done("Failed");
     })
     .catch(function(err) {
@@ -74,7 +74,7 @@ describe("Services: subscriptionStatusService", function() {
   it("should handle subscription status api failure", function(done) {
     storeProduct.status.returns(Q.reject("API Failed"));
 
-    subscriptionStatusService.get("1", "12345").then(function(){
+    subscriptionStatusService.get("1").then(function(){
       done("Failed");
     })
     .catch(function(err) {
@@ -87,9 +87,9 @@ describe("Services: subscriptionStatusService", function() {
   it("should call authorization api if subscription status returns false", function(done) {
     response.items[0].status = "Cancelled";
 
-    subscriptionStatusService.get("1", "12345").then(function(data){
+    subscriptionStatusService.get("1").then(function(data){
       storeProduct.status.should.have.been.calledWith(["1"]);
-      $http.get.should.have.been.called;
+      storeAuthorization.check.should.have.been.calledWith("1");
 
       done();
     });
@@ -99,11 +99,11 @@ describe("Services: subscriptionStatusService", function() {
     it("should return free product", function(done) {
       response.items[0].status = "Free";
 
-      subscriptionStatusService.get("1", "12345").then(function(data){
+      subscriptionStatusService.get("1").then(function(data){
         expect(data).be.defined;
         expect(data.status).be.equal("Free");
         expect(data.statusCode).be.equal("free");
-        expect(data.subscribed).be.equal(true);
+        expect(data.isSubscribed).be.be.true;
 
         done();
       });
@@ -112,11 +112,11 @@ describe("Services: subscriptionStatusService", function() {
     it("should return expired product", function(done) {
       response.items[0].status = "Trial Expired";
 
-      subscriptionStatusService.get("2", "12345").then(function(data){
+      subscriptionStatusService.get("2").then(function(data){
         expect(data).be.defined;
         expect(data.status).be.equal("Trial Expired");
         expect(data.statusCode).be.equal("trial-expired");
-        expect(data.subscribed).be.equal(false);
+        expect(data.isSubscribed).be.be.false;
 
         done();
       });
@@ -124,13 +124,44 @@ describe("Services: subscriptionStatusService", function() {
 
     it("should return active subscription for cancelled product", function(done) {
       response.items[0].status = "Cancelled";
-      $http.get.returns(Q.resolve({ data: { authorized: true }}));
+      storeAuthorization.check.returns(Q.resolve(true));
 
-      subscriptionStatusService.get("3", "12345").then(function(data){
+      subscriptionStatusService.get("3").then(function(data){
         expect(data).be.defined;
         expect(data.status).be.equal("Cancelled");
         expect(data.statusCode).be.equal("cancelled");
-        expect(data.subscribed).be.equal(true);
+        expect(data.isSubscribed).be.be.true;
+
+        done();
+      });
+    });
+
+    it("should return inactive subscription if authorization fails", function(done) {
+      response.items[0].status = "Cancelled";
+      storeAuthorization.check.returns(Q.reject("error"));
+
+      subscriptionStatusService.get("3").then(function(data){
+        expect(data).be.defined;
+        expect(data.status).be.equal("Cancelled");
+        expect(data.statusCode).be.equal("cancelled");
+        expect(data.isSubscribed).be.be.false;
+
+        done();
+      });
+    });
+
+    it("should return trial available", function(done) {
+      response.items[0] = {
+        status: "Not Subscribed",
+        trialPeriod: 5
+      };
+
+      subscriptionStatusService.get("3").then(function(data){
+        expect(data).be.defined;
+        expect(data.status).be.equal("Not Subscribed");
+        expect(data.statusCode).be.equal("trial-available");
+        expect(data.isSubscribed).be.be.false;
+        expect(data.trialAvailable).be.be.true;
 
         done();
       });
@@ -142,7 +173,7 @@ describe("Services: subscriptionStatusService", function() {
         { pc: 2, status: "Trial Expired" },
         { pc: 3, status: "Cancelled" }];
 
-      subscriptionStatusService.list(["1", "2", "3"], "12345").then(function(data){
+      subscriptionStatusService.list(["1", "2", "3"]).then(function(data){
         expect(data).be.defined;
         expect(data.length).be.equal(3);
         expect(data[0].status).be.equal("Free");

--- a/test/unit/storage/controllers/ctr-files-list.tests.js
+++ b/test/unit/storage/controllers/ctr-files-list.tests.js
@@ -123,7 +123,7 @@ describe('controller: Files List', function() {
   });
   
   it('should update subscription status', function(done) {
-    var subscriptionStatus = {statusCode: 'trial-available'};
+    var subscriptionStatus = {trialAvailable: true};
     $scope.$emit('subscription-status:changed', subscriptionStatus);
     
     setTimeout(function() {

--- a/web/partials/components/subscription-status/subscription-status-template.html
+++ b/web/partials/components/subscription-status/subscription-status-template.html
@@ -18,7 +18,7 @@
   </a>
 </div>
 
-<div class="subscription-status cancelled" ng-show="subscriptionStatus.statusCode === 'cancelled' && !subscriptionStatus.subscribed">
+<div class="subscription-status cancelled" ng-show="subscriptionStatus.statusCode === 'cancelled' && !subscriptionStatus.isSubscribed">
  <span translate="subscription-status.expanded-cancelled"></span>
  <a type="button" class="btn btn-primary u_margin-left" ng-href="{{storeUrl}}" target="_blank" ng-show="!customOnClick">
   <span translate="subscription-status.subscribe-now"></span>

--- a/web/partials/storage/global-actions.html
+++ b/web/partials/storage/global-actions.html
@@ -1,13 +1,13 @@
 
-<button id="newFolderButton" class="btn btn-default" ng-click="storageUtils.addFolder(filesFactory)" ng-disabled="filesFactory.isTrashFolder() || !subscriptionStatus.subscribed">
+<button id="newFolderButton" class="btn btn-default" ng-click="storageUtils.addFolder(filesFactory)" ng-disabled="filesFactory.isTrashFolder() || !subscriptionStatus.isSubscribed">
   <span translate>storage-client.new-folder</span>
 </button>
 
-<label id="uploadButton" class="btn btn-primary" for="upload-files" ng-disabled="filesFactory.isTrashFolder() || !subscriptionStatus.subscribed">
+<label id="uploadButton" class="btn btn-primary" for="upload-files" ng-disabled="filesFactory.isTrashFolder() || !subscriptionStatus.isSubscribed">
   <span translate>storage-client.upload-files</span>
 </label>
 
-<label id="uploadFolderButton" class="btn btn-primary" for="upload-folder" ng-disabled="filesFactory.isTrashFolder() || !subscriptionStatus.subscribed">
+<label id="uploadFolderButton" class="btn btn-primary" for="upload-folder" ng-disabled="filesFactory.isTrashFolder() || !subscriptionStatus.isSubscribed">
   <span translate>storage-client.upload-folder</span>
   <i class="fa fa-folder icon-right hidden-xs"></i>
 </label>

--- a/web/scripts/components/core-api-client/svc-store-authorization.js
+++ b/web/scripts/components/core-api-client/svc-store-authorization.js
@@ -3,16 +3,16 @@
 angular.module('risevision.store.authorization', [
     'risevision.common.gapi'
   ])
-  .factory('storeAuthorization', ['$q', '$log', '$http',
-    'STORE_SERVER_URL', 'userState',
-    function ($q, $log, $http, STORE_SERVER_URL, userState) {
+  .value('AUTH_PATH_URL', 'v1/widget/auth')
+  .factory('storeAuthorization', ['$q', '$log', '$http', 'userState', 'STORE_SERVER_URL', 'AUTH_PATH_URL',
+    function ($q, $log, $http, userState, STORE_SERVER_URL, AUTH_PATH_URL) {
       var factory = {};
 
       factory.check = function (productCode) {
         var deferred = $q.defer();
 
         $http({
-          url: STORE_SERVER_URL + '/v1/widget/auth',
+          url: STORE_SERVER_URL + AUTH_PATH_URL,
           method: 'GET',
           params: {
             cid: userState.getSelectedCompanyId(),

--- a/web/scripts/components/core-api-client/svc-store-product.js
+++ b/web/scripts/components/core-api-client/svc-store-product.js
@@ -2,7 +2,9 @@
 
 /*jshint camelcase: false */
 
-angular.module('risevision.store.product', [])
+angular.module('risevision.store.product', [
+    'risevision.common.gapi'
+  ])
   .service('storeProduct', ['$q', '$log', 'storeAPILoader', 'userState',
     function ($q, $log, storeAPILoader, userState) {
       var service = {

--- a/web/scripts/components/subscription-status/app.js
+++ b/web/scripts/components/subscription-status/app.js
@@ -13,8 +13,7 @@
 
   angular.module('risevision.common.components.subscription-status.config', [])
     .value('IN_RVA_PATH', 'product/productId/?cid=companyId')
-    .value('ACCOUNT_PATH', 'account?cid=companyId')
-    .value('AUTH_PATH_URL', 'v1/widget/auth?cid=companyId&pc=');
+    .value('ACCOUNT_PATH', 'account?cid=companyId');
 
   angular.module('risevision.common.components.subscription-status.filters', [
     'risevision.common.i18n'
@@ -36,6 +35,7 @@
   ]);
 
   angular.module('risevision.common.components.subscription-status.service', [
+    'risevision.store.authorization',
     'risevision.store.product',
     'risevision.common.config',
     'risevision.common.components.subscription-status.config'

--- a/web/scripts/storage/controllers/ctr-files-list.js
+++ b/web/scripts/storage/controllers/ctr-files-list.js
@@ -66,8 +66,7 @@ angular.module('risevision.storage.controllers')
       $rootScope.$on('subscription-status:changed',
         function (e, subscriptionStatus) {
           $scope.subscriptionStatus = subscriptionStatus;
-          $scope.trialAvailable =
-            subscriptionStatus.statusCode === 'trial-available';
+          $scope.trialAvailable = subscriptionStatus.trialAvailable;
         });
 
       var trashLabel;


### PR DESCRIPTION
## Description
Rename variable for consistency

Fix trial-available case for Storage

[stage-17]

## Motivation and Context
Use existing service rather than custom HTTP call. Mostly for clean up and refactoring. In preparation for subsequent PR.

## How Has This Been Tested?
Manual testing with the local environment. Updated unit and e2e tests

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.