### PR TITLE
Retrieve subscriptionStatus from Plan if available

### DIFF
--- a/test/e2e/common/pages/homepage.js
+++ b/test/e2e/common/pages/homepage.js
@@ -10,6 +10,12 @@ var HomePage = function() {
   var schedulesUrl = config.rootUrl + '/schedules/list';
   var storageUrl = config.rootUrl + '/storage';
 
+  var homeLink = element(by.css('.nav.navbar-nav #HomeLink'));
+  var displaysLink = element(by.css('.nav.navbar-nav #DisplaysLink'));
+  var editorLink = element(by.css('.nav.navbar-nav #PresentationsLink'));
+  var schedulesLink = element(by.css('.nav.navbar-nav #SchedulesLink'));
+  var storageLink = element(by.css('.nav.navbar-nav #StorageLink'));
+
   var appLauncherContainer = element(by.id('appLauncherContainer'));
 
   var presentationAddButton = element(by.id('presentationAddButton'));
@@ -78,6 +84,26 @@ var HomePage = function() {
   this.getProtectedPageUrl = function() {
     return displaysUrl;
   }
+
+  this.getHomeLink = function() {
+    return homeLink;
+  };
+
+  this.getDisplaysLink = function() {
+    return displaysLink;
+  };
+
+  this.getEditorLink = function() {
+    return editorLink;
+  };
+
+  this.getSchedulesLink = function() {
+    return schedulesLink;
+  };
+
+  this.getStorageLink = function() {
+    return storageLink;
+  };
 
   this.getAppLauncherContainer = function() {
     return appLauncherContainer;

--- a/test/e2e/registration/cases/registration.js
+++ b/test/e2e/registration/cases/registration.js
@@ -145,10 +145,6 @@
         expect(commonHeaderPage.getProfilePic().isDisplayed()).to.eventually.be.true;
       });
 
-      it("should sign out", function() {
-        commonHeaderPage.signOut(true);
-      });
-
       after(function(){
         mailListener.stop();
       });

--- a/test/e2e/registration/cases/trial.js
+++ b/test/e2e/registration/cases/trial.js
@@ -39,12 +39,9 @@ var TrialScenarios = function() {
     describe('Given a user that just signed up for Rise Vision', function () {
 
       before(function () {
-        // Add delay waiting for Trial to start
-        browser.sleep(30000);
+        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
 
-        homepage.getStorage();
-
-        signInPage.customAuthSignIn(commonHeaderPage.getStageEmailAddress(), commonHeaderPage.getPassword());
+        helper.clickWhenClickable(homepage.getStorageLink(), 'Storage link');
       });
       
       it('should load Storage Home', function () {
@@ -55,7 +52,7 @@ var TrialScenarios = function() {
         helper.waitDisappear(filesListPage.getFilesListLoader(), 'Storage Files Loader');
       });
 
-      it('should not show Storage Trial on Storage home', function () {
+      it('should show Storage Trial on Storage home', function () {
         helper.wait(storageSelectorModalPage.getActiveTrialBanner(), 'Active Trial Banner');
 
         expect(storageSelectorModalPage.getActiveTrialBanner().isDisplayed()).to.eventually.be.true;
@@ -86,8 +83,21 @@ var TrialScenarios = function() {
         storageSelectorModalPage.getCloseButton().click();
       });
 
+      it('should show Strage trial after page refresh', function () {
+        homepage.getStorage();
+
+        helper.wait(storageHomePage.getStorageAppContainer(), 'Storage Apps Container');
+        helper.waitDisappear(filesListPage.getFilesListLoader(), 'Storage Files Loader');
+
+        helper.wait(storageSelectorModalPage.getActiveTrialBanner(), 'Active Trial Banner');
+
+        expect(storageSelectorModalPage.getActiveTrialBanner().isDisplayed()).to.eventually.be.true;
+        expect(storageSelectorModalPage.getStartTrialButton().isDisplayed()).to.eventually.be.false;
+
+        expect(storageHomePage.getNewFolderButton().isDisplayed()).to.eventually.be.true;
+      });
+
       after(function() {
-        homepage.get();
         commonHeaderPage.signOut(true);
       });
 

--- a/test/unit/components/plans/svc-current-plan-factory-spec.js
+++ b/test/unit/components/plans/svc-current-plan-factory-spec.js
@@ -65,6 +65,7 @@ describe("Services: current plan factory", function() {
         planProductCode: BASIC_PLAN_CODE,
         planSubscriptionStatus: "Subscribed",
         planCurrentPeriodEndDate: "Jan 1, 2018",
+        planTrialExpiryDate: "Jan 14, 2018",
         playerProTotalLicenseCount: 3,
         playerProAvailableLicenseCount: 1,
         shareCompanyPlan: true,
@@ -82,6 +83,7 @@ describe("Services: current plan factory", function() {
         expect(currentPlanFactory.currentPlan.type).to.equal("basic");
         expect(currentPlanFactory.currentPlan.status).to.equal("Subscribed");
         expect(currentPlanFactory.currentPlan.currentPeriodEndDate.getTime()).to.equal(new Date("Jan 1, 2018").getTime());
+        expect(currentPlanFactory.currentPlan.trialExpiryDate.getTime()).to.equal(new Date("Jan 14, 2018").getTime());
         expect(currentPlanFactory.currentPlan.playerProTotalLicenseCount).to.equal(3);
         expect(currentPlanFactory.currentPlan.playerProAvailableLicenseCount).to.equal(1);
 

--- a/test/unit/components/plans/svc-plans-factory-spec.js
+++ b/test/unit/components/plans/svc-plans-factory-spec.js
@@ -81,15 +81,30 @@ describe("Services: plans factory", function() {
     
   });
 
-  it("initVolumePlanTrial: ", function() {
-    plansFactory.initVolumePlanTrial();
+  describe("initVolumePlanTrial:", function() {
+    it("should update company settings", function() {
+      plansFactory.initVolumePlanTrial();
 
-    userState.updateCompanySettings.should.have.been.calledWith({
-      planProductCode: VOLUME_PLAN.productCode,
-      planTrialPeriod: VOLUME_PLAN.trialPeriod,
-      planSubscriptionStatus: "Trial",
-      playerProTotalLicenseCount: VOLUME_PLAN.proLicenseCount,
-      playerProAvailableLicenseCount: VOLUME_PLAN.proLicenseCount
+      userState.updateCompanySettings.should.have.been.calledWith({
+        planProductCode: VOLUME_PLAN.productCode,
+        planTrialPeriod: VOLUME_PLAN.trialPeriod,
+        planTrialExpiryDate: sinon.match.date,
+        planSubscriptionStatus: "Trial",
+        playerProTotalLicenseCount: VOLUME_PLAN.proLicenseCount,
+        playerProAvailableLicenseCount: VOLUME_PLAN.proLicenseCount
+      });
+
+    });
+    
+    it("should calculate trial expiry", function() {
+      plansFactory.initVolumePlanTrial();
+
+      var plan = userState.updateCompanySettings.getCall(0).args[0];
+      var daysDiff = function (date1, date2) {
+        return Math.ceil(Math.abs((date1 - date2) / 1000 / 60 / 60 / 24));
+      };
+
+      expect(daysDiff(plan.planTrialExpiryDate, new Date())).to.equal(plan.planTrialPeriod);
     });
   });
 

--- a/test/unit/components/subscription-status/svc-subscription-status.tests.js
+++ b/test/unit/components/subscription-status/svc-subscription-status.tests.js
@@ -8,6 +8,16 @@ describe("Services: subscriptionStatusService", function() {
   beforeEach(module(function ($provide) {
     $provide.service("$q", function() {return Q;});
 
+    $provide.service("currentPlanFactory", function() {
+      return {
+        currentPlan: {
+          trialExpiryDate: new Date()
+        },
+        isPlanActive: sinon.stub().returns(false),
+        isCancelledActive: sinon.stub().returns(false)
+      };
+    });
+
     $provide.service("storeAuthorization", function() {
       return {
         check: sinon.stub().returns(Q.reject(false))
@@ -22,7 +32,7 @@ describe("Services: subscriptionStatusService", function() {
 
   }));
 
-  var subscriptionStatusService, storeAuthorization, storeProduct, response;
+  var subscriptionStatusService, currentPlanFactory, storeAuthorization, storeProduct, response;
 
   beforeEach(function(){
     response = {
@@ -33,6 +43,7 @@ describe("Services: subscriptionStatusService", function() {
     };
 
     inject(function($injector){
+      currentPlanFactory = $injector.get('currentPlanFactory');
       storeAuthorization = $injector.get('storeAuthorization');
       storeProduct = $injector.get('storeProduct');
       subscriptionStatusService = $injector.get('subscriptionStatusService');
@@ -43,55 +54,163 @@ describe("Services: subscriptionStatusService", function() {
     expect(subscriptionStatusService).be.defined;
   });
 
-  it("should call product status api", function() {
-    subscriptionStatusService.get("1");
+  describe("Plan: ", function() {
+    describe("should check Plan", function() {
+      beforeEach(function() {
+        currentPlanFactory.isCancelled = sinon.stub().returns(true);
+      });
 
-    storeProduct.status.should.have.been.calledWith(["1"]);
+      it("should use active plan", function() {
+        currentPlanFactory.isPlanActive.returns(true);
+
+        subscriptionStatusService.get("1");
+
+        storeProduct.status.should.not.have.been.called;
+      });
+
+      it("should use cancelled but active plan", function() {
+        currentPlanFactory.isCancelledActive.returns(true);
+
+        subscriptionStatusService.get("1");
+
+        storeProduct.status.should.not.have.been.called;
+      });      
+    });
+
+    describe("should map Plan to Subscription Status", function() {
+      beforeEach(function() {
+        currentPlanFactory.isPlanActive.returns(true);
+
+        currentPlanFactory.isCancelled = sinon.stub().returns(false);
+        currentPlanFactory.isSubscribed = sinon.stub().returns(false);
+        currentPlanFactory.isOnTrial = sinon.stub().returns(false);
+      });
+
+      it("should default to Not Subscribed", function(done) {
+        subscriptionStatusService.get("1").then(function(subscriptionStatus) {
+          expect(subscriptionStatus).to.be.an('Object');
+          expect(subscriptionStatus.pc).to.equal("1");
+          expect(subscriptionStatus.status).to.equal("Not Subscribed");
+          expect(subscriptionStatus.expiry).to.equal(currentPlanFactory.currentPlan.trialExpiryDate);
+
+          done();
+        });
+      });
+
+      it("should map a list of products", function(done) {
+        subscriptionStatusService.list(["1", "2"]).then(function(statusList) {
+          expect(statusList).to.be.an('Array');
+          expect(statusList[0].pc).to.equal("1");
+          expect(statusList[1].pc).to.equal("2");
+
+          done();
+        });
+      });
+
+      it("should map Cancelled Plan", function(done) {
+        currentPlanFactory.isCancelled = sinon.stub().returns(true);
+
+        subscriptionStatusService.get("1").then(function(subscriptionStatus) {
+          expect(subscriptionStatus).to.be.an('Object');
+          expect(subscriptionStatus.pc).to.equal("1");
+          expect(subscriptionStatus.status).to.equal("Cancelled");
+
+          done();
+        });
+      });
+
+      it("should map Subscribed Plan", function(done) {
+        currentPlanFactory.isSubscribed = sinon.stub().returns(true);
+
+        subscriptionStatusService.get("1").then(function(subscriptionStatus) {
+          expect(subscriptionStatus).to.be.an('Object');
+          expect(subscriptionStatus.pc).to.equal("1");
+          expect(subscriptionStatus.status).to.equal("Subscribed");
+
+          done();
+        });
+      });
+
+      it("should map Plan Trial", function(done) {
+        currentPlanFactory.isOnTrial = sinon.stub().returns(true);
+
+        subscriptionStatusService.get("1").then(function(subscriptionStatus) {
+          expect(subscriptionStatus).to.be.an('Object');
+          expect(subscriptionStatus.pc).to.equal("1");
+          expect(subscriptionStatus.status).to.equal("On Trial");
+
+          done();
+        });
+      });
+
+      it("should calculate Trial expiry", function(done) {
+        var trialExpiry = new Date();
+        trialExpiry.setDate(trialExpiry.getDate() + 5);
+        currentPlanFactory.currentPlan.trialExpiryDate = trialExpiry;
+        currentPlanFactory.isOnTrial = sinon.stub().returns(true);
+
+        subscriptionStatusService.get("1").then(function(subscriptionStatus) {
+          expect(subscriptionStatus.status).to.equal("On Trial");
+          expect(subscriptionStatus.expiry).to.equal(6);
+
+          done();
+        });
+      });
+
+    });
   });
 
-  it("should not call authorization api if subscribed", function(done) {
-    subscriptionStatusService.get("1").then(function(data){
+  describe("No Plan: ", function() {
+    it("should call product status api", function() {
+      subscriptionStatusService.get("1");
+
       storeProduct.status.should.have.been.calledWith(["1"]);
-      storeAuthorization.check.should.not.have.been.called;
-
-      done();
     });
-  });
 
-  it("should handle blank responses", function(done) {
-    response.items = undefined;
+    it("should not call authorization api if subscribed", function(done) {
+      subscriptionStatusService.get("1").then(function(data){
+        storeProduct.status.should.have.been.calledWith(["1"]);
+        storeAuthorization.check.should.not.have.been.called;
 
-    subscriptionStatusService.get("1").then(function(){
-      done("Failed");
-    })
-    .catch(function(err) {
-      expect(err).to.equal("No results.");
-
-      done();
+        done();
+      });
     });
-  });
 
-  it("should handle subscription status api failure", function(done) {
-    storeProduct.status.returns(Q.reject("API Failed"));
+    it("should handle blank responses", function(done) {
+      response.items = undefined;
 
-    subscriptionStatusService.get("1").then(function(){
-      done("Failed");
-    })
-    .catch(function(err) {
-      expect(err).to.equal("API Failed");
+      subscriptionStatusService.get("1").then(function(){
+        done("Failed");
+      })
+      .catch(function(err) {
+        expect(err).to.equal("No results.");
 
-      done();
+        done();
+      });
     });
-  });
 
-  it("should call authorization api if subscription status returns false", function(done) {
-    response.items[0].status = "Cancelled";
+    it("should handle subscription status api failure", function(done) {
+      storeProduct.status.returns(Q.reject("API Failed"));
 
-    subscriptionStatusService.get("1").then(function(data){
-      storeProduct.status.should.have.been.calledWith(["1"]);
-      storeAuthorization.check.should.have.been.calledWith("1");
+      subscriptionStatusService.get("1").then(function(){
+        done("Failed");
+      })
+      .catch(function(err) {
+        expect(err).to.equal("API Failed");
 
-      done();
+        done();
+      });
+    });
+
+    it("should call authorization api if subscription status returns false", function(done) {
+      response.items[0].status = "Cancelled";
+
+      subscriptionStatusService.get("1").then(function(data){
+        storeProduct.status.should.have.been.calledWith(["1"]);
+        storeAuthorization.check.should.have.been.calledWith("1");
+
+        done();
+      });
     });
   });
 

--- a/test/unit/components/subscription-status/svc-subscription-status.tests.js
+++ b/test/unit/components/subscription-status/svc-subscription-status.tests.js
@@ -223,7 +223,7 @@ describe("Services: subscriptionStatusService", function() {
         expect(data).be.defined;
         expect(data.status).be.equal("Free");
         expect(data.statusCode).be.equal("free");
-        expect(data.isSubscribed).be.be.true;
+        expect(data.isSubscribed).to.be.true;
 
         done();
       });
@@ -236,7 +236,7 @@ describe("Services: subscriptionStatusService", function() {
         expect(data).be.defined;
         expect(data.status).be.equal("Trial Expired");
         expect(data.statusCode).be.equal("trial-expired");
-        expect(data.isSubscribed).be.be.false;
+        expect(data.isSubscribed).to.be.false;
 
         done();
       });
@@ -250,7 +250,7 @@ describe("Services: subscriptionStatusService", function() {
         expect(data).be.defined;
         expect(data.status).be.equal("Cancelled");
         expect(data.statusCode).be.equal("cancelled");
-        expect(data.isSubscribed).be.be.true;
+        expect(data.isSubscribed).to.be.true;
 
         done();
       });
@@ -264,7 +264,7 @@ describe("Services: subscriptionStatusService", function() {
         expect(data).be.defined;
         expect(data.status).be.equal("Cancelled");
         expect(data.statusCode).be.equal("cancelled");
-        expect(data.isSubscribed).be.be.false;
+        expect(data.isSubscribed).to.be.false;
 
         done();
       });
@@ -280,8 +280,8 @@ describe("Services: subscriptionStatusService", function() {
         expect(data).be.defined;
         expect(data.status).be.equal("Not Subscribed");
         expect(data.statusCode).be.equal("trial-available");
-        expect(data.isSubscribed).be.be.false;
-        expect(data.trialAvailable).be.be.true;
+        expect(data.isSubscribed).to.be.false;
+        expect(data.trialAvailable).to.be.true;
 
         done();
       });

--- a/test/unit/components/subscription-status/svc-subscription-status.tests.js
+++ b/test/unit/components/subscription-status/svc-subscription-status.tests.js
@@ -146,12 +146,13 @@ describe("Services: subscriptionStatusService", function() {
       it("should calculate Trial expiry", function(done) {
         var trialExpiry = new Date();
         trialExpiry.setDate(trialExpiry.getDate() + 5);
+        trialExpiry.setHours(trialExpiry.getHours() - 1);
         currentPlanFactory.currentPlan.trialExpiryDate = trialExpiry;
         currentPlanFactory.isOnTrial = sinon.stub().returns(true);
 
         subscriptionStatusService.get("1").then(function(subscriptionStatus) {
           expect(subscriptionStatus.status).to.equal("On Trial");
-          expect(subscriptionStatus.expiry).to.equal(6);
+          expect(subscriptionStatus.expiry).to.equal(5);
 
           done();
         });

--- a/web/partials/common-header/common-header.html
+++ b/web/partials/common-header/common-header.html
@@ -38,8 +38,8 @@
 							<span class="env-name-label">{{ENV_NAME}}</span>
 						</li>
 						<li ng-repeat="opt in navOptions">
-							<a ng-if="opt.cid" ng-href="{{opt.link}}" link-cid target="{{opt.target}}" ng-class="{'selected': opt.states && opt.states.indexOf(navSelected) > -1}">{{opt.title}}</a>
-							<a ng-if="!opt.cid" ng-href="{{opt.link}}" target="{{opt.target}}" ng-class="{'selected': opt.states && opt.states.indexOf(navSelected) > -1}">{{opt.title}}</a>
+							<a id="{{opt.title + 'Link'}}" ng-if="opt.cid" ng-href="{{opt.link}}" link-cid target="{{opt.target}}" ng-class="{'selected': opt.states && opt.states.indexOf(navSelected) > -1}">{{opt.title}}</a>
+							<a id="{{opt.title + 'Link'}}" ng-if="!opt.cid" ng-href="{{opt.link}}" target="{{opt.target}}" ng-class="{'selected': opt.states && opt.states.indexOf(navSelected) > -1}">{{opt.title}}</a>
 						</li>
 						
 						<li ng-if="!inRVAFrame && !hideHelpMenu">

--- a/web/scripts/components/plans/svc-current-plan-factory.js
+++ b/web/scripts/components/plans/svc-current-plan-factory.js
@@ -18,6 +18,7 @@
             plan.status = company.planSubscriptionStatus;
             plan.trialPeriod = company.planTrialPeriod;
             plan.currentPeriodEndDate = new Date(company.planCurrentPeriodEndDate);
+            plan.trialExpiryDate = new Date(company.planTrialExpiryDate);
 
           } else {
             plan = _.cloneDeep(_plansByType.free);

--- a/web/scripts/components/plans/svc-plans-factory.js
+++ b/web/scripts/components/plans/svc-plans-factory.js
@@ -158,8 +158,9 @@
           var selectedCompany = userState.getCopyOfSelectedCompany(true);
           var licenses = _plansByCode[plan.productCode].proLicenseCount;
           var trialExpiry = new Date();
-          // Round down for the date
-          trialExpiry.setDate(trialExpiry.getDate() + plan.trialPeriod - 1);
+          trialExpiry.setDate(trialExpiry.getDate() + plan.trialPeriod);
+          // Round down the date otherwise the subtraction may calculate an extra day
+          trialExpiry.setHours(trialExpiry.getHours() - 1);
 
           selectedCompany.planProductCode = plan.productCode;
           selectedCompany.planTrialPeriod = plan.trialPeriod;

--- a/web/scripts/components/plans/svc-plans-factory.js
+++ b/web/scripts/components/plans/svc-plans-factory.js
@@ -157,9 +157,13 @@
           var plan = _plansByType.volume;
           var selectedCompany = userState.getCopyOfSelectedCompany(true);
           var licenses = _plansByCode[plan.productCode].proLicenseCount;
+          var trialExpiry = new Date();
+          // Round down for the date
+          trialExpiry.setDate(trialExpiry.getDate() + plan.trialPeriod - 1);
 
           selectedCompany.planProductCode = plan.productCode;
           selectedCompany.planTrialPeriod = plan.trialPeriod;
+          selectedCompany.planTrialExpiryDate = trialExpiry;
           selectedCompany.planSubscriptionStatus = 'Trial';
           selectedCompany.playerProTotalLicenseCount = licenses;
           selectedCompany.playerProAvailableLicenseCount = licenses;

--- a/web/scripts/components/subscription-status/svc-subscription-status.js
+++ b/web/scripts/components/subscription-status/svc-subscription-status.js
@@ -2,8 +2,8 @@
   'use strict';
 
   angular.module('risevision.common.components.subscription-status.service')
-    .service('subscriptionStatusService', ['$http', '$q', 'storeProduct', 'storeAuthorization',
-      function ($http, $q, storeProduct, storeAuthorization) {
+    .service('subscriptionStatusService', ['$http', '$q', 'currentPlanFactory', 'storeProduct', 'storeAuthorization',
+      function ($http, $q, currentPlanFactory, storeProduct, storeAuthorization) {
         var _MS_PER_DAY = 1000 * 60 * 60 * 24;
 
         // a and b are javascript Date objects
@@ -66,29 +66,71 @@
           }
         };
 
+        var mapPlanStatus = function (planStatus) {
+          var status = 'Not Subscribed';
+
+          if (currentPlanFactory.isCancelled()) {
+            // Cancelled or CancelledActive
+            status = 'Cancelled';
+          } else if (currentPlanFactory.isFree()) {
+            status = 'Free';
+          } else if (currentPlanFactory.isSubscribed()) {
+            status = 'Subscribed';
+          } else if (currentPlanFactory.isOnTrial()) {
+            status = 'On Trial';
+          } else if (currentPlanFactory.isTrialExpired()) {
+            status = 'Trial Expired';
+          } else if (currentPlanFactory.isSuspended()) {
+            status = 'Suspended';
+          }
+
+          return status;
+        };
+
+        var mapCurrentPlan = function (productCodes) {
+          var statusList = [];
+          for (var i = 0; i < productCodes.length; i++) {
+            var subscriptionStatus = {
+              pc: productCodes[i],
+              status: mapPlanStatus(currentPlanFactory.currentPlan.status),
+              expiry: currentPlanFactory.currentPlan.trialExpiryDate
+            };
+
+            updateStatus(subscriptionStatus);
+
+            statusList.push(subscriptionStatus);
+          };
+
+          return statusList;
+        };
+
         var checkSubscriptionStatus = function (productCodes) {
-          return storeProduct.status(productCodes)
-            .then(function (result) {
-              if (result && result.items) {
-                var statusList = [];
+          if (currentPlanFactory.isPlanActive() || currentPlanFactory.isCancelledActive()) {
+            return $q.resolve(mapCurrentPlan(productCodes));
+          } else {
+            return storeProduct.status(productCodes)
+              .then(function (result) {
+                if (result && result.items) {
+                  var statusList = [];
 
-                for (var i = 0; i < result.items.length; i++) {
-                  var subscriptionStatus = result.items[i];
+                  for (var i = 0; i < result.items.length; i++) {
+                    var subscriptionStatus = result.items[i];
 
-                  updateStatus(subscriptionStatus);
+                    updateStatus(subscriptionStatus);
 
-                  statusList.push(subscriptionStatus);
+                    statusList.push(subscriptionStatus);
+                  }
+
+                  return $q.resolve(statusList);
+                } else {
+                  return $q.reject('No results.');
                 }
-
-                return $q.resolve(statusList);
-              } else {
-                return $q.reject('No results.');
-              }
-            })
-            .catch(function (e) {
-              console.error('Failed to get status of products.', e);
-              return $q.reject(e);
-            });
+              })
+              .catch(function (e) {
+                console.error('Failed to get status of products.', e);
+                return $q.reject(e);
+              });
+          }
         };
 
         this.get = function (productCode) {
@@ -103,7 +145,7 @@
                     subscriptionStatus.isSubscribed = authorized;
 
                     return subscriptionStatus;
-                  }, function(authorized) {
+                  }, function (authorized) {
                     // storeAuthorization rejects if authorized=FALSE
                     // In case of error, fail gracefully
                     return subscriptionStatus;

--- a/web/scripts/components/subscription-status/svc-subscription-status.js
+++ b/web/scripts/components/subscription-status/svc-subscription-status.js
@@ -72,16 +72,17 @@
           if (currentPlanFactory.isCancelled()) {
             // Cancelled or CancelledActive
             status = 'Cancelled';
-          } else if (currentPlanFactory.isFree()) {
-            status = 'Free';
           } else if (currentPlanFactory.isSubscribed()) {
             status = 'Subscribed';
           } else if (currentPlanFactory.isOnTrial()) {
             status = 'On Trial';
-          } else if (currentPlanFactory.isTrialExpired()) {
-            status = 'Trial Expired';
-          } else if (currentPlanFactory.isSuspended()) {
-            status = 'Suspended';
+          // Unreachable cases
+          // } else if (currentPlanFactory.isFree()) {
+          //   status = 'Free';
+          // } else if (currentPlanFactory.isTrialExpired()) {
+          //   status = 'Trial Expired';
+          // } else if (currentPlanFactory.isSuspended()) {
+          //   status = 'Suspended';
           }
 
           return status;
@@ -99,7 +100,7 @@
             updateStatus(subscriptionStatus);
 
             statusList.push(subscriptionStatus);
-          };
+          }
 
           return statusList;
         };


### PR DESCRIPTION
## Description
Retrieve subscriptionStatus from Plan if available

Assume that if a Company has a Plan any individual product is available to them. Do not need to check individual Subscriptions at that point.

## Motivation and Context
Fix for #1323 
Overall improvement to Subscription status retrieval and trial after registration.

## How Has This Been Tested?
Validated changes locally and updated unit and e2e tests to cover the scenario.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
