### PR TITLE
Feature/restriction on auth attempts

### DIFF
--- a/web/partials/components/userstate/auth-form.html
+++ b/web/partials/components/userstate/auth-form.html
@@ -5,15 +5,27 @@
     <div class="panel-body bg-danger u_margin-sm-top" ng-show="errors.duplicateError">
       <p class="u_remove-bottom">
         <i class="fa fa-warning icon-left"></i>
-        <span id="already-registered-warning">This email address is already registered. You can <a ui-sref="common.auth.unauthorized">sign in</a> with this address.</span> 
-      </p> 
+        <span id="already-registered-warning">This email address is already registered. You can <a ui-sref="common.auth.unauthorized">sign in</a> with this address.</span>
+      </p>
     </div>
 
     <!-- ERROR PANEL 2 -->
     <div class="panel-body bg-danger u_margin-sm-top" ng-show="errors.loginError">
       <p class="u_remove-bottom">
         <i class="fa fa-warning icon-left"></i>
-        <span id="incorrect-credentials-error">Your email address/password combination is incorrect. <br/>If you are having problems signing in, please check this <a href="https://help.risevision.com/hc/en-us/articles/115001402743-I-am-having-trouble-logging-in-what-can-I-do-" target="_blank">Help Center article</a>.</span> 
+        <span id="incorrect-credentials-error">Your email address/password combination is incorrect. <br/>If you are having problems signing in, please check this <a href="https://help.risevision.com/hc/en-us/articles/115001402743-I-am-having-trouble-logging-in-what-can-I-do-" target="_blank">Help Center article</a>.</span>
+      </p>
+    </div>
+
+    <!-- ERROR PANEL 3 -->
+    <div class="panel-body bg-danger u_margin-sm-top" ng-show="errors.userAccountLockoutError">
+      <p class="u_remove-bottom">
+        <i class="fa fa-warning icon-left"></i>
+        <span id="user-account-lockout-error">
+          Access to your account has been blocked because the maximum number of failed login attempts was reached.
+          <br/>
+          Please try again after 24 hours.
+        </span>
       </p>
     </div>
 
@@ -21,7 +33,7 @@
     <div class="panel-body bg-info u_margin-sm-top" ng-show="errors.unconfirmedError">
       <p class="u_remove-bottom">
         <i class="fa fa-warning icon-left"></i>
-        <span>Your email address has not been confirmed. <br/> <a ui-sref="common.auth.requestconfirmationemail">Resend Email Confirmation</a></span> 
+        <span>Your email address has not been confirmed. <br/> <a ui-sref="common.auth.requestconfirmationemail">Resend Email Confirmation</a></span>
       </p>
     </div>
 
@@ -29,7 +41,7 @@
     <div class="panel-body bg-info u_margin-sm-top" ng-show="errors.confirmationRequired">
       <p class="u_remove-bottom">
         <i class="fa fa-warning icon-left"></i>
-        <span>We've sent a confirmation email to {{credentials.username}}. <br/> Please check your inbox to complete your account registration.</span> 
+        <span>We've sent a confirmation email to {{credentials.username}}. <br/> Please check your inbox to complete your account registration.</span>
       </p>
     </div>
 
@@ -59,7 +71,7 @@
   </div>
 
   <div class="u_margin-sm-top" ng-show="!errors.confirmationRequired">
-  
+
     <div class="form-group" ng-class="{'has-error': (forms.loginForm.$submitted && forms.loginForm.username.$invalid)}" show-errors>
       <label class="control-label">Email</label>
       <input type="email" class="form-control" placeholder="Enter Your Email Address" id="username" name="username" ng-model="credentials.username" required focus-me="true" autocomplete="email">

--- a/web/partials/components/userstate/auth-form.html
+++ b/web/partials/components/userstate/auth-form.html
@@ -22,9 +22,12 @@
       <p class="u_remove-bottom">
         <i class="fa fa-warning icon-left"></i>
         <span id="user-account-lockout-error">
-          Access to your account has been blocked because the maximum number of failed login attempts was reached.
+          Hmm ... you've had too many failed login attempts.
+          As a security precaution, we've blocked access to your account.
+          You can try again in 24 hours.
           <br/>
-          Please try again after 24 hours.
+          Feel like your account shouldn't be blocked?
+          Please <a target="_blank" href="mailto:support@risevision.com">reach out to our support team</a>.
         </span>
       </p>
     </div>

--- a/web/scripts/components/userstate/controllers/ctr-login.js
+++ b/web/scripts/components/userstate/controllers/ctr-login.js
@@ -39,41 +39,43 @@ angular.module('risevision.common.components.userstate')
               urlStateService.redirectToState($stateParams.state);
             })
             .catch(function (err) {
-              if (err.status === 400) {
-                $scope.messages.isGoogleAccount = true;
-              } else if (err.status === 409) {
-                $scope.errors.unconfirmedError = true;
+                if (err.status === 400) {
+                  $scope.messages.isGoogleAccount = true;
+                } else if (err.status === 409) {
+                  $scope.errors.unconfirmedError = true;
+                } else if (err.status === 403) {
+                  $scope.errors.userAccountLockoutError = true;
+                }
               } else { // No special case for 404, for security reasons
                 console.error(err);
                 $scope.errors.loginError = true;
               }
             })
-            .finally(function () {
-              $loading.stopGlobal('auth-buttons-login');
-              uiFlowManager.invalidateStatus(endStatus);
-            });
-        }
-      };
+        .finally(function () {
+          $loading.stopGlobal('auth-buttons-login');
+          uiFlowManager.invalidateStatus(endStatus);
+        });
+      }
+    };
 
-      $scope.createAccount = function (endStatus) {
-        $scope.errors = {};
-        $scope.messages = {};
+    $scope.createAccount = function (endStatus) {
+      $scope.errors = {};
+      $scope.messages = {};
 
-        if ($scope.forms.loginForm.$valid) {
-          $loading.startGlobal('auth-buttons-login');
+      if ($scope.forms.loginForm.$valid) {
+        $loading.startGlobal('auth-buttons-login');
 
-          customAuthFactory.addUser($scope.credentials)
-            .then(function () {
-              $scope.errors.confirmationRequired = true;
-            })
-            .then(null, function () {
-              $scope.errors.duplicateError = true;
-            })
-            .finally(function () {
-              $loading.stopGlobal('auth-buttons-login');
-              uiFlowManager.invalidateStatus(endStatus);
-            });
-        }
-      };
-    }
-  ]);
+        customAuthFactory.addUser($scope.credentials)
+          .then(function () {
+            $scope.errors.confirmationRequired = true;
+          })
+          .then(null, function () {
+            $scope.errors.duplicateError = true;
+          })
+          .finally(function () {
+            $loading.stopGlobal('auth-buttons-login');
+            uiFlowManager.invalidateStatus(endStatus);
+          });
+      }
+    };
+  }]);

--- a/web/scripts/components/userstate/controllers/ctr-login.js
+++ b/web/scripts/components/userstate/controllers/ctr-login.js
@@ -39,43 +39,43 @@ angular.module('risevision.common.components.userstate')
               urlStateService.redirectToState($stateParams.state);
             })
             .catch(function (err) {
-                if (err.status === 400) {
-                  $scope.messages.isGoogleAccount = true;
-                } else if (err.status === 409) {
-                  $scope.errors.unconfirmedError = true;
-                } else if (err.status === 403) {
-                  $scope.errors.userAccountLockoutError = true;
-                }
+              if (err.status === 400) {
+                $scope.messages.isGoogleAccount = true;
+              } else if (err.status === 409) {
+                $scope.errors.unconfirmedError = true;
+              } else if (err.status === 403) {
+                $scope.errors.userAccountLockoutError = true;
               } else { // No special case for 404, for security reasons
                 console.error(err);
                 $scope.errors.loginError = true;
               }
             })
-        .finally(function () {
-          $loading.stopGlobal('auth-buttons-login');
-          uiFlowManager.invalidateStatus(endStatus);
-        });
-      }
-    };
+            .finally(function () {
+              $loading.stopGlobal('auth-buttons-login');
+              uiFlowManager.invalidateStatus(endStatus);
+            });
+        }
+      };
 
-    $scope.createAccount = function (endStatus) {
-      $scope.errors = {};
-      $scope.messages = {};
+      $scope.createAccount = function (endStatus) {
+        $scope.errors = {};
+        $scope.messages = {};
 
-      if ($scope.forms.loginForm.$valid) {
-        $loading.startGlobal('auth-buttons-login');
+        if ($scope.forms.loginForm.$valid) {
+          $loading.startGlobal('auth-buttons-login');
 
-        customAuthFactory.addUser($scope.credentials)
-          .then(function () {
-            $scope.errors.confirmationRequired = true;
-          })
-          .then(null, function () {
-            $scope.errors.duplicateError = true;
-          })
-          .finally(function () {
-            $loading.stopGlobal('auth-buttons-login');
-            uiFlowManager.invalidateStatus(endStatus);
-          });
-      }
-    };
-  }]);
+          customAuthFactory.addUser($scope.credentials)
+            .then(function () {
+              $scope.errors.confirmationRequired = true;
+            })
+            .then(null, function () {
+              $scope.errors.duplicateError = true;
+            })
+            .finally(function () {
+              $loading.stopGlobal('auth-buttons-login');
+              uiFlowManager.invalidateStatus(endStatus);
+            });
+        }
+      };
+    }
+  ]);


### PR DESCRIPTION
## Description
Display custom message when an account is locked out. 

## Motivation and Context
Accounts can now be locked out when a maximum number of attempts is reached. This implementation shows that message when an HTTP 403 is received from a login attempt sent to Core.

## How Has This Been Tested?
This was tested in stage-9: https://apps-stage-9.risevision.com

A locked out account attempt now shows:

![locked-out](https://user-images.githubusercontent.com/33162690/68320444-95143000-0085-11ea-9c34-c670eba1c8ca.png)

Automated tests were also added.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     - Manual and automated tests completed
     - To be released before Friday
     - Low risk change, simple rollback is enough to undo it.
     - I'll notify Support once this change is applied.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to update documentation.
