### PR TITLE
Use https for Facebook widget

### DIFF
--- a/web/scripts/editor/services/svc-widget-professional-list.js
+++ b/web/scripts/editor/services/svc-widget-professional-list.js
@@ -223,6 +223,6 @@ angular.module('risevision.editor.services')
       imageAlt: 'add facebook feed widget',
       gadgetType: 'Widget',
       id: '5dba4bee-b26d-4592-9f22-a7b46b1bd693',
-      url: 'http://rep.smartplayds.com/plugin/facebook-widget/widget.html'
+      url: 'https://rep.smartplayds.com/plugin/facebook-widget/widget.html'
     }
   ]);


### PR DESCRIPTION
## Description
Updated Facebook Widget URL from http to https.

## Motivation and Context
Requested by Support team. It was causing widget to fail to load.

## How Has This Been Tested?
As it is a configuration change specific to production data, this could not be tested in stage environment. I did confirm the updated URL is valid.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
Mentioned above.

@alex-deaconu Please review. Thanks!