### PR TITLE
Refactor Current Password to use password-input directive

### DIFF
--- a/test/unit/common-header/controllers/ctr-user-settings-spec.js
+++ b/test/unit/common-header/controllers/ctr-user-settings-spec.js
@@ -265,8 +265,11 @@ describe("controller: user settings", function() {
     });
 
     describe('change password:', function() {
-      it('should clear error on success', function(done) {
+      beforeEach(function(){
         $scope.showChangePassword = true;
+      });
+
+      it('should clear error on success', function(done) {
         $scope.save();
 
         setTimeout(function() {
@@ -278,7 +281,7 @@ describe("controller: user settings", function() {
 
       it('should set error on failure', function(done) {
         userauth.updatePassword.returns(Q.reject({result: {error: {code: 409}}}));
-        $scope.showChangePassword = true;
+
         $scope.save();
 
         setTimeout(function() {
@@ -286,6 +289,13 @@ describe("controller: user settings", function() {
           done();
         },10);
       });
+
+      it('should clear invalid password error on input changed',function(){
+        $scope.userPassword.currentPassword = 'changedPassword';
+        $scope.$digest();
+
+        expect($scope.forms.userSettingsForm.currentPassword.$setValidity).to.have.been.calledWith('currentPasswordNotValid',true);
+      })
     });
   });
 

--- a/test/unit/common-header/controllers/ctr-user-settings-spec.js
+++ b/test/unit/common-header/controllers/ctr-user-settings-spec.js
@@ -71,9 +71,15 @@ describe("controller: user settings", function() {
       return function() { return filterStub; };
     });
 
+    $provide.service("userauth", function() {
+      return {
+        updatePassword: sandbox.stub().returns(Q.resolve())
+      };
+    });
+
   }));
   var $scope, userProfile, savedUser, userState, $modalInstance, createUserError,
-  trackerCalled, deleteUserStub, messageBoxStub, confirmModalStub, filterStub;
+  trackerCalled, deleteUserStub, messageBoxStub, confirmModalStub, filterStub, userauth;
   var isRiseAdmin = true, isUserAdmin = true, isRiseVisionUser = true, isRiseAuthUser = false;
   beforeEach(function(){
     createUserError = false;
@@ -128,6 +134,7 @@ describe("controller: user settings", function() {
       $scope = $rootScope.$new();
       $modalInstance = $injector.get("$modalInstance");
       userState = $injector.get("userState");
+      userauth = $injector.get('userauth');
 
       filterStub = sinon.stub();
 
@@ -180,6 +187,9 @@ describe("controller: user settings", function() {
         email: {},
         firstName: {},
         lastName: {},
+        currentPassword: {
+          $setValidity: sandbox.stub()
+        },
         $valid: true
       };
       setTimeout(function(){
@@ -252,6 +262,30 @@ describe("controller: user settings", function() {
 
         done();
       },10);
+    });
+
+    describe('change password:', function() {
+      it('should clear error on success', function(done) {
+        $scope.showChangePassword = true;
+        $scope.save();
+
+        setTimeout(function() {
+          expect($scope.forms.userSettingsForm.currentPassword.$setValidity).to.have.been.calledWith('currentPasswordNotValid',true);
+          done();
+        },10);
+
+      });
+
+      it('should set error on failure', function(done) {
+        userauth.updatePassword.returns(Q.reject({result: {error: {code: 409}}}));
+        $scope.showChangePassword = true;
+        $scope.save();
+
+        setTimeout(function() {
+          expect($scope.forms.userSettingsForm.currentPassword.$setValidity).to.have.been.calledWith('currentPasswordNotValid',false);
+          done();
+        },10);
+      });
     });
   });
 

--- a/test/unit/components/password-input/dtv-password-input.tests.js
+++ b/test/unit/components/password-input/dtv-password-input.tests.js
@@ -41,7 +41,7 @@ describe('directive: password input', function() {
     $scope = $rootScope.$new();
     $scope.password = "password";
     $scope.isCreating = true;
-    element = $compile('<password-input ng-model="password" is-creating="isCreating"></password-input>')($scope);
+    element = $compile('<password-input ng-model="password" is-creating="isCreating" label="label-text" placeholder="placehodler-text"></password-input>')($scope);
     $scope = element.isolateScope();
     $scope.$digest();
   }));
@@ -49,7 +49,16 @@ describe('directive: password input', function() {
   it('should exist', function() {
     expect($scope).to.be.ok;
     expect($scope.ngModel).to.be.ok;
-    expect($scope.isCreating).to.be.true;    
+    expect($scope.isCreating).to.be.true;
+    expect($scope.label).to.be.ok;
+    expect($scope.placeholder).to.be.ok;
+  });
+
+  it('should init', function() {
+    expect($scope.ngModel).to.equal('password');
+    expect($scope.isCreating).to.be.true;
+    expect($scope.label).to.equal('label-text');
+    expect($scope.placeholder).to.equal('placehodler-text');
   });
 
   it('should replace the element with the appropriate content', function() {

--- a/web/partials/common-header/user-settings-modal.html
+++ b/web/partials/common-header/user-settings-modal.html
@@ -55,25 +55,20 @@ rv-spinner-start-active="1">
         </div>
       </div>
       <div id="passwordForm" class="animated" ng-if="editingYourself && !isAdd && isRiseAuthUser && showChangePassword" ng-class="{ 'fadeIn': showChangePassword }">
-        <div class="form-group"
-             ng-class="{ 'has-error' : (forms.resetPasswordForm.$submitted && forms.resetPasswordForm.newPassword.$invalid) || currentPasswordNotValid }">
-          <label for="user-settings-current-password">
-            Current Password *
-          </label>
-          <input id="user-settings-current-password"
-                 type="password" name="currentPassword"
-                 placeholder="Enter Current Password" 
-                 class="form-control"
-                 ng-model="userPassword.currentPassword" required />
-          <p class="text-danger" ng-show="forms.userSettingsForm.$submitted && forms.userSettingsForm.currentPassword.$error.required">
-            Current Password is required.
-          </p>
-          <p ng-show="currentPasswordNotValid" class="help-block validation-error-message-mail">
-            Current Password is not valid.
-          </p>
-        </div>
+
+        <password-input 
+          id="user-settings-current-password"
+          name="currentPassword"
+          ng-model="userPassword.currentPassword"
+          label="Current Password *"
+          placeholder="Enter Current Password"
+          minlength="4" required>
+        </password-input>
+      
         <password-input 
           name="newPassword"
+          label="New Password *"
+          placeholder="Enter New Password"
           ng-model="userPassword.newPassword"
           is-creating="true" minlength="12" required>
         </password-input>

--- a/web/partials/components/password-input/password-input.html
+++ b/web/partials/components/password-input/password-input.html
@@ -1,16 +1,17 @@
 <div class="form-group" ng-class="{ 'has-error' : (ngModelCtrl.$invalid && ngModelCtrl.$dirty) }">
   <label class="control-label" for="password">
-    {{ isCreating ? 'Create ' : ''}}Password
+    {{ label || (isCreating ? 'Create Password' : 'Password') }}
   </label>
   <input id="password"
     type="password"
     class="form-control"
-    placeholder="Enter Password"
+    placeholder="{{ placeholder || 'Enter Password' }}"
     ng-model="ngModel"/>
 
   <ng-messages role="alert" for="ngModelCtrl.$error" ng-if="ngModelCtrl.$invalid && ngModelCtrl.$dirty">
     <p ng-message="required" class="text-danger">Oops, don't leave this blank.</p>
     <p ng-message="minlength" class="text-danger">Password needs to be {{ isCreating ? 12 : 4}} or more characters in length.</p>
+    <p ng-message="currentPasswordNotValid" class="text-danger">Current Password is not valid.</p>
   </ng-messages>
 
   <div id="passwordMeter" ng-if="isCreating && scorePercentage && ngModelCtrl.$dirty">

--- a/web/scripts/common-header/controllers/ctr-user-settings-modal.js
+++ b/web/scripts/common-header/controllers/ctr-user-settings-modal.js
@@ -40,6 +40,12 @@ angular.module('risevision.common.header')
         }
       });
 
+      $scope.$watch('userPassword.currentPassword', function () {
+        if ($scope.showChangePassword) {
+          $scope.forms.userSettingsForm.currentPassword.$setValidity('currentPasswordNotValid', true);
+        }
+      });
+
       $scope.isUserAdmin = userState.isUserAdmin();
       $scope.username = username;
 

--- a/web/scripts/common-header/controllers/ctr-user-settings-modal.js
+++ b/web/scripts/common-header/controllers/ctr-user-settings-modal.js
@@ -90,7 +90,7 @@ angular.module('risevision.common.header')
 
       $scope.save = function () {
         if ($scope.showChangePassword) {
-          $scope.currentPasswordNotValid = false;
+          $scope.forms.userSettingsForm.currentPassword.$setValidity('currentPasswordNotValid', true);
         }
 
         if ($scope.forms.userSettingsForm.$valid) {
@@ -112,7 +112,7 @@ angular.module('risevision.common.header')
                 var newError = err.result.error;
 
                 if (newError.code === 409) {
-                  $scope.currentPasswordNotValid = true;
+                  $scope.forms.userSettingsForm.currentPassword.$setValidity('currentPasswordNotValid', false);
                   newError.changePassword = true;
                 }
                 return $q.reject(newError);

--- a/web/scripts/components/password-input/dtv-password-input.js
+++ b/web/scripts/components/password-input/dtv-password-input.js
@@ -12,7 +12,9 @@
           require: '?ngModel',
           scope: {
             ngModel: '=',
-            isCreating: '='
+            isCreating: '=',
+            label: '@',
+            placeholder: '@'
           },
           template: $templateCache.get(
             'partials/components/password-input/password-input.html'),


### PR DESCRIPTION
## Description
Use password-input directive on Current Password field
Refactor directive to accept label and placeholder attributes.

## Motivation and Context
Refactoring for code consistency, related to https://github.com/Rise-Vision/rise-vision-apps/pull/1353.

## How Has This Been Tested?
Manually tested locally and on [stage-1].

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why


@alex-deaconu Please review. Thanks!