### PR TITLE
Feature/call revised user get

### DIFF
--- a/test/unit/common-header/controllers/ctr-registration-modal-spec.js
+++ b/test/unit/common-header/controllers/ctr-registration-modal-spec.js
@@ -10,12 +10,12 @@ describe("controller: registration modal", function() {
       return {
         _closed: false,
         close: function(reason) {
-          expect(reason).to.equal("success");          
+          expect(reason).to.equal("success");
           this._closed = true;
         }
       };
     });
-  
+
     $provide.service("userState", function(){
       return {
         getCopyOfProfile : function(){
@@ -25,7 +25,7 @@ describe("controller: registration modal", function() {
           return "e@mail.com";
         },
         _restoreState : function(){
-          
+
         },
         getUserCompanyId : function(){
           return "some_company_id";
@@ -36,9 +36,9 @@ describe("controller: registration modal", function() {
         updateCompanySettings: sinon.stub(),
         refreshProfile: function() {
           var deferred = Q.defer();
-          
+
           deferred.resolve({});
-          
+
           return deferred.promise;
         }
       };
@@ -51,12 +51,12 @@ describe("controller: registration modal", function() {
         return Q.resolve("companyResult");
       };
     });
-    
+
     var registrationService = function(calledFrom){
       return function() {
         newUser = calledFrom === "addAccount";
         var deferred = Q.defer();
-        
+
         if(registerUser){
           deferred.resolve("registered");
         }else{
@@ -65,7 +65,7 @@ describe("controller: registration modal", function() {
         return deferred.promise;
       };
     };
-    
+
     $provide.service("addAccount", function(){
       return registrationService("addAccount");
     });
@@ -79,7 +79,7 @@ describe("controller: registration modal", function() {
       };
     });
 
-    $provide.service("segmentAnalytics", function() { 
+    $provide.service("segmentAnalytics", function() {
       return {
         track: function(name) {
           trackerCalled = name;
@@ -88,7 +88,7 @@ describe("controller: registration modal", function() {
       };
     });
 
-    $provide.service("bigQueryLogging", function() { 
+    $provide.service("bigQueryLogging", function() {
       return {
         logEvent: function(name) {
           bqCalled = name;
@@ -96,7 +96,7 @@ describe("controller: registration modal", function() {
       };
     });
 
-    $provide.service("analyticsEvents", function() { 
+    $provide.service("analyticsEvents", function() {
       return {
         initialize: function() {},
         identify: function() {}
@@ -115,12 +115,12 @@ describe("controller: registration modal", function() {
       return function() {};
     });
     $translateProvider.useLoader("customLoader");
-        
+
   }));
   var $scope, userProfile, userState, $modalInstance, newUser;
   var registerUser, account, trackerCalled, bqCalled, identifySpy,
     updateCompanyCalled, plansFactory;
-  
+
   beforeEach(function() {
     registerUser = true;
     trackerCalled = undefined;
@@ -131,7 +131,7 @@ describe("controller: registration modal", function() {
       lastName : "last",
       telephone : "telephone"
     };
-    
+
     inject(function($injector,$rootScope, $controller){
       $scope = $rootScope.$new();
       $modalInstance = $injector.get("$modalInstance");
@@ -161,16 +161,17 @@ describe("controller: registration modal", function() {
       };
     });
   });
-  
+
   it("should initialize",function(){
     expect($scope).to.be.truely;
     expect($scope.profile).to.be.truely;
-    
+
     expect($scope.profile).to.deep.equal({
       email: "e@mail.com",
       firstName: "first",
       lastName: "last",
       mailSyncEnabled: false,
+      alreadyOptedIn: false,
       accepted: false
     });
 
@@ -178,23 +179,23 @@ describe("controller: registration modal", function() {
 
     expect($scope.save).to.exist;
   });
-  
-  describe("save new user: ", function() {      
+
+  describe("save new user: ", function() {
     it("should not save if form is invalid", function() {
       $scope.forms.registrationForm.$invalid = true;
       $scope.save();
-      expect($scope.registering).to.be.false;        
+      expect($scope.registering).to.be.false;
     });
 
     it("should use username as email",function(){
       expect($scope.profile.email).to.be.equal("e@mail.com");
     });
-    
+
     it("should register user and close the modal",function(done){
       $scope.forms.registrationForm.$invalid = false;
       $scope.save();
       expect($scope.registering).to.be.true;
-      
+
       var profileSpy = sinon.spy(userState, "refreshProfile");
       setTimeout(function() {
         expect(newUser).to.be.true;
@@ -216,7 +217,7 @@ describe("controller: registration modal", function() {
       registerUser = false;
       $scope.forms.registrationForm.$invalid = false;
       $scope.save();
-      
+
       var profileSpy = sinon.spy(userState, "refreshProfile");
       setTimeout(function(){
         expect(newUser).to.be.true;
@@ -232,25 +233,25 @@ describe("controller: registration modal", function() {
         done();
       },10);
     });
-  
+
   });
-    
+
   describe("save existing user: ", function() {
     beforeEach(function() {
       account = userProfile;
     });
-    
+
     it("should not save if form is invalid", function() {
       $scope.forms.registrationForm.$invalid = true;
       $scope.save();
-      expect($scope.registering).to.be.false;        
+      expect($scope.registering).to.be.false;
     });
-    
+
     it("should register user and close the modal",function(done){
       $scope.forms.registrationForm.$invalid = false;
       $scope.save();
       expect($scope.registering).to.be.true;
-      
+
       var profileSpy = sinon.spy(userState, "refreshProfile");
       setTimeout(function() {
         expect(newUser).to.be.false;
@@ -266,12 +267,12 @@ describe("controller: registration modal", function() {
         done();
       },10);
     });
-    
+
     it("should handle failure to create user",function(done){
       registerUser = false;
       $scope.forms.registrationForm.$invalid = false;
       $scope.save();
-      
+
       var profileSpy = sinon.spy(userState, "refreshProfile");
       setTimeout(function(){
         expect(newUser).to.be.false;
@@ -285,8 +286,7 @@ describe("controller: registration modal", function() {
         done();
       },10);
     });
-      
+
   });
 
 });
-  

--- a/test/unit/common-header/controllers/ctr-registration-modal-spec.js
+++ b/test/unit/common-header/controllers/ctr-registration-modal-spec.js
@@ -171,7 +171,6 @@ describe("controller: registration modal", function() {
       firstName: "first",
       lastName: "last",
       mailSyncEnabled: false,
-      alreadyOptedIn: false,
       accepted: false
     });
 

--- a/test/unit/common-header/controllers/ctr-registration-modal-spec.js
+++ b/test/unit/common-header/controllers/ctr-registration-modal-spec.js
@@ -10,12 +10,12 @@ describe("controller: registration modal", function() {
       return {
         _closed: false,
         close: function(reason) {
-          expect(reason).to.equal("success");
+          expect(reason).to.equal("success");          
           this._closed = true;
         }
       };
     });
-
+  
     $provide.service("userState", function(){
       return {
         getCopyOfProfile : function(){
@@ -25,7 +25,7 @@ describe("controller: registration modal", function() {
           return "e@mail.com";
         },
         _restoreState : function(){
-
+          
         },
         getUserCompanyId : function(){
           return "some_company_id";
@@ -36,9 +36,9 @@ describe("controller: registration modal", function() {
         updateCompanySettings: sinon.stub(),
         refreshProfile: function() {
           var deferred = Q.defer();
-
+          
           deferred.resolve({});
-
+          
           return deferred.promise;
         }
       };
@@ -51,12 +51,12 @@ describe("controller: registration modal", function() {
         return Q.resolve("companyResult");
       };
     });
-
+    
     var registrationService = function(calledFrom){
       return function() {
         newUser = calledFrom === "addAccount";
         var deferred = Q.defer();
-
+        
         if(registerUser){
           deferred.resolve("registered");
         }else{
@@ -65,7 +65,7 @@ describe("controller: registration modal", function() {
         return deferred.promise;
       };
     };
-
+    
     $provide.service("addAccount", function(){
       return registrationService("addAccount");
     });
@@ -79,7 +79,7 @@ describe("controller: registration modal", function() {
       };
     });
 
-    $provide.service("segmentAnalytics", function() {
+    $provide.service("segmentAnalytics", function() { 
       return {
         track: function(name) {
           trackerCalled = name;
@@ -88,7 +88,7 @@ describe("controller: registration modal", function() {
       };
     });
 
-    $provide.service("bigQueryLogging", function() {
+    $provide.service("bigQueryLogging", function() { 
       return {
         logEvent: function(name) {
           bqCalled = name;
@@ -96,7 +96,7 @@ describe("controller: registration modal", function() {
       };
     });
 
-    $provide.service("analyticsEvents", function() {
+    $provide.service("analyticsEvents", function() { 
       return {
         initialize: function() {},
         identify: function() {}
@@ -115,12 +115,12 @@ describe("controller: registration modal", function() {
       return function() {};
     });
     $translateProvider.useLoader("customLoader");
-
+        
   }));
   var $scope, userProfile, userState, $modalInstance, newUser;
   var registerUser, account, trackerCalled, bqCalled, identifySpy,
     updateCompanyCalled, plansFactory;
-
+  
   beforeEach(function() {
     registerUser = true;
     trackerCalled = undefined;
@@ -131,7 +131,7 @@ describe("controller: registration modal", function() {
       lastName : "last",
       telephone : "telephone"
     };
-
+    
     inject(function($injector,$rootScope, $controller){
       $scope = $rootScope.$new();
       $modalInstance = $injector.get("$modalInstance");
@@ -161,11 +161,11 @@ describe("controller: registration modal", function() {
       };
     });
   });
-
+  
   it("should initialize",function(){
     expect($scope).to.be.truely;
     expect($scope.profile).to.be.truely;
-
+    
     expect($scope.profile).to.deep.equal({
       email: "e@mail.com",
       firstName: "first",
@@ -179,23 +179,23 @@ describe("controller: registration modal", function() {
 
     expect($scope.save).to.exist;
   });
-
-  describe("save new user: ", function() {
+  
+  describe("save new user: ", function() {      
     it("should not save if form is invalid", function() {
       $scope.forms.registrationForm.$invalid = true;
       $scope.save();
-      expect($scope.registering).to.be.false;
+      expect($scope.registering).to.be.false;        
     });
 
     it("should use username as email",function(){
       expect($scope.profile.email).to.be.equal("e@mail.com");
     });
-
+    
     it("should register user and close the modal",function(done){
       $scope.forms.registrationForm.$invalid = false;
       $scope.save();
       expect($scope.registering).to.be.true;
-
+      
       var profileSpy = sinon.spy(userState, "refreshProfile");
       setTimeout(function() {
         expect(newUser).to.be.true;
@@ -217,7 +217,7 @@ describe("controller: registration modal", function() {
       registerUser = false;
       $scope.forms.registrationForm.$invalid = false;
       $scope.save();
-
+      
       var profileSpy = sinon.spy(userState, "refreshProfile");
       setTimeout(function(){
         expect(newUser).to.be.true;
@@ -233,25 +233,25 @@ describe("controller: registration modal", function() {
         done();
       },10);
     });
-
+  
   });
-
+    
   describe("save existing user: ", function() {
     beforeEach(function() {
       account = userProfile;
     });
-
+    
     it("should not save if form is invalid", function() {
       $scope.forms.registrationForm.$invalid = true;
       $scope.save();
-      expect($scope.registering).to.be.false;
+      expect($scope.registering).to.be.false;        
     });
-
+    
     it("should register user and close the modal",function(done){
       $scope.forms.registrationForm.$invalid = false;
       $scope.save();
       expect($scope.registering).to.be.true;
-
+      
       var profileSpy = sinon.spy(userState, "refreshProfile");
       setTimeout(function() {
         expect(newUser).to.be.false;
@@ -267,12 +267,12 @@ describe("controller: registration modal", function() {
         done();
       },10);
     });
-
+    
     it("should handle failure to create user",function(done){
       registerUser = false;
       $scope.forms.registrationForm.$invalid = false;
       $scope.save();
-
+      
       var profileSpy = sinon.spy(userState, "refreshProfile");
       setTimeout(function(){
         expect(newUser).to.be.false;
@@ -286,7 +286,8 @@ describe("controller: registration modal", function() {
         done();
       },10);
     });
-
+      
   });
 
 });
+  

--- a/test/unit/common-header/directives/dtv-newsletter-signup-spec.js
+++ b/test/unit/common-header/directives/dtv-newsletter-signup-spec.js
@@ -10,9 +10,9 @@ describe("directive: newsletter signup", function() {
     $scope = $rootScope.$new();
     var validHTML =
       "<form name=\"form\">" +
-      "  <newsletter-signup ng-model=\"user.mailSyncEnabled\" company-industry=\"company.companyIndustry\" />" +
+      "  <newsletter-signup ng-model=\"user.mailSyncEnabled\" already-opted-in=\"user.alreadyOptedIn\" company-industry=\"company.companyIndustry\" />" +
       "</form>";
-    $scope.user = {};
+    $scope.user = { alreadyOptedIn: false };
     $scope.company = {};
     var elem = $compile(validHTML)($scope);
     elemScope = elem.children().isolateScope();
@@ -68,9 +68,9 @@ describe("directive: newsletter already opted in", function() {
     $scope = $rootScope.$new();
     var validHTML =
       "<form name=\"form\">" +
-      "  <newsletter-signup ng-model=\"user.mailSyncEnabled\" company-industry=\"company.companyIndustry\" />" +
+      "  <newsletter-signup ng-model=\"user.mailSyncEnabled\" already-opted-in=\"user.alreadyOptedIn\" company-industry=\"company.companyIndustry\" />" +
       "</form>";
-    $scope.user = { mailSyncEnabled: true };
+    $scope.user = { mailSyncEnabled: true, alreadyOptedIn: true };
     $scope.company = {};
     var elem = $compile(validHTML)($scope);
     elemScope = elem.children().isolateScope();

--- a/test/unit/common-header/directives/dtv-newsletter-signup-spec.js
+++ b/test/unit/common-header/directives/dtv-newsletter-signup-spec.js
@@ -10,9 +10,11 @@ describe("directive: newsletter signup", function() {
     $scope = $rootScope.$new();
     var validHTML =
       "<form name=\"form\">" +
-      "  <newsletter-signup ng-model=\"user.mailSyncEnabled\" already-opted-in=\"user.alreadyOptedIn\" company-industry=\"company.companyIndustry\" />" +
+      "  <newsletter-signup ng-model=\"user.mailSyncEnabled\" already-opted-in=\"alreadyOptedIn\" company-industry=\"company.companyIndustry\" />" +
       "</form>";
-    $scope.user = { alreadyOptedIn: false };
+
+    $scope.alreadyOptedIn = false;
+    $scope.user = {};
     $scope.company = {};
     var elem = $compile(validHTML)($scope);
     elemScope = elem.children().isolateScope();
@@ -68,9 +70,11 @@ describe("directive: newsletter already opted in", function() {
     $scope = $rootScope.$new();
     var validHTML =
       "<form name=\"form\">" +
-      "  <newsletter-signup ng-model=\"user.mailSyncEnabled\" already-opted-in=\"user.alreadyOptedIn\" company-industry=\"company.companyIndustry\" />" +
+      "  <newsletter-signup ng-model=\"user.mailSyncEnabled\" already-opted-in=\"alreadyOptedIn\" company-industry=\"company.companyIndustry\" />" +
       "</form>";
-    $scope.user = { mailSyncEnabled: true, alreadyOptedIn: true };
+
+    $scope.alreadyOptedIn = true;
+    $scope.user = { mailSyncEnabled: true };
     $scope.company = {};
     var elem = $compile(validHTML)($scope);
     elemScope = elem.children().isolateScope();

--- a/web/partials/common-header/company-icp-modal.html
+++ b/web/partials/common-header/company-icp-modal.html
@@ -2,7 +2,7 @@
   <div class="modal-header">
     <h2 id="icpModalTitle" class="modal-title">Help us personalize your experience</h2>
   </div>
-  <div class="modal-body" stop-event="touchend">    
+  <div class="modal-body" stop-event="touchend">
     <form id="forms.companyIcpForm" role="form" name="forms.companyIcpForm">
       <div class="form-group">
         <label for="company-industry" class="control-label">
@@ -15,17 +15,17 @@
       </div>
 
       <!-- Newsletter -->
-      <newsletter-signup ng-model="user.mailSyncEnabled" company-industry="company.companyIndustry"></newsletter-signup>
+      <newsletter-signup ng-model="user.mailSyncEnabled" already-opted-in="alreadyOptedIn" company-industry="company.companyIndustry"></newsletter-signup>
 
     </form>
 
   </div> <!-- //Modal Body -->
 
-  <div class="modal-footer"> 
+  <div class="modal-footer">
     <button id="saveButton" type="submit" class="btn btn-primary btn-lg btn-block ng-binding" aria-label="Apply" tabindex="1" form="forms.companyIcpForm" ng-click="save()" ng-disabled="forms.companyIcpForm.$invalid">
-      Apply 
+      Apply
       <i class="fa fa-check icon-right"></i>
-    </button> 
+    </button>
   </div>
 
 </div>

--- a/web/partials/common-header/registration-modal.html
+++ b/web/partials/common-header/registration-modal.html
@@ -3,7 +3,7 @@
     <h2 class="modal-title">One last step!</h2>
   </div>
   <div id="registration-modal" class="modal-body" stop-event="touchend">
-    
+
     <form id="forms.registrationForm" novalidate role="form" name="forms.registrationForm" autocomplete="on">
       <div class="row">
         <div class="col-xs-12">
@@ -51,7 +51,7 @@
           </div>
 
           <!-- Newsletter -->
-          <newsletter-signup ng-model="profile.mailSyncEnabled" company-industry="company.companyIndustry"></newsletter-signup>
+          <newsletter-signup ng-model="profile.mailSyncEnabled" already-opted-in="profile.alreadyOptedIn" company-industry="company.companyIndustry"></newsletter-signup>
 
           <!-- Terms of Service and Privacy -->
           <div class="form-group">
@@ -59,9 +59,9 @@
               <label for="accepted">
                 <input type="checkbox" id="accepted" name="accepted" class="accept-terms-checkbox" ng-model="profile.accepted" tabindex="1" required />
                 <span>
-                   I accept the 
-                   <a href="https://help.risevision.com/hc/en-us/articles/360000924446-Terms-of-Service" target="_blank" tabindex="1">Terms of Service</a> 
-                   and 
+                   I accept the
+                   <a href="https://help.risevision.com/hc/en-us/articles/360000924446-Terms-of-Service" target="_blank" tabindex="1">Terms of Service</a>
+                   and
                    <a href="https://help.risevision.com/hc/en-us/articles/360000915023-Privacy-Policy" target="_blank" tabindex="1">Privacy Policy</a> *
                 </span
               </label>
@@ -77,7 +77,7 @@
 
   </div> <!-- //Modal Body -->
 
-  <div class="modal-footer"> 
+  <div class="modal-footer">
     <!-- buttons -->
     <div class="row">
       <div class="col-xs-12 u_margin-sm-top">

--- a/web/partials/common-header/registration-modal.html
+++ b/web/partials/common-header/registration-modal.html
@@ -51,7 +51,7 @@
           </div>
 
           <!-- Newsletter -->
-          <newsletter-signup ng-model="profile.mailSyncEnabled" already-opted-in="profile.alreadyOptedIn" company-industry="company.companyIndustry"></newsletter-signup>
+          <newsletter-signup ng-model="profile.mailSyncEnabled" already-opted-in="alreadyOptedIn" company-industry="company.companyIndustry"></newsletter-signup>
 
           <!-- Terms of Service and Privacy -->
           <div class="form-group">

--- a/web/scripts/common-header/controllers/ctr-company-icp-modal.js
+++ b/web/scripts/common-header/controllers/ctr-company-icp-modal.js
@@ -8,6 +8,7 @@ angular.module('risevision.common.header')
 
       $scope.company = company;
       $scope.user = user;
+      $scope.alreadyOptedIn = user.mailSyncEnabled;
       $scope.DROPDOWN_INDUSTRY_FIELDS = COMPANY_INDUSTRY_FIELDS;
 
       $scope.save = function () {

--- a/web/scripts/common-header/controllers/ctr-registration-modal.js
+++ b/web/scripts/common-header/controllers/ctr-registration-modal.js
@@ -35,12 +35,12 @@ angular.module('risevision.common.header')
         $scope.profile.mailSyncEnabled = false;
       }
 
-      $scope.profile.alreadyOptedIn = $scope.profile.mailSyncEnabled;
+      $scope.alreadyOptedIn = $scope.profile.mailSyncEnabled;
 
       if ($scope.newUser) {
-        getAccount($scope.profile.email).then(function (account) {
-          if (account && account.mailSyncEnabled) {
-            $scope.profile.alreadyOptedIn = true;
+        getAccount($scope.profile.email).then(function (subscriber) {
+          if (subscriber && subscriber.mailSyncEnabled) {
+            $scope.alreadyOptedIn = true;
           }
         });
       }

--- a/web/scripts/common-header/controllers/ctr-registration-modal.js
+++ b/web/scripts/common-header/controllers/ctr-registration-modal.js
@@ -7,12 +7,12 @@ angular.module('risevision.common.header')
     'userState', 'pick', 'uiFlowManager', 'messageBox', 'humanReadableError',
     'agreeToTermsAndUpdateUser', 'account', 'segmentAnalytics',
     'bigQueryLogging', 'analyticsEvents', 'updateCompany', 'plansFactory',
-    'COMPANY_INDUSTRY_FIELDS', 'urlStateService',
+    'COMPANY_INDUSTRY_FIELDS', 'urlStateService', 'getAccount',
     function ($q, $scope, $rootScope, $modalInstance, $loading, addAccount,
       $log, userState, pick, uiFlowManager, messageBox, humanReadableError,
       agreeToTermsAndUpdateUser, account, segmentAnalytics, bigQueryLogging,
       analyticsEvents, updateCompany, plansFactory, COMPANY_INDUSTRY_FIELDS,
-      urlStateService) {
+      urlStateService, getAccount) {
 
       $scope.newUser = !account;
       $scope.DROPDOWN_INDUSTRY_FIELDS = COMPANY_INDUSTRY_FIELDS;
@@ -33,6 +33,14 @@ angular.module('risevision.common.header')
       if (!angular.isDefined($scope.profile.mailSyncEnabled)) {
         //'no sign up' by default
         $scope.profile.mailSyncEnabled = false;
+      }
+
+      if ($scope.newUser) {
+        getAccount($scope.profile.email).then(function (account) {
+          if (account && account.mailSyncEnabled) {
+            $scope.profile.mailSyncEnabled = true;
+          }
+        });
       }
 
       // check status, load spinner, or close dialog if registration is complete

--- a/web/scripts/common-header/controllers/ctr-registration-modal.js
+++ b/web/scripts/common-header/controllers/ctr-registration-modal.js
@@ -35,10 +35,12 @@ angular.module('risevision.common.header')
         $scope.profile.mailSyncEnabled = false;
       }
 
+      $scope.profile.alreadyOptedIn = $scope.profile.mailSyncEnabled;
+
       if ($scope.newUser) {
         getAccount($scope.profile.email).then(function (account) {
           if (account && account.mailSyncEnabled) {
-            $scope.profile.mailSyncEnabled = true;
+            $scope.profile.alreadyOptedIn = true;
           }
         });
       }

--- a/web/scripts/common-header/directives/dtv-newsletter-signup.js
+++ b/web/scripts/common-header/directives/dtv-newsletter-signup.js
@@ -7,18 +7,17 @@ angular.module('risevision.common.header.directives')
         restrict: 'E',
         require: 'ngModel',
         scope: {
+          alreadyOptedIn: '=',
           mailSyncEnabled: '=ngModel',
           companyIndustry: '='
         },
         template: $templateCache.get('partials/common-header/newsletter-signup.html'),
         link: function ($scope) {
-          var alreadyOptedIn = $scope.mailSyncEnabled;
-
           $scope.showNewsletterSignup = function () {
             var isEducation = $scope.companyIndustry === 'PRIMARY_SECONDARY_EDUCATION' ||
               $scope.companyIndustry === 'HIGHER_EDUCATION';
 
-            return isEducation && !alreadyOptedIn;
+            return isEducation && !$scope.alreadyOptedIn;
           };
 
         }

--- a/web/scripts/common-header/services/svc-account.js
+++ b/web/scripts/common-header/services/svc-account.js
@@ -79,11 +79,17 @@
 
     .factory('getAccount', ['$q', 'riseAPILoader', '$log',
       function ($q, riseAPILoader, $log) {
-        return function () {
+        return function (email) {
           $log.debug('getAccount called.');
           var deferred = $q.defer();
+
+          var criteria = {};
+          if (email) {
+            criteria.email = email;
+          }
+
           riseAPILoader().then(function (riseApi) {
-            var request = riseApi.account.get();
+            var request = riseApi.account.get(criteria);
             request.execute(function (resp) {
               $log.debug('getAccount resp', resp);
               if (resp.item) {


### PR DESCRIPTION
## Description
Calls 'account.get' API with email parameter for new users before presenting dialog with newsletter signup.

## Motivation and Context
Profiles for new users doesn't retrieve the flag that indicates if it already has opted in for newsletter subscription. So we need to explicitly ask for that value using the updated account.get API call with a parameter.

## How Has This Been Tested?
Manually tested locally by changing the 'isSubscribed' flag of NewsletterSubscriber entities and clearing memcached.

The ICP modal was also manually tested by manipulating state and forcing it to appear.

It was also tested remotely using the same procedure here:
https://apps-stage-9.risevision.com/

Automated tests were updated to consider the new changes.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     - To be released on Monday
     - Simple rollback is needed if there are issues, this release is low risk as it does not modify user data.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify support, or to update documentation.
