### PR TITLE
No unhandled rejection logging for Storage

### DIFF
--- a/web/scripts/common-header/dtv-common-header.js
+++ b/web/scripts/common-header/dtv-common-header.js
@@ -175,12 +175,6 @@ angular.module('risevision.common.header', [
     }
   ])
 
-  .config(['$qProvider',
-    function ($qProvider) {
-      $qProvider.errorOnUnhandledRejections(false);
-    }
-  ])
-
   .run(['segmentAnalytics', 'SEGMENT_API_KEY', 'analyticsEvents', '$document',
     function (segmentAnalytics, SEGMENT_API_KEY, analyticsEvents, $document) {
       analyticsEvents.initialize();

--- a/web/scripts/components/userstate/services/svc-exception-handler.js
+++ b/web/scripts/components/userstate/services/svc-exception-handler.js
@@ -1,6 +1,12 @@
 'use strict';
 
 angular.module('risevision.common.components.logging')
+  .config(['$qProvider',
+    function ($qProvider) {
+      $qProvider.errorOnUnhandledRejections(false);
+    }
+  ])
+
   .factory('$exceptionHandler', ['$log', '$injector', 'getError',
     function ($log, $injector, getError) {
       var _stringify = function (object) {


### PR DESCRIPTION
## Description
No unhandled rejection logging for Storage
Move unhandled rejection code to userState

[stage-2]

## Motivation and Context
`storage-selector.html` does not load `dtv-common-header` and does not have that configuration applied. Moved configuration to a common location.

## How Has This Been Tested?
Validated that the unhandled rejection errors no longer appear.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
