### PR TITLE
Support 'non-completion' attribute to force hide completion message UI

### DIFF
--- a/web/partials/template-editor/components/component-counter.html
+++ b/web/partials/template-editor/components/component-counter.html
@@ -52,7 +52,7 @@
         </span>
       </div>
     </div>
-    <div class="form-group mt-4" ng-show="counterType == 'down'">
+    <div class="form-group mt-4" ng-show="counterType == 'down' && !nonCompletion">
       <label class="control-label" for="completionMessage">Enter countdown completion message:</label>
       <input type="text" id="completionMessage" class="form-control u_ellipsis" ng-model="completionMessage" ng-change="save()" placeholder="Eg. &quot;It's time for...&quot;">
     </div>

--- a/web/scripts/components/userstate/services/svc-exception-handler.js
+++ b/web/scripts/components/userstate/services/svc-exception-handler.js
@@ -37,7 +37,9 @@ angular.module('risevision.common.components.logging')
           message += '; cause: ' + _stringify(cause);
         }
 
-        segmentAnalytics.track(eventName, {message: message});
+        segmentAnalytics.track(eventName, {
+          message: message
+        });
         bigQueryLogging.logEvent(eventName, message);
       };
 

--- a/web/scripts/template-editor/components/directives/dtv-component-counter.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-counter.js
@@ -47,7 +47,8 @@ angular.module('risevision.template-editor.directives')
                 $scope.counterType = $scope.getAvailableAttributeData($scope.componentId, 'type');
                 $scope.targetDate = $scope.getAvailableAttributeData($scope.componentId, 'date');
                 $scope.targetTime = $scope.getAvailableAttributeData($scope.componentId, 'time');
-                $scope.nonCompletion = $scope.getAvailableAttributeData($scope.componentId, 'non-completion') === "";
+                $scope.nonCompletion = $scope.getAvailableAttributeData($scope.componentId,
+                  'non-completion') === '';
                 $scope.completionMessage = $scope.getAvailableAttributeData($scope.componentId, 'completion');
 
                 if ($scope.targetDate) {

--- a/web/scripts/template-editor/components/directives/dtv-component-counter.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-counter.js
@@ -47,6 +47,7 @@ angular.module('risevision.template-editor.directives')
                 $scope.counterType = $scope.getAvailableAttributeData($scope.componentId, 'type');
                 $scope.targetDate = $scope.getAvailableAttributeData($scope.componentId, 'date');
                 $scope.targetTime = $scope.getAvailableAttributeData($scope.componentId, 'time');
+                $scope.nonCompletion = $scope.getAvailableAttributeData($scope.componentId, 'non-completion') === "";
                 $scope.completionMessage = $scope.getAvailableAttributeData($scope.componentId, 'completion');
 
                 if ($scope.targetDate) {
@@ -69,7 +70,7 @@ angular.module('risevision.template-editor.directives')
                     .targetTime));
                 }
 
-                if ($scope.counterType === 'down') {
+                if ($scope.counterType === 'down' && !$scope.nonCompletion) {
                   $scope.setAttributeData($scope.componentId, 'completion', $scope.completionMessage);
                 }
               };


### PR DESCRIPTION
## Description
Counter directive now handles an empty `non-completion` attribute being present in attribute/blueprint data, and if is present, hides the completion message field. 

## Motivation and Context
This is to provide support for Creative to force a completion message and not allow for it to be configured by a user. This resolves https://github.com/Rise-Vision/rise-data-counter/issues/12 

## How Has This Been Tested?
Tested locally and on stage-8 by deploying a staged version of _example counter component_ template that applies the `non-completion` attribute to the _rise-counter_ instance of _down_ type.

https://apps-stage-8.risevision.com/templates/edit/fe730335-b4d7-4301-9e8c-bf7b5bab9ab5/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

Upon merging this PR, I will deploy a staged version of _example counter component_ with `non-completion` removed. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Validate on production after deploying
  - Rollback not required, no users will be impacted by this change as we have no editable templates visible to users yet. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
Documentation, notifying Support
