### PR TITLE
Load hubspot script and call identity at registration

### DIFF
--- a/test/e2e/registration/cases/registration.js
+++ b/test/e2e/registration/cases/registration.js
@@ -53,6 +53,7 @@
         PASSWORD = commonHeaderPage.getPassword();
         NEW_COMPANY_NAME = commonHeaderPage.addStageSuffix("Public School");
 
+        console.log('Checking login for ' + EMAIL_ADDRESS);
         detectAndFixUserAlreadyRegistered();
 
         signUpPage.get();

--- a/test/unit/components/hubspot/svc-hubspot.tests.js
+++ b/test/unit/components/hubspot/svc-hubspot.tests.js
@@ -1,0 +1,41 @@
+/*jshint expr:true */
+"use strict";
+
+describe("Services: hubspot", function() {
+
+  beforeEach(module("risevision.common.components.hubspot"));
+  beforeEach(module(function ($provide) {
+    $provide.factory("HUBSPOT_ACCOUNT", [function () {
+      return "0000";
+    }]);
+  }));
+
+  var hubspot, $window;
+  beforeEach(function(){
+    inject(function($injector){
+      hubspot = $injector.get("hubspot");
+      $window = $injector.get("$window");
+    });
+  });
+
+  afterEach(function(){
+    $window._hsq.length = 0;
+  });
+
+  it("should load correct script and trigger identity function", function() {
+    hubspot.loadAs("test-user@example.com");
+
+    expect($window.document.getElementById("hs-script-loader").src.indexOf("0000") > -1).to.be.true;
+    expect($window._hsq[0][0]).to.equal("identify");
+    expect($window._hsq[0][1].email).to.equal("test-user@example.com");
+  });
+
+  it("should load only once", function() {
+    hubspot.loadAs("test-user@example.com");
+    expect($window.document.getElementById("hs-script-loader").src.indexOf("0000") > -1).to.be.true;
+    expect($window._hsq.length).to.equal(1);
+
+    hubspot.loadAs("test-user@example.com");
+    expect($window._hsq.length).to.equal(1);
+  });
+});

--- a/test/unit/components/userstate/services/svc-custom-auth-factory.tests.js
+++ b/test/unit/components/userstate/services/svc-custom-auth-factory.tests.js
@@ -4,6 +4,13 @@ describe("service: customAuthFactory:", function() {
 
   beforeEach(module(function ($provide) {
     $provide.service("$q", function() {return Q;});
+
+    $provide.factory("hubspot", [function () {
+      return {
+        loadAs: function() {}
+      };
+    }]);
+
     $provide.service("userauth", function() {
       return {
         add: function(username, password){

--- a/web/index.html
+++ b/web/index.html
@@ -234,6 +234,7 @@
   <script src="scripts/components/stop-event/dtv-stop-event.js"></script>
 
   <script src="scripts/components/segment-analytics/svc-segment-analytics.js"></script>
+  <script src="scripts/components/hubspot/svc-hubspot.js"></script>
 
   <script src="scripts/components/message-box/ctr-message-box.js"></script>
   <script src="scripts/components/message-box/svc-message-box.js"></script>

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -20,6 +20,7 @@ angular.module('risevision.apps', [
     'risevision.common.components.timeline',
     'risevision.common.components.timeline-basic',
     'risevision.common.components.analytics',
+    'risevision.common.components.hubspot',
     'risevision.common.components.distribution-selector',
     'risevision.common.components.background-image-setting',
     'risevision.common.components.message-box',

--- a/web/scripts/common-header/controllers/ctr-auth-buttons.js
+++ b/web/scripts/common-header/controllers/ctr-auth-buttons.js
@@ -3,12 +3,12 @@
 angular.module('risevision.common.header')
   .controller('AuthButtonsCtr', ['$scope', '$modal', '$templateCache',
     'userState', 'userAuthFactory', 'canAccessApps',
-    '$loading',
+    '$loading', 'hubspot',
     '$log', 'uiFlowManager', 'oauth2APILoader', 'bindToScopeWithWatch',
     '$window', 'APPS_URL',
     function ($scope, $modal, $templateCache, userState, userAuthFactory,
       canAccessApps,
-      $loading, $log, uiFlowManager, oauth2APILoader,
+      $loading, hubspot, $log, uiFlowManager, oauth2APILoader,
       bindToScopeWithWatch, $window, APPS_URL) {
 
       window.$loading = $loading; //DEBUG
@@ -43,6 +43,7 @@ angular.module('risevision.common.header')
             if (newStatus === 'registeredAsRiseVisionUser') {
               if (!userState.registrationModalInstance && userState
                 .isLoggedIn()) { // avoid duplicate registration modals
+                hubspot.loadAs(userState.getUsername());
                 userState.registrationModalInstance = $modal.open({
                   template: $templateCache.get('partials/common-header/registration-modal.html'),
                   controller: 'RegistrationModalCtrl',

--- a/web/scripts/common-header/dtv-common-header.js
+++ b/web/scripts/common-header/dtv-common-header.js
@@ -32,6 +32,7 @@ angular.module('risevision.common.header', [
     'risevision.common.components.scrolling-list',
     'risevision.common.components.stop-event',
     'risevision.common.components.analytics',
+    'risevision.common.components.hubspot',
     'risevision.common.components.message-box',
     'risevision.common.components.confirm-modal',
     'risevision.common.components.svg',

--- a/web/scripts/components/hubspot/svc-hubspot.js
+++ b/web/scripts/components/hubspot/svc-hubspot.js
@@ -1,0 +1,35 @@
+(function (angular) {
+
+  'use strict';
+
+  angular.module('risevision.common.components.hubspot', [])
+
+    .factory('hubspot', ['$window', 'HUBSPOT_ACCOUNT',
+      function ($window, hubspotAccount) {
+        var service = {};
+        var loaded = false;
+
+        var _hsq = window._hsq = window._hsq || [];
+
+        service.loadAs = function (email) {
+          if (!loaded) {
+             _hsq.push(['identify',{ email: email }]);
+
+            var e = document.createElement('script');
+            e.type = 'text/javascript';
+            e.defer = !0;
+            e.async = !0;
+            e.id = 'hs-script-loader';
+            e.src = '//js.hs-scripts.com/' + hubspotAccount + '.js';
+            var n = document.getElementsByTagName('script')[0];
+            n.parentNode.insertBefore(e, n);
+
+            loaded = true;
+          }
+        };
+
+        return service;
+      }
+    ]);
+
+})(angular);

--- a/web/scripts/config/beta.js
+++ b/web/scripts/config/beta.js
@@ -38,6 +38,7 @@
     .value('CHARGEBEE_PROD_SITE', 'risevision')
     .value('STRIPE_PROD_KEY', 'pk_live_31dWkTWQU125m2RcWpK4HQBR')
     .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
+    .value('HUBSPOT_ACCOUNT', '2700250')
     .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/src/template.html')
     .value('BLUEPRINT_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/blueprint.json');
 

--- a/web/scripts/config/dev.js
+++ b/web/scripts/config/dev.js
@@ -46,6 +46,7 @@
     .value('CHARGEBEE_PLANS_USE_PROD', 'false')
     .value('STRIPE_PROD_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
     .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
+    .value('HUBSPOT_ACCOUNT', '2939619')
     .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/src/template.html')
     .value('BLUEPRINT_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/blueprint.json');
 

--- a/web/scripts/config/prod.js
+++ b/web/scripts/config/prod.js
@@ -38,6 +38,7 @@
     .value('CHARGEBEE_PLANS_USE_PROD', 'true')
     .value('STRIPE_PROD_KEY', 'pk_live_31dWkTWQU125m2RcWpK4HQBR')
     .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
+    .value('HUBSPOT_ACCOUNT', '2700250')
     .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/src/template.html')
     .value('BLUEPRINT_URL', 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/blueprint.json');
 

--- a/web/scripts/config/stage.js
+++ b/web/scripts/config/stage.js
@@ -44,6 +44,7 @@
     .value('CHARGEBEE_PROD_SITE', 'risevision-test')
     .value('STRIPE_PROD_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
     .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
+    .value('HUBSPOT_ACCOUNT', '2939619')
     .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/src/template.html')
     .value('BLUEPRINT_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/blueprint.json');
 

--- a/web/scripts/config/test.js
+++ b/web/scripts/config/test.js
@@ -47,6 +47,7 @@
     .value('CHARGEBEE_PLANS_USE_PROD', 'false')
     .value('STRIPE_PROD_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
     .value('STRIPE_TEST_KEY', 'pk_test_GrMIAHSoqhaik4tcHepsxjOR')
+    .value('HUBSPOT_ACCOUNT', '2939619')
     .value('HTML_TEMPLATE_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/src/template.html')
     .value('BLUEPRINT_URL', 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/blueprint.json');
 


### PR DESCRIPTION
## Description
Loads hubspot tracking script from `js.hs-scripts.com/` and then calls the identify action through the script. This is to ensure that users are created in hubspot via the script, and any previous activity from a previous risevision.com session is captured in their hubspot user data.

## Motivation and Context
Improved functionality for marketing.  See [doc](https://drive.google.com/open?id=1xGOVuslmtSXk5VZuPbZDRHPwM6AUZ_JZ4so592cJocM)

## How Has This Been Tested?
E2E + manual testing to confirm user is created in hubspot and updated with company id via backend.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
