### PR TITLE
Handle user with only System Administrator role

### DIFF
--- a/test/unit/displays/controllers/ctr-display-details.tests.js
+++ b/test/unit/displays/controllers/ctr-display-details.tests.js
@@ -76,7 +76,8 @@ describe('controller: display details', function() {
           getSelectedCompanyId: function() {return "company1"},
           getCopyOfSelectedCompany: function() {return company;},
           _restoreState: function(){},
-          updateCompanySettings: sandbox.stub()
+          updateCompanySettings: sandbox.stub(),
+          hasRole: sandbox.stub().returns(true)
       };
     });
     
@@ -501,6 +502,12 @@ describe('controller: display details', function() {
       sandbox.stub($scope, 'areAllProLicensesUsed').returns(true);
 
       currentPlanFactory.currentPlan.isPurchasedByParent = true;
+
+      expect($scope.isProToggleEnabled()).to.be.false;
+    });
+
+    it('should return false if user is not display administrator', function () {
+      userState.hasRole.returns(false);
 
       expect($scope.isProToggleEnabled()).to.be.false;
     });

--- a/web/partials/template-editor/footer.html
+++ b/web/partials/template-editor/footer.html
@@ -1,5 +1,5 @@
 <div>
-  <div class="auto-saving-changes">
+  <div class="auto-saving-changes" ng-if="hasContentEditorRole()">
     <div ng-show="!factory.savingPresentation && factory.isUnsaved()">
       Unsaved changes
     </div>
@@ -12,7 +12,9 @@
       <streamline-icon name="checkmark" width="12" height="12"></streamline-icon>
     </div>
   </div>
-
+  <div class="auto-saving-changes" ng-if="!hasContentEditorRole()">
+    <div class="text-danger">You don’t have permission to edit</div>
+  </div>
   <button id="publishButton" require-role="cp" class="btn btn-primary btn-block"
           ng-disabled="isPublishDisabled()"
           ng-click="factory.publish()">

--- a/web/partials/template-editor/toolbar.html
+++ b/web/partials/template-editor/toolbar.html
@@ -10,8 +10,8 @@
   </button>
 </div>
 
-<div class="toolbar-right">
-  <div id="autoSavingDesktop" class="auto-saving-changes hidden-xs">
+<div class="toolbar-right hidden-xs">
+  <div id="autoSavingDesktop" class="auto-saving-changes" ng-if="hasContentEditorRole()">
     <div ng-show="!factory.savingPresentation && factory.isUnsaved()">
       Unsaved changes
     </div>
@@ -24,7 +24,10 @@
       </div>
     </div>
   </div>
-  <button id="publishButtonDesktop" require-role="cp" class="btn btn-primary btn-fixed-width hidden-xs"
+  <div class="auto-saving-changes" ng-if="!hasContentEditorRole()">
+    <div class="text-danger">You don’t have permission to edit</div>
+  </div>
+  <button id="publishButtonDesktop" require-role="cp" class="btn btn-primary btn-fixed-width"
           ng-disabled="isPublishDisabled()"
           ng-click="factory.publish()">
     Publish To Display

--- a/web/scripts/components/hubspot/svc-hubspot.js
+++ b/web/scripts/components/hubspot/svc-hubspot.js
@@ -13,7 +13,9 @@
 
         service.loadAs = function (email) {
           if (!loaded) {
-             _hsq.push(['identify',{ email: email }]);
+            _hsq.push(['identify', {
+              email: email
+            }]);
 
             var e = document.createElement('script');
             e.type = 'text/javascript';

--- a/web/scripts/displays/controllers/ctr-display-details.js
+++ b/web/scripts/displays/controllers/ctr-display-details.js
@@ -100,8 +100,8 @@ angular.module('risevision.displays.controllers')
       };
 
       $scope.isProToggleEnabled = function () {
-        return ($scope.display && $scope.display.playerProAuthorized) ||
-          ($scope.areAllProLicensesUsed() ? !currentPlanFactory.currentPlan.isPurchasedByParent : true);
+        return userState.hasRole('da') && (($scope.display && $scope.display.playerProAuthorized) ||
+          ($scope.areAllProLicensesUsed() ? !currentPlanFactory.currentPlan.isPurchasedByParent : true));
       };
 
       $scope.confirmDelete = function () {

--- a/web/scss/sections/template-editor-layout.scss
+++ b/web/scss/sections/template-editor-layout.scss
@@ -122,7 +122,7 @@ $maderio-green-disabled: #a2dbb2;
 
     .auto-saving-changes {
       position: relative;
-      width: 120px;
+      width: 180px;
       height: 33px;
       margin-right: 20px;
       overflow: hidden;


### PR DESCRIPTION
## Description
Don't auto save Template if user is not Content Editor
Show status message in Template Editor to let user know they don't have permission
Disable display licensing toggle if user is not Display Administrator

## Motivation and Context
Fix #1364.

## How Has This Been Tested?
Manually tested locally and on stage-1.
Sample user: dipiwed551@xmail2.net
Sample Display: https://apps-stage-1.risevision.com/displays/details/4RDXFBWF5DU7
Sample Template: https://apps-stage-1.risevision.com/templates/edit/9838caf0-c634-4446-9761-5ccaa58f2034/

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
As it requires user with a special role setup, E2E test was skipped.

@alex-deaconu Please review. Thanks
