### PR TITLE
Remove min length validation on sign in Password field

### DIFF
--- a/test/e2e/common/cases/signin-custom.js
+++ b/test/e2e/common/cases/signin-custom.js
@@ -35,11 +35,11 @@ var SigninCustomScenarios = function() {
       expect(signInPage.getSigninButton().isPresent()).to.eventually.be.true;
     });
 
-    it('should show minimum length error', function() {
+    it('should not show minimum length error', function() {
       signInPage.getUsernameTextBox().sendKeys('test@test.com');
       signInPage.getPasswordTextBox().sendKeys('pas');
 
-      expect(signInPage.getPasswordMinLengthError().isDisplayed()).to.eventually.be.true;
+      expect(signInPage.getPasswordMinLengthError().isPresent()).to.eventually.be.false;
     });
 
     it('should show required field error', function() {

--- a/web/partials/common-header/user-settings-modal.html
+++ b/web/partials/common-header/user-settings-modal.html
@@ -62,7 +62,7 @@ rv-spinner-start-active="1">
           ng-model="userPassword.currentPassword"
           label="Current Password *"
           placeholder="Enter Current Password"
-          minlength="4" required>
+          required>
         </password-input>
       
         <password-input 

--- a/web/partials/components/userstate/auth-form.html
+++ b/web/partials/components/userstate/auth-form.html
@@ -81,7 +81,7 @@
       </p>
     </div>
       
-    <password-input name="password" ng-model="credentials.password" is-creating="isSignUp" minlength="{{ isSignUp ? 12 : 4}}" required></password-input>
+    <password-input name="password" ng-model="credentials.password" is-creating="isSignUp" minlength="{{ isSignUp ? 12 : 0}}" required></password-input>
 
     </div>
   </div>


### PR DESCRIPTION
## Description
Remove min length validation on sign in Password field.
Remove min length validation on Current Password field for Password Change.

## Motivation and Context
Fix #1372.

## How Has This Been Tested?
Manually tested locally and on stage-19

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

@alex-deaconu Please review. Thanks