### PR TITLE
Retrieve subscription status from factory

### DIFF
--- a/test/e2e/registration/cases/trial.js
+++ b/test/e2e/registration/cases/trial.js
@@ -96,7 +96,7 @@ var TrialScenarios = function() {
 
                 helper.waitDisappear(commonHeaderPage.getLoader(), 'CH Spinner Loader');
 
-                _this.waitForPlanUpdate(retries - 1);
+                _getTrialWithRetries(retries - 1);
               } else {
                 throw e;
               }

--- a/test/e2e/registration/cases/trial.js
+++ b/test/e2e/registration/cases/trial.js
@@ -84,12 +84,28 @@ var TrialScenarios = function() {
       });
 
       it('should show Strage trial after page refresh', function () {
+        var _getTrialWithRetries = function(retries) {
+          helper.wait(storageSelectorModalPage.getActiveTrialBanner(), 'Active Trial')
+            .catch(function (e) {
+              retries = typeof(retries) === 'undefined' ? 3 : retries;
+
+              if (retries > 0) {
+                browser.call(()=>console.log("waiting for trial to appear, attempt: " + (4 - retries)));
+
+                browser.driver.navigate().refresh();
+
+                helper.waitDisappear(commonHeaderPage.getLoader(), 'CH Spinner Loader');
+
+                _this.waitForPlanUpdate(retries - 1);
+              } else {
+                throw e;
+              }
+            });
+        };
+
         homepage.getStorage();
 
-        helper.wait(storageHomePage.getStorageAppContainer(), 'Storage Apps Container');
-        helper.waitDisappear(filesListPage.getFilesListLoader(), 'Storage Files Loader');
-
-        helper.wait(storageSelectorModalPage.getActiveTrialBanner(), 'Active Trial Banner');
+        _getTrialWithRetries();
 
         expect(storageSelectorModalPage.getActiveTrialBanner().isDisplayed()).to.eventually.be.true;
         expect(storageSelectorModalPage.getStartTrialButton().isDisplayed()).to.eventually.be.false;

--- a/test/unit/components/subscription-status/svc-subscription-status-factory.tests.js
+++ b/test/unit/components/subscription-status/svc-subscription-status-factory.tests.js
@@ -30,6 +30,7 @@ describe('service: subscriptionStatusFactory:', function() {
   it('should exist',function(){
     expect(subscriptionStatusFactory).to.be.truely;
     expect(subscriptionStatusFactory.checkProductCode).to.be.a('function');
+    expect(subscriptionStatusFactory.check).to.be.a('function');
     expect(subscriptionStatusFactory.checkProductCodes).to.be.a('function');
   });
 
@@ -135,6 +136,37 @@ describe('service: subscriptionStatusFactory:', function() {
         expect(err).to.be.equal("Failure");
         done();
       }); 
+    });
+
+  });
+
+  describe('check:', function() {
+    var pc = "pc1";
+
+    it('should resolve if subscribed', function(done) {
+      sinon.stub(subscriptionStatusFactory, 'checkProductCode').returns(Q.resolve({isSubscribed: true}));
+
+      subscriptionStatusFactory.check(pc).then(function(status){
+        expect(status).to.be.true;
+
+        done();
+      },function(err){
+        done('Should not reject');
+      }); 
+
+    });
+
+    it('should reject if unsubscribed', function(done) {
+      sinon.stub(subscriptionStatusFactory, 'checkProductCode').returns(Q.resolve({isSubscribed: false}));
+
+      subscriptionStatusFactory.check(pc).then(function(){
+        done('Should not resolve');
+      },function(status){
+        expect(status).to.be.false;
+
+        done();
+      }); 
+
     });
 
   });

--- a/test/unit/editor/services/svc-check-template-access.tests.js
+++ b/test/unit/editor/services/svc-check-template-access.tests.js
@@ -10,7 +10,7 @@ describe('service: checkTemplateAccess:', function() {
     $provide.value("TEMPLATE_LIBRARY_PRODUCT_CODE", TEMPLATE_LIBRARY_PRODUCT_CODE);
     $provide.service('$q', function() {return Q;});
 
-    $provide.service('storeAuthorization', function() {
+    $provide.service('subscriptionStatusFactory', function() {
       return {
         check: function(templateCode) {
           var deferred = Q.defer();

--- a/web/scripts/components/subscription-status/svc-subscription-status-factory.js
+++ b/web/scripts/components/subscription-status/svc-subscription-status-factory.js
@@ -37,6 +37,17 @@ angular.module('risevision.common.components.subscription-status.service')
             return null;
           });
       };
+      
+      factory.check = function (productCode) {
+        return factory.checkProductCode(productCode)
+          .then(function(statusItem) {
+            if (statusItem.isSubscribed) {
+              return $q.resolve(true);
+            } else {
+              return $q.reject(false);
+            }
+          });
+      };
 
       factory.checkProductCodes = function (productCodes) {
         var cachedItems = [];

--- a/web/scripts/editor/services/svc-check-template-access.js
+++ b/web/scripts/editor/services/svc-check-template-access.js
@@ -2,12 +2,12 @@
 
 angular.module('risevision.editor.services')
   .value('TEMPLATE_LIBRARY_PRODUCT_CODE', '61dd6aa64152a228522ddf5950e5abb526416f27')
-  .factory('checkTemplateAccess', ['storeAuthorization', 'TEMPLATE_LIBRARY_PRODUCT_CODE',
-    function (storeAuthorization, TEMPLATE_LIBRARY_PRODUCT_CODE) {
+  .factory('checkTemplateAccess', ['subscriptionStatusFactory', 'TEMPLATE_LIBRARY_PRODUCT_CODE',
+    function (subscriptionStatusFactory, TEMPLATE_LIBRARY_PRODUCT_CODE) {
       return function (templateCode) {
-        return storeAuthorization.check(TEMPLATE_LIBRARY_PRODUCT_CODE)
+        return subscriptionStatusFactory.check(TEMPLATE_LIBRARY_PRODUCT_CODE)
           .catch(function () {
-            return storeAuthorization.check(templateCode);
+            return subscriptionStatusFactory.check(templateCode);
           });
       };
     }


### PR DESCRIPTION
## Description
Retrieve subscription status from factory

Retrieving from the Store server can cause
issues with latency

[stage-18]

## Motivation and Context
Fix for #1373 

## How Has This Been Tested?
Verified that the Subscription status is retrieved correctly when Adding a Template for both Subscribed and Unsubscribed companies.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
