### PR TITLE
Send keys to challenge input directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13121,8 +13121,8 @@
       }
     },
     "rv-common-e2e": {
-      "version": "git://github.com/Rise-Vision/rv-common-e2e.git#185b70048eec65431b2940c6fcfaf0b868f2c722",
-      "from": "git://github.com/Rise-Vision/rv-common-e2e.git",
+      "version": "git://github.com/Rise-Vision/rv-common-e2e.git#74435350d262f07a1d20a7cabe6233e9b1fabe2f",
+      "from": "git://github.com/Rise-Vision/rv-common-e2e.git#fix/send-keys",
       "dev": true,
       "requires": {
         "chai": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13121,8 +13121,8 @@
       }
     },
     "rv-common-e2e": {
-      "version": "git://github.com/Rise-Vision/rv-common-e2e.git#74435350d262f07a1d20a7cabe6233e9b1fabe2f",
-      "from": "git://github.com/Rise-Vision/rv-common-e2e.git#fix/send-keys",
+      "version": "git://github.com/Rise-Vision/rv-common-e2e.git#6cb186eb1d4f695b103157610e7b8aed8dc11f1c",
+      "from": "git://github.com/Rise-Vision/rv-common-e2e.git",
       "dev": true,
       "requires": {
         "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "rollup-plugin-node-resolve": "^5.0.3",
     "rollup-plugin-terser": "^5.0.0",
     "run-sequence": "^1.1.1",
-    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git#fix/send-keys",
+    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git",
     "terser": "^4.0.0",
     "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "rollup-plugin-node-resolve": "^5.0.3",
     "rollup-plugin-terser": "^5.0.0",
     "run-sequence": "^1.1.1",
-    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git",
+    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git#fix/send-keys",
     "terser": "^4.0.0",
     "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
   },

--- a/test/e2e/common/cases/homepage.js
+++ b/test/e2e/common/cases/homepage.js
@@ -33,12 +33,8 @@ var HomepageScenarios = function() {
       expect(signInPage.getSignInPageContainer().isPresent()).to.eventually.be.true;
     });
 
-    it('should sign in the user through google and load launch page',function(){
-      helper.wait(signInPage.getSignInGoogleLink(), 'Sign In Google Link');
-      signInPage.getSignInGoogleLink().click().then(function () {
-        googleAuthPage.signin();
-        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
-      });
+    it('should sign in the user and load launch page',function(){
+      signInPage.signIn();
 
       expect(homepage.getAppLauncherContainer().isDisplayed()).to.eventually.be.true;
     });
@@ -179,7 +175,7 @@ var HomepageScenarios = function() {
 
     after('Should sign out user', function() {
       helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
-      commonHeaderPage.signOut();
+      commonHeaderPage.signOut(true);
     });
   });
 };


### PR DESCRIPTION
## Description
Send keys to challenge input directly

Don't use google auth for homepage tests

[stage-19]

## Motivation and Context
Fix failing e2e tests. Reduce usage of the Google account authentication.

## How Has This Been Tested?
Validated that the e2e tests pass and that specific email challenge can be completed correctly

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No