### PR TITLE
Set Display Add to be a button

### DIFF
--- a/web/partials/displays/displays-list.html
+++ b/web/partials/displays/displays-list.html
@@ -6,10 +6,10 @@
   <h1 class="app-header-title" id="title" translate>displays-app.title</h1>
 
   <div class="ml-auto">
-    <a id="displayAddButton" class="btn btn-lg btn-primary" ng-click="displayFactory.addDisplayModal()">
+    <button id="displayAddButton" class="btn btn-lg btn-primary" ng-click="displayFactory.addDisplayModal()">
       {{ 'displays-app.actions.new' | translate }}
       <i class="fa fa-plus icon-right"></i>
-    </a>
+    </button>
   </div>
 </div>
 


### PR DESCRIPTION
## Description
Set Display Add to be a button
Fixes focus issues

[stage-19]

## Motivation and Context
Fix for #1377 

Note: Caused by using an `<a>` tag without a `href=` attribute. Setting `tabindex=0` would work as well, however this is consistent with the other pages where we use buttons.

## How Has This Been Tested?
Verified in the local environment that the button functions correctly

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No