### PR TITLE
Add time picker to date section of Counter component

### DIFF
--- a/test/e2e/template-editor/cases/components/counter.js
+++ b/test/e2e/template-editor/cases/components/counter.js
@@ -51,6 +51,22 @@ var CounterComponentScenarios = function () {
 
         expect(counterComponentPage.getTargetDate().getAttribute('value')).to.eventually.not.equal('');
 
+        helper.wait(counterComponentPage.getDateTimePickerButton(), 'Target time button');
+        counterComponentPage.getDateTimePickerButton().click();
+
+        helper.wait(counterComponentPage.getIncreaseHours('date'), 'Increase hours');
+        counterComponentPage.getIncreaseHours('date').click();
+        counterComponentPage.getIncreaseHours('date').click();
+        counterComponentPage.getIncreaseHours('date').click();
+
+        helper.wait(counterComponentPage.getDecreaseMinutes('date'), 'Decrease hours');
+        counterComponentPage.getDecreaseMinutes('date').click();
+
+        // Close time picker
+        counterComponentPage.getDateTimePickerButton().click();
+
+        expect(counterComponentPage.getTargetDateTime().getAttribute('value')).to.eventually.equal('03:59 PM');
+
         //wait for presentation to be auto-saved
         templateEditorPage.waitForAutosave();
       });
@@ -62,13 +78,13 @@ var CounterComponentScenarios = function () {
         helper.wait(counterComponentPage.getTimePickerButton(), 'Target time button');
         counterComponentPage.getTimePickerButton().click();
 
-        helper.wait(counterComponentPage.getIncreaseHours(), 'Increase hours');
-        counterComponentPage.getIncreaseHours().click();
+        helper.wait(counterComponentPage.getIncreaseHours('time'), 'Increase hours');
+        counterComponentPage.getIncreaseHours('time').click();
 
-        helper.wait(counterComponentPage.getDecreaseMinutes(), 'Decrease hours');
-        counterComponentPage.getDecreaseMinutes().click();
-        counterComponentPage.getDecreaseMinutes().click();
-        counterComponentPage.getDecreaseMinutes().click();
+        helper.wait(counterComponentPage.getDecreaseMinutes('time'), 'Decrease hours');
+        counterComponentPage.getDecreaseMinutes('time').click();
+        counterComponentPage.getDecreaseMinutes('time').click();
+        counterComponentPage.getDecreaseMinutes('time').click();
 
         // Close time picker
         counterComponentPage.getTimePickerButton().click();

--- a/test/e2e/template-editor/pages/components/counterComponentPage.js
+++ b/test/e2e/template-editor/pages/components/counterComponentPage.js
@@ -4,11 +4,11 @@ var CounterComponentPage = function() {
   var specificDateLabel = element(by.id('specificDateLabel'));
   var specificTimeLabel = element(by.id('specificTimeLabel'));
   var targetDate = element(by.id('targetDate'));
+  var targetDateTime = element(by.id('targetDateTime'));
   var targetTime = element(by.id('targetTime'));
   var datePickerButton = element(by.id('datePickerButton'));
+  var dateTimePickerButton = element(by.id('dateTimePickerButton'));
   var timePickerButton = element(by.id('timePickerButton'));
-  var increaseHours = element(by.css('[ng-click="increaseHours()"]'));
-  var decreaseMinutes = element(by.css('[ng-click="decreaseMinutes()"]'));
   var completionMessage = element(by.id('completionMessage'));
 
   this.getSpecificDateLabel = function () {
@@ -23,12 +23,20 @@ var CounterComponentPage = function() {
     return targetDate;
   };
 
+  this.getTargetDateTime = function () {
+    return targetDateTime;
+  };
+
   this.getTargetTime = function () {
     return targetTime;
   };
 
   this.getDatePickerButton = function () {
     return datePickerButton;
+  };
+
+  this.getDateTimePickerButton = function () {
+    return dateTimePickerButton;
   };
 
   this.getTimePickerButton = function () {
@@ -39,12 +47,12 @@ var CounterComponentPage = function() {
     return element(by.css('[ng-repeat="dt in row track by dt.date"]:nth-child(7) button'));
   };
 
-  this.getIncreaseHours = function () {
-    return increaseHours;
+  this.getIncreaseHours = function (section) {
+    return element(by.css('#' + section + 'Radio [ng-click="increaseHours()"]'));
   };
 
-  this.getDecreaseMinutes = function () {
-    return decreaseMinutes;
+  this.getDecreaseMinutes = function (section) {
+    return element(by.css('#' + section + 'Radio [ng-click="decreaseMinutes()"]'));
   };
 
   this.getCompletionMessage = function () {

--- a/test/unit/template-editor/components/directives/dtv-component-counter.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-counter.tests.js
@@ -64,8 +64,8 @@ describe('directive: templateComponentCounter', function() {
   describe('load', function () {
     function _initLoad(type, date, time) {
       $scope.getAvailableAttributeData = sandbox.stub();
-      $scope.getAvailableAttributeData.onCall(0).returns(date);
-      $scope.getAvailableAttributeData.onCall(1).returns(type);
+      $scope.getAvailableAttributeData.onCall(0).returns(type);
+      $scope.getAvailableAttributeData.onCall(1).returns(date);
       $scope.getAvailableAttributeData.onCall(2).returns(time);
     }
 
@@ -74,15 +74,32 @@ describe('directive: templateComponentCounter', function() {
 
       $scope.load();
 
-      expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('date');
-      expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('type');
+      expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('type');
+      expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('date');
       expect($scope.getAvailableAttributeData.getCall(2).args[1]).to.equal('time');
 
       var expectedDate = new Date('2019-10-25');
       expectedDate.setMinutes(expectedDate.getMinutes() + expectedDate.getTimezoneOffset());
 
       expect($scope.targetDate).to.deep.equal(expectedDate);
-      expect($scope.targetTime).to.equal(null);
+      expect($scope.targetDateTime).to.equal(null);
+      expect($scope.targetUnit).to.equal('targetDate');
+    });
+
+    it('should load the date and time', function () {
+      _initLoad('down', '2019-10-25', '15:27');
+
+      $scope.load();
+
+      expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('type');
+      expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('date');
+      expect($scope.getAvailableAttributeData.getCall(2).args[1]).to.equal('time');
+
+      var expectedDate = new Date('2019-10-25');
+      expectedDate.setMinutes(expectedDate.getMinutes() + expectedDate.getTimezoneOffset());
+
+      expect($scope.targetDate).to.deep.equal(expectedDate);
+      expect($scope.targetDateTime).to.equal('03:27 PM');
       expect($scope.targetUnit).to.equal('targetDate');
     });
 
@@ -91,8 +108,8 @@ describe('directive: templateComponentCounter', function() {
 
       $scope.load();
 
-      expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('date');
-      expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('type');
+      expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('type');
+      expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('date');
       expect($scope.getAvailableAttributeData.getCall(2).args[1]).to.equal('time');
 
       expect($scope.targetDate).to.not.be.ok;
@@ -114,6 +131,16 @@ describe('directive: templateComponentCounter', function() {
       expect($scope.setAttributeData.getCall(0).args[2]).to.equal('2019-10-25');
       expect($scope.setAttributeData.getCall(1).args[1]).to.equal('time');
       expect($scope.setAttributeData.getCall(1).args[2]).to.equal(null);
+    });
+
+    it('should save the date and time', function () {
+      $scope.targetDateTime = '03:27 PM';
+      $scope.targetUnit = 'targetDate';
+      $scope.save();
+      expect($scope.setAttributeData.getCall(0).args[1]).to.equal('date');
+      expect($scope.setAttributeData.getCall(0).args[2]).to.equal('2019-10-25');
+      expect($scope.setAttributeData.getCall(1).args[1]).to.equal('time');
+      expect($scope.setAttributeData.getCall(1).args[2]).to.equal('15:27');
     });
 
     it('should only save the time', function () {

--- a/web/partials/template-editor/components/component-counter.html
+++ b/web/partials/template-editor/components/component-counter.html
@@ -26,7 +26,7 @@
           <button type="button" id="datePickerButton" class="btn btn-primary" ng-click="openDatePicker($event)"><i class="fa fa-calendar"></i></button>
         </span>
       </div>
-      <div class="input-group rise-date-picker radio-nested-input-group" ng-show="targetUnit == 'targetDate'">
+      <div class="input-group rise-date-picker radio-nested-input-group mt-3" ng-show="targetUnit == 'targetDate'">
         <input type="text"
                class="form-control"
                readonly="true"
@@ -34,12 +34,12 @@
                name="targetDateTime"
                ng-model="targetDateTime"
                ng-change="save()"
-               ng-click="openTimePicker($event)"
+               ng-click="openTimePicker($event, 'date')"
                time-picker-popup
                is-open="targetDateTimePicker.isOpen"
         />
         <span class="input-group-btn">
-          <button type="button" id="dateTimePickerButton" class="btn btn-primary" ng-click="openTimePicker($event)">
+          <button type="button" id="dateTimePickerButton" class="btn btn-primary" ng-click="openTimePicker($event, 'date')">
             <streamline-icon name="clock"></streamline-icon>
           </button>
         </span>

--- a/web/partials/template-editor/components/component-counter.html
+++ b/web/partials/template-editor/components/component-counter.html
@@ -2,7 +2,7 @@
   <div class="attribute-editor-row counter-container">
     <label ng-show="counterType == 'down'" class="u_margin-sm-top">Countdown to:</label>
     <label ng-show="counterType == 'up'" class="u_margin-sm-top">Count up from:</label>
-    <div class="radio">
+    <div class="radio" id="dateRadio">
       <input type="radio" ng-model="targetUnit" value="targetDate" id="specificDate" name="specificDate" ng-change="save()" aria-required="true" tabindex="1" required>
       <label for="specificDate" id="specificDateLabel">
         A specific date and time:
@@ -46,7 +46,7 @@
       </div>
     </div>
 
-    <div class="radio">
+    <div class="radio" id="timeRadio">
       <input type="radio" ng-model="targetUnit" value="targetTime" id="specificTime" name="specificTime" ng-change="save()" aria-required="true" tabindex="1" required>
       <label for="specificTime" id="specificTimeLabel">
         A specific time, every day:

--- a/web/partials/template-editor/components/component-counter.html
+++ b/web/partials/template-editor/components/component-counter.html
@@ -5,7 +5,7 @@
     <div class="radio">
       <input type="radio" ng-model="targetUnit" value="targetDate" id="specificDate" name="specificDate" ng-change="save()" aria-required="true" tabindex="1" required>
       <label for="specificDate" id="specificDateLabel">
-        A specific date:
+        A specific date and time:
       </label>
       <div class="input-group rise-date-picker radio-nested-input-group" ng-show="targetUnit == 'targetDate'">
         <input type="text"
@@ -24,6 +24,24 @@
                min-date="today"/>
         <span class="input-group-btn">
           <button type="button" id="datePickerButton" class="btn btn-primary" ng-click="openDatePicker($event)"><i class="fa fa-calendar"></i></button>
+        </span>
+      </div>
+      <div class="input-group rise-date-picker radio-nested-input-group" ng-show="targetUnit == 'targetDate'">
+        <input type="text"
+               class="form-control"
+               readonly="true"
+               id="targetDateTime"
+               name="targetDateTime"
+               ng-model="targetDateTime"
+               ng-change="save()"
+               ng-click="openTimePicker($event)"
+               time-picker-popup
+               is-open="targetDateTimePicker.isOpen"
+        />
+        <span class="input-group-btn">
+          <button type="button" id="dateTimePickerButton" class="btn btn-primary" ng-click="openTimePicker($event)">
+            <streamline-icon name="clock"></streamline-icon>
+          </button>
         </span>
       </div>
     </div>

--- a/web/scripts/template-editor/components/directives/dtv-component-counter.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-counter.js
@@ -22,6 +22,10 @@ angular.module('risevision.template-editor.directives')
                 initDate: null
               };
 
+              $scope.targetDateTimePicker = {
+                isOpen: false
+              };
+
               $scope.targetTimePicker = {
                 isOpen: false
               };
@@ -44,13 +48,15 @@ angular.module('risevision.template-editor.directives')
               });
 
               $scope.load = function () {
+                var counterType = $scope.getAvailableAttributeData($scope.componentId, 'type');
                 var targetDate = $scope.getAvailableAttributeData($scope.componentId, 'date');
+                var targetTime = $scope.getAvailableAttributeData($scope.componentId, 'time');
+                var nonCompletion = $scope.getAvailableAttributeData($scope.componentId, 'non-completion');
+                var completion = $scope.getAvailableAttributeData($scope.componentId, 'completion');
 
-                $scope.counterType = $scope.getAvailableAttributeData($scope.componentId, 'type');
-                $scope.targetTime = $scope.getAvailableAttributeData($scope.componentId, 'time');
-                $scope.nonCompletion = $scope.getAvailableAttributeData($scope.componentId,
-                  'non-completion') === '';
-                $scope.completionMessage = $scope.getAvailableAttributeData($scope.componentId, 'completion');
+                $scope.counterType = counterType;
+                $scope.nonCompletion = nonCompletion === '';
+                $scope.completionMessage = completion;
 
                 if (targetDate) {
                   var localDate = new Date(targetDate);
@@ -60,9 +66,11 @@ angular.module('risevision.template-editor.directives')
                   // Set init-date attribute to fix issue with Date initialization
                   // https://github.com/angular-ui/bootstrap/issues/5081
                   $scope.targetDatePicker.initDate = localDate;
+
                   $scope.targetDate = localDate;
-                } else if ($scope.targetTime) {
-                  $scope.targetTime = utils.absoluteTimeToMeridian($scope.targetTime);
+                  $scope.targetDateTime = utils.absoluteTimeToMeridian(targetTime);
+                } else if (targetTime) {
+                  $scope.targetTime = utils.absoluteTimeToMeridian(targetTime);
                   $scope.targetUnit = 'targetTime';
                 }
 
@@ -75,7 +83,8 @@ angular.module('risevision.template-editor.directives')
                   localDate.setMinutes(localDate.getMinutes() - localDate.getTimezoneOffset());
 
                   $scope.setAttributeData($scope.componentId, 'date', utils.formatISODate(localDate));
-                  $scope.setAttributeData($scope.componentId, 'time', null);
+                  $scope.setAttributeData($scope.componentId, 'time', utils.meridianTimeToAbsolute($scope
+                    .targetDateTime));
                 } else if ($scope.targetUnit === 'targetTime') {
                   $scope.setAttributeData($scope.componentId, 'date', null);
                   $scope.setAttributeData($scope.componentId, 'time', utils.meridianTimeToAbsolute($scope
@@ -94,11 +103,13 @@ angular.module('risevision.template-editor.directives')
                 $scope.targetDatePicker.isOpen = !$scope.targetDatePicker.isOpen;
               };
 
-              $scope.openTimePicker = function ($event) {
+              $scope.openTimePicker = function ($event, type) {
+                var picker = type === 'date' ? 'targetDateTimePicker' : 'targetTimePicker';
+
                 $event.preventDefault();
                 $event.stopPropagation();
 
-                $scope.targetTimePicker.isOpen = !$scope.targetTimePicker.isOpen;
+                $scope[picker].isOpen = !$scope[picker].isOpen;
               };
 
               function _registerDatePickerClosingWatch() {

--- a/web/scss/sections/template-editor-layout.scss
+++ b/web/scss/sections/template-editor-layout.scss
@@ -1329,6 +1329,7 @@ $maderio-green-disabled: #a2dbb2;
     height: 100px;
     text-align: center;
     background-color: $white;
+    z-index: 1;
 
     border: 1px solid rgba(0,0,0,.15);
     border-radius: 4px;


### PR DESCRIPTION
## Description
Adds a time picker to the date section of counter component.

## Motivation and Context
Several planned templates need users to provide a specific time on a given day.

## How Has This Been Tested?
Unit and e2e tests have been updated.

Functionality can be tested here: https://apps-stage-7.risevision.com/templates/edit/51c4a6c1-6aa8-4279-9d51-e3689f47c83a/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@stulees please review