### PR TITLE
Hide Save & Preview if user doesn't have content editor permission

### DIFF
--- a/test/unit/template-editor/controllers/ctr-template-editor.tests.js
+++ b/test/unit/template-editor/controllers/ctr-template-editor.tests.js
@@ -323,6 +323,17 @@ describe('controller: TemplateEditor', function() {
       expect(result).to.equal('common.saveBeforeLeave');
     });
 
+    it('should not notify unsaved changes when closing window if user is not Content Editor', function () {
+      userState.hasRole.returns(false);
+      factory.presentation.id = '1234';
+      factory.presentation.name = 'New Name';
+      $scope.$apply();
+      $timeout.flush();
+
+      var result = $window.onbeforeunload();
+      expect(result).to.equal(undefined);
+    });
+
     it('should not notify unsaved changes when closing window if there are no changes', function() {
       var result = $window.onbeforeunload();
       expect(result).to.equal(undefined);

--- a/web/partials/editor/toolbar.html
+++ b/web/partials/editor/toolbar.html
@@ -45,11 +45,11 @@
     <i class="fa fa-th icon-right"></i>
   </button>
   <span class="text-muted u_margin-left u_margin-right" ng-if="!factory.presentation.id" translate >editor-app.workspace.toolbar.or</span>
-  <button id="previewButton" ng-if="!hasUnsavedChanges" class="btn btn-primary" ng-click="factory.preview(factory.presentation.id)" ng-disabled="!factory.presentation.id">
+  <button id="previewButton" ng-if="!(hasUnsavedChanges && hasContentEditorRole())" class="btn btn-primary" ng-click="factory.preview(factory.presentation.id)" ng-disabled="!factory.presentation.id">
     {{'editor-app.workspace.toolbar.preview' | translate}}
     <i class="fa fa-play icon-right"></i>
   </button>
-  <button id="saveAndPreviewButton" class="btn btn-primary u_margin-left" ng-if="hasUnsavedChanges"  ng-click="factory.saveAndPreview()">
+  <button id="saveAndPreviewButton" class="btn btn-primary u_margin-left" ng-if="hasUnsavedChanges && hasContentEditorRole()"  ng-click="factory.saveAndPreview()">
     {{'editor-app.workspace.toolbar.saveAndPreview' | translate}}
     <i class="fa fa-play icon-right"></i>
   </button>

--- a/web/scripts/components/subscription-status/svc-subscription-status-factory.js
+++ b/web/scripts/components/subscription-status/svc-subscription-status-factory.js
@@ -37,10 +37,10 @@ angular.module('risevision.common.components.subscription-status.service')
             return null;
           });
       };
-      
+
       factory.check = function (productCode) {
         return factory.checkProductCode(productCode)
-          .then(function(statusItem) {
+          .then(function (statusItem) {
             if (statusItem.isSubscribed) {
               return $q.resolve(true);
             } else {

--- a/web/scripts/editor/controllers/ctr-workspace.js
+++ b/web/scripts/editor/controllers/ctr-workspace.js
@@ -107,7 +107,7 @@ angular.module('risevision.editor.controllers')
       });
 
       $window.onbeforeunload = function () {
-        if ($scope.hasUnsavedChanges) {
+        if ($scope.hasUnsavedChanges && $scope.hasContentEditorRole()) {
           return $filter('translate')('common.saveBeforeLeave');
         }
       };

--- a/web/scripts/editor/controllers/ctr-workspace.js
+++ b/web/scripts/editor/controllers/ctr-workspace.js
@@ -11,14 +11,18 @@ angular.module('risevision.editor.controllers')
   .controller('WorkspaceController', ['$scope', 'editorFactory',
     'artboardFactory', 'placeholderFactory', '$modal',
     '$templateCache', '$location', '$stateParams', '$window', 'RVA_URL',
-    'IGNORE_FIELDS', '$timeout', '$state', '$filter',
+    'IGNORE_FIELDS', '$timeout', '$state', '$filter', 'userState',
     function ($scope, editorFactory, artboardFactory, placeholderFactory,
       $modal, $templateCache, $location, $stateParams, $window,
-      RVA_URL, IGNORE_FIELDS, $timeout, $state, $filter) {
+      RVA_URL, IGNORE_FIELDS, $timeout, $state, $filter, userState) {
       $scope.factory = editorFactory;
       $scope.artboardFactory = artboardFactory;
       $scope.placeholderFactory = placeholderFactory;
       $scope.hasUnsavedChanges = false;
+
+      $scope.hasContentEditorRole = function () {
+        return userState.hasRole('ce');
+      };
 
       var _isEqualIgnoringFields = function (o1, o2) {
         if (typeof o1 === 'object') {
@@ -86,7 +90,7 @@ angular.module('risevision.editor.controllers')
           _bypass = false;
           return;
         }
-        if ($scope.hasUnsavedChanges && (toState.name !==
+        if ($scope.hasUnsavedChanges && $scope.hasContentEditorRole() && (toState.name !==
             'apps.editor.workspace.artboard' && toState.name !==
             'apps.editor.workspace.htmleditor')) {
           event.preventDefault();


### PR DESCRIPTION
## Description
Check if user has Content Editor permission and hide Save & Preview from Editor based on that.
Don't show unsaved Changes modal if user is not Content Editor.

## Motivation and Context
Improvement related to issue #1364.

## How Has This Been Tested?
Manually tested locally and on stage-1.
Sample user: dipiwed551@xmail2.net
https://apps-stage-1.risevision.com/editor/workspace/

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

@alex-deaconu Please review. Thanks