### PR TITLE
Reset Counter directive model values when blueprint data is not available

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-counter.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-counter.tests.js
@@ -116,6 +116,20 @@ describe('directive: templateComponentCounter', function() {
       expect($scope.targetTime).to.equal('06:30 PM');
       expect($scope.targetUnit).to.equal('targetTime');
     });
+
+    it('should not load anything', function () {
+      _initLoad('down', null, null);
+
+      $scope.load();
+
+      expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('type');
+      expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('date');
+      expect($scope.getAvailableAttributeData.getCall(2).args[1]).to.equal('time');
+
+      expect($scope.targetDate).to.not.be.ok;
+      expect($scope.targetDateTime).to.not.be.ok;
+      expect($scope.targetUnit).to.not.be.ok;
+    });
   });
 
   describe('save', function () {

--- a/web/scripts/template-editor/components/directives/dtv-component-counter.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-counter.js
@@ -72,6 +72,10 @@ angular.module('risevision.template-editor.directives')
                 } else if (targetTime) {
                   $scope.targetTime = utils.absoluteTimeToMeridian(targetTime);
                   $scope.targetUnit = 'targetTime';
+                } else {
+                  $scope.targetDate = null;
+                  $scope.targetTime = null;
+                  $scope.targetUnit = null;
                 }
 
                 _registerDatePickerClosingWatch();


### PR DESCRIPTION
## Description
Resets Counter directive values if blueprint data is not available or is null.

## Motivation and Context
Entering a counter instance with valid data first, then entering an instance without data, would cause the date of the first instance in the second instance's UI

## How Has This Been Tested?
It can be tested here: https://apps-stage-7.risevision.com/templates/edit/a3ada9f6-57d1-43cb-b4a8-53325d2d0413/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@stulees please review
