### PR TITLE
Do not save invalid Counter date

### DIFF
--- a/test/e2e/template-editor/cases/components/counter.js
+++ b/test/e2e/template-editor/cases/components/counter.js
@@ -36,7 +36,7 @@ var CounterComponentScenarios = function () {
         expect(counterComponentPage.getSpecificDateLabel().isEnabled()).to.eventually.be.true;
         expect(counterComponentPage.getSpecificTimeLabel().isEnabled()).to.eventually.be.true;
         expect(counterComponentPage.getTargetDate().getAttribute('value')).to.eventually.equal('');
-        expect(counterComponentPage.getTargetTime().getAttribute('value')).to.eventually.equal('12:00 PM');
+        expect(counterComponentPage.getTargetTime().getAttribute('value')).to.eventually.equal('12:00 AM');
       });
 
       it('should select a date', function () {
@@ -65,7 +65,7 @@ var CounterComponentScenarios = function () {
         // Close time picker
         counterComponentPage.getDateTimePickerButton().click();
 
-        expect(counterComponentPage.getTargetDateTime().getAttribute('value')).to.eventually.equal('03:59 PM');
+        expect(counterComponentPage.getTargetDateTime().getAttribute('value')).to.eventually.equal('03:59 AM');
 
         //wait for presentation to be auto-saved
         templateEditorPage.waitForAutosave();
@@ -89,7 +89,7 @@ var CounterComponentScenarios = function () {
         // Close time picker
         counterComponentPage.getTimePickerButton().click();
 
-        expect(counterComponentPage.getTargetTime().getAttribute('value')).to.eventually.equal('01:57 PM');
+        expect(counterComponentPage.getTargetTime().getAttribute('value')).to.eventually.equal('01:57 AM');
 
         //wait for presentation to be auto-saved
         templateEditorPage.waitForAutosave();
@@ -108,7 +108,7 @@ var CounterComponentScenarios = function () {
         presentationsListPage.loadPresentation(presentationName);
         templateEditorPage.selectComponent(componentLabel);
         expect(counterComponentPage.getTargetDate().getAttribute('value')).to.eventually.equal('');
-        expect(counterComponentPage.getTargetTime().getAttribute('value')).to.eventually.equal('01:57 PM');
+        expect(counterComponentPage.getTargetTime().getAttribute('value')).to.eventually.equal('01:57 AM');
         expect(counterComponentPage.getCompletionMessage().getAttribute('value')).to.eventually.equal('Test message');
       });
     });

--- a/test/unit/template-editor/components/directives/dtv-component-counter.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-counter.tests.js
@@ -135,6 +135,7 @@ describe('directive: templateComponentCounter', function() {
   describe('save', function () {
     beforeEach(function () {
       $scope.targetDate = 'October 25, 2019';
+      $scope.targetDateTime = '06:30 PM';
       $scope.targetTime = '06:30 PM';
     });
 
@@ -162,7 +163,7 @@ describe('directive: templateComponentCounter', function() {
       expect($scope.setAttributeData.getCall(0).args[1]).to.equal('date');
       expect($scope.setAttributeData.getCall(0).args[2]).to.equal('2019-10-25');
       expect($scope.setAttributeData.getCall(1).args[1]).to.equal('time');
-      expect($scope.setAttributeData.getCall(1).args[2]).to.equal(null);
+      expect($scope.setAttributeData.getCall(1).args[2]).to.equal('18:30');
     });
 
     it('should save the date and time', function () {

--- a/test/unit/template-editor/components/directives/dtv-component-counter.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-counter.tests.js
@@ -138,6 +138,24 @@ describe('directive: templateComponentCounter', function() {
       $scope.targetTime = '06:30 PM';
     });
 
+    it('should not save date if null', function () {
+      $scope.targetDate = null;
+      $scope.targetTime = null;
+      $scope.targetUnit = 'targetDate';
+
+      $scope.save();
+      expect($scope.setAttributeData).to.have.not.been.called;
+    });
+
+    it('should not save time if null', function () {
+      $scope.targetDate = null;
+      $scope.targetTime = null;
+      $scope.targetUnit = 'targetTime';
+
+      $scope.save();
+      expect($scope.setAttributeData).to.have.not.been.called;
+    });
+
     it('should only save the date', function () {
       $scope.targetUnit = 'targetDate';
       $scope.save();

--- a/test/unit/template-editor/directives/dtv-time-picker.tests.js
+++ b/test/unit/template-editor/directives/dtv-time-picker.tests.js
@@ -23,6 +23,13 @@ describe('directive: time-picker', function() {
     expect($scope.updateTime).is.a.function;
   });
 
+  it('should initialize time even if provided value is not valid', function () {
+    $scope.time = 'invalid date';
+    $scope.$digest();
+    expect($scope.hours).to.equal(12);
+    expect($scope.minutes).to.equal(0);
+  });
+
   describe('operations', function() {
     beforeEach(function () {
       $scope.time = '11:59 PM';

--- a/web/scripts/template-editor/components/directives/dtv-component-counter.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-counter.js
@@ -83,16 +83,17 @@ angular.module('risevision.template-editor.directives')
 
               $scope.save = function () {
                 if ($scope.targetUnit === 'targetDate') {
+                  var formattedDateTime = utils.meridianTimeToAbsolute($scope.targetDateTime);
                   var localDate = new Date($scope.targetDate);
                   localDate.setMinutes(localDate.getMinutes() - localDate.getTimezoneOffset());
 
                   $scope.setAttributeData($scope.componentId, 'date', utils.formatISODate(localDate));
-                  $scope.setAttributeData($scope.componentId, 'time', utils.meridianTimeToAbsolute($scope
-                    .targetDateTime));
-                } else if ($scope.targetUnit === 'targetTime') {
+                  $scope.setAttributeData($scope.componentId, 'time', formattedDateTime);
+                } else if ($scope.targetUnit === 'targetTime' && $scope.targetTime) {
+                  var formattedTime = utils.meridianTimeToAbsolute($scope.targetTime);
+
                   $scope.setAttributeData($scope.componentId, 'date', null);
-                  $scope.setAttributeData($scope.componentId, 'time', utils.meridianTimeToAbsolute($scope
-                    .targetTime));
+                  $scope.setAttributeData($scope.componentId, 'time', formattedTime);
                 }
 
                 if ($scope.counterType === 'down' && !$scope.nonCompletion) {

--- a/web/scripts/template-editor/components/directives/dtv-component-counter.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-counter.js
@@ -82,7 +82,7 @@ angular.module('risevision.template-editor.directives')
               };
 
               $scope.save = function () {
-                if ($scope.targetUnit === 'targetDate') {
+                if ($scope.targetUnit === 'targetDate' && $scope.targetDate && $scope.targetDateTime) {
                   var formattedDateTime = utils.meridianTimeToAbsolute($scope.targetDateTime);
                   var localDate = new Date($scope.targetDate);
                   localDate.setMinutes(localDate.getMinutes() - localDate.getTimezoneOffset());

--- a/web/scripts/template-editor/directives/dtv-time-picker.js
+++ b/web/scripts/template-editor/directives/dtv-time-picker.js
@@ -19,7 +19,7 @@ angular.module('risevision.template-editor.directives')
               $scope.minutes = Math.min(_minutes, 59);
               $scope.meridian = parts[3];
             } else {
-              $scope.time = '12:00 PM';
+              $scope.time = '12:00 AM';
             }
           });
 


### PR DESCRIPTION
## Description
Validates a date was entered before saving it. Default time is `12:00 AM` instead of `12:00 PM`. 

## Motivation and Context
Fixes minor issues.

## How Has This Been Tested?
It can be tested here (the instances are empty in purpose, to be able to validate the changes): https://apps-stage-7.risevision.com/templates/edit/217bc8c4-6021-4144-9cf0-38297fd726a8/?cid=87977ab8-38b6-47fb-ad5e-256b8cc4b46d

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@stulees please review
