### PR TITLE
Hide classic editor link for new companies

### DIFF
--- a/test/unit/common-header/directives/dtv-classic-editor-link-spec.js
+++ b/test/unit/common-header/directives/dtv-classic-editor-link-spec.js
@@ -1,0 +1,76 @@
+/*jshint expr:true */
+
+"use strict";
+describe("directive: classic editor link", function() {
+  beforeEach(module("risevision.common.header.directives"));
+
+  var $scope, elem, $window, userState;
+  beforeEach(module(function ($provide) {
+    $provide.service("userState", function() {
+      return {
+        getSelectedCompanyId: function() {
+          return "aa";
+        },
+        getCopyOfSelectedCompany: sinon.stub().returns({}),
+        _restoreState: function() {}
+      };
+    });
+
+  }));
+
+  beforeEach(inject(function($injector, $compile, $rootScope) {
+    $window = $injector.get("$window");
+    userState = $injector.get("userState");
+
+    elem = angular.element("<div classic-editor-link ng-hide=\"hideEditorLink\"><a>mock</a></div>");
+
+    $scope = $rootScope.$new();
+    $compile(elem)($scope);
+    $scope.$digest();
+  }));
+
+  it("should populate html", function() {
+    expect(elem[0].outerHTML).to.equal("<div classic-editor-link=\"\" ng-hide=\"hideEditorLink\" class=\"ng-scope\"><a>mock</a></div>");
+  });
+
+  it("should handle click event and open classic editor", function() {
+    sinon.stub($window, 'open');
+
+    var link = elem.find('a');
+
+    link.click();
+
+    $window.open.should.have.been.calledWith('https://rva.risevision.com/#PRESENTATIONS?cid=aa', '_blank');
+  });
+
+  describe("hideEditorLink:", function() {
+    it("should refresh hideEditorLink value on company change", function() {
+      userState.getCopyOfSelectedCompany.returns({
+        creationDate: new Date('Dec 29, 2019')
+      });
+
+      expect(elem.scope().hideEditorLink).to.be.undefined;
+
+      $scope.$broadcast("risevision.company.selectedCompanyChanged");
+      $scope.$digest();
+
+      expect(elem.scope().hideEditorLink).to.be.true;
+
+      expect(elem[0].outerHTML).to.equal("<div classic-editor-link=\"\" ng-hide=\"hideEditorLink\" class=\"ng-scope ng-hide\"><a>mock</a></div>");
+    });
+    
+    it("should not hideEditorLink if the company was created before the release date", function() {
+      userState.getCopyOfSelectedCompany.returns({
+        creationDate: new Date('Oct 29, 2019')
+      });
+
+      $scope.$broadcast("risevision.company.selectedCompanyChanged");
+      $scope.$digest();
+
+      expect(elem.scope().hideEditorLink).to.be.false;
+
+      expect(elem[0].outerHTML).to.equal("<div classic-editor-link=\"\" ng-hide=\"hideEditorLink\" class=\"ng-scope\"><a>mock</a></div>");
+    });
+    
+  });
+});

--- a/web/partials/common-header/app-nav-buttons-menu.html
+++ b/web/partials/common-header/app-nav-buttons-menu.html
@@ -27,8 +27,8 @@
       </a>
   </li>
 
-   <li>
-      <a href="#" class="old-app" classic-editor-link>
+   <li classic-editor-link ng-hide="hideEditorLink">
+      <a href="#" class="old-app">
         <div class="image"><img src="https://s3.amazonaws.com/Rise-Images/landing-page/editor-image-gray.png"></div>
         <span>Classic Editor</span>
       </a>

--- a/web/scripts/common-header/directives/dtv-classic-editor-link.js
+++ b/web/scripts/common-header/directives/dtv-classic-editor-link.js
@@ -6,16 +6,27 @@ angular.module('risevision.common.header.directives')
     function ($window, userState, CLASSIC_EDITOR_URL) {
       return {
         restrict: 'A',
-        scope: false,
-        compile: function (elem) {
-          elem.bind('click', function () {
+        scope: true,
+        link: function ($scope, elem) {
+          var editorLink = elem.find('a');
+          
+          editorLink.bind('click', function () {
             var companyId = userState.getSelectedCompanyId();
             var url = CLASSIC_EDITOR_URL + (companyId ? '?cid=' + companyId : '');
 
             $window.open(url, '_blank');
-
           });
 
+          var _isShowingLink = function() {
+            var company = userState.getCopyOfSelectedCompany();
+            var creationDate = ((company && company.creationDate) ? (new Date(company.creationDate)) : (
+              new Date()));
+            $scope.hideEditorLink = creationDate > new Date('Nov 25, 2019');
+          };
+
+          $scope.$on('risevision.company.selectedCompanyChanged', function () {
+            _isShowingLink();
+          });
         } //link()
       };
     }


### PR DESCRIPTION
## Description
Hide classic editor link for new companies

[stage-18]

## Motivation and Context
Reduce confusion and the amount of new users having access to the classic editor.

## How Has This Been Tested?
Validated changes with Companies created before and after the specific date.
Validated that the link still works correcly when it's being shown.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
