### PR TITLE
Show Time and Date component title according to instance type

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-time-date.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-time-date.tests.js
@@ -46,4 +46,15 @@ describe('directive: templateComponentTimeDate', function() {
     expect(directive.show).to.be.a('function');
   });
 
+  it('should return the correct title', function () {
+    var directive = $scope.registerDirective.getCall(0).args[0];
+    var timeDateInstance = { attributes: { type: { value: 'timedate' } } };
+    var timeInstance = { attributes: { type: { value: 'time' } } };
+    var dateInstance = { attributes: { type: { value: 'date' } } };
+
+    expect(directive.getTitle(timeDateInstance)).to.equal('template.rise-time-date-timedate');
+    expect(directive.getTitle(timeInstance)).to.equal('template.rise-time-date-time');
+    expect(directive.getTitle(dateInstance)).to.equal('template.rise-time-date-date');
+  });
+
 });

--- a/web/locales/en/template.json
+++ b/web/locales/en/template.json
@@ -73,5 +73,8 @@
   "rise-data-weather": "Weather",
   "rise-slides": "Google Slides",
   "rise-text": "Text",
+  "rise-time-date-timedate": "Time and Date",
+  "rise-time-date-time": "Time",
+  "rise-time-date-date": "Date",
   "rise-video": "Video"
 }

--- a/web/scripts/template-editor/components/directives/dtv-component-time-date.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-time-date.js
@@ -18,6 +18,9 @@ angular.module('risevision.template-editor.directives')
             show: function () {
               element.show();
               $scope.componentId = $scope.factory.selected.id;
+            },
+            getTitle: function (component) {
+              return 'template.rise-time-date' + '-' + component.attributes.type.value;
             }
           });
 


### PR DESCRIPTION
## Description
Updates the Time and Date instance's title according to its type. 

## Motivation and Context
Needed to show the correct title.

## How Has This Been Tested?
Can be tested here: https://apps-stage-7.risevision.com/templates/edit/83f6c3c1-16c8-4c66-8faa-3b347ac7d816/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No

@stulees please review