### PR TITLE
Require at least one billing contact if field is touched

### DIFF
--- a/test/unit/common-header/directives/dtv-emails-field-spec.js
+++ b/test/unit/common-header/directives/dtv-emails-field-spec.js
@@ -10,7 +10,7 @@ describe("directive: emails field", function() {
     $scope = $rootScope.$new();
     var validHTML = 
       "<form name=\"form\">" +
-      "  <emails-field ng-model=\"display.monitoringEmails\" />" +
+      "  <emails-field name=\"monitoringEmails\" ng-model=\"display.monitoringEmails\" require-emails-on-change=\"true\" />" +
       "</form>";
     $scope.display = { 
     };
@@ -29,6 +29,29 @@ describe("directive: emails field", function() {
       expect(elemScope.emailsList.length).to.equal(2);
       expect(elemScope.emailsList[0].text).to.equal("email1@test.com");
       done();
+    });
+  });
+
+  describe('requireEmailsOnChange:', function(){
+    it('should set error on empty emails list',function(){
+      $scope.display.monitoringEmails = [];
+      $scope.$digest();
+      elemScope.updateModel();
+      expect(form.monitoringEmails.$error['require-emails']).to.be.true;
+    });
+
+    it('should set error on undefined list',function(){
+      $scope.display.monitoringEmails = undefined;
+      $scope.$digest();
+      elemScope.updateModel();
+      expect(form.monitoringEmails.$error['require-emails']).to.be.true;
+    });
+
+    it('should not set error when at least one email is provided',function(){
+      $scope.display.monitoringEmails = ["email1@test.com"];
+      $scope.$digest();
+      elemScope.updateModel();
+      expect(form.monitoringEmails.$error['require-emails']).to.be.undefined;
     });
   });
 

--- a/web/partials/common-header/company-fields.html
+++ b/web/partials/common-header/company-fields.html
@@ -121,7 +121,11 @@
     <option value="{{c[1]}}" ng-repeat="c in timezones">{{c[0]}}</option>
   </select>
 </div>
-<div class="form-group" ng-show="company.isChargebee">
+<div class="form-group" ng-show="company.isChargebee" ng-class="{'has-error': forms.companyForm.billingContactEmails.$invalid}">
   <label class="form-control-label">Billing Notifications Email</label>
-  <emails-field ng-model="company.billingContactEmails" />
+  <emails-field name="billingContactEmails" ng-model="company.billingContactEmails" require-emails-on-change="true"></emails-field>
+  <ng-messages role="alert" for="forms.companyForm.billingContactEmails.$error">
+    <p ng-message="emails" class="help-block">Please provide a valid email.</p>
+    <p ng-message="require-emails" class="help-block">Please enter at least one email.</p>
+  </ng-messages>
 </div>

--- a/web/scripts/common-header/directives/dtv-emails-field.js
+++ b/web/scripts/common-header/directives/dtv-emails-field.js
@@ -10,7 +10,8 @@ angular.module('risevision.common.header.directives')
         restrict: 'E',
         require: 'ngModel',
         scope: {
-          emails: '=ngModel'
+          emails: '=ngModel',
+          requireEmailsOnChange: '='
         },
         template: $templateCache.get('partials/common-header/emails-field.html'),
         link: function ($scope, elem, attr, ngModel) {
@@ -34,6 +35,7 @@ angular.module('risevision.common.header.directives')
               $timeout(function () {
                 if (spanField.text() === 'Add an email') {
                   _setValid(true);
+                  _checkRequireEmailsOnChange();
                   $scope.$digest();
                 }
               });
@@ -56,6 +58,7 @@ angular.module('risevision.common.header.directives')
             _setValid(true);
             updatingEmails = true;
             $scope.emails = _emailsModelToStrings();
+            _checkRequireEmailsOnChange();
           };
 
           $scope.invalidateModel = function () {
@@ -71,6 +74,14 @@ angular.module('risevision.common.header.directives')
                 .text) ===
               -1);
           };
+
+          function _checkRequireEmailsOnChange() {
+            if ($scope.requireEmailsOnChange && (!$scope.emails || $scope.emails.length < 1)) {
+              ngModel.$setValidity('require-emails', false);
+            } else {
+              ngModel.$setValidity('require-emails', true);
+            }
+          }
 
           function _emailsModelToStrings() {
             return $scope.emailsList.map(function (t) {


### PR DESCRIPTION
## Description
Require at least one billing contact if field is touched
The idea is to allow saving the Company if field has not been provided yet, but require it if there are already existing contacts.

## Motivation and Context
Additional task re. Rise-Vision/rise-vision-apps#1376

## How Has This Been Tested?
Manually tested on stage-1.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
