### PR TITLE
Add date format UI

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -30,7 +30,8 @@
     "expect": false,
     "it": false,
     "inject": false,
-    "Draggable": false
+    "Draggable": false,
+    "moment": false
   },
   "predef":["angular","_"]
 }

--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,8 @@
     "Sortable": "^1.4.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git",
-    "xmlToJSON.js": "^1.3.2"
+    "xmlToJSON.js": "^1.3.2",
+    "moment": "^2.24.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.7.0",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -73,6 +73,7 @@ var unitTestFiles = [
   "web/bower_components/widget-settings-ui-components/dist/js/angular/tooltip.js",
   "web/bower_components/widget-settings-ui-components/dist/js/angular/file-selector.js",
   "web/bower_components/widget-settings-ui-components/dist/js/angular/widget-button-toolbar.js",
+  "web/bower_components/moment/moment.js",
   "node_modules/widget-tester/mocks/translate-mock.js",
   "web/tmp/partials.js",
   "web/scripts/components/**/*.js",

--- a/test/unit/template-editor/components/directives/dtv-component-time-date.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-time-date.tests.js
@@ -57,4 +57,8 @@ describe('directive: templateComponentTimeDate', function() {
     expect(directive.getTitle(dateInstance)).to.equal('template.rise-time-date-date');
   });
 
+
+  it('should load the correct list of formats', function () {
+    expect($scope.dateFormats.length).to.equal(4);
+  });
 });

--- a/web/index.html
+++ b/web/index.html
@@ -86,6 +86,7 @@
   <script src="bower_components/angular-md5/angular-md5.min.js"></script>
   <script src="bower_components/angular-local-storage/dist/angular-local-storage.js"></script>
   <script src="bower_components/angular-messages/angular-messages.js"></script>
+  <script src="bower_components/moment/moment.js"></script>
 
   <!-- misc dependencies -->
   <script src="vendor/@shopify/draggable/draggable.bundle.js"></script>

--- a/web/partials/template-editor/components/component-time-date.html
+++ b/web/partials/template-editor/components/component-time-date.html
@@ -1,3 +1,13 @@
-<div>
-  Time & Date settings
+<div class="attribute-editor-component">
+  <div class="attribute-editor-row" ng-show="type === 'timedate' || type === 'date'">
+    <div class="form-group">
+      <label class="control-label" for="te-td-date-format">Date format:</label>
+      <select id="te-td-date-format"
+              class="form-control"
+              ng-model="dateFormat"
+              ng-options="df.format as df.date for df in dateFormats"
+              ng-change="saveChanges()">
+      </select>
+    </div>
+  </div>
 </div>

--- a/web/scripts/template-editor/components/directives/dtv-component-time-date.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-time-date.js
@@ -8,7 +8,16 @@ angular.module('risevision.template-editor.directives')
         scope: true,
         templateUrl: 'partials/template-editor/components/component-time-date.html',
         link: function ($scope, element) {
+          var DATE_FORMATS = [ 'MMMM DD, YYYY', 'MMM DD YYYY', 'MM/DD/YYYY', 'DD/MM/YYYY' ];
+
           $scope.factory = templateEditorFactory;
+          $scope.dateFormats = DATE_FORMATS.map(function (format) {
+            return {
+              format: format,
+              date: moment().format(format)
+            };
+          });
+          $scope.dateFormat = $scope.dateFormats[0].format;
 
           $scope.registerDirective({
             type: 'rise-time-date',
@@ -18,12 +27,22 @@ angular.module('risevision.template-editor.directives')
             show: function () {
               element.show();
               $scope.componentId = $scope.factory.selected.id;
+              $scope.load();
             },
             getTitle: function (component) {
               return 'template.rise-time-date' + '-' + component.attributes.type.value;
             }
           });
 
+          $scope.load = function () {
+            var type = $scope.getAvailableAttributeData($scope.componentId, 'type');
+
+            $scope.type = type;
+          };
+
+          $scope.saveChanges = function () {
+
+          };
         }
       };
     }


### PR DESCRIPTION
## Description
Adds the date component with the valid formatting options (copied from the existing widget). This section is only displayed for `timedate` and `date`.

## Motivation and Context
It's part of our epic.

Actually, I messed up and implemented a card that did not belong to this spring. I'm requesting review anyway to avoid wasting the effort. I will branch off from this task to actually implement the Time UI that I was supposed to.

## How Has This Been Tested?
It can be tested here: https://apps-stage-7.risevision.com/templates/edit/722d3c1b-19cd-4c11-a7ac-18461632fb96/?cid=87977ab8-38b6-47fb-ad5e-256b8cc4b46d

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@stulees please review