### PR TITLE
Save time and date formats to attribute data

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-time-date.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-time-date.tests.js
@@ -3,7 +3,8 @@
 describe('directive: templateComponentTimeDate', function() {
   var $scope,
     element,
-    factory;
+    factory,
+    sandbox = sinon.sandbox.create();
 
   beforeEach(function() {
     factory = { selected: { id: "TEST-ID" } };
@@ -32,6 +33,10 @@ describe('directive: templateComponentTimeDate', function() {
     $scope.$digest();
   }));
 
+  afterEach(function () {
+    sandbox.restore();
+  });
+
   it('should exist', function() {
     expect($scope).to.be.ok;
     expect($scope.factory).to.be.ok;
@@ -57,8 +62,111 @@ describe('directive: templateComponentTimeDate', function() {
     expect(directive.getTitle(dateInstance)).to.equal('template.rise-time-date-date');
   });
 
+  describe('load', function () {
+    function _initLoad(type, time, date) {
+      $scope.getAvailableAttributeData = sandbox.stub();
+      $scope.getAvailableAttributeData.onCall(0).returns(type);
+      $scope.getAvailableAttributeData.onCall(1).returns(time);
+      $scope.getAvailableAttributeData.onCall(2).returns(date);
+    }
 
-  it('should load the correct list of formats', function () {
-    expect($scope.dateFormats.length).to.equal(4);
+    it('should load the correct list of date formats', function () {
+      expect($scope.dateFormats.length).to.equal(4);
+    });
+
+    it('should initialize the time format from data', function () {
+      _initLoad('time', 'Hours24', null);
+
+      $scope.load();
+
+      expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('type');
+      expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('time');
+      expect($scope.getAvailableAttributeData.getCall(2).args[1]).to.equal('date');
+
+      expect($scope.type).to.equal('time');
+      expect($scope.dateFormat).to.not.be.ok;
+      expect($scope.timeFormat).to.equal('Hours24');
+    });
+
+    it('should initialize the date format from data', function () {
+      _initLoad('date', null, 'DD/MM/YYYY');
+
+      $scope.load();
+
+      expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('type');
+      expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('time');
+      expect($scope.getAvailableAttributeData.getCall(2).args[1]).to.equal('date');
+
+      expect($scope.type).to.equal('date');
+      expect($scope.timeFormat).to.not.be.ok;
+      expect($scope.dateFormat).to.equal('DD/MM/YYYY');
+    });
+
+    it('should initialize the date and time formats from data', function () {
+      _initLoad('timedate', 'Hours24', 'MMM DD YYYY');
+
+      $scope.load();
+
+      expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('type');
+      expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('time');
+      expect($scope.getAvailableAttributeData.getCall(2).args[1]).to.equal('date');
+
+      expect($scope.type).to.equal('timedate');
+      expect($scope.timeFormat).to.equal('Hours24');
+      expect($scope.dateFormat).to.equal('MMM DD YYYY');
+    });
+
+    it('should initialize time and date formats with default values', function () {
+      _initLoad('timedate', null, null);
+
+      $scope.load();
+
+      expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('type');
+      expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('time');
+      expect($scope.getAvailableAttributeData.getCall(2).args[1]).to.equal('date');
+
+      expect($scope.type).to.equal('timedate');
+      expect($scope.timeFormat).to.equal('Hours12');
+      expect($scope.dateFormat).to.equal('MMMM DD, YYYY');
+    });
   });
+
+  describe('save', function () {
+    beforeEach(function () {
+      $scope.type = 'timedate';
+      $scope.timeFormat = 'Hours12';
+      $scope.dateFormat = 'MMMM DD, YYYY';
+    });
+
+    it('should only save time format and not save date format if type is "time"', function () {
+      $scope.type = 'time';
+      $scope.timeFormat = 'Hours24';
+
+      $scope.save();
+      expect($scope.setAttributeData.getCall(0).args[1]).to.equal('time');
+      expect($scope.setAttributeData.getCall(0).args[2]).to.equal('Hours24');
+      expect($scope.setAttributeData.getCall(1)).to.not.be.ok;
+    });
+
+    it('should only save date format and not save time format if type is "date"', function () {
+      $scope.type = 'date';
+      $scope.dateFormat = 'DD/MM/YYYY';
+
+      $scope.save();
+      expect($scope.setAttributeData.getCall(0).args[1]).to.equal('date');
+      expect($scope.setAttributeData.getCall(0).args[2]).to.equal('DD/MM/YYYY');
+      expect($scope.setAttributeData.getCall(1)).to.not.be.ok;
+    });
+
+    it('should save the time and date formats', function () {
+      $scope.save();
+
+      expect($scope.setAttributeData.getCall(0).args[1]).to.equal('time');
+      expect($scope.setAttributeData.getCall(0).args[2]).to.equal('Hours12');
+      expect($scope.setAttributeData.getCall(1).args[1]).to.equal('date');
+      expect($scope.setAttributeData.getCall(1).args[2]).to.equal('MMMM DD, YYYY');
+    });
+
+  });
+
 });

--- a/web/partials/template-editor/components/component-time-date.html
+++ b/web/partials/template-editor/components/component-time-date.html
@@ -6,7 +6,7 @@
               class="form-control"
               ng-model="dateFormat"
               ng-options="df.format as df.date for df in dateFormats"
-              ng-change="saveChanges()">
+              ng-change="save()">
       </select>
     </div>
   </div>
@@ -14,15 +14,15 @@
     <label class="u_margin-sm-top mb-0">Time format:</label>
 
     <div class="radio" id="time12HoursRadio">
-      <input type="radio" ng-model="timeFormat" value="time12Hours" id="time12Hours" name="time12Hours" ng-change="save()" aria-required="true" required>
-      <label for="time12Hours" id="time12HoursLabel">
+      <input type="radio" ng-model="timeFormat" value="Hours12" id="Hours12" name="Hours12" ng-change="save()" aria-required="true" required>
+      <label for="Hours12" id="Hours12Label">
         12 hour.
       </label>
     </div>
 
     <div class="radio" id="time24HoursRadio">
-      <input type="radio" ng-model="timeFormat" value="time24Hours" id="time24Hours" name="time24Hours" ng-change="save()" aria-required="true" required>
-      <label for="time24Hours" id="time24HoursLabel">
+      <input type="radio" ng-model="timeFormat" value="Hours24" id="Hours24" name="Hours24" ng-change="save()" aria-required="true" required>
+      <label for="Hours24" id="Hours24Label">
         24 hour.
       </label>
     </div>

--- a/web/scripts/template-editor/components/directives/dtv-component-time-date.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-time-date.js
@@ -8,7 +8,7 @@ angular.module('risevision.template-editor.directives')
         scope: true,
         templateUrl: 'partials/template-editor/components/component-time-date.html',
         link: function ($scope, element) {
-          var DATE_FORMATS = [ 'MMMM DD, YYYY', 'MMM DD YYYY', 'MM/DD/YYYY', 'DD/MM/YYYY' ];
+          var DATE_FORMATS = ['MMMM DD, YYYY', 'MMM DD YYYY', 'MM/DD/YYYY', 'DD/MM/YYYY'];
 
           $scope.factory = templateEditorFactory;
           $scope.dateFormats = DATE_FORMATS.map(function (format) {
@@ -37,32 +37,32 @@ angular.module('risevision.template-editor.directives')
             var type = $scope.getAvailableAttributeData($scope.componentId, 'type');
             var timeFormat = $scope.getAvailableAttributeData($scope.componentId, 'time');
             var dateFormat = $scope.getAvailableAttributeData($scope.componentId, 'date');
-            var timeFormatVal = timeFormat || "Hours12";
+            var timeFormatVal = timeFormat || 'Hours12';
             var dateFormatVal = dateFormat || $scope.dateFormats[0].format;
 
             $scope.type = type;
 
-            if ( $scope.type === "time" ) {
-              return $scope.timeFormat = timeFormatVal;
+            if ($scope.type === 'time') {
+              $scope.timeFormat = timeFormatVal;
             }
 
-            if ( $scope.type === "date" ) {
-              return $scope.dateFormat = dateFormatVal;
+            if ($scope.type === 'date') {
+              $scope.dateFormat = dateFormatVal;
             }
 
-            if ( $scope.type === "timedate" ) {
+            if ($scope.type === 'timedate') {
               $scope.timeFormat = timeFormatVal;
               $scope.dateFormat = dateFormatVal;
             }
           };
 
           $scope.save = function () {
-            if ( $scope.type === "timedate" ) {
+            if ($scope.type === 'timedate') {
               $scope.setAttributeData($scope.componentId, 'time', $scope.timeFormat);
               $scope.setAttributeData($scope.componentId, 'date', $scope.dateFormat);
-            } else if ( $scope.type === "time" ) {
+            } else if ($scope.type === 'time') {
               $scope.setAttributeData($scope.componentId, 'time', $scope.timeFormat);
-            } else if ( $scope.type === "date" ) {
+            } else if ($scope.type === 'date') {
               $scope.setAttributeData($scope.componentId, 'date', $scope.dateFormat);
             }
 

--- a/web/scripts/template-editor/components/directives/dtv-component-time-date.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-time-date.js
@@ -17,7 +17,6 @@ angular.module('risevision.template-editor.directives')
               date: moment().format(format)
             };
           });
-          $scope.dateFormat = $scope.dateFormats[0].format;
 
           $scope.registerDirective({
             type: 'rise-time-date',
@@ -36,11 +35,36 @@ angular.module('risevision.template-editor.directives')
 
           $scope.load = function () {
             var type = $scope.getAvailableAttributeData($scope.componentId, 'type');
+            var timeFormat = $scope.getAvailableAttributeData($scope.componentId, 'time');
+            var dateFormat = $scope.getAvailableAttributeData($scope.componentId, 'date');
+            var timeFormatVal = timeFormat || "Hours12";
+            var dateFormatVal = dateFormat || $scope.dateFormats[0].format;
 
             $scope.type = type;
+
+            if ( $scope.type === "time" ) {
+              return $scope.timeFormat = timeFormatVal;
+            }
+
+            if ( $scope.type === "date" ) {
+              return $scope.dateFormat = dateFormatVal;
+            }
+
+            if ( $scope.type === "timedate" ) {
+              $scope.timeFormat = timeFormatVal;
+              $scope.dateFormat = dateFormatVal;
+            }
           };
 
-          $scope.saveChanges = function () {
+          $scope.save = function () {
+            if ( $scope.type === "timedate" ) {
+              $scope.setAttributeData($scope.componentId, 'time', $scope.timeFormat);
+              $scope.setAttributeData($scope.componentId, 'date', $scope.dateFormat);
+            } else if ( $scope.type === "time" ) {
+              $scope.setAttributeData($scope.componentId, 'time', $scope.timeFormat);
+            } else if ( $scope.type === "date" ) {
+              $scope.setAttributeData($scope.componentId, 'date', $scope.dateFormat);
+            }
 
           };
         }


### PR DESCRIPTION
## Description
Initializes the time format and date format UI selection from attribute data, otherwise initializes them with a default selection.

Saves the time format and date format selections to attribute data. Ensures to only save time format if type is _time_ and only saves date format if type is _date_. Otherwise saves both when type is _timedate_.

## Motivation and Context
Component UI development

## How Has This Been Tested?
Tested locally and on staging with example template

https://apps-stage-8.risevision.com/templates/edit/7bba17fa-b8cf-4221-9fea-3f9270a7e2a2/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

To test from a new instance of template, search for _Example Time and Date_

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
