### PR TITLE
Show error message if User enters a Template ID

### DIFF
--- a/test/unit/editor/controllers/ctr-presentation-item-modal.tests.js
+++ b/test/unit/editor/controllers/ctr-presentation-item-modal.tests.js
@@ -41,6 +41,8 @@ describe('controller: presentation item modal', function() {
         })
       };
     });
+    $provide.value('HTML_PRESENTATION_TYPE', 'HTML Template');
+
 
   }));
   var $scope, $modalInstance, $modal, $timeout, presentationFactory, returnPresentation, itemProperties, itemType, PRESENTATION_SEARCH;
@@ -58,7 +60,8 @@ describe('controller: presentation item modal', function() {
       $scope = $rootScope.$new();
       $scope.presentationItemFields = {
         presentationId: {
-          $error: {}
+          $error: {},
+          $setValidity: sinon.stub()
         }
       };
     });
@@ -115,6 +118,29 @@ describe('controller: presentation item modal', function() {
       }, 10);
     });
 
+    it('should show template error for HTML Templates', function(done) {
+      presentationFactory.getPresentationCached = sinon.spy(function() {
+        return Q.resolve({
+          name: 'presentationName',
+          presentationType: 'HTML Template'
+        });
+      });
+
+      $scope.presentationId = 'newId';
+
+      $scope.$digest();
+
+      expect($scope.item.objectData).to.equal('newId');
+
+      setTimeout(function() {
+        $scope.$digest();
+
+        $scope.presentationItemFields.presentationId.$setValidity.should.have.been.calledWith('template', false);
+
+        done();
+      }, 10);
+    });
+
     it('should not load Id if blank or invalid', function() {
       $scope.presentationItemFields.presentationId.$error.guid = true;
       $scope.presentationId = 'newId';
@@ -146,11 +172,13 @@ describe('controller: presentation item modal', function() {
       }, 10);
     });
     
-    it('should reset warning when Id is changed', function(done) {
+    it('should reset warnings when Id is changed', function(done) {
       returnPresentation = false;
       $scope.presentationId = 'newId';
       
       $scope.$digest();
+
+      $scope.presentationItemFields.presentationId.$setValidity.should.have.been.calledWith('template', true);
 
       setTimeout(function() {
         $scope.presentationId = '';

--- a/web/locales/en/editor-app.json
+++ b/web/locales/en/editor-app.json
@@ -79,6 +79,7 @@
         "invalidId": "Presentation ID is not valid. Please enter a valid ID.",
         "noAccess": "There was an error accessing the Presentation. This could indicate it does not exist or you cannot access it.",
         "noId": "Please enter a Presentation ID",
+        "noTemplate": "Templates cannot be embedded in a Presentation. Please enter a valid Presentation ID.",
         "noneSelected": "No Presentation selected. Please select a Presentation or enter an ID."
       },
       "name": "Embedded Presentation",

--- a/web/partials/editor/presentation-item-settings.html
+++ b/web/partials/editor/presentation-item-settings.html
@@ -1,67 +1,67 @@
 <div id="presentationItemModal">
-	<div class="modal-header">
-		<button type="button" class="close" ng-click="dismiss()">
-			<i class="fa fa-times"></i>
-		</button>
-		<h3 class="modal-title" translate="editor-app.playlistItem.presentation.title"></h3>
-	</div>
-	<div class="modal-body">
-		<h4>Presentation</h4>
-		<div class="row">
-			<div class="col-md-12">
-				<button id="selectPresentationButton" ng-click="showPresentationId = false; selectPresentation()" type="button" class="btn btn-default" ng-class="{'active' : !showPresentationId}">
-					<span translate="editor-app.playlistItem.presentation.select"></span>
-				</button>
+  <div class="modal-header">
+    <button type="button" class="close" ng-click="dismiss()">
+      <i class="fa fa-times"></i>
+    </button>
+    <h3 class="modal-title" translate="editor-app.playlistItem.presentation.title"></h3>
+  </div>
+  <div class="modal-body">
+    <h4>Presentation</h4>
+    <div class="row">
+      <div class="col-md-12">
+        <button id="selectPresentationButton" ng-click="showPresentationId = false; selectPresentation()" type="button" class="btn btn-default" ng-class="{'active' : !showPresentationId}">
+          <span translate="editor-app.playlistItem.presentation.select"></span>
+        </button>
 
-				<span class="u_padding-sm-horizontal text-muted" translate="common.or"></span>
+        <span class="u_padding-sm-horizontal text-muted" translate="common.or"></span>
 
-				<button id="enterPresentationIdButton" ng-click="showPresentationId = true" type="button" class="btn btn-default" ng-class="{'active' : showPresentationId}">
-					<span translate="editor-app.playlistItem.presentation.enterId"></span>
-				</button>
-			
-			</div><!--col-->
-		</div><!--row-->
+        <button id="enterPresentationIdButton" ng-click="showPresentationId = true" type="button" class="btn btn-default" ng-class="{'active' : showPresentationId}">
+          <span translate="editor-app.playlistItem.presentation.enterId"></span>
+        </button>
+      
+      </div><!--col-->
+    </div><!--row-->
 
-		<div class="form-group u_margin-sm-top">
-			<form role="form" name="presentationItemFields" novalidate>
+    <div class="form-group u_margin-sm-top">
+      <form role="form" name="presentationItemFields" novalidate>
 
-				<div class="row">
-					<div class="col-sm-9">
+        <div class="row">
+          <div class="col-sm-9">
 
-						<div class="input-group u_margin-sm-bottom">
-							<input id="presentationId" name="presentationId" type="text" class="form-control" ng-show="showPresentationId" ng-model="presentationId" required guid-validator />
-							<input id="presentationName" name="presentationName" type="text" class="form-control" ng-show="!showPresentationId" ng-model="presentationName" readonly="readonly" />
-							<span class="input-group-addon" ng-click="clearSelection()">
-								<i class="fa fa-times"></i>
-							</span>
-						</div>
+            <div class="input-group u_margin-sm-bottom">
+              <input id="presentationId" name="presentationId" type="text" class="form-control" ng-show="showPresentationId" ng-model="presentationId" required guid-validator />
+              <input id="presentationName" name="presentationName" type="text" class="form-control" ng-show="!showPresentationId" ng-model="presentationName" readonly="readonly" />
+              <span class="input-group-addon" ng-click="clearSelection()">
+                <i class="fa fa-times"></i>
+              </span>
+            </div>
 
-					</div>
-					<div class="col-sm-3">
-						<a class="btn btn-default btn-block" ng-disabled="apiWarning || presentationItemFields.$invalid" ui-sref="apps.editor.workspace.artboard({presentationId: item.objectData})" target="_blank" translate="editor-app.playlistItem.presentation.open">
-							<i class="fa fa-external-link icon-right"></i>
-						</a>
-					</div>
-				</div>
+          </div>
+          <div class="col-sm-3">
+            <a class="btn btn-default btn-block" ng-disabled="apiWarning || presentationItemFields.$invalid" ui-sref="apps.editor.workspace.artboard({presentationId: item.objectData})" target="_blank" translate="editor-app.playlistItem.presentation.open">
+              <i class="fa fa-external-link icon-right"></i>
+            </a>
+          </div>
+        </div>
 
-				<p id="requiredValidation" class="text-danger" ng-if="showPresentationId" ng-show="!presentationItemFields.presentationId.$pristine && presentationItemFields.presentationId.$error.required"  translate="editor-app.playlistItem.presentation.error.noId">
-				</p>
-				<p id="invalidGuidValidation" class="text-danger" ng-if="showPresentationId" ng-show="!presentationItemFields.presentationId.$pristine && presentationItemFields.presentationId.$error.guid" translate="editor-app.playlistItem.presentation.error.invalidId">
-				</p>
-				<p id="invalidGuidValidation" class="text-danger" ng-if="!showPresentationId" ng-show="presentationItemFields.$invalid" translate="editor-app.playlistItem.presentation.error.noneSelected">
-				</p>
-				<p id="htmlTemplateValidation" class="text-danger" ng-if="showPresentationId" ng-show="!presentationItemFields.presentationId.$pristine && presentationItemFields.presentationId.$error.template" translate="editor-app.playlistItem.presentation.error.noTemplate">
-				</p>
+        <p id="requiredValidation" class="text-danger" ng-if="showPresentationId" ng-show="!presentationItemFields.presentationId.$pristine && presentationItemFields.presentationId.$error.required"  translate="editor-app.playlistItem.presentation.error.noId">
+        </p>
+        <p id="invalidGuidValidation" class="text-danger" ng-if="showPresentationId" ng-show="!presentationItemFields.presentationId.$pristine && presentationItemFields.presentationId.$error.guid" translate="editor-app.playlistItem.presentation.error.invalidId">
+        </p>
+        <p id="invalidGuidValidation" class="text-danger" ng-if="!showPresentationId" ng-show="presentationItemFields.$invalid" translate="editor-app.playlistItem.presentation.error.noneSelected">
+        </p>
+        <p id="htmlTemplateValidation" class="text-danger" ng-if="showPresentationId" ng-show="!presentationItemFields.presentationId.$pristine && presentationItemFields.presentationId.$error.template" translate="editor-app.playlistItem.presentation.error.noTemplate">
+        </p>
 
-				<div class="alert alert-warning" ng-show="apiWarning" translate="editor-app.playlistItem.presentation.error.noAccess">
-				</div>
+        <div class="alert alert-warning" ng-show="apiWarning" translate="editor-app.playlistItem.presentation.error.noAccess">
+        </div>
 
-			</form>
-		</div><!--form-group-->
+      </form>
+    </div><!--form-group-->
 
-	</div><!--modal-body-->
-	<div class="modal-footer">
-		<button id="presentationItemSave" class="btn btn-primary btn-fixed-width" ng-click="save()" ng-disabled="presentationItemFields.$invalid">{{isNew ? 'common.add' : 'common.apply' | translate}} <i class="fa fa-check icon-right"></i></button>
-		<button class="btn btn-default btn-fixed-width" ng-click="dismiss()">{{'common.cancel' | translate}} <i class="fa fa-times icon-right"></i></button>
-	</div>
+  </div><!--modal-body-->
+  <div class="modal-footer">
+    <button id="presentationItemSave" class="btn btn-primary btn-fixed-width" ng-click="save()" ng-disabled="presentationItemFields.$invalid">{{isNew ? 'common.add' : 'common.apply' | translate}} <i class="fa fa-check icon-right"></i></button>
+    <button class="btn btn-default btn-fixed-width" ng-click="dismiss()">{{'common.cancel' | translate}} <i class="fa fa-times icon-right"></i></button>
+  </div>
 </div>

--- a/web/partials/editor/presentation-item-settings.html
+++ b/web/partials/editor/presentation-item-settings.html
@@ -50,6 +50,8 @@
 	      </p>
 	      <p id="invalidGuidValidation" class="text-danger" ng-if="!showPresentationId" ng-show="presentationItemFields.$invalid" translate="editor-app.playlistItem.presentation.error.noneSelected">
 	      </p>
+				<p id="htmlTemplateValidation" class="text-danger" ng-if="showPresentationId" ng-show="!presentationItemFields.presentationId.$pristine && presentationItemFields.presentationId.$error.template" translate="editor-app.playlistItem.presentation.error.noTemplate">
+	      </p>
 
 	      <div class="alert alert-warning" ng-show="apiWarning" translate="editor-app.playlistItem.presentation.error.noAccess">
 	      </div>

--- a/web/partials/editor/presentation-item-settings.html
+++ b/web/partials/editor/presentation-item-settings.html
@@ -1,63 +1,63 @@
 <div id="presentationItemModal">
 	<div class="modal-header">
 		<button type="button" class="close" ng-click="dismiss()">
-	    <i class="fa fa-times"></i>
-	  </button>
+			<i class="fa fa-times"></i>
+		</button>
 		<h3 class="modal-title" translate="editor-app.playlistItem.presentation.title"></h3>
 	</div>
 	<div class="modal-body">
 		<h4>Presentation</h4>
-	  <div class="row">
-	    <div class="col-md-12">
+		<div class="row">
+			<div class="col-md-12">
 				<button id="selectPresentationButton" ng-click="showPresentationId = false; selectPresentation()" type="button" class="btn btn-default" ng-class="{'active' : !showPresentationId}">
-	        <span translate="editor-app.playlistItem.presentation.select"></span>
+					<span translate="editor-app.playlistItem.presentation.select"></span>
 				</button>
 
-	      <span class="u_padding-sm-horizontal text-muted" translate="common.or"></span>
+				<span class="u_padding-sm-horizontal text-muted" translate="common.or"></span>
 
-	      <button id="enterPresentationIdButton" ng-click="showPresentationId = true" type="button" class="btn btn-default" ng-class="{'active' : showPresentationId}">
-	        <span translate="editor-app.playlistItem.presentation.enterId"></span>
-	      </button>
-	    
-	    </div><!--col-->
-	  </div><!--row-->
+				<button id="enterPresentationIdButton" ng-click="showPresentationId = true" type="button" class="btn btn-default" ng-class="{'active' : showPresentationId}">
+					<span translate="editor-app.playlistItem.presentation.enterId"></span>
+				</button>
+			
+			</div><!--col-->
+		</div><!--row-->
 
-	  <div class="form-group u_margin-sm-top">
-	    <form role="form" name="presentationItemFields" novalidate>
+		<div class="form-group u_margin-sm-top">
+			<form role="form" name="presentationItemFields" novalidate>
 
-	    	<div class="row">
-	    		<div class="col-sm-9">
+				<div class="row">
+					<div class="col-sm-9">
 
-	    			<div class="input-group u_margin-sm-bottom">
-	            <input id="presentationId" name="presentationId" type="text" class="form-control" ng-show="showPresentationId" ng-model="presentationId" required guid-validator />
-	            <input id="presentationName" name="presentationName" type="text" class="form-control" ng-show="!showPresentationId" ng-model="presentationName" readonly="readonly" />
-	            <span class="input-group-addon" ng-click="clearSelection()">
-	              <i class="fa fa-times"></i>
-	            </span>
-	          </div>
+						<div class="input-group u_margin-sm-bottom">
+							<input id="presentationId" name="presentationId" type="text" class="form-control" ng-show="showPresentationId" ng-model="presentationId" required guid-validator />
+							<input id="presentationName" name="presentationName" type="text" class="form-control" ng-show="!showPresentationId" ng-model="presentationName" readonly="readonly" />
+							<span class="input-group-addon" ng-click="clearSelection()">
+								<i class="fa fa-times"></i>
+							</span>
+						</div>
 
-	    		</div>
-	    		<div class="col-sm-3">
-	    			<a class="btn btn-default btn-block" ng-disabled="apiWarning || presentationItemFields.$invalid" ui-sref="apps.editor.workspace.artboard({presentationId: item.objectData})" target="_blank" translate="editor-app.playlistItem.presentation.open">
-	          	<i class="fa fa-external-link icon-right"></i>
-	          </a>
-	    		</div>
-	    	</div>
+					</div>
+					<div class="col-sm-3">
+						<a class="btn btn-default btn-block" ng-disabled="apiWarning || presentationItemFields.$invalid" ui-sref="apps.editor.workspace.artboard({presentationId: item.objectData})" target="_blank" translate="editor-app.playlistItem.presentation.open">
+							<i class="fa fa-external-link icon-right"></i>
+						</a>
+					</div>
+				</div>
 
-	      <p id="requiredValidation" class="text-danger" ng-if="showPresentationId" ng-show="!presentationItemFields.presentationId.$pristine && presentationItemFields.presentationId.$error.required"  translate="editor-app.playlistItem.presentation.error.noId">
-	      </p>
-	      <p id="invalidGuidValidation" class="text-danger" ng-if="showPresentationId" ng-show="!presentationItemFields.presentationId.$pristine && presentationItemFields.presentationId.$error.guid" translate="editor-app.playlistItem.presentation.error.invalidId">
-	      </p>
-	      <p id="invalidGuidValidation" class="text-danger" ng-if="!showPresentationId" ng-show="presentationItemFields.$invalid" translate="editor-app.playlistItem.presentation.error.noneSelected">
-	      </p>
+				<p id="requiredValidation" class="text-danger" ng-if="showPresentationId" ng-show="!presentationItemFields.presentationId.$pristine && presentationItemFields.presentationId.$error.required"  translate="editor-app.playlistItem.presentation.error.noId">
+				</p>
+				<p id="invalidGuidValidation" class="text-danger" ng-if="showPresentationId" ng-show="!presentationItemFields.presentationId.$pristine && presentationItemFields.presentationId.$error.guid" translate="editor-app.playlistItem.presentation.error.invalidId">
+				</p>
+				<p id="invalidGuidValidation" class="text-danger" ng-if="!showPresentationId" ng-show="presentationItemFields.$invalid" translate="editor-app.playlistItem.presentation.error.noneSelected">
+				</p>
 				<p id="htmlTemplateValidation" class="text-danger" ng-if="showPresentationId" ng-show="!presentationItemFields.presentationId.$pristine && presentationItemFields.presentationId.$error.template" translate="editor-app.playlistItem.presentation.error.noTemplate">
-	      </p>
+				</p>
 
-	      <div class="alert alert-warning" ng-show="apiWarning" translate="editor-app.playlistItem.presentation.error.noAccess">
-	      </div>
+				<div class="alert alert-warning" ng-show="apiWarning" translate="editor-app.playlistItem.presentation.error.noAccess">
+				</div>
 
-	    </form>
-	  </div><!--form-group-->
+			</form>
+		</div><!--form-group-->
 
 	</div><!--modal-body-->
 	<div class="modal-footer">

--- a/web/scripts/editor/controllers/ctr-presentation-item-modal.js
+++ b/web/scripts/editor/controllers/ctr-presentation-item-modal.js
@@ -2,9 +2,9 @@
 
 angular.module('risevision.editor.controllers')
   .controller('PresentationItemModalController', ['$scope', '$timeout', '$log', '$modal',
-    '$modalInstance', 'presentationFactory', 'item', 'PRESENTATION_SEARCH',
+    '$modalInstance', 'presentationFactory', 'item', 'PRESENTATION_SEARCH', 'HTML_PRESENTATION_TYPE',
     function ($scope, $timeout, $log, $modal, $modalInstance, presentationFactory,
-      item, PRESENTATION_SEARCH) {
+      item, PRESENTATION_SEARCH, HTML_PRESENTATION_TYPE) {
       var initialPresentationName;
       $scope.item = angular.copy(item);
 
@@ -17,12 +17,17 @@ angular.module('risevision.editor.controllers')
       };
 
       $scope.$watch('presentationId', function (id) {
+        $scope.presentationItemFields.presentationId.$setValidity('template', true);
         $scope.apiWarning = false;
 
         if (id && !$scope.presentationItemFields.presentationId.$error.guid) {
           $scope.item.objectData = id;
           presentationFactory.getPresentationCached(id)
             .then(function (presentation) {
+              if (presentation && presentation.presentationType === HTML_PRESENTATION_TYPE) {
+                $scope.presentationItemFields.presentationId.$setValidity('template', false);                
+              }
+
               if (presentation && presentation.name) {
                 $scope.presentationName = presentation.name;
               }


### PR DESCRIPTION
## Description
Show error message if User enters a Template ID

Templates cannot be embedded in Presentations

[stage-2]

## Motivation and Context
Partial fix for #1390.

We want to show an error when the ID of an HTML Template is added. However, if the User does not have access to the Presentation in question, we cannot validate the ID and allow them to enter the value as before.

## How Has This Been Tested?
Validated on staging with both an HTML Template and a Presentation. Ensured the button is disabled and the validation is cleared when a new ID is entered. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No