### PR TITLE
Fix white space issue with counter component

### DIFF
--- a/web/scss/sections/components/counter.scss
+++ b/web/scss/sections/components/counter.scss
@@ -22,4 +22,8 @@
     margin-right: -1px;
     fill: $white;
   }
+
+  .radio {
+    margin-bottom: 5px;
+  }
 }


### PR DESCRIPTION
## Description
Add 5 more pixels separating the time input and the "A specific time ..." radio option.

## Motivation and Context
Fixes issue #1403 

## How Has This Been Tested?
Locally and on staging:

https://apps-stage-8.risevision.com/templates/edit/bfd9a935-d0dc-4065-a331-1a18ea833a30/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
