### PR TITLE
Remove browserUpgradeMode field from UI

### DIFF
--- a/test/unit/displays/controllers/ctr-display-details.tests.js
+++ b/test/unit/displays/controllers/ctr-display-details.tests.js
@@ -224,27 +224,6 @@ describe('controller: display details', function() {
 
   });
 
-  describe('browserUpgradeMode:',function(){
-    it('should watch display.browserUpgradeMode',function(){
-      expect($scope.$$watchers[0].exp).to.equal('display.browserUpgradeMode');
-    });
-
-    it('should change to User Managed (1) any value different than Auto Upgrade (0)',function(){
-      $scope.display = {id:123, browserUpgradeMode: 2};
-      $scope.$digest();
-      expect($scope.display.browserUpgradeMode).to.equal(1);
-      $scope.display = {id:123, browserUpgradeMode: 1};
-      $scope.$digest();
-      expect($scope.display.browserUpgradeMode).to.equal(1);
-    });
-
-    it('should not change Auto Upgrade (0)',function(){
-      $scope.display = {id:123, browserUpgradeMode: 0};
-      $scope.$digest();
-      expect($scope.display.browserUpgradeMode).to.equal(0);
-    });
-  });
-
   describe('toggleProAuthorized', function () {
     it('should show the plans modal', function () {
       $scope.display = {};

--- a/test/unit/displays/services/svc-display-factory.tests.js
+++ b/test/unit/displays/services/svc-display-factory.tests.js
@@ -10,8 +10,7 @@ describe('service: displayFactory:', function() {
       return {
         _display: {
           id: "displayId",
-          name: "some display",
-          browserUpgradeMode: 1
+          name: "some display"
         },
         list: function() {
           var deferred = Q.defer();
@@ -254,19 +253,7 @@ describe('service: displayFactory:', function() {
       })
       .then(null,done);
     });
-    
-    it("showBrowserUpgradeMode: ",function(done){
-      displayFactory.getDisplay("displayId")
-      .then(function() {
-        expect(displayFactory.showBrowserUpgradeMode).to.be.true;
 
-        done();
-      })
-      .then(null, function() {
-        done("error");
-      })
-      .then(null,done);
-    });
   });
   
   describe('addDisplay:',function(){

--- a/web/locales/en/displays-app.json
+++ b/web/locales/en/displays-app.json
@@ -177,15 +177,6 @@
       "required": "Required"
     },
     "player": {
-      "browser": {
-        "installed": "Browser Version:",
-        "recommended": "Recommended Browser:",
-        "upgrade": {
-          "autoUpgrade": "Auto Upgrade",
-          "name": "Browser Upgrade:",
-          "userManaged": "User Managed"
-        }
-      },
       "browserVersion": "Browser Version",
       "displayControl": {
         "label": "Display Control",

--- a/web/partials/displays/display-fields.html
+++ b/web/partials/displays/display-fields.html
@@ -260,19 +260,6 @@
       <option value="270" translate>displays-app.fields.player.orientation.270</option>
     </select>
   </div>
-
-  <div class="form-group form-inline" ng-show="factory.showBrowserUpgradeMode">
-    <label class="control-label" translate>displays-app.fields.player.browser.upgrade.name</label>
-    <select class="form-control" ng-model="display.browserUpgradeMode" integer-parser ng-disabled="!display.playerName && !display.playerVersion">
-      <option value="0" translate>displays-app.fields.player.browser.upgrade.autoUpgrade</option>
-      <option value="1" translate>displays-app.fields.player.browser.upgrade.userManaged</option>
-    </select>
-  </div>
-
-  <div class="form-group form-inline" ng-show="display.browserUpgradeMode !== 0">
-    <label class="control-label" translate>displays-app.fields.player.browser.recommended</label>
-    <div class="form-control-static">{{display.recommendedBrowserVersion}}</div>
-  </div>
 </div>
 
 <div class="form-group">

--- a/web/scripts/displays/controllers/ctr-display-details.js
+++ b/web/scripts/displays/controllers/ctr-display-details.js
@@ -188,10 +188,5 @@ angular.module('risevision.displays.controllers')
         startTrialListener();
       });
 
-      $scope.$watch('display.browserUpgradeMode', function () {
-        if ($scope.display && $scope.display.browserUpgradeMode !== 0) {
-          $scope.display.browserUpgradeMode = 1;
-        }
-      });
     }
   ]);

--- a/web/scripts/displays/services/svc-display-factory.js
+++ b/web/scripts/displays/services/svc-display-factory.js
@@ -70,10 +70,6 @@ angular.module('risevision.displays.services')
           .then(function (result) {
             factory.display = result.item;
 
-            if (factory.display) {
-              factory.showBrowserUpgradeMode = factory.display.browserUpgradeMode !== 0;
-            }
-
             deferred.resolve();
           })
           .then(null, function (e) {

--- a/web/scripts/displays/services/svc-display.js
+++ b/web/scripts/displays/services/svc-display.js
@@ -9,7 +9,7 @@
     .constant('DISPLAY_WRITABLE_FIELDS', [
       'name', 'status', 'useCompanyAddress', 'addressDescription', 'street',
       'unit', 'city', 'province', 'country', 'postalCode', 'timeZoneOffset',
-      'restartEnabled', 'restartTime', 'browserUpgradeMode', 'width',
+      'restartEnabled', 'restartTime', 'width',
       'height', 'orientation', 'monitoringEnabled', 'monitoringEmails', 'monitoringSchedule'
     ])
     .constant('DISPLAY_SEARCH_FIELDS', [


### PR DESCRIPTION
## Description
Remove browserUpgradeMode field from UI
Field is deprecated and no longer used

[stage-19]

## Motivation and Context
As per discussion in the Issue we decided to remove this field. Double checked that the field is not used by the current players.

Fix for #1408 

## How Has This Been Tested?
Tested the field removal does not break anything in the local environment.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.
