### PR TITLE
Load/save timezone data for Time and Date component

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-time-date.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-time-date.tests.js
@@ -63,11 +63,12 @@ describe('directive: templateComponentTimeDate', function() {
   });
 
   describe('load', function () {
-    function _initLoad(type, time, date) {
+    function _initLoad(type, time, date, timezone) {
       $scope.getAvailableAttributeData = sandbox.stub();
       $scope.getAvailableAttributeData.onCall(0).returns(type);
       $scope.getAvailableAttributeData.onCall(1).returns(time);
       $scope.getAvailableAttributeData.onCall(2).returns(date);
+      $scope.getAvailableAttributeData.onCall(3).returns(timezone);
     }
 
     it('should load the correct list of date formats', function () {
@@ -79,45 +80,54 @@ describe('directive: templateComponentTimeDate', function() {
     });
 
     it('should initialize the time format from data', function () {
-      _initLoad('time', 'Hours24', null);
+      _initLoad('time', 'Hours24', null, null);
 
       $scope.load();
 
       expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('type');
       expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('time');
       expect($scope.getAvailableAttributeData.getCall(2).args[1]).to.equal('date');
+      expect($scope.getAvailableAttributeData.getCall(3).args[1]).to.equal('timezone');
 
       expect($scope.type).to.equal('time');
       expect($scope.dateFormat).to.not.be.ok;
       expect($scope.timeFormat).to.equal('Hours24');
+      expect($scope.timezoneType).to.equal('DisplayTz');
+      expect($scope.timezone).to.not.be.ok;
     });
 
     it('should initialize the date format from data', function () {
-      _initLoad('date', null, 'DD/MM/YYYY');
+      _initLoad('date', null, 'DD/MM/YYYY', 'Atlantic/South_Georgia');
 
       $scope.load();
 
       expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('type');
       expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('time');
       expect($scope.getAvailableAttributeData.getCall(2).args[1]).to.equal('date');
+      expect($scope.getAvailableAttributeData.getCall(3).args[1]).to.equal('timezone');
 
       expect($scope.type).to.equal('date');
       expect($scope.timeFormat).to.not.be.ok;
       expect($scope.dateFormat).to.equal('DD/MM/YYYY');
+      expect($scope.timezoneType).to.equal('SpecificTz');
+      expect($scope.timezone).to.equal('Atlantic/South_Georgia');
     });
 
     it('should initialize the date and time formats from data', function () {
-      _initLoad('timedate', 'Hours24', 'MMM DD YYYY');
+      _initLoad('timedate', 'Hours24', 'MMM DD YYYY', null);
 
       $scope.load();
 
       expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('type');
       expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('time');
       expect($scope.getAvailableAttributeData.getCall(2).args[1]).to.equal('date');
+      expect($scope.getAvailableAttributeData.getCall(3).args[1]).to.equal('timezone');
 
       expect($scope.type).to.equal('timedate');
       expect($scope.timeFormat).to.equal('Hours24');
       expect($scope.dateFormat).to.equal('MMM DD YYYY');
+      expect($scope.timezoneType).to.equal('DisplayTz');
+      expect($scope.timezone).to.not.be.ok;
     });
 
     it('should initialize time and date formats with default values', function () {
@@ -128,10 +138,13 @@ describe('directive: templateComponentTimeDate', function() {
       expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('type');
       expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('time');
       expect($scope.getAvailableAttributeData.getCall(2).args[1]).to.equal('date');
+      expect($scope.getAvailableAttributeData.getCall(3).args[1]).to.equal('timezone');
 
       expect($scope.type).to.equal('timedate');
       expect($scope.timeFormat).to.equal('Hours12');
       expect($scope.dateFormat).to.equal('MMMM DD, YYYY');
+      expect($scope.timezoneType).to.equal('DisplayTz');
+      expect($scope.timezone).to.not.be.ok;
     });
   });
 
@@ -149,7 +162,8 @@ describe('directive: templateComponentTimeDate', function() {
       $scope.save();
       expect($scope.setAttributeData.getCall(0).args[1]).to.equal('time');
       expect($scope.setAttributeData.getCall(0).args[2]).to.equal('Hours24');
-      expect($scope.setAttributeData.getCall(1)).to.not.be.ok;
+      expect($scope.setAttributeData.getCall(1).args[1]).to.equal('timezone');
+      expect($scope.setAttributeData.getCall(1).args[2]).to.not.be.ok;
     });
 
     it('should only save date format and not save time format if type is "date"', function () {
@@ -159,7 +173,8 @@ describe('directive: templateComponentTimeDate', function() {
       $scope.save();
       expect($scope.setAttributeData.getCall(0).args[1]).to.equal('date');
       expect($scope.setAttributeData.getCall(0).args[2]).to.equal('DD/MM/YYYY');
-      expect($scope.setAttributeData.getCall(1)).to.not.be.ok;
+      expect($scope.setAttributeData.getCall(1).args[1]).to.equal('timezone');
+      expect($scope.setAttributeData.getCall(1).args[2]).to.not.be.ok;
     });
 
     it('should save the time and date formats', function () {
@@ -169,8 +184,29 @@ describe('directive: templateComponentTimeDate', function() {
       expect($scope.setAttributeData.getCall(0).args[2]).to.equal('Hours12');
       expect($scope.setAttributeData.getCall(1).args[1]).to.equal('date');
       expect($scope.setAttributeData.getCall(1).args[2]).to.equal('MMMM DD, YYYY');
+      expect($scope.setAttributeData.getCall(2).args[1]).to.equal('timezone');
+      expect($scope.setAttributeData.getCall(2).args[2]).to.not.be.ok;
     });
 
+    it('should save null timezone if Display timezone is selected', function () {
+      $scope.timezoneType = 'DisplayTz';
+      $scope.timezone = 'Not empty';
+
+      $scope.save();
+
+      expect($scope.setAttributeData.getCall(2).args[1]).to.equal('timezone');
+      expect($scope.setAttributeData.getCall(2).args[2]).to.not.be.ok;
+    });
+
+    it('should save the timezone if specific timezone is selected', function () {
+      $scope.timezoneType = 'SpecificTz';
+      $scope.timezone = 'Selected timezone';
+
+      $scope.save();
+
+      expect($scope.setAttributeData.getCall(2).args[1]).to.equal('timezone');
+      expect($scope.setAttributeData.getCall(2).args[2]).to.equal('Selected timezone');
+    });
   });
 
 });

--- a/web/partials/template-editor/components/component-time-date.html
+++ b/web/partials/template-editor/components/component-time-date.html
@@ -28,7 +28,7 @@
     </div>
   </div>
 
-  <div class="attribute-editor-row" ng-show="type === 'timedate' || type === 'time'">
+  <div class="attribute-editor-row">
     <label class="u_margin-sm-top mb-0">Show the time and date according to:</label>
 
     <div class="radio" id="displayTzRadio">

--- a/web/scripts/template-editor/components/directives/dtv-component-time-date.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-time-date.js
@@ -38,10 +38,13 @@ angular.module('risevision.template-editor.directives')
             var type = $scope.getAvailableAttributeData($scope.componentId, 'type');
             var timeFormat = $scope.getAvailableAttributeData($scope.componentId, 'time');
             var dateFormat = $scope.getAvailableAttributeData($scope.componentId, 'date');
+            var timezone = $scope.getAvailableAttributeData($scope.componentId, 'timezone');
             var timeFormatVal = timeFormat || 'Hours12';
             var dateFormatVal = dateFormat || $scope.dateFormats[0].format;
 
             $scope.type = type;
+            $scope.timezoneType = !timezone ? 'DisplayTz' : 'SpecificTz';
+            $scope.timezone = timezone;
 
             if ($scope.type === 'time') {
               $scope.timeFormat = timeFormatVal;
@@ -58,6 +61,10 @@ angular.module('risevision.template-editor.directives')
           };
 
           $scope.save = function () {
+            if ($scope.timezoneType === 'DisplayTz' || !$scope.timezone) {
+              $scope.timezone = null;
+            }
+
             if ($scope.type === 'timedate') {
               $scope.setAttributeData($scope.componentId, 'time', $scope.timeFormat);
               $scope.setAttributeData($scope.componentId, 'date', $scope.dateFormat);
@@ -66,6 +73,8 @@ angular.module('risevision.template-editor.directives')
             } else if ($scope.type === 'date') {
               $scope.setAttributeData($scope.componentId, 'date', $scope.dateFormat);
             }
+
+            $scope.setAttributeData($scope.componentId, 'timezone', $scope.timezone);
           };
         }
       };


### PR DESCRIPTION
## Description
Loads and saves timezone information. Also shows timezone for Date only instances, fixing a previously introduced bug. 

## Motivation and Context
It's part of our epic.

## How Has This Been Tested?
It can be tested here: https://apps-stage-7.risevision.com/templates/edit/722d3c1b-19cd-4c11-a7ac-18461632fb96/?cid=87977ab8-38b6-47fb-ad5e-256b8cc4b46d

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@stulees please review
