### PR TITLE
Add Time and Date component e2e

### DIFF
--- a/test/e2e/template-editor/cases/components/time-date.js
+++ b/test/e2e/template-editor/cases/components/time-date.js
@@ -1,0 +1,74 @@
+'use strict';
+
+var expect = require('rv-common-e2e').expect;
+var helper = require('rv-common-e2e').helper;
+var PresentationListPage = require('./../../pages/presentationListPage.js');
+var TemplateEditorPage = require('./../../pages/templateEditorPage.js');
+var TimeDateComponentPage = require('./../../pages/components/timeDateComponentPage.js');
+
+var TimeDateComponentScenarios = function () {
+  describe('Time and Date Component', function () {
+    var presentationName;
+    var presentationsListPage;
+    var templateEditorPage;
+    var timeDateComponentPage;
+    var componentLabel = ' Time and Date - Time and Date Example';
+
+    before(function () {
+      presentationsListPage = new PresentationListPage();
+      templateEditorPage = new TemplateEditorPage();
+      timeDateComponentPage = new TimeDateComponentPage();
+
+      presentationsListPage.loadCurrentCompanyPresentationList();
+
+      presentationsListPage.createNewPresentationFromTemplate('Example Time and Date Component', 'example-time-and-date-component');
+
+      templateEditorPage.getPresentationName().getAttribute('value').then(function(name) {
+        expect(name).to.contain('Copy of');
+
+        presentationName = name;
+      });
+    });
+
+    describe('basic operations', function () {
+      it('should open properties of Counter Component', function () {
+        templateEditorPage.selectComponent(componentLabel);
+        expect(timeDateComponentPage.getDateFormat().isEnabled()).to.eventually.be.true;
+        expect(timeDateComponentPage.getHours12().isEnabled()).to.eventually.be.true;
+        expect(timeDateComponentPage.getHours24().isEnabled()).to.eventually.be.true;
+        expect(timeDateComponentPage.getDisplayTz().isEnabled()).to.eventually.be.true;
+        expect(timeDateComponentPage.getSpecificTz().isEnabled()).to.eventually.be.true;
+      });
+
+      it('should select date, time and timezone formatting', function () {
+        helper.wait(timeDateComponentPage.getDateFormat(), 'Date format');
+        timeDateComponentPage.selectOption(timeDateComponentPage.getDateFormatOptions().get(1).getText());
+
+        helper.wait(timeDateComponentPage.getHours24Label(), '24 hours');
+        timeDateComponentPage.getHours24Label().click();
+
+        helper.wait(timeDateComponentPage.getSpecificTzLabel(), 'Specific TZ');
+        timeDateComponentPage.getSpecificTzLabel().click();
+
+        helper.wait(timeDateComponentPage.getTimeZone(), 'Time Zone');
+        timeDateComponentPage.selectOption(timeDateComponentPage.getTimeZoneOptions().get(60).getText());
+
+        //wait for presentation to be auto-saved
+        templateEditorPage.waitForAutosave();
+      });
+
+      it('should reload the Presentation, and validate changes were saved', function () {
+        // Load presentation
+        presentationsListPage.loadPresentation(presentationName);
+        templateEditorPage.selectComponent(componentLabel);
+
+        helper.wait(timeDateComponentPage.getDateFormat(), 'Date format');
+
+        expect(timeDateComponentPage.getDateFormat().getAttribute('value')).to.eventually.equal('string:MMM DD YYYY');
+        expect(timeDateComponentPage.getTimeZone().getAttribute('value')).to.eventually.equal('string:America/Argentina/Buenos_Aires');
+      });
+    });
+  });
+};
+
+module.exports = TimeDateComponentScenarios;

--- a/test/e2e/template-editor/cases/components/time-date.js
+++ b/test/e2e/template-editor/cases/components/time-date.js
@@ -31,7 +31,7 @@ var TimeDateComponentScenarios = function () {
     });
 
     describe('basic operations', function () {
-      it('should open properties of Counter Component', function () {
+      it('should open properties of Time and Date Component', function () {
         templateEditorPage.selectComponent(componentLabel);
         expect(timeDateComponentPage.getDateFormat().isEnabled()).to.eventually.be.true;
         expect(timeDateComponentPage.getHours12().isEnabled()).to.eventually.be.true;

--- a/test/e2e/template-editor/cases/components/time-date.js
+++ b/test/e2e/template-editor/cases/components/time-date.js
@@ -65,6 +65,8 @@ var TimeDateComponentScenarios = function () {
         helper.wait(timeDateComponentPage.getDateFormat(), 'Date format');
 
         expect(timeDateComponentPage.getDateFormat().getAttribute('value')).to.eventually.equal('string:MMM DD YYYY');
+        expect(timeDateComponentPage.getHours24().isSelected()).to.eventually.be.true;
+        expect(timeDateComponentPage.getSpecificTz().isSelected()).to.eventually.be.true;
         expect(timeDateComponentPage.getTimeZone().getAttribute('value')).to.eventually.equal('string:America/Argentina/Buenos_Aires');
       });
     });

--- a/test/e2e/template-editor/pages/components/timeDateComponentPage.js
+++ b/test/e2e/template-editor/pages/components/timeDateComponentPage.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var TimeDateComponentPage = function() {
+  var dateFormat = element(by.id('te-td-date-format'));
+  var dateFormatOptions = element.all(by.options('df.format as df.date for df in dateFormats'));
+  var hours12 = element(by.id('Hours12'));
+  var hours24 = element(by.id('Hours24'));
+  var hours24Label = element(by.id('Hours24Label'));
+  var displayTz = element(by.id('DisplayTz'));
+  var specificTz = element(by.id('SpecificTz'));
+  var specificTzLabel = element(by.id('SpecificTzLabel'));
+  var timeZone = element(by.id('te-td-timezone'));
+  var timeZoneOptions = element.all(by.options('tz for tz in timezones'));
+
+  this.getDateFormat = function () {
+    return dateFormat;
+  };
+
+  this.getDateFormatOptions = function () {
+    return dateFormatOptions;
+  };
+
+  this.getHours12 = function () {
+    return hours12;
+  };
+
+  this.getHours24 = function () {
+    return hours24;
+  };
+
+  this.getHours24Label = function () {
+    return hours24Label;
+  };
+
+  this.getDisplayTz = function () {
+    return displayTz;
+  };
+
+  this.getSpecificTz = function () {
+    return specificTz;
+  };
+
+  this.getSpecificTzLabel = function () {
+    return specificTzLabel;
+  };
+
+  this.getTimeZone = function () {
+    return timeZone;
+  };
+
+  this.getTimeZoneOptions = function () {
+    return timeZoneOptions;
+  };
+
+  this.selectOption = function (optionText) {
+    element(by.cssContainingText('option', optionText)).click();
+  };
+};
+
+module.exports = TimeDateComponentPage;

--- a/test/e2e/template-editor/template-editor2.cases.js
+++ b/test/e2e/template-editor/template-editor2.cases.js
@@ -9,6 +9,7 @@
   var VideoComponentScenarios = require('./cases/components/video.js');
   var RssComponentScenarios = require('./cases/components/rss.js');
   var CounterComponentScenarios = require('./cases/components/counter.js');
+  var TimeDateComponentScenarios = require('./cases/components/time-date.js');
 
   describe('Template Editor 2', function() {
 
@@ -36,6 +37,7 @@
     var videoComponentScenarios = new VideoComponentScenarios();
     var rssComponentScenarios = new RssComponentScenarios();
     var counterComponentScenarios = new CounterComponentScenarios();
+    var timeDateComponentScenarios = new TimeDateComponentScenarios();
 
     after(function() {
       // Loading the Presentation List is a workaround to a Chrome Driver issue that has it fail to click on elements over the Preview iframe


### PR DESCRIPTION
## Description
Adds e2e tests to Time and Date component.

## Motivation and Context
It's part of our epic.

## How Has This Been Tested?
Tests pass both locally and on CCI.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@santiagonoguez please review

Please note, this PR will not be merged until after the holidays.
