### PR TITLE
Use $broadcast for assets updated the event

### DIFF
--- a/web/scripts/launcher/services/svc-company-assets-factory.js
+++ b/web/scripts/launcher/services/svc-company-assets-factory.js
@@ -30,7 +30,7 @@ angular.module('risevision.apps.launcher.services')
       var displaysListListener, activeDisplayCompleted;
 
       var _sendUpdateEvent = function () {
-        $rootScope.$emit('companyAssetsUpdated');
+        $rootScope.$broadcast('companyAssetsUpdated');
       };
 
       factory.hasPresentations = function (forceReload) {


### PR DESCRIPTION
## Description
Event wasn't being received in the controller

## Motivation and Context
Fixes issue where an active Display would not update onboarding flow.

This is staged on Beta to make it easier to replicate the scenario.
Can use https://apps-beta.risevision.com/?cid=cc3f29ae-9a59-47ab-a5f2-2bec502696da to replicate.

## How Has This Been Tested?
Tested locally. Also updated a unit test to validate that the event was received correctly via `$scope.$on`. However this is not relevant to this factory so I did not commit the test.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
Did not update unit tests as per the above.
