### PR TITLE
Load/Refresh onboarding factory outside of controller

### DIFF
--- a/test/e2e/common/cases/first-signin.js
+++ b/test/e2e/common/cases/first-signin.js
@@ -67,6 +67,8 @@ var FirstSigninScenarios = function() {
       it('should show the Get Started page', function() {
         helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
 
+        helper.waitDisappear(homepage.getAppLauncherLoader(), 'App Launcher Loader');
+
         expect(getStartedPage.getGetStartedContainer().isDisplayed()).to.eventually.be.true;
       });
       

--- a/test/unit/launcher/controllers/ctr-onboarding.tests.js
+++ b/test/unit/launcher/controllers/ctr-onboarding.tests.js
@@ -71,26 +71,4 @@ describe('controller: Onboarding', function() {
     });    
   });
 
-  describe("loading:",function(){
-    it("should refresh onboardingFactory",function(){
-      onboardingFactory.refresh.should.have.been.called;
-    });
-
-    it("should refresh on companyAssetsUpdated event",function(){
-      $scope.$emit('companyAssetsUpdated');
-      $scope.$digest();
-
-      onboardingFactory.refresh.should.have.been.calledTwice;
-    });
-
-    it("should refresh on selectedCompanyChanged event and reset details",function(){
-      $scope.$emit('risevision.company.selectedCompanyChanged');
-      $scope.$digest();
-
-      onboardingFactory.refresh.should.have.been.calledTwice;
-      onboardingFactory.refresh.should.have.been.calledWith(true);
-    });
-
-  });
-
 });

--- a/test/unit/launcher/services/svc-onboarding-factory.tests.js
+++ b/test/unit/launcher/services/svc-onboarding-factory.tests.js
@@ -135,6 +135,29 @@ describe('service: onboardingFactory:', function() {
     });
   });
 
+  
+  describe("loading:",function(){
+    beforeEach(function() {
+      sinon.stub(onboardingFactory, 'refresh');
+    });
+
+    it("should refresh on companyAssetsUpdated event",function(){
+      $rootScope.$emit('companyAssetsUpdated');
+      $rootScope.$digest();
+
+      onboardingFactory.refresh.should.have.been.called;
+    });
+
+    it("should refresh on selectedCompanyChanged event and reset details",function(){
+      $rootScope.$emit('risevision.company.selectedCompanyChanged');
+      $rootScope.$digest();
+
+      onboardingFactory.refresh.should.have.been.called;
+      onboardingFactory.refresh.should.have.been.calledWith(true);
+    });
+
+  });
+
   describe('refresh:', function() {
     it('should go to initial step', function(done) {
       expect(onboardingFactory.isCurrentStep('addTemplate')).to.be.false;

--- a/web/scripts/launcher/controllers/ctr-onboarding.js
+++ b/web/scripts/launcher/controllers/ctr-onboarding.js
@@ -20,14 +20,5 @@ angular.module('risevision.apps.launcher.controllers')
         }
       });
 
-      $scope.$on('companyAssetsUpdated', function () {
-        onboardingFactory.refresh();
-      });
-
-      $scope.$on('risevision.company.selectedCompanyChanged', function () {
-        onboardingFactory.refresh(true);
-      });
-
-      onboardingFactory.refresh();
     }
   ]); //ctr

--- a/web/scripts/launcher/services/svc-onboarding-factory.js
+++ b/web/scripts/launcher/services/svc-onboarding-factory.js
@@ -165,7 +165,7 @@ angular.module('risevision.apps.launcher.services')
         var company = userState.getCopyOfSelectedCompany();
         var creationDate = ((company && company.creationDate) ? (new Date(company.creationDate)) : (
           new Date()));
-        return creationDate > new Date('Jan 7, 2020');
+        return creationDate > new Date('Dec 3, 2010');
       };
 
       var _isMailSyncEnabled = function () {
@@ -280,6 +280,14 @@ angular.module('risevision.apps.launcher.services')
             factory.loading = false;
           });
       };
+
+      $rootScope.$on('companyAssetsUpdated', function () {
+        factory.refresh();
+      });
+
+      $rootScope.$on('risevision.company.selectedCompanyChanged', function () {
+        factory.refresh(true);
+      });
 
       _defaults();
 

--- a/web/scripts/launcher/services/svc-onboarding-factory.js
+++ b/web/scripts/launcher/services/svc-onboarding-factory.js
@@ -165,7 +165,7 @@ angular.module('risevision.apps.launcher.services')
         var company = userState.getCopyOfSelectedCompany();
         var creationDate = ((company && company.creationDate) ? (new Date(company.creationDate)) : (
           new Date()));
-        return creationDate > new Date('Dec 3, 2010');
+        return creationDate > new Date('Jan 7, 2020');
       };
 
       var _isMailSyncEnabled = function () {


### PR DESCRIPTION
## Description
Load/Refresh onboarding factory outside of controller

Loading onboarding in the controller is problematic
when not on the Start page. Initialize onboarding
and assets in the service

[stage-2]

## Motivation and Context
When adding and publishing a template directly from the Templates Gallery (on the public website), it shows the Auto Schedule creation modal instead of showing the Onboarding step as completed.

## How Has This Been Tested?
Validated the issue is resolved. Tested other scenarios to ensure everything still works as expected. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No