### PR TITLE
Hide fields if Player is not installed

### DIFF
--- a/web/partials/displays/display-fields.html
+++ b/web/partials/displays/display-fields.html
@@ -97,7 +97,7 @@
           </tr>
           <tr class="table-body__row">
             <td class="table-body__cell"><span translate>displays-app.fields.player.resolution</span></td>
-            <td class="table-body__cell"><span>{{display.width | resolution: display.height}}</span></td>
+            <td class="table-body__cell"><span ng-show="display.playerVersion">{{display.width | resolution: display.height}}</span></td>
           </tr>
           <tr class="table-body__row">
             <td class="table-body__cell"><span translate>displays-app.fields.player.ipAddress</span></td>
@@ -111,18 +111,19 @@
             <td class="table-body__cell"><span translate>displays-app.fields.player.macAddress</span></td>
             <td class="table-body__cell"><span>{{display.macAddress}}</span></td>
           </tr>
-          <tr class="table-body__row" ng-class="{'alert-warning':playerProFactory.isOutdatedPlayer(display), 'alert-danger':playerProFactory.isUnsupportedPlayer(display)}">
+          <tr class="table-body__row" ng-class="{'alert-warning': display.playerVersion && playerProFactory.isOutdatedPlayer(display), 'alert-danger': display.playerVersion && playerProFactory.isUnsupportedPlayer(display)}">
             <td class="table-body__cell"><span translate>displays-app.fields.player.playerVersion</span></td>
-            <td class="table-body__cell" ng-if="playerProFactory.isOutdatedPlayer(display)">
-              <span>{{(display.playerName ? display.playerName + " " : "") + (display.playerVersion ? display.playerVersion + " " : "") + (display.offlineSubscription ? 'Licensed' : 'Free')}}</span>
+            <td class="table-body__cell" ng-if="!display.playerVersion"></td>
+            <td class="table-body__cell" ng-if="display.playerVersion && playerProFactory.isOutdatedPlayer(display)">
+              <span>{{(display.playerName ? display.playerName + " " : "") + (display.playerVersion ? display.playerVersion + " " : "") + (display.playerProAuthorized ? 'Licensed' : 'Free')}}</span>
               <a href="https://help.risevision.com/hc/en-us/articles/115004250723-Why-is-Rise-Player-version-not-current-" target="_blank" translate>displays-app.fields.player.version.notCurrent</a>
             </td>
-            <td class="table-body__cell" ng-if="playerProFactory.isUnsupportedPlayer(display)">
+            <td class="table-body__cell" ng-if="display.playerVersion && playerProFactory.isUnsupportedPlayer(display)">
               <span>{{(display.playerName ? display.playerName + " " : "") + (display.playerVersion ? display.playerVersion + " " : "")}}</span>
               <a href="" ng-click="factory.addDisplayModal(display)"><span class="text-danger" translate>displays-app.fields.player.version.unsupported</span> - {{'displays-app.fields.player.version.upgrade' | translate}}</a>
             </td>
-            <td class="table-body__cell" ng-if="!playerProFactory.isOutdatedPlayer(display) && !playerProFactory.isUnsupportedPlayer(display)">
-              <span>{{(display.playerName ? display.playerName + " " : "") + (display.playerVersion ? display.playerVersion + " " : "") + (display.offlineSubscription ? 'Licensed' : 'Free')}}</span>
+            <td class="table-body__cell" ng-if="display.playerVersion && !playerProFactory.isOutdatedPlayer(display) && !playerProFactory.isUnsupportedPlayer(display)">
+              <span>{{(display.playerName ? display.playerName + " " : "") + (display.playerVersion ? display.playerVersion + " " : "") + (display.playerProAuthorized ? 'Licensed' : 'Free')}}</span>
             </td>
           </tr>
           <tr class="table-body__row">

--- a/web/scripts/launcher/services/svc-onboarding-factory.js
+++ b/web/scripts/launcher/services/svc-onboarding-factory.js
@@ -165,7 +165,7 @@ angular.module('risevision.apps.launcher.services')
         var company = userState.getCopyOfSelectedCompany();
         var creationDate = ((company && company.creationDate) ? (new Date(company.creationDate)) : (
           new Date()));
-        return creationDate > new Date('Jan 7, 2020');
+        return creationDate > new Date('Dec 3, 2010');
       };
 
       var _isMailSyncEnabled = function () {

--- a/web/scripts/launcher/services/svc-onboarding-factory.js
+++ b/web/scripts/launcher/services/svc-onboarding-factory.js
@@ -165,7 +165,7 @@ angular.module('risevision.apps.launcher.services')
         var company = userState.getCopyOfSelectedCompany();
         var creationDate = ((company && company.creationDate) ? (new Date(company.creationDate)) : (
           new Date()));
-        return creationDate > new Date('Dec 3, 2010');
+        return creationDate > new Date('Jan 7, 2020');
       };
 
       var _isMailSyncEnabled = function () {


### PR DESCRIPTION
## Description
Hide resolution field
Hide Player Version field and don't highlight

Use playerProAuthorized value for license check
it is more accurate than the offlineSubscription

[stage-18]

## Motivation and Context
Showing those fields can be confusing. Resolution holds default values which are not an indication of the real resolution of the Display. The license information may be incorrect as it appears based on the Player report (which may not have happened). Also, the fact that it says "Player Version not Current" can be misleading to the User.

## How Has This Been Tested?
Validated all the scenarios with various Active/Inactive and Licensed/Unlicensed Displays.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No