### PR TITLE
Fix #1457 - Forward to billing if user has a plan but no available licenses

### DIFF
--- a/test/unit/displays/controllers/ctr-display-details.tests.js
+++ b/test/unit/displays/controllers/ctr-display-details.tests.js
@@ -37,17 +37,6 @@ describe('controller: display details', function() {
         isElectronPlayer: function(){ return true;}
       };
     });
-    $provide.service('$state',function(){
-      return {
-        _state : '',
-        go : function(state, params){
-          if (state){
-            this._state = state;
-          }
-          return this._state;
-        }
-      };
-    });
     $provide.service('$modal',function(){
       return {
         open : function(obj){
@@ -89,6 +78,11 @@ describe('controller: display details', function() {
         getCompanyProStatus: function() {
           return Q.resolve({status: 'Subscribed', statusCode: 'subscribed'});
         }
+      }
+    });
+    $provide.service('$state', function() {
+      return {
+        go: sandbox.stub()
       }
     });
     $provide.service('screenshotFactory', function() {
@@ -232,6 +226,19 @@ describe('controller: display details', function() {
 
       $scope.toggleProAuthorized();
       expect($scope.showPlansModal).to.have.been.called;
+      expect(enableCompanyProduct).to.not.have.been.called;
+    });
+
+    it('should forward to billing if has a plan but no available licenses', function () {
+      $scope.display = {};
+      sandbox.stub($scope, 'isProAvailable').returns(false);
+      sandbox.stub($scope, 'showPlansModal');
+      sandbox.stub($scope, 'getProLicenseCount').returns(1);
+      sandbox.stub($scope, 'areAllProLicensesUsed').returns(true);
+
+      $scope.toggleProAuthorized();      
+      expect($state.go).to.have.been.calledWith('apps.billing.home');
+      expect($scope.showPlansModal).to.not.have.been.called;
       expect(enableCompanyProduct).to.not.have.been.called;
     });
 

--- a/web/scripts/displays/controllers/ctr-display-details.js
+++ b/web/scripts/displays/controllers/ctr-display-details.js
@@ -4,10 +4,10 @@ angular.module('risevision.displays.controllers')
   .controller('displayDetails', ['$scope', '$rootScope', '$q',
     'displayFactory', 'display', 'screenshotFactory', 'playerProFactory', '$loading', '$log', '$modal',
     '$templateCache', 'displayId', 'enableCompanyProduct', 'userState', 'plansFactory',
-    'currentPlanFactory', 'playerLicenseFactory', 'PLAYER_PRO_PRODUCT_CODE',
+    'currentPlanFactory', 'playerLicenseFactory', 'PLAYER_PRO_PRODUCT_CODE', '$state',
     function ($scope, $rootScope, $q, displayFactory, display, screenshotFactory, playerProFactory,
       $loading, $log, $modal, $templateCache, displayId, enableCompanyProduct, userState,
-      plansFactory, currentPlanFactory, playerLicenseFactory, PLAYER_PRO_PRODUCT_CODE) {
+      plansFactory, currentPlanFactory, playerLicenseFactory, PLAYER_PRO_PRODUCT_CODE, $state) {
       $scope.displayId = displayId;
       $scope.factory = displayFactory;
       $scope.displayService = display;
@@ -38,7 +38,11 @@ angular.module('risevision.displays.controllers')
       $scope.toggleProAuthorized = function () {
         if (!$scope.isProAvailable()) {
           $scope.display.playerProAuthorized = false;
-          $scope.showPlansModal();
+          if ($scope.getProLicenseCount() > 0 && $scope.areAllProLicensesUsed()) {
+            $state.go('apps.billing.home');
+          } else {
+            $scope.showPlansModal();
+          }
         } else {
           var apiParams = {};
           var playerProAuthorized = $scope.display.playerProAuthorized;


### PR DESCRIPTION
## Description
When trying to license a display but no licenses are available, users will be forwarded to billing so that they can adjust their plan.

Users without a plan will continue to see the Plans modal.

## Motivation and Context
Fix #1457.

## How Has This Been Tested?
Manually tested locally and on stage-1.

No Plan - should show plans modal: https:/apps-stage-1.risevision.com/displays/details/N6A7HQB9JFB8?cid=a7ece267-3ed2-4f66-8fba-17af5e5f96c1
No licenses left - should send to billing: https:/apps-stage-1.risevision.com/displays/details/ETKA2XARN89V?cid=20b453dd-59e2-432a-bb1d-b42a3a02fd05
 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
