### PR TITLE
Poll displays list for Activated Displays

### DIFF
--- a/test/unit/launcher/services/svc-company-assets-factory.tests.js
+++ b/test/unit/launcher/services/svc-company-assets-factory.tests.js
@@ -89,6 +89,14 @@ describe('service: company assets factory:', function() {
         });
     });
 
+    it('should force refresh list if flag is set to true', function() {
+      requestExecute.returns(Q.resolve());
+
+      companyAssetsFactory.hasPresentations(true);
+
+      requestExecute.should.have.been.calledWith(true);
+    });
+
     it('should resolve false if Company does not have templates', function(done) {
       requestExecute.returns(Q.resolve({
         items: []
@@ -231,6 +239,14 @@ describe('service: company assets factory:', function() {
         .catch(function() {
           done('error');
         });
+    });
+
+    it('should force refresh list if flag is set to true', function() {
+      requestExecute.returns(Q.resolve());
+
+      companyAssetsFactory.hasDisplays(true);
+
+      requestExecute.should.have.been.calledWith(true);
     });
 
     it('should indicate if Company has activated displays', function(done) {

--- a/web/scripts/launcher/controllers/ctr-onboarding.js
+++ b/web/scripts/launcher/controllers/ctr-onboarding.js
@@ -1,12 +1,15 @@
 'use strict';
 
 angular.module('risevision.apps.launcher.controllers')
-  .controller('OnboardingCtrl', ['$scope', '$loading', 'onboardingFactory', 'editorFactory',
-    'FEATURED_TEMPLATES',
-    function ($scope, $loading, onboardingFactory, editorFactory, FEATURED_TEMPLATES) {
+  .controller('OnboardingCtrl', ['$scope', '$interval', '$loading', 'onboardingFactory', 'companyAssetsFactory',
+    'editorFactory', 'FEATURED_TEMPLATES',
+    function ($scope, $interval, $loading, onboardingFactory, companyAssetsFactory,
+      editorFactory, FEATURED_TEMPLATES) {
       $scope.factory = onboardingFactory;
       $scope.editorFactory = editorFactory;
       $scope.featuredTemplates = FEATURED_TEMPLATES;
+
+      var activeDisplayPolling;
 
       $scope.select = function (product) {
         editorFactory.addFromProduct(product);
@@ -18,6 +21,35 @@ angular.module('risevision.apps.launcher.controllers')
         } else {
           $loading.stop('onboarding-loader');
         }
+      });
+
+      var _clearActiveDisplayPolling = function () {
+        if (activeDisplayPolling) {
+          $interval.cancel(activeDisplayPolling);
+          activeDisplayPolling = null;
+        }
+      };
+
+      var _startActiveDisplayPolling = function () {
+        if (!activeDisplayPolling) {
+          activeDisplayPolling = $interval(function () {
+            companyAssetsFactory.hasDisplays(true);
+          }, 30 * 1000);
+        }
+      };
+
+      $scope.$watch(function() {
+        return onboardingFactory.isCurrentStep('activateDisplay');
+      }, function(isActivateDisplay) {
+        if (isActivateDisplay) {
+          _startActiveDisplayPolling();
+        } else {
+          _clearActiveDisplayPolling();
+        }
+      });
+
+      $scope.$on('$destroy', function () {
+        _clearActiveDisplayPolling();
       });
 
     }

--- a/web/scripts/launcher/services/svc-company-assets-factory.js
+++ b/web/scripts/launcher/services/svc-company-assets-factory.js
@@ -141,7 +141,7 @@ angular.module('risevision.apps.launcher.services')
         });
       };
 
-      factory.hasDisplays = function () {
+      factory.hasDisplays = function (forceReload) {
         if (addDisplayCompleted && activeDisplayCompleted) {
           return $q.resolve({
             hasDisplays: addDisplayCompleted,
@@ -151,7 +151,7 @@ angular.module('risevision.apps.launcher.services')
 
         var deferred = $q.defer();
 
-        return displayListRequest.execute().then(function (resp) {
+        return displayListRequest.execute(forceReload).then(function (resp) {
           addDisplayCompleted = !!(resp && resp.items && resp.items.length > 0);
 
           if (!addDisplayCompleted) {


### PR DESCRIPTION
## Description
Poll displays list for Activated Displays

If the current step is to wait for a display to be activated
initiate a 30 second poll to check if any display
in the company was activated.

This happens only if the Onboarding is actually shown

## Motivation and Context
Improve user Onboarding experience by automatically checking if they Activate a Display.

## How Has This Been Tested?
Validated that the list is reloaded every 30 seconds, and that result from the Messaging Service of the Display being online is interpreted correctly. The UI updates as expected. Also validated that the polling stops in the cases that the user navigates away from Onboarding, or the step is completed as per the Display being found online.

Test coverage updated as necessary.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.