### PR TITLE
Set cookie check url via config

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "rollup-plugin-node-resolve": "^5.0.3",
     "rollup-plugin-terser": "^5.0.0",
     "run-sequence": "^1.1.1",
-    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git#feature/iframe-click",
+    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git",
     "terser": "^4.0.0",
-    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git#fix/web-security"
+    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "run-sequence": "^1.1.1",
     "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git#feature/iframe-click",
     "terser": "^4.0.0",
-    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
+    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git#fix/web-security"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "rollup-plugin-node-resolve": "^5.0.3",
     "rollup-plugin-terser": "^5.0.0",
     "run-sequence": "^1.1.1",
-    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git",
+    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git#feature/iframe-click",
     "terser": "^4.0.0",
     "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
   },

--- a/test/e2e/template-editor/cases/template-editor-add.js
+++ b/test/e2e/template-editor/cases/template-editor-add.js
@@ -87,10 +87,6 @@ var TemplateAddScenarios = function() {
         presentationsListPage.loadCurrentCompanyPresentationList();
         presentationsListPage.createNewPresentationFromTemplate('Example Financial Template V4', 'example-financial-template-v4');
         templateEditorPage.dismissFinancialDataLicenseMessage();
-
-        //workaround as protactor can't click on top of iframes
-        //decrease window size to hide template preview        
-        browser.driver.manage().window().setSize(500, 800); 
       });
 
       it('should delete the Presentation', function () {
@@ -99,7 +95,7 @@ var TemplateAddScenarios = function() {
 
         browser.sleep(500);
         helper.wait(templateEditorPage.getDeleteForeverButton(), 'Template Delete Forever Button');      
-        helper.clickWhenClickable(templateEditorPage.getDeleteForeverButton(), 'Template Delete Forever Button');
+        helper.clickOverIFrame(templateEditorPage.getDeleteForeverButton());
 
         helper.wait(presentationsListPage.getTitle(), 'Presentation List');
       });
@@ -110,10 +106,6 @@ var TemplateAddScenarios = function() {
         expect(templateEditorPage.getErrorModal().isPresent()).to.eventually.be.false;
       });
 
-      after(function(){
-        //revert workaround
-        browser.driver.manage().window().setSize(1920, 1080); 
-      });
     });    
 
   });

--- a/web/scripts/config/dev.js
+++ b/web/scripts/config/dev.js
@@ -18,7 +18,8 @@
     .constant('LOCALES_SUFIX', '.json');
 
   angular.module('risevision.common.config')
-    .value('CORE_URL', 'https://rvacore-test.appspot.com/_ah/api'); // override default core value
+    .value('CORE_URL', 'https://rvacore-test.appspot.com/_ah/api') // override default core value
+    .value('COOKIE_CHECK_URL', '//http-only-dot-storage-dot-rvacore-test.appspot.com');
 
   angular.module('risevision.apps.config', [])
     .value('APPS_ENV', 'TEST')

--- a/web/scripts/config/dev.js
+++ b/web/scripts/config/dev.js
@@ -19,7 +19,7 @@
 
   angular.module('risevision.common.config')
     .value('CORE_URL', 'https://rvacore-test.appspot.com/_ah/api') // override default core value
-    .value('COOKIE_CHECK_URL', '//http-only-dot-storage-dot-rvacore-test.appspot.com');
+    .value('COOKIE_CHECK_URL', '//storage-dot-rvacore-test.appspot.com');
 
   angular.module('risevision.apps.config', [])
     .value('APPS_ENV', 'TEST')

--- a/web/scripts/config/stage.js
+++ b/web/scripts/config/stage.js
@@ -17,7 +17,8 @@
     .constant('LOCALES_SUFIX', '.json');
 
   angular.module('risevision.common.config')
-    .value('CORE_URL', 'https://rvacore-test.appspot.com/_ah/api'); // override default core value
+    .value('CORE_URL', 'https://rvacore-test.appspot.com/_ah/api') // override default core value
+    .value('COOKIE_CHECK_URL', '//http-only-dot-storage-dot-rvacore-test.appspot.com');
 
   angular.module('risevision.apps.config', [])
     .value('APPS_ENV', 'TEST')

--- a/web/scripts/config/stage.js
+++ b/web/scripts/config/stage.js
@@ -18,7 +18,7 @@
 
   angular.module('risevision.common.config')
     .value('CORE_URL', 'https://rvacore-test.appspot.com/_ah/api') // override default core value
-    .value('COOKIE_CHECK_URL', '//http-only-dot-storage-dot-rvacore-test.appspot.com');
+    .value('COOKIE_CHECK_URL', '//storage-dot-rvacore-test.appspot.com');
 
   angular.module('risevision.apps.config', [])
     .value('APPS_ENV', 'TEST')

--- a/web/scripts/config/test.js
+++ b/web/scripts/config/test.js
@@ -18,7 +18,8 @@
     .constant('LOCALES_SUFIX', '.json');
 
   angular.module('risevision.common.config')
-    .value('CORE_URL', 'https://rvacore-test.appspot.com/_ah/api'); // override default core value
+    .value('CORE_URL', 'https://rvacore-test.appspot.com/_ah/api') // override default core value
+    .value('COOKIE_CHECK_URL', '//http-only-dot-storage-dot-rvacore-test.appspot.com');
 
   angular.module('risevision.apps.config', [])
     .value('APPS_ENV', 'TEST')

--- a/web/scripts/config/test.js
+++ b/web/scripts/config/test.js
@@ -19,7 +19,7 @@
 
   angular.module('risevision.common.config')
     .value('CORE_URL', 'https://rvacore-test.appspot.com/_ah/api') // override default core value
-    .value('COOKIE_CHECK_URL', '//http-only-dot-storage-dot-rvacore-test.appspot.com');
+    .value('COOKIE_CHECK_URL', '//storage-dot-rvacore-test.appspot.com');
 
   angular.module('risevision.apps.config', [])
     .value('APPS_ENV', 'TEST')


### PR DESCRIPTION
## Description
Set cookie check url via config

Use iframe click function from common-e2e
Fix issue where webdriver clicks fail

Remove disable web security flag for e2e tests

## Motivation and Context
Allow testing cookie check URLs from storage-server staging
Fix issues with clicking over an iframe

## How Has This Been Tested?
Validated that e2e tests pass with the above changes. No functionality changes in this PR.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
