### PR TITLE
Add new branch prefix for stage only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,33 +222,63 @@ workflows:
       - test_unit:
           requires:
             - test_build
+          filters:
+            branches:
+              ignore: /(stage).*/
       - e2e_schedules:
           requires:
             - test_build
+          filters:
+            branches:
+              ignore: /(stage).*/
       - e2e_common:
           requires:
             - test_build
+          filters:
+            branches:
+              ignore: /(stage).*/
       - e2e_common_header:
           requires:
             - test_build
+          filters:
+            branches:
+              ignore: /(stage).*/
       - e2e_registration:
           requires:
             - test_build
+          filters:
+            branches:
+              ignore: /(stage).*/
       - e2e_editor:
           requires:
             - test_build
+          filters:
+            branches:
+              ignore: /(stage).*/
       - e2e_displays:
           requires:
             - test_build
+          filters:
+            branches:
+              ignore: /(stage).*/
       - e2e_storage:
           requires:
             - test_build
+          filters:
+            branches:
+              ignore: /(stage).*/
       - e2e_template_editor:
           requires:
             - test_build
+          filters:
+            branches:
+              ignore: /(stage).*/
       - e2e_template_editor2:
           requires:
             - test_build
+          filters:
+            branches:
+              ignore: /(stage).*/
       - test_e2e:
           requires:
             - e2e_schedules
@@ -260,6 +290,9 @@ workflows:
             - e2e_storage
             - e2e_template_editor
             - e2e_template_editor2
+          filters:
+            branches:
+              ignore: /(stage).*/
       - deploy_production:
           requires:
             - test_unit
@@ -272,7 +305,7 @@ workflows:
             - test_build
           filters:
             branches:
-              only: /(feature|fix|chore).*/
+              only: /(feature|fix|chore|stage).*/
       - deploy_beta:
           requires:
             - test_unit


### PR DESCRIPTION
## Description
Add new branch prefix for stage only
Does not run tests; just deploy

[stage-2]

## Motivation and Context
Some changes don't require tests and we just want to stage the branch. Save resources and blocking other more important builds by skipping irrelevant steps.

These branches cannot be merged as PRs because of the blocks for merging.

## How Has This Been Tested?
Validated that stage only works. Also validated that other branches still run tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
