### PR TITLE
Fix image file selector issues

### DIFF
--- a/test/unit/template-editor/directives/dtv-attribute-editor.tests.js
+++ b/test/unit/template-editor/directives/dtv-attribute-editor.tests.js
@@ -6,6 +6,7 @@ describe('directive: TemplateAttributeEditor', function() {
       factory,
       timeout,
       window,
+      blueprintFactory,
       sandbox = sinon.sandbox.create();
 
   beforeEach(function() {
@@ -29,6 +30,12 @@ describe('directive: TemplateAttributeEditor', function() {
 
     $provide.service('$window', function() {
       return window;
+    });
+
+    blueprintFactory = {};
+
+    $provide.service('blueprintFactory', function() {
+      return blueprintFactory;
     });
   }));
 
@@ -115,6 +122,85 @@ describe('directive: TemplateAttributeEditor', function() {
     $scope.editComponent(component);
 
     expect(factory.selected).to.deep.equal(component);
+
+    expect(directive.element.show).to.have.been.called;
+    expect(directive.show).to.have.been.called;
+
+    expect($scope.showAttributeList).to.be.true;
+
+    timeout.flush();
+    expect($scope.showAttributeList).to.be.false;
+  });
+
+  it('Edits a highlighted component', function() {
+    var directive = {
+      type: 'rise-test',
+      icon: 'fa-test',
+      element: {
+        hide: function() {},
+        show: sandbox.stub()
+      },
+      show: sandbox.stub()
+    };
+
+    var component = {
+      id: 'test',
+      type: 'rise-test'
+    }
+
+    blueprintFactory.blueprintData = {
+      components: [component]
+    };
+
+    $scope.registerDirective(directive);
+    $scope.editHighlightedComponent(component.id);
+
+    expect(factory.selected).to.deep.equal(component);
+
+    expect(directive.element.show).to.have.been.called;
+    expect(directive.show).to.have.been.called;
+
+    expect($scope.showAttributeList).to.be.true;
+
+    timeout.flush();
+    expect($scope.showAttributeList).to.be.false;
+  });
+
+  it('Resets selected panels when editing a highlighted component', function() {
+    var directive = {
+      type: 'rise-test',
+      icon: 'fa-test',
+      element: {
+        hide: function() {},
+        show: sandbox.stub()
+      },
+      show: sandbox.stub()
+    };
+
+    var component = {
+      id: 'test',
+      type: 'rise-test'
+    }
+    
+    $scope.registerDirective(directive);
+
+    blueprintFactory.blueprintData = {
+      components: [component]
+    };
+
+    factory.selected = component;
+    $scope.panels = [{}, {}, {}];
+    $scope.setPanelIcon('previous-icon', 'streamline');
+    $scope.setPanelTitle('Previous Title');
+    
+    $scope.editHighlightedComponent(component.id);
+
+    expect(factory.selected).to.deep.equal(component);
+
+    expect($scope.panels).to.be.empty;
+    expect($scope.panelIcon).to.be.null;
+    expect($scope.panelIconType).to.be.null;
+    expect($scope.panelTitle).to.be.null;
 
     expect(directive.element.show).to.have.been.called;
     expect(directive.show).to.have.been.called;

--- a/web/partials/template-editor/components/component-image/image-list.html
+++ b/web/partials/template-editor/components/component-image/image-list.html
@@ -12,8 +12,7 @@
 </div>
 <div class="image-component-list file-component-list te-scrollable-container"
      ng-class="{'active-duration' : selectedImages.length > 1 && !isUploading}"
-     rv-spinner rv-spinner-key="template-editor-loader"
-     rv-spinner-start-active="1">
+     rv-spinner rv-spinner-key="template-editor-loader">
   <template-editor-file-entry
     ng-repeat="image in selectedImages track by $index"
     ng-show="selectedImages.length > 0 && !isUploading"

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -63,6 +63,9 @@ angular.module('risevision.template-editor.directives')
                 $scope.setPanelIcon('riseStorage', 'riseSvg');
                 $scope.setPanelTitle('Rise Storage');
               }
+            },
+            reset: function () {
+              // for override
             }
           };
           $scope.values = {};
@@ -70,6 +73,7 @@ angular.module('risevision.template-editor.directives')
           function _reset() {
             _setSelectedImages([]);
             $scope.isUploading = false;
+            $scope.storageManager.reset();
           }
 
           function _addFilesToMetadata(files, alwaysAppend) {

--- a/web/scripts/template-editor/directives/dtv-attribute-editor.js
+++ b/web/scripts/template-editor/directives/dtv-attribute-editor.js
@@ -200,6 +200,7 @@ angular.module('risevision.template-editor.directives')
               if (component) {
                 if ($scope.factory.selected) {
                   $scope.backToList();
+                  $scope.panels = [];
                 }
                 $scope.editComponent(component);
               }

--- a/web/scripts/template-editor/directives/dtv-attribute-editor.js
+++ b/web/scripts/template-editor/directives/dtv-attribute-editor.js
@@ -201,6 +201,7 @@ angular.module('risevision.template-editor.directives')
                 if ($scope.factory.selected) {
                   $scope.backToList();
                   $scope.panels = [];
+                  $scope.resetPanelHeader();
                 }
                 $scope.editComponent(component);
               }

--- a/web/scripts/template-editor/directives/dtv-attribute-editor.js
+++ b/web/scripts/template-editor/directives/dtv-attribute-editor.js
@@ -142,6 +142,18 @@ angular.module('risevision.template-editor.directives')
             $scope.panelTitle = panelTitle;
           };
 
+          $scope.editHighlightedComponent = function (componentId) {
+            var component = _.find(blueprintFactory.blueprintData.components, function (element) { return element.id === componentId; });
+            if (component) {
+              if ($scope.factory.selected) {
+                $scope.backToList();
+                $scope.panels = [];
+                $scope.resetPanelHeader();
+              }
+              $scope.editComponent(component);
+            }
+          };
+
           function _showAttributeList(value, delay) {
             $timeout(function () {
               $scope.showAttributeList = value;
@@ -195,16 +207,7 @@ angular.module('risevision.template-editor.directives')
 
             switch (data.type) {
             case 'editComponent':
-              console.log(data.value);
-              var component = blueprintFactory.blueprintData.components.find(function (element) { return element.id === data.value; });
-              if (component) {
-                if ($scope.factory.selected) {
-                  $scope.backToList();
-                  $scope.panels = [];
-                  $scope.resetPanelHeader();
-                }
-                $scope.editComponent(component);
-              }
+              $scope.editHighlightedComponent(data.value);
               break;
             default:
               break;

--- a/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
+++ b/web/scripts/template-editor/directives/dtv-basic-storage-selector.js
@@ -46,7 +46,8 @@ angular.module('risevision.template-editor.directives')
 
                 return true;
               }
-            }
+            },
+            reset: _reset
           });
 
           function _reset() {


### PR DESCRIPTION
## Description
Fix multiple issues when navigating and selecting components that include file selector

## Motivation and Context

- Fix image component editor does not appear on second click
- Fix file selector title remains showing up after selecting highlighted component
- Fix previous file selection appearing when clicking on another highlighted component
- Fix loading spinner never disappearing the first time a highlighted image component is selected

## How Has This Been Tested?
Tested manually locally and Unit tests added 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
