### PR TITLE
Refresh billing page on Plan purchase

### DIFF
--- a/test/unit/billing/controllers/ctr-billing.tests.js
+++ b/test/unit/billing/controllers/ctr-billing.tests.js
@@ -114,6 +114,25 @@ describe('controller: BillingCtrl', function () {
 
   });
 
+  describe('checkCreationDate: ', function() {
+    it('should return false if creation date is null', function() {
+      expect($scope.checkCreationDate()).to.be.false;
+    });
+
+    it('should return false if company was created after the launch date', function() {
+      $scope.company.creationDate = 'Sep 25, 2018';
+
+      expect($scope.checkCreationDate()).to.be.false;
+    });
+
+    it('should return true if company has not completed onboarding', function() {
+      $scope.company.creationDate = 'Aug 25, 2015';
+
+      expect($scope.checkCreationDate()).to.be.true;
+    });
+
+  });
+
   describe('hasUnpaidInvoices: ', function() {
     it('should default to false', function() {
       expect($scope.invoices).to.be.an('object');
@@ -192,7 +211,7 @@ describe('controller: BillingCtrl', function () {
     });
   });
 
-  describe('chargebee events', function () {
+  describe('events: ', function () {
     it('should reload Subscriptions when Subscription is updated on Customer Portal', function () {
       $rootScope.$emit('chargebee.subscriptionChanged');
       $timeout.flush();
@@ -200,6 +219,13 @@ describe('controller: BillingCtrl', function () {
       expect($loading.stopGlobal).to.be.calledOnce;
       expect(listServiceInstance.doSearch).to.be.calledOnce;
     });
+
+    it('should reload Subscriptions when Subscription is started', function () {
+      $rootScope.$emit('risevision.company.planStarted');
+      $rootScope.$digest();
+      expect(listServiceInstance.doSearch).to.be.calledOnce;
+    });
+
   });
 
   describe('data formatting', function () {

--- a/test/unit/components/purchase-flow/services/svc-purchase-factory-spec.js
+++ b/test/unit/components/purchase-flow/services/svc-purchase-factory-spec.js
@@ -594,7 +594,7 @@ describe("Services: purchase factory", function() {
           userState.reloadSelectedCompany.should.have.been.called;
 
           setTimeout(function() {
-            $rootScope.$emit.should.have.been.calledWith("risevision.company.trial.started");
+            $rootScope.$emit.should.have.been.calledWith("risevision.company.planStarted");
             expect(purchaseFactory.purchase.reloadingCompany).to.be.false;
 
             done();

--- a/web/partials/billing/app-billing.html
+++ b/web/partials/billing/app-billing.html
@@ -12,7 +12,7 @@
         <h4>Invoice History</h4>
         <ul class="list-unstyled">
           <li><a href="#" ng-click="viewPastInvoices()">View Past Invoices</a></li>
-          <li><a href="#" ng-click="viewPastInvoicesStore()">View Past Invoices (Prior to September 2018)</a></li>
+          <li><a href="#" ng-click="viewPastInvoicesStore()" ng-show="checkCreationDate()">View Past Invoices (Prior to September 2018)</a></li>
           <li><a href="#" ng-click="viewUnpaidInvoicesStore()" ng-show="hasUnpaidInvoices">View Unpaid Invoices (Prior to September 2018)</a></li>
         </ul>
       </div>

--- a/web/scripts/billing/controllers/ctr-billing.js
+++ b/web/scripts/billing/controllers/ctr-billing.js
@@ -35,9 +35,18 @@ angular.module('risevision.apps.billing.controllers')
 
       $rootScope.$on('chargebee.subscriptionChanged', _reloadSubscriptions);
       $rootScope.$on('chargebee.subscriptionCancelled', _reloadSubscriptions);
+      $rootScope.$on('risevision.company.planStarted', function() {
+        $scope.subscriptions.doSearch();
+      });
 
       $scope.viewPastInvoices = function () {
         $scope.chargebeeFactory.openBillingHistory(userState.getSelectedCompanyId());
+      };
+
+      $scope.checkCreationDate = function () {
+        var creationDate = (($scope.company && $scope.company.creationDate) ? 
+          (new Date($scope.company.creationDate)) : (new Date()));
+        return creationDate < new Date('Sep 1, 2018');
       };
 
       $scope.viewPastInvoicesStore = function () {

--- a/web/scripts/components/purchase-flow/services/svc-purchase-factory.js
+++ b/web/scripts/components/purchase-flow/services/svc-purchase-factory.js
@@ -277,7 +277,7 @@
                   return userState.reloadSelectedCompany();
                 })
                 .then(function () {
-                  $rootScope.$emit('risevision.company.trial.started');
+                  $rootScope.$emit('risevision.company.planStarted');
                 })
                 .catch(function (err) {
                   $log.debug('Failed to reload company', err);

--- a/web/scripts/displays/controllers/ctr-displays-list.js
+++ b/web/scripts/displays/controllers/ctr-displays-list.js
@@ -39,7 +39,7 @@ angular.module('risevision.displays.controllers')
         $scope.displays.doSearch();
       });
 
-      $rootScope.$on('risevision.company.trial.started', function () {
+      $rootScope.$on('risevision.company.planStarted', function () {
         $scope.displays.doSearch();
       });
 


### PR DESCRIPTION
## Description
Refresh billing page on Plan purchase

Hide old subscriptions link based on creation date
Re-name subscription created event

[stage-2]

## Motivation and Context
Better user experience and removing confusion re old subscriptions.

Fix for #1472 

## How Has This Been Tested?
Tested in local environment. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
