### PR TITLE
Use Apps hardcoded value for Volume Plan names

### DIFF
--- a/test/unit/billing/controllers/ctr-billing.tests.js
+++ b/test/unit/billing/controllers/ctr-billing.tests.js
@@ -229,52 +229,67 @@ describe('controller: BillingCtrl', function () {
   });
 
   describe('data formatting', function () {
-    it('should format subscription name', function () {
-      expect($scope.getSubscriptionDesc({
-        productName: 'Enterprise Plan',
-        quantity: 1,
-        unit: 'per Company per Month',
-        currencyCode: 'usd'
-      })).to.equal('Enterprise Plan (Monthly/USD)');
+    describe('getSubscriptionDesc: ', function() {
+      it('should format legacy subscription names', function () {
+        expect($scope.getSubscriptionDesc({
+          productName: 'Enterprise Plan',
+          quantity: 1,
+          unit: 'per Company per Month'
+        })).to.equal('Enterprise Plan Monthly');
 
-      expect($scope.getSubscriptionDesc({
-        productName: 'Enterprise Plan',
-        quantity: 3,
-        unit: 'per Display per month',
-        currencyCode: 'cad'
-      })).to.equal('3 x Enterprise Plan (Monthly/CAD)');
+        expect($scope.getSubscriptionDesc({
+          productName: 'Enterprise Plan',
+          quantity: 3,
+          unit: 'per Display per month'
+        })).to.equal('3 x Enterprise Plan Monthly');
 
-      expect($scope.getSubscriptionDesc({
-        productName: 'Advanced Plan',
-        quantity: 1,
-        unit: 'per Company per Year',
-        billingPeriod: 0,
-        currencyCode: 'usd'
-      })).to.equal('Advanced Plan (Yearly/USD)');
+        expect($scope.getSubscriptionDesc({
+          productName: 'Advanced Plan',
+          quantity: 1,
+          unit: 'per Company per Year',
+          billingPeriod: 0
+        })).to.equal('Advanced Plan Yearly');
 
-      expect($scope.getSubscriptionDesc({
-        productName: 'Basic Plan',
-        quantity: 2,
-        unit: 'per Company per Year',
-        billingPeriod: 1,
-        currencyCode: 'cad'
-      })).to.equal('2 x Basic Plan (Yearly/CAD)');
+        expect($scope.getSubscriptionDesc({
+          productName: 'Basic Plan',
+          quantity: 2,
+          unit: 'per Company per Year',
+          billingPeriod: 1
+        })).to.equal('2 x Basic Plan Yearly');
 
-      expect($scope.getSubscriptionDesc({
-        productName: 'Basic Plan',
-        quantity: 2,
-        unit: 'per Company per Year',
-        billingPeriod: 3,
-        currencyCode: 'cad'
-      })).to.equal('2 x Basic Plan (3 Year/CAD)');
+        expect($scope.getSubscriptionDesc({
+          productName: 'Basic Plan',
+          quantity: 2,
+          unit: 'per Company per Year',
+          billingPeriod: 3
+        })).to.equal('2 x Basic Plan 3 Year');
 
-      expect($scope.getSubscriptionDesc({
-        productName: 'Additional Licenses',
-        quantity: 1,
-        unit: 'per Display per Year',
-        currencyCode: 'cad',
-        productCode: 'pppc'
-      })).to.equal('1 x Additional Licenses (Yearly/CAD)');
+        expect($scope.getSubscriptionDesc({
+          productName: 'Additional Licenses',
+          quantity: 1,
+          unit: 'per Display per Year',
+          productCode: 'pppc'
+        })).to.equal('1 x Additional Licenses Yearly');
+
+      });
+
+      it('should format volume plan names', function () {
+        expect($scope.getSubscriptionDesc({
+          productName: 'Volume Plan',
+          quantity: 1,
+          unit: 'per Company per Month',
+          productCode: '34e8b511c4cc4c2affa68205cd1faaab427657dc'
+        })).to.equal('1 x Display Licenses Monthly Plan');
+
+        expect($scope.getSubscriptionDesc({
+          productName: 'Volume Plan for Education',
+          quantity: 3,
+          unit: 'per Company per Year',
+          productCode: '88725121a2c7a57deefcf06688ffc8e84cc4f93b'
+        })).to.equal('3 x Display Licenses for Education Yearly Plan');
+
+      });
+
     });
 
     it('should calculate total price', function () {

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -611,8 +611,12 @@ angular.module('risevision.apps.launcher.services', [
   'ngStorage'
 ]);
 
-angular.module('risevision.apps.billing.controllers', []);
-angular.module('risevision.apps.billing.services', []);
+angular.module('risevision.apps.billing.controllers', [
+  'risevision.apps.billing.services'
+]);
+angular.module('risevision.apps.billing.services', [
+  'risevision.common.components.plans'
+]);
 
 angular.module('risevision.schedules.services', [
   'risevision.common.header',

--- a/web/scripts/billing/controllers/ctr-billing.js
+++ b/web/scripts/billing/controllers/ctr-billing.js
@@ -5,10 +5,10 @@ angular.module('risevision.apps.billing.controllers')
   .value('UNPAID_INVOICES_PATH', 'account/view/invoicesDue?cid=companyId')
   .controller('BillingCtrl', ['$rootScope', '$scope', '$loading', '$window', '$timeout',
     'ScrollingListService', 'userState', 'currentPlanFactory', 'ChargebeeFactory', 'billing',
-    'STORE_URL', 'PAST_INVOICES_PATH', 'UNPAID_INVOICES_PATH', 'companySettingsFactory',
+    'STORE_URL', 'PAST_INVOICES_PATH', 'UNPAID_INVOICES_PATH', 'PLANS_LIST', 'companySettingsFactory',
     function ($rootScope, $scope, $loading, $window, $timeout, ScrollingListService, userState,
       currentPlanFactory, ChargebeeFactory, billing, STORE_URL, PAST_INVOICES_PATH, UNPAID_INVOICES_PATH,
-      companySettingsFactory) {
+      PLANS_LIST, companySettingsFactory) {
 
       $scope.search = {
         count: $scope.listLimit,
@@ -83,18 +83,28 @@ angular.module('risevision.apps.billing.controllers')
         $scope.chargebeeFactory.openSubscriptionDetails(userState.getSelectedCompanyId(), subscriptionId);
       };
 
+      var _getVolumePlan = function(subscription) {
+        var volumePlan = _.find(PLANS_LIST, function(plan) {
+          return plan.productCode === subscription.productCode &&
+            plan.type.indexOf('volume') !== -1;
+        });
+
+        return volumePlan;
+      };
+
       $scope.getSubscriptionDesc = function (subscription) {
         var prefix = subscription.quantity > 1 ? subscription.quantity + ' x ' : '';
+        var volumePlan = _getVolumePlan(subscription);
 
         // Show `1` quantity for Per Display subscriptions
-        if (_isPerDisplay(subscription) && subscription.quantity > 0) {
+        if ((_isPerDisplay(subscription) || volumePlan) && subscription.quantity > 0) {
           prefix = subscription.quantity + ' x ';
         }
 
         var period = _getPeriod(subscription);
-        var currency = _getCurrency(subscription);
+        var name =  volumePlan ? volumePlan.name : subscription.productName;
 
-        return prefix + subscription.productName + ' (' + period + '/' + currency + ')';
+        return prefix + name + ' ' + period + (volumePlan ? ' Plan' : '');
       };
 
       $scope.getSubscriptionPrice = function (subscription) {
@@ -122,10 +132,6 @@ angular.module('risevision.apps.billing.controllers')
           $loading.stopGlobal('subscriptions-changed-loader');
           $scope.subscriptions.doSearch();
         }, 10000);
-      }
-
-      function _getCurrency(subscription) {
-        return subscription.currencyCode.toUpperCase();
       }
 
       function _getPeriod(subscription) {

--- a/web/scripts/billing/controllers/ctr-billing.js
+++ b/web/scripts/billing/controllers/ctr-billing.js
@@ -35,7 +35,7 @@ angular.module('risevision.apps.billing.controllers')
 
       $rootScope.$on('chargebee.subscriptionChanged', _reloadSubscriptions);
       $rootScope.$on('chargebee.subscriptionCancelled', _reloadSubscriptions);
-      $rootScope.$on('risevision.company.planStarted', function() {
+      $rootScope.$on('risevision.company.planStarted', function () {
         $scope.subscriptions.doSearch();
       });
 
@@ -44,7 +44,7 @@ angular.module('risevision.apps.billing.controllers')
       };
 
       $scope.checkCreationDate = function () {
-        var creationDate = (($scope.company && $scope.company.creationDate) ? 
+        var creationDate = (($scope.company && $scope.company.creationDate) ?
           (new Date($scope.company.creationDate)) : (new Date()));
         return creationDate < new Date('Sep 1, 2018');
       };
@@ -83,8 +83,8 @@ angular.module('risevision.apps.billing.controllers')
         $scope.chargebeeFactory.openSubscriptionDetails(userState.getSelectedCompanyId(), subscriptionId);
       };
 
-      var _getVolumePlan = function(subscription) {
-        var volumePlan = _.find(PLANS_LIST, function(plan) {
+      var _getVolumePlan = function (subscription) {
+        var volumePlan = _.find(PLANS_LIST, function (plan) {
           return plan.productCode === subscription.productCode &&
             plan.type.indexOf('volume') !== -1;
         });
@@ -102,7 +102,7 @@ angular.module('risevision.apps.billing.controllers')
         }
 
         var period = _getPeriod(subscription);
-        var name =  volumePlan ? volumePlan.name : subscription.productName;
+        var name = volumePlan ? volumePlan.name : subscription.productName;
 
         return prefix + name + ' ' + period + (volumePlan ? ' Plan' : '');
       };

--- a/web/scripts/components/logging/svc-segment-analytics.js
+++ b/web/scripts/components/logging/svc-segment-analytics.js
@@ -54,7 +54,7 @@
               'store.risevision.com', 'help.risevision.com',
               'apps.risevision.com', 'risevision.com',
               'preview.risevision.com', 'rva.risevision.com'
-            ], GA_LINKER_USE_ANCHOR);            
+            ], GA_LINKER_USE_ANCHOR);
           }
         });
 

--- a/web/scripts/components/plans/ctr-plans-modal.js
+++ b/web/scripts/components/plans/ctr-plans-modal.js
@@ -7,9 +7,9 @@ angular.module('risevision.common.components.plans')
     function ($scope, $modalInstance, currentPlanFactory, userState, purchaseFactory,
       PLANS_LIST, CHARGEBEE_PLANS_USE_PROD) {
 
-      var volumePlan = PLANS_LIST.filter(function (plan) {
-        return plan.name === 'Volume';
-      })[0];
+      var volumePlan = _.find(PLANS_LIST, {
+        type: 'volume'
+      });
 
       $scope.pricingAtLeastOneDisplay = true;
       $scope.currentPlan = currentPlanFactory.currentPlan;

--- a/web/scripts/components/plans/svc-plans-factory.js
+++ b/web/scripts/components/plans/svc-plans-factory.js
@@ -22,7 +22,7 @@
         save: 0
       }
     }, {
-      name: 'Volume',
+      name: 'Display Licenses',
       type: 'volume',
       order: 1,
       productId: '2317',
@@ -49,7 +49,7 @@
         'RELIGIOUS_INSTITUTIONS'
       ]
     }, {
-      name: 'Volume for Education',
+      name: 'Display Licenses for Education',
       // cannot use type 'volume', it may interfere with the other plan
       type: 'volume for education',
       order: 1,

--- a/web/scripts/components/plans/svc-plans-factory.js
+++ b/web/scripts/components/plans/svc-plans-factory.js
@@ -162,8 +162,6 @@
     .factory('plansFactory', ['$modal', '$templateCache', 'userState', 'PLANS_LIST',
       function ($modal, $templateCache, userState, PLANS_LIST) {
         var _factory = {};
-        var _plansByType = _.keyBy(PLANS_LIST, 'type');
-        var _plansByCode = _.keyBy(PLANS_LIST, 'productCode');
 
         _factory.showPlansModal = function () {
           if (!_factory.isPlansModalOpen) {
@@ -182,9 +180,11 @@
         };
 
         _factory.initVolumePlanTrial = function () {
-          var plan = _plansByType.volume;
+          var plan = _.find(PLANS_LIST, {
+            type: 'volume'
+          });
+          var licenses = plan.proLicenseCount;
           var selectedCompany = userState.getCopyOfSelectedCompany(true);
-          var licenses = _plansByCode[plan.productCode].proLicenseCount;
           var trialExpiry = new Date();
           trialExpiry.setDate(trialExpiry.getDate() + plan.trialPeriod);
           // Round down the date otherwise the subtraction may calculate an extra day

--- a/web/scripts/template-editor/directives/dtv-attribute-editor.js
+++ b/web/scripts/template-editor/directives/dtv-attribute-editor.js
@@ -1,9 +1,9 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
-  .directive('templateAttributeEditor', ['$timeout', 'templateEditorFactory', 'templateEditorUtils', 
-  'blueprintFactory', '$window', 'HTML_TEMPLATE_DOMAIN',
-    function ($timeout, templateEditorFactory, templateEditorUtils, blueprintFactory, $window, 
+  .directive('templateAttributeEditor', ['$timeout', 'templateEditorFactory', 'templateEditorUtils',
+    'blueprintFactory', '$window', 'HTML_TEMPLATE_DOMAIN',
+    function ($timeout, templateEditorFactory, templateEditorUtils, blueprintFactory, $window,
       HTML_TEMPLATE_DOMAIN) {
       return {
         restrict: 'E',
@@ -145,7 +145,9 @@ angular.module('risevision.template-editor.directives')
           };
 
           $scope.editHighlightedComponent = function (componentId) {
-            var component = _.find(blueprintFactory.blueprintData.components, function (element) { return element.id === componentId; });
+            var component = _.find(blueprintFactory.blueprintData.components, function (element) {
+              return element.id === componentId;
+            });
             if (component) {
               if ($scope.factory.selected) {
                 $scope.backToList();
@@ -203,7 +205,7 @@ angular.module('risevision.template-editor.directives')
             _showElement(swappedInSelector, 'left');
             _hideElement(swappedOutSelector);
           }
-          
+
           function _handleMessageFromTemplate(event) {
             var data = JSON.parse(event.data);
 


### PR DESCRIPTION
## Description
Use Apps hardcoded value for Volume Plan names

Server name does not match the name in Chargebee
Update format for the name; remove currency

Fix volume plan queries to use type
Name should not be used as it can be changed

[stage-2]

## Motivation and Context
Fix for #1474 

Updating names for the Display License & Display License for Education plans as per the discussion here:
https://trello.com/c/rQBmwlKD/5819-issue-1474-the-subscription-name-in-apps-does-not-match-the-invoice-2

Also updating the name format for other Subscriptions to be consistent. Removing currency.

Fixing issue where a single Display License was not showing the amount as expected.

## How Has This Been Tested?
Validated new formats in the testing environment with various Subscriptions. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No