### PR TITLE
Fix selected displays not updating

### DIFF
--- a/web/scripts/editor/services/svc-editor-factory.js
+++ b/web/scripts/editor/services/svc-editor-factory.js
@@ -139,9 +139,8 @@ angular.module('risevision.editor.services')
           presentationParser.parsePresentation(factory.presentation);
         } else {
           presentationParser.updatePresentation(factory.presentation);
+          distributionParser.updateDistribution(factory.presentation);
         }
-
-        distributionParser.updateDistribution(factory.presentation);
 
         _updateEmbeddedIds(factory.presentation);
       };


### PR DESCRIPTION
## Description
Fix selected displays not updating

When updating Placeholder distribution, switching
to HTML view, and saving, the Distribution displays
are lost

updateDistribution takes Distribution from the Placeholder list and
updates the presentation.distribution. However, when in
HTML mode, the Placeholder list is refreshed (cleared) based
on the HTML, so the Distribution is lost. This can be corrected
via parseDistribution, but that call is not needed
in this case because it's called after the update.

Also, fixing unit tests. Promise results do not count as failures
since they are not linked to the done sent in the timeout. Moving
timeout to Promise results.

[stage-2]

## Motivation and Context
Fix for #1483 

## How Has This Been Tested?
Replicated the issue in the current version. Debugged the source. Tested fix in the local environment. Validated with unit tests, noticed tests were not failing where expected so I had to do a bit of refactoring to the unit tests to get them to accurately test the functionality.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No