### PR TITLE
Disable actions when saving Presentation

### DIFF
--- a/web/partials/editor/footerbar.html
+++ b/web/partials/editor/footerbar.html
@@ -9,13 +9,13 @@
   <span class="save-status u_margin-right" ng-show="factory.presentation.id">
     <last-revised revision-status-name="factory.presentation.revisionStatusName" change-date="factory.presentation.changeDate" changed-by="factory.presentation.changedBy"></last-revised>
   </span>
-  <button id="restoreButton" require-role="cp" class="btn btn-default" ng-disabled="!factory.presentation.id || (!factory.isRevised() && !hasUnsavedChanges)" ng-click="factory.confirmRestorePresentation()" >{{'common.restore' | translate}}</button>
+  <button id="restoreButton" require-role="cp" class="btn btn-default" ng-disabled="!factory.presentation.id || (!factory.isRevised() && !hasUnsavedChanges)" ng-click="factory.confirmRestorePresentation()" ng-disabled="factory.savingPresentation">{{'common.restore' | translate}}</button>
 
   <!-- Indicates a successful or positive action -->
-  <button id="saveButton" require-role="ce cp" type="submit" class="btn btn-primary btn-fixed-width" ng-click="factory.save()">
+  <button id="saveButton" require-role="ce cp" type="submit" class="btn btn-primary btn-fixed-width" ng-click="factory.save()" ng-disabled="factory.savingPresentation">
     {{ factory.savingPresentation ? ('common.saving' | translate) : ('common.save' | translate)}}
     <i class="fa fa-check icon-right"></i>
   </button>
 
-  <button id="publishButton" require-role="cp" class="btn btn-primary" ng-disabled="hasUnsavedChanges || !factory.isRevised()" ng-click="factory.publishPresentation()" >{{'common.publish' | translate}}</button>
+  <button id="publishButton" require-role="cp" class="btn btn-primary" ng-disabled="hasUnsavedChanges || !factory.isRevised()" ng-click="factory.publishPresentation()" ng-disabled="factory.savingPresentation">{{'common.publish' | translate}}</button>
 </div>

--- a/web/partials/editor/toolbar.html
+++ b/web/partials/editor/toolbar.html
@@ -45,11 +45,11 @@
     <i class="fa fa-th icon-right"></i>
   </button>
   <span class="text-muted u_margin-left u_margin-right" ng-if="!factory.presentation.id" translate >editor-app.workspace.toolbar.or</span>
-  <button id="previewButton" ng-if="!(hasUnsavedChanges && hasContentEditorRole())" class="btn btn-primary" ng-click="factory.preview(factory.presentation.id)" ng-disabled="!factory.presentation.id">
+  <button id="previewButton" ng-if="!(hasUnsavedChanges && hasContentEditorRole())" class="btn btn-primary" ng-click="factory.preview(factory.presentation.id)" ng-disabled="!factory.presentation.id || factory.savingPresentation">
     {{'editor-app.workspace.toolbar.preview' | translate}}
     <i class="fa fa-play icon-right"></i>
   </button>
-  <button id="saveAndPreviewButton" class="btn btn-primary u_margin-left" ng-if="hasUnsavedChanges && hasContentEditorRole()"  ng-click="factory.saveAndPreview()">
+  <button id="saveAndPreviewButton" class="btn btn-primary u_margin-left" ng-if="hasUnsavedChanges && hasContentEditorRole()"  ng-click="factory.saveAndPreview()" ng-disabled="factory.savingPresentation">
     {{'editor-app.workspace.toolbar.saveAndPreview' | translate}}
     <i class="fa fa-play icon-right"></i>
   </button>


### PR DESCRIPTION
## Description
Disable actions when saving Presentation
Could cause issues with mutliple Presentations being added

[stage-2]

## Motivation and Context
Improved user experience. Preventing multiple items from being added by mistake.

## How Has This Been Tested?
Validated that the buttons are being disabled on save and publish. They are also enabled after the operation is completed.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No