### PR TITLE
Open Colors component settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4648,8 +4648,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4670,14 +4669,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4692,20 +4689,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4822,8 +4816,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4835,7 +4828,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4850,7 +4842,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4858,14 +4849,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4884,7 +4873,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4972,8 +4960,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4985,7 +4972,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5071,8 +5057,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5108,7 +5093,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5128,7 +5112,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5172,14 +5155,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/test/unit/template-editor/components/directives/dtv-component-colors.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-colors.tests.js
@@ -1,0 +1,49 @@
+'use strict';
+
+describe('directive: templateComponentColors', function() {
+  var $scope,
+    element,
+    factory;
+
+  beforeEach(function() {
+    factory = { selected: { id: "TEST-ID" } };
+  });
+
+  beforeEach(module('risevision.template-editor.directives'));
+  beforeEach(module('risevision.template-editor.controllers'));
+  beforeEach(module('risevision.template-editor.services'));
+  beforeEach(module('risevision.editor.services'));
+  beforeEach(module(mockTranlate()));
+  beforeEach(module(function ($provide) {
+    $provide.service('templateEditorFactory', function() {
+      return factory;
+    });
+  }));
+
+  beforeEach(inject(function($compile, $rootScope, $templateCache){
+    $templateCache.put('partials/template-editor/components/component-colors.html', '<p>mock</p>');
+    $scope = $rootScope.$new();
+
+    $scope.registerDirective = sinon.stub();
+    $scope.setAttributeData = sinon.stub();
+
+    element = $compile("<template-component-colors></template-component-colors>")($scope);
+    $scope = element.scope();
+    $scope.$digest();
+  }));
+
+  it('should exist', function() {
+    expect($scope).to.be.ok;
+    expect($scope.factory).to.be.ok;
+    expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" } });
+    expect($scope.registerDirective).to.have.been.called;
+
+    var directive = $scope.registerDirective.getCall(0).args[0];
+    expect(directive).to.be.ok;
+    expect(directive.type).to.equal('rise-data-colors');
+    expect(directive.iconType).to.equal('streamline');
+    expect(directive.icon).to.exist;
+    expect(directive.show).to.be.a('function');
+  });
+
+});

--- a/test/unit/template-editor/components/directives/dtv-component-colors.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-colors.tests.js
@@ -13,7 +13,7 @@ describe('directive: templateComponentColors', function() {
   beforeEach(module('risevision.template-editor.controllers'));
   beforeEach(module('risevision.template-editor.services'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
       return factory;

--- a/test/unit/template-editor/components/directives/dtv-component-time-date.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-time-date.tests.js
@@ -14,7 +14,7 @@ describe('directive: templateComponentTimeDate', function() {
   beforeEach(module('risevision.template-editor.controllers'));
   beforeEach(module('risevision.template-editor.services'));
   beforeEach(module('risevision.editor.services'));
-  beforeEach(module(mockTranlate()));
+  beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
       return factory;

--- a/web/index.html
+++ b/web/index.html
@@ -514,6 +514,7 @@
   <script src="scripts/template-editor/components/directives/dtv-component-rss.js"></script>
   <script src="scripts/template-editor/components/directives/dtv-component-counter.js"></script>
   <script src="scripts/template-editor/components/directives/dtv-component-time-date.js"></script>
+  <script src="scripts/template-editor/components/directives/dtv-component-colors.js"></script>
   <script src="scripts/template-editor/components/directives/dtv-component-weather.js"></script>
 
   <!-- storage -->

--- a/web/locales/en/template.json
+++ b/web/locales/en/template.json
@@ -68,6 +68,7 @@
   "rise-image": "Image",
   "rise-data-financial": "Financial",
   "rise-data-rss": "RSS",
+  "rise-data-colors": "Colors",
   "rise-data-counter-down": "Count Down",
   "rise-data-counter-up": "Count Up",
   "rise-data-weather": "Weather",

--- a/web/partials/template-editor/component.html
+++ b/web/partials/template-editor/component.html
@@ -31,5 +31,6 @@
   <template-component-rss></template-component-rss>
   <template-component-counter></template-component-counter>
   <template-component-time-date></template-component-time-date>
+  <template-component-colors></template-component-colors>
   <template-component-weather></template-component-weather>
 </div>

--- a/web/partials/template-editor/components/component-colors.html
+++ b/web/partials/template-editor/components/component-colors.html
@@ -1,0 +1,3 @@
+<div>
+  Colors settings
+</div>

--- a/web/scripts/template-editor/components/directives/dtv-component-colors.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-colors.js
@@ -1,0 +1,27 @@
+'use strict';
+
+angular.module('risevision.template-editor.directives')
+  .directive('templateComponentColors', ['templateEditorFactory',
+    function (templateEditorFactory) {
+      return {
+        restrict: 'E',
+        scope: true,
+        templateUrl: 'partials/template-editor/components/component-colors.html',
+        link: function ($scope, element) {
+          $scope.factory = templateEditorFactory;
+
+          $scope.registerDirective({
+            type: 'rise-data-colors',
+            iconType: 'streamline',
+            icon: 'palette',
+            element: element,
+            show: function () {
+              element.show();
+              $scope.componentId = $scope.factory.selected.id;
+            }
+          });
+
+        }
+      };
+    }
+  ]);


### PR DESCRIPTION
## Description
Opens the ( empty ) Colors settings editor and adds the streamline colors icon

## Motivation and Context
Colors component UI Settings development

## How Has This Been Tested?
Locally and on staging:

https://apps-stage-8.risevision.com/templates/edit/920df1a0-4b38-4611-ad82-e2c1d0f9d6c2/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manually tested
  - Initial automated unit tests added
  - There are no templates visible to users that use _rise-data-colors_ component in them, very low risk deployment
  - Rollback will involve re-running last master CCI build followed by reverting code changes in repo
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- No documentation required
- Support not required
