### PR TITLE
Check blueprint when creating first Schedule

### DIFF
--- a/test/unit/editor/services/svc-editor-factory.tests.js
+++ b/test/unit/editor/services/svc-editor-factory.tests.js
@@ -341,7 +341,7 @@ describe('service: editorFactory:', function() {
       editorFactory.addPresentation();
 
       setTimeout(function(){
-        scheduleFactory.createFirstSchedule.should.have.been.called;
+        scheduleFactory.createFirstSchedule.should.have.been.calledWith(sinon.match.object);
 
         done();
       },100);

--- a/test/unit/schedules/controllers/ctr-playlist-item-modal.tests.js
+++ b/test/unit/schedules/controllers/ctr-playlist-item-modal.tests.js
@@ -50,13 +50,7 @@ describe('controller: Playlist Item Modal', function() {
     });
     $provide.service('blueprintFactory',function(){
       return {
-        isPlayUntilDone: function() {
-          return this.playUntilDone;
-        },
-        load: function(){
-          this.playUntilDone = playUntilDone;
-          return Q.resolve();
-        }
+        isPlayUntilDone: sinon.stub()
       };
     });
     $provide.service('$loading',function(){
@@ -69,7 +63,7 @@ describe('controller: Playlist Item Modal', function() {
     $provide.constant('HTML_PRESENTATION_TYPE', 'HTML Template');
   }));
 
-  var $scope, $modalInstance, $modalInstanceDismissSpy, itemUpdated, playlistItem, presentationType, playUntilDone;
+  var $scope, $modalInstance, $modalInstanceDismissSpy, itemUpdated, playlistItem, presentationType, blueprintFactory;
 
   beforeEach(function(){
     itemUpdated = false;
@@ -84,6 +78,8 @@ describe('controller: Playlist Item Modal', function() {
       $scope = $rootScope.$new();
       $modalInstance = $injector.get('$modalInstance');
       $modalInstanceDismissSpy = sinon.spy($modalInstance, 'dismiss');
+      blueprintFactory = $injector.get('blueprintFactory');
+
       $controller('playlistItemModal', {
         $scope : $scope,
         $rootScope: $rootScope,
@@ -135,70 +131,73 @@ describe('controller: Playlist Item Modal', function() {
     }, 10);
   });
 
-  it('should set playUntilDoneSupported to FALSE for HTML template', function(done) {
+  describe('playUntilDone: ', function() {
+    it('should set playUntilDoneSupported to FALSE for HTML template', function(done) {
 
-    presentationType = 'HTML Template';
-    playUntilDone = false;
+      presentationType = 'HTML Template';
+      blueprintFactory.isPlayUntilDone.returns(Q.resolve(false));
 
-    $scope.selectPresentation();
+      $scope.selectPresentation();
 
-    setTimeout(function() {
-      expect($scope.playlistItem.objectReference).to.equal('presentationId');
-      expect($scope.playUntilDoneSupported).to.equal(false);
-      
-      done();
-    }, 10);
-  });
+      setTimeout(function() {
+        expect($scope.playlistItem.objectReference).to.equal('presentationId');
+        expect($scope.playUntilDoneSupported).to.equal(false);
+        
+        done();
+      }, 10);
+    });
 
-  it('should set playUntilDoneSupported to TRUE for HTML template', function(done) {
+    it('should set playUntilDoneSupported to TRUE for HTML template', function(done) {
 
-    presentationType = 'HTML Template';
-    playUntilDone = true;
+      presentationType = 'HTML Template';
+      blueprintFactory.isPlayUntilDone.returns(Q.resolve(true));
 
-    $scope.selectPresentation();
+      $scope.selectPresentation();
 
-    setTimeout(function() {
-      expect($scope.playlistItem.objectReference).to.equal('presentationId');
-      expect($scope.playUntilDoneSupported).to.equal(true);
-      
-      done();
-    }, 10);
-  });
+      setTimeout(function() {
+        expect($scope.playlistItem.objectReference).to.equal('presentationId');
+        expect($scope.playUntilDoneSupported).to.equal(true);
+        
+        done();
+      }, 10);
+    });
 
-  it('should set playlistItem.playUntilDone to TRUE when adding a new HTML template that is PUD', function(done) {
+    it('should set playlistItem.playUntilDone to TRUE when adding a new HTML template that is PUD', function(done) {
 
-    presentationType = 'HTML Template';
-    playUntilDone = true;
-    $scope.playlistItem.playUntilDone = undefined;
-    $scope.isNew = true;
+      presentationType = 'HTML Template';
+      blueprintFactory.isPlayUntilDone.returns(Q.resolve(true));
+      $scope.playlistItem.playUntilDone = undefined;
+      $scope.isNew = true;
 
-    $scope.selectPresentation();
+      $scope.selectPresentation();
 
-    setTimeout(function() {
-      expect($scope.playlistItem.objectReference).to.equal('presentationId');
-      expect($scope.playUntilDoneSupported).to.equal(true);
-      expect($scope.playlistItem.playUntilDone).to.equal(true);
-      
-      done();
-    }, 10);
-  });
+      setTimeout(function() {
+        expect($scope.playlistItem.objectReference).to.equal('presentationId');
+        expect($scope.playUntilDoneSupported).to.equal(true);
+        expect($scope.playlistItem.playUntilDone).to.equal(true);
+        
+        done();
+      }, 10);
+    });
 
-  it('should not set playlistItem.playUntilDone to TRUE when editing existing HTML template that is PUD', function(done) {
+    it('should not set playlistItem.playUntilDone to TRUE when editing existing HTML template that is PUD', function(done) {
 
-    presentationType = 'HTML Template';
-    playUntilDone = true;
-    $scope.playlistItem.playUntilDone = false;
-    $scope.isNew = false;
+      presentationType = 'HTML Template';
+      blueprintFactory.isPlayUntilDone.returns(Q.resolve(true));
+      $scope.playlistItem.playUntilDone = false;
+      $scope.isNew = false;
 
-    $scope.selectPresentation();
+      $scope.selectPresentation();
 
-    setTimeout(function() {
-      expect($scope.playlistItem.objectReference).to.equal('presentationId');
-      expect($scope.playUntilDoneSupported).to.equal(true);
-      expect($scope.playlistItem.playUntilDone).to.equal(false);
-      
-      done();
-    }, 10);
+      setTimeout(function() {
+        expect($scope.playlistItem.objectReference).to.equal('presentationId');
+        expect($scope.playUntilDoneSupported).to.equal(true);
+        expect($scope.playlistItem.playUntilDone).to.equal(false);
+        
+        done();
+      }, 10);
+    });
+    
   });
 
 });

--- a/test/unit/schedules/services/svc-schedule-factory.tests.js
+++ b/test/unit/schedules/services/svc-schedule-factory.tests.js
@@ -77,6 +77,11 @@ describe('service: scheduleFactory:', function() {
         isTemplateOnboarding: sinon.stub().returns(false)
       };
     });
+    $provide.service('blueprintFactory', function() {
+      return {
+        isPlayUntilDone: sinon.stub()
+      };
+    });
 
     $provide.service('processErrorCode', function() {
       return processErrorCode = sinon.spy(function() { return 'error'; });
@@ -85,7 +90,7 @@ describe('service: scheduleFactory:', function() {
 
   }));
   var scheduleFactory, trackerCalled, updateSchedule, $state, returnList, scheduleListSpy, scheduleAddSpy, processErrorCode, $modal;
-  var $rootScope, onboardingFactory;
+  var $rootScope, onboardingFactory, blueprintFactory;
   beforeEach(function(){
     trackerCalled = undefined;
     updateSchedule = true;
@@ -102,6 +107,7 @@ describe('service: scheduleFactory:', function() {
       sinon.spy($rootScope, '$emit');
       $state = $injector.get('$state');
       onboardingFactory = $injector.get('onboardingFactory');
+      blueprintFactory = $injector.get('blueprintFactory');
     });
   });
 
@@ -317,22 +323,32 @@ describe('service: scheduleFactory:', function() {
   });
 
   describe('createFirstSchedule:', function(){
-    var firstScheduleSample = {
-      name: 'All Displays - 24/7',
-      content: [{
+    var samplePresentation, firstScheduleSample;
+
+    beforeEach(function() {
+      samplePresentation = {
         name: 'presentationName',
-        objectReference: 'presentationId',
-        duration: 10,
-        timeDefined: false,
-        type: 'presentation'
-      }],
-      distributeToAll: true,
-      timeDefined: false
-    };
+        id: 'presentationId'
+      };
+      firstScheduleSample = {
+        name: 'All Displays - 24/7',
+        content: [{
+          name: 'presentationName',
+          objectReference: 'presentationId',
+          playUntilDone: false,
+          duration: 10,
+          timeDefined: false,
+          type: 'presentation'
+        }],
+        distributeToAll: true,
+        timeDefined: false
+      };
+      
+    });
 
     it('should create first schedule and show modal', function(done) {
       returnList = {};
-      scheduleFactory.createFirstSchedule('presentationId','presentationName')
+      scheduleFactory.createFirstSchedule(samplePresentation)
       // .then(function(){
       setTimeout(function() {
         scheduleListSpy.should.have.been.calledWith({count:1});
@@ -352,10 +368,57 @@ describe('service: scheduleFactory:', function() {
       }, 100);
     });
 
+    describe('HTML_PRESENTATION_TYPE:', function() {
+      beforeEach(function() {
+        samplePresentation.presentationType = 'HTML Template';
+        firstScheduleSample.content[0].presentationType = 'HTML Template';
+
+        blueprintFactory.isPlayUntilDone.returns(Q.resolve(false));
+      });
+
+      it('should set correct presentation type', function(done) {
+        returnList = {};
+        scheduleFactory.createFirstSchedule(samplePresentation)
+        // .then(function(){
+        setTimeout(function() {
+          scheduleAddSpy.should.have.been.calledWith(firstScheduleSample);
+
+          done();
+        }, 100);
+      });
+
+      it('should retrieve and update playUntilDone', function(done) {
+        blueprintFactory.isPlayUntilDone.returns(Q.resolve(true));
+        firstScheduleSample.content[0].playUntilDone = true;
+
+        returnList = {};
+        scheduleFactory.createFirstSchedule(samplePresentation)
+        // .then(function(){
+        setTimeout(function() {
+          scheduleAddSpy.should.have.been.calledWith(firstScheduleSample);
+
+          done();
+        }, 100);
+      });
+
+      it('should handle failure to retrieve blueprint', function(done) {
+        blueprintFactory.isPlayUntilDone.returns(Q.reject());
+
+        returnList = {};
+        scheduleFactory.createFirstSchedule(samplePresentation)
+        // .then(function(){
+        setTimeout(function() {
+          scheduleAddSpy.should.have.been.calledWith(firstScheduleSample);
+
+          done();
+        }, 100);
+      });
+    });
+
     it('should create first schedule and redirect to onboarding', function(done) {
       returnList = {};
       onboardingFactory.isTemplateOnboarding.returns(true);
-      scheduleFactory.createFirstSchedule('presentationId','presentationName')
+      scheduleFactory.createFirstSchedule(samplePresentation)
       .then(function(){
         scheduleListSpy.should.have.been.calledWith({count:1});
 
@@ -373,7 +436,7 @@ describe('service: scheduleFactory:', function() {
 
     it('should not create twice', function(done) {
       returnList = {};
-      scheduleFactory.createFirstSchedule('presentationId','presentationName')
+      scheduleFactory.createFirstSchedule(samplePresentation)
       .then(function(){
         scheduleListSpy.should.have.been.calledWith({count:1});
 
@@ -382,7 +445,7 @@ describe('service: scheduleFactory:', function() {
         $rootScope.$emit.should.have.been.calledWith('scheduleCreated');
         expect(trackerCalled).to.equal('Schedule Created');
 
-        scheduleFactory.createFirstSchedule('presentationId','presentationName').then(function(){
+        scheduleFactory.createFirstSchedule(samplePresentation).then(function(){
           done("Error: schedule created again");
         },function(){
           scheduleListSpy.should.have.been.calledOnce;
@@ -394,7 +457,7 @@ describe('service: scheduleFactory:', function() {
 
     it('should handle error loading list', function(done) {
       returnList = false;
-      scheduleFactory.createFirstSchedule('presentationId','presentationName')
+      scheduleFactory.createFirstSchedule(samplePresentation)
       .then(null,function(){
         scheduleListSpy.should.have.been.calledOnce;
         done();
@@ -404,7 +467,7 @@ describe('service: scheduleFactory:', function() {
     it('should handle error saving schedule', function(done) {
       returnList = {};
       updateSchedule = false;
-      scheduleFactory.createFirstSchedule('presentationId','presentationName')
+      scheduleFactory.createFirstSchedule(samplePresentation)
       .then(null,function(){
         scheduleListSpy.should.have.been.calledOnce;
         done();
@@ -413,7 +476,7 @@ describe('service: scheduleFactory:', function() {
 
     it('should not create if already have schedules',function(done){
       returnList = { items: [{name:'schedule'}] };
-      scheduleFactory.createFirstSchedule('presentationId','presentationName')
+      scheduleFactory.createFirstSchedule(samplePresentation)
       .then(null, function(){
         scheduleListSpy.should.have.been.calledWith({count:1});
 
@@ -427,13 +490,13 @@ describe('service: scheduleFactory:', function() {
 
     it('should cache result',function(done){
       returnList = { items: [{name:'schedule'}] };
-      scheduleFactory.createFirstSchedule('presentationId','presentationName')
+      scheduleFactory.createFirstSchedule(samplePresentation)
       .then(null, function(){
         scheduleListSpy.should.have.been.calledWith({count:1});
         scheduleAddSpy.should.not.have.been.called;
         expect(trackerCalled).to.not.be.ok;
 
-        scheduleFactory.createFirstSchedule('presentationId','presentationName').then(function(){
+        scheduleFactory.createFirstSchedule(samplePresentation).then(function(){
           done("Error: schedule created again");
         },function(){
           scheduleListSpy.should.have.been.calledOnce;

--- a/test/unit/schedules/services/svc-schedule-factory.tests.js
+++ b/test/unit/schedules/services/svc-schedule-factory.tests.js
@@ -363,6 +363,7 @@ describe('service: scheduleFactory:', function() {
 
         expect($modal.open.getCall(0).args[0].templateUrl).to.equal('partials/schedules/auto-schedule-modal.html');
         expect($modal.open.getCall(0).args[0].controller).to.equal('AutoScheduleModalController');
+        expect($modal.open.getCall(0).args[0].resolve.presentationName()).to.equal('presentationName');
 
         done();
       }, 100);

--- a/test/unit/template-editor/services/svc-blueprint-factory.tests.js
+++ b/test/unit/template-editor/services/svc-blueprint-factory.tests.js
@@ -89,9 +89,20 @@ describe('service: blueprint factory', function() {
   });
 
   describe('isPlayUntilDone: ', function() {
+    beforeEach(function() {
+      sinon.stub(blueprintFactory, 'load').returns(Q.resolve());
+    });
+
+    it('should return a promise',function() {
+      expect(blueprintFactory.isPlayUntilDone('productCode').then).to.be.a('function');
+
+      blueprintFactory.load.should.have.been.calledWith('productCode');
+    });
 
     it('should return false if blueprintData is not populated',function() {
-      expect(blueprintFactory.isPlayUntilDone()).to.be.false;
+      return blueprintFactory.isPlayUntilDone().then(function(result) {
+        expect(result).to.be.false;
+      });
     });
 
     it('should return true if blueprintData.playUntilDone is true',function() {
@@ -99,7 +110,9 @@ describe('service: blueprint factory', function() {
         playUntilDone: true
       };
 
-      expect(blueprintFactory.isPlayUntilDone()).to.be.true;
+      return blueprintFactory.isPlayUntilDone().then(function(result) {
+        expect(result).to.be.true;
+      });
     });
 
     it('should return true if blueprintData.playUntilDone exists',function() {
@@ -107,7 +120,9 @@ describe('service: blueprint factory', function() {
         playUntilDone: "something"
       };
 
-      expect(blueprintFactory.isPlayUntilDone()).to.be.true;
+      return blueprintFactory.isPlayUntilDone().then(function(result) {
+        expect(result).to.be.true;
+      });
     });
 
     it('should return false otherwise',function() {
@@ -115,7 +130,9 @@ describe('service: blueprint factory', function() {
         playUntilDone: false
       };
 
-      expect(blueprintFactory.isPlayUntilDone()).to.be.false;
+      return blueprintFactory.isPlayUntilDone().then(function(result) {
+        expect(result).to.be.false;
+      });
     });
   });
 

--- a/test/unit/template-editor/services/svc-template-editor-factory.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-factory.tests.js
@@ -704,7 +704,7 @@ describe('service: templateEditorFactory:', function() {
         templateEditorFactory.publish(templateEditorFactory)
           .then(function() {
             setTimeout(function() {
-              scheduleFactory.createFirstSchedule.should.have.been.called;
+              scheduleFactory.createFirstSchedule.should.have.been.calledWith(templateEditorFactory.presentation);
 
               done();
             });

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -621,7 +621,8 @@ angular.module('risevision.apps.billing.services', [
 angular.module('risevision.schedules.services', [
   'risevision.common.header',
   'risevision.common.gapi',
-  'risevision.apps.launcher.services'
+  'risevision.apps.launcher.services',
+  'risevision.template-editor.services'
 ]);
 angular.module('risevision.schedules.filters', []);
 angular.module('risevision.schedules.directives', [

--- a/web/scripts/editor/services/svc-editor-factory.js
+++ b/web/scripts/editor/services/svc-editor-factory.js
@@ -192,7 +192,7 @@ angular.module('risevision.editor.services')
                 notify: false,
                 location: 'replace'
               }).then(function () {
-                scheduleFactory.createFirstSchedule(resp.item.id, resp.item.name, resp.item.presentationType);
+                scheduleFactory.createFirstSchedule(resp.item);
               });
               deferred.resolve(resp.item.id);
             }

--- a/web/scripts/schedules/controllers/ctr-playlist-item-modal.js
+++ b/web/scripts/schedules/controllers/ctr-playlist-item-modal.js
@@ -41,14 +41,14 @@ angular.module('risevision.schedules.controllers')
 
           presentation.get($scope.playlistItem.objectReference).then(function (result) {
 
-              return blueprintFactory.load(result.item.productCode);
+              return blueprintFactory.isPlayUntilDone(result.item.productCode);
             })
-            .then(function () {
-              if (blueprintFactory.isPlayUntilDone() && $scope.isNew) {
+            .then(function (playUntilDone) {
+              if (playUntilDone && $scope.isNew) {
                 //When user schedules a PUD template, then set schedule item to PUD by default.
                 $scope.playlistItem.playUntilDone = true;
               }
-              if (!blueprintFactory.isPlayUntilDone()) {
+              if (!playUntilDone) {
                 $scope.playUntilDoneSupported = false;
                 $scope.playlistItem.playUntilDone = false;
               }

--- a/web/scripts/schedules/services/svc-schedule-factory.js
+++ b/web/scripts/schedules/services/svc-schedule-factory.js
@@ -2,9 +2,9 @@
 
 angular.module('risevision.schedules.services')
   .factory('scheduleFactory', ['$q', '$state', '$log', '$modal', '$rootScope', 'schedule', 'scheduleTracker',
-    'onboardingFactory', 'processErrorCode', 'VIEWER_URL',
+    'onboardingFactory', 'blueprintFactory', 'processErrorCode', 'VIEWER_URL', 'HTML_PRESENTATION_TYPE',
     function ($q, $state, $log, $modal, $rootScope, schedule, scheduleTracker, onboardingFactory,
-      processErrorCode, VIEWER_URL) {
+      blueprintFactory, processErrorCode, VIEWER_URL, HTML_PRESENTATION_TYPE) {
       var factory = {};
       var _hasSchedules;
       var _scheduleId;
@@ -109,33 +109,52 @@ angular.module('risevision.schedules.services')
         return deferred.promise;
       };
 
-      var _initFirstSchedule = function (presentationId, presentationName, presentationType) {
+      var _initFirstSchedule = function (presentation) {
         var item = {
-          name: presentationName,
-          objectReference: presentationId,
+          name: presentation.name,
+          objectReference: presentation.id,
+          playUntilDone: false,
           duration: 10,
           timeDefined: false,
           type: 'presentation'
         };
-
-        if (presentationType) {
-          item.presentationType = presentationType;
-        }
-
-        return {
+        var schedule = {
           name: 'All Displays - 24/7',
           content: [item],
           distributeToAll: true,
           timeDefined: false
         };
+
+        if (presentation.presentationType) {
+          item.presentationType = presentation.presentationType;
+        }
+
+        if (presentation.presentationType === HTML_PRESENTATION_TYPE) {
+          return blueprintFactory.isPlayUntilDone(presentation.productCode)
+            .then(function (playUntilDone) {
+              if (playUntilDone) {
+                item.playUntilDone = true;
+              }
+            })
+            .catch(function (e) {
+              $log.error(factory.errorMessage, e);
+            })
+            .then(function () {
+              return schedule;
+            });
+        } else {
+          return schedule;          
+        }
+
       };
 
-      factory.createFirstSchedule = function (presentationId, presentationName, presentationType) {
+      factory.createFirstSchedule = function (presentation) {
 
         return _checkFirstSchedule()
           .then(function (result) {
-            var firstSchedule = _initFirstSchedule(presentationId, presentationName, presentationType);
-
+            return _initFirstSchedule(presentation);
+          })
+          .then(function(firstSchedule) {
             return schedule.add(firstSchedule);
           })
           .then(function (resp) {

--- a/web/scripts/schedules/services/svc-schedule-factory.js
+++ b/web/scripts/schedules/services/svc-schedule-factory.js
@@ -143,7 +143,7 @@ angular.module('risevision.schedules.services')
               return schedule;
             });
         } else {
-          return schedule;
+          return $q.resolve(schedule);
         }
 
       };

--- a/web/scripts/schedules/services/svc-schedule-factory.js
+++ b/web/scripts/schedules/services/svc-schedule-factory.js
@@ -143,7 +143,7 @@ angular.module('risevision.schedules.services')
               return schedule;
             });
         } else {
-          return schedule;          
+          return schedule;
         }
 
       };
@@ -154,7 +154,7 @@ angular.module('risevision.schedules.services')
           .then(function (result) {
             return _initFirstSchedule(presentation);
           })
-          .then(function(firstSchedule) {
+          .then(function (firstSchedule) {
             return schedule.add(firstSchedule);
           })
           .then(function (resp) {
@@ -180,7 +180,7 @@ angular.module('risevision.schedules.services')
                 controller: 'AutoScheduleModalController',
                 resolve: {
                   presentationName: function () {
-                    return presentationName;
+                    return presentation.name;
                   }
                 }
               });

--- a/web/scripts/template-editor/services/svc-blueprint-factory.js
+++ b/web/scripts/template-editor/services/svc-blueprint-factory.js
@@ -18,8 +18,8 @@ angular.module('risevision.template-editor.services')
 
       factory.isPlayUntilDone = function (productCode) {
         return factory.load(productCode)
-          .then(function() {
-            return !!(factory.blueprintData && factory.blueprintData.playUntilDone);            
+          .then(function () {
+            return !!(factory.blueprintData && factory.blueprintData.playUntilDone);
           });
       };
 

--- a/web/scripts/template-editor/services/svc-blueprint-factory.js
+++ b/web/scripts/template-editor/services/svc-blueprint-factory.js
@@ -16,8 +16,11 @@ angular.module('risevision.template-editor.services')
           });
       };
 
-      factory.isPlayUntilDone = function () {
-        return !!(factory.blueprintData && factory.blueprintData.playUntilDone);
+      factory.isPlayUntilDone = function (productCode) {
+        return factory.load(productCode)
+          .then(function() {
+            return !!(factory.blueprintData && factory.blueprintData.playUntilDone);            
+          });
       };
 
       factory.hasBranding = function () {

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -310,8 +310,7 @@ angular.module('risevision.template-editor.services')
       };
 
       var _createFirstSchedule = function () {
-        return scheduleFactory.createFirstSchedule(factory.presentation.id, factory.presentation.name, factory
-            .presentation.presentationType)
+        return scheduleFactory.createFirstSchedule(factory.presentation)
           .catch(function (err) {
             return err === 'Already have Schedules' ? $q.resolve() : $q.reject(err);
           });


### PR DESCRIPTION
## Description
When publishing an HTML Template, check blueprint
and update Schedule Item `playUntilDone` accordingly

Refactor `scheduleFactory.createFirstSchedule()` to take the
`presentation` object.
Refactor `blueprintFactory.isPlayUntilDone()` to take a `productCode'
parameter, load the blueprint and resolve the value via a promise.

[stage-2]

## Motivation and Context
Fix for #1494 

## How Has This Been Tested?
Validated in the local environment:

- That HTML Templates with `playUntilDone: true` have that setting enabled in the First Schedule that is created
- That non PUD HTML Templates have the setting disabled/false
- That Schedule Creating from the old Editor works as expected
- That Schedule Playlist Item loads as expected

Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
