### PR TITLE
Dynamic page titles for Apps

### DIFF
--- a/test/unit/app.tests.js
+++ b/test/unit/app.tests.js
@@ -458,13 +458,15 @@ describe('app:', function() {
       var $location = {
         search: function() { 
           return {};
-        }
+        },
+        replace: sinon.spy()
       };
 
       sinon.spy($state,'go');
       
       $state.get('common.auth.signup').controller[4]($location, $state, canAccessApps, plansFactory);
       setTimeout(function() {
+        $location.replace.should.have.been.called;
         $state.go.should.have.been.calledWith('apps.launcher.home');
 
         done();
@@ -525,9 +527,14 @@ describe('app:', function() {
       };
 
       sinon.spy($state,'go');
-      
-      $state.get('common.auth.signin').controller[2]($state, canAccessApps);
+
+      var $location = {
+        replace: sinon.spy()
+      };
+
+      $state.get('common.auth.signin').controller[3]($state, canAccessApps, $location);
       setTimeout(function() {
+        $location.replace.should.have.been.called;
         $state.go.should.have.been.calledWith('apps.launcher.home');
 
         done();
@@ -540,9 +547,14 @@ describe('app:', function() {
       };
 
       sinon.spy($state,'go');
-      $state.get('common.auth.signin').controller[2]($state, canAccessApps);
 
+      var $location = {
+        replace: sinon.spy()
+      };
+
+      $state.get('common.auth.signin').controller[3]($state, canAccessApps, $location);
       setTimeout(function() {
+        $location.replace.should.not.have.been.called;
         $state.go.should.not.have.been.called;
 
         done();

--- a/test/unit/common/directives/dtv-page-title.tests.js
+++ b/test/unit/common/directives/dtv-page-title.tests.js
@@ -1,8 +1,8 @@
-/*jshint expr, );true */
+/*jshint expr:true */
 
 'use strict';
 
-describe.only('directive, ); page title', function() {
+describe('directive: page title', function() {
   beforeEach(module('risevision.apps.directives'));
 
   var $rootScope, $timeout, $state, elem;

--- a/test/unit/common/directives/dtv-page-title.tests.js
+++ b/test/unit/common/directives/dtv-page-title.tests.js
@@ -1,0 +1,122 @@
+/*jshint expr, );true */
+
+'use strict';
+
+describe.only('directive, ); page title', function() {
+  beforeEach(module('risevision.apps.directives'));
+
+  var $rootScope, $timeout, $state, elem;
+  beforeEach(module(function ($provide) {
+    $provide.value('$state', {
+      current: {}
+    });
+  }));
+
+  beforeEach(inject(function($injector, $compile, _$rootScope_) {
+    $timeout = $injector.get('$timeout');
+    $state = $injector.get('$state');
+
+    $rootScope = _$rootScope_;
+
+    elem = angular.element('<title page-title>mock</title>');
+
+    $compile(elem)($rootScope);
+
+    $rootScope.$digest();
+  }));
+
+  it('should populate html', function() {
+    expect(elem[0].outerHTML).to.equal('<title page-title="" class="ng-scope">mock</title>');
+  });
+
+  it('should initialize default title', function() {
+    $timeout.flush();
+
+    expect(elem.text()).to.equal('Rise Vision Apps');
+  });
+
+  it('should refresh value on state change', function() {
+    $state.current.name = 'common.auth.signin';
+    $rootScope.$broadcast('$stateChangeSuccess');
+    $rootScope.$digest();
+
+    $timeout.flush();
+
+    expect(elem.text()).to.equal('Sign In | Rise Vision Apps');
+  });
+  
+  it('should map states correctly to names', function() {
+    var checkState = function(stateName, pageTitle) {
+      $state.current.name = stateName;
+      $rootScope.$broadcast('$stateChangeSuccess');
+      $rootScope.$digest();
+
+      $timeout.flush();
+
+      expect(elem.text()).to.equal(pageTitle + ' | Rise Vision Apps');
+    };
+
+    // userstate routes:
+    checkState('common', 'Sign In');
+    checkState('common.auth', 'Sign In');
+    checkState('common.auth.unauthorized', 'Sign In');
+
+    checkState('common.auth.createaccount', 'Sign Up');
+    checkState('common.auth.joinaccount', 'Sign Up');
+
+    checkState('common.auth.requestpasswordreset', 'Reset Password');
+    checkState('common.auth.resetpassword', 'Reset Password');
+
+    checkState('common.auth.confirmaccount', 'Confirm Account');
+
+    checkState('common.auth.unsubscribe', 'Unsubscribe');
+
+    // Apps auth routes:
+    checkState('common.auth.signin', 'Sign In');
+
+    checkState('common.auth.signup', 'Sign Up');
+    checkState('common.auth.unregistered', 'Sign Up');
+
+    // Apps routes:
+    checkState('apps', 'Home');
+    checkState('apps.launcher', 'Home');
+    checkState('apps.launcher.home', 'Home');
+
+    checkState('apps.launcher.onboarding', 'Onboarding');
+
+    checkState('apps.billing', 'Billing');
+    checkState('apps.billing.home', 'Billing');
+
+    checkState('apps.schedules', 'Schedules');
+    checkState('apps.schedules.list', 'Schedules');
+
+    checkState('apps.schedules.details', 'Edit Schedule');
+
+    checkState('apps.schedules.add', 'Add Schedule');
+
+    checkState('apps.displays', 'Displays');
+    checkState('apps.displays.list', 'Displays');
+
+    checkState('apps.displays.change', 'Display Settings');
+    checkState('apps.displays.details', 'Display Settings');
+
+    checkState('apps.displays.alerts', 'Alert Settings');
+
+    checkState('apps.editor', 'Presentations');
+    checkState('apps.editor.home', 'Presentations');
+    checkState('apps.editor.list', 'Presentations');
+    checkState('apps.editor.add', 'Presentations');
+
+    checkState('apps.editor.workspace', 'Edit Presentation');
+    checkState('apps.editor.workspace.artboard', 'Edit Presentation');
+    checkState('apps.editor.workspace.htmleditor', 'Edit Presentation');
+
+    checkState('apps.editor.templates', 'Edit HTML Presentation');
+    checkState('apps.editor.templates.edit', 'Edit HTML Presentation');
+
+    checkState('apps.storage', 'Storage');
+    checkState('apps.storage.home', 'Storage');
+
+  });
+  
+});

--- a/web/index.html
+++ b/web/index.html
@@ -19,7 +19,7 @@
   <meta itemprop="description" content="We have a couple of apps that will allow you to manage your Digital Signage. Managing from the content creation to its delivery on an unlimited number of displays anywhere in the world.">
   <meta itemprop="image" content="https://s3.amazonaws.com/Rise-Images/landing-page/rv-image.png">
 
-  <title itemprop='name'>Rise Vision | Apps</title>
+  <title itemprop='name' page-title>Rise Vision Apps</title>
   <meta name="description" content="We have a couple of apps that will allow you to manage your Digital Signage. Managing from the content creation to its delivery on an unlimited number of displays anywhere in the world.">
   <link rel="canonical" itemprop="url" href="https://apps.risevision.com">
   <link rel="publisher" href="https://plus.google.com/+Risevision/">
@@ -332,6 +332,7 @@
   <script src="scripts/config/config.js"></script>
   <script src="scripts/app.js"></script>
   <script src="scripts/common/controllers/ctr-app.js"></script>
+  <script src="scripts/common/directives/dtv-page-title.js"></script>
   <script src="scripts/common/directives/dtv-rv-sortable.js"></script>
   <script src="scripts/common/directives/dtv-guid-validator.js"></script>
   <script src="scripts/common/directives/dtv-in-app-messages.js"></script>

--- a/web/partials/common-header/auth-buttons-menu.html
+++ b/web/partials/common-header/auth-buttons-menu.html
@@ -23,7 +23,7 @@
       <i class="fa fa-shopping-cart"></i>
       <span class="item-name">Account & Billing</span>
     </a>
-    <a ui-sref="apps.billing.home" class="store-account-button action" ng-show="isChargebee() && isApps()">
+    <a ui-sref="apps.billing.home" link-cid class="store-account-button action" ng-show="isChargebee() && isApps()">
       <i class="fa fa-shopping-cart"></i>
       <span class="item-name">Account & Billing</span>
     </a>

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -135,6 +135,7 @@ angular.module('risevision.apps', [
                   plansFactory.showPlansModal();
                 }
 
+                $location.replace();
                 $state.go('apps.launcher.home');
               });
             }
@@ -143,9 +144,10 @@ angular.module('risevision.apps', [
 
         .state('common.auth.signin', {
           url: '/signin',
-          controller: ['$state', 'canAccessApps',
-            function ($state, canAccessApps) {
+          controller: ['$state', 'canAccessApps', '$location',
+            function ($state, canAccessApps, $location) {
               canAccessApps().then(function () {
+                $location.replace();
                 $state.go('apps.launcher.home');
               });
             }
@@ -192,9 +194,10 @@ angular.module('risevision.apps', [
 
         .state('apps.schedules.home', {
           url: '/schedules',
-          controller: ['canAccessApps', '$state',
-            function (canAccessApps, $state) {
+          controller: ['canAccessApps', '$state', '$location',
+            function (canAccessApps, $state, $location) {
               canAccessApps().then(function () {
+                $location.replace();
                 $state.go('apps.schedules.list');
               });
             }
@@ -262,9 +265,10 @@ angular.module('risevision.apps', [
 
         .state('apps.displays.home', {
           url: '/displays',
-          controller: ['canAccessApps', '$state',
-            function (canAccessApps, $state) {
+          controller: ['canAccessApps', '$state', '$location',
+            function (canAccessApps, $state, $location) {
               canAccessApps().then(function () {
+                $location.replace();
                 $state.go('apps.displays.list');
               });
             }
@@ -353,9 +357,10 @@ angular.module('risevision.apps', [
 
         .state('apps.editor.home', {
           url: '/editor',
-          controller: ['canAccessApps', '$state',
-            function (canAccessApps, $state) {
+          controller: ['canAccessApps', '$state', '$location',
+            function (canAccessApps, $state, $location) {
               canAccessApps().then(function () {
+                $location.replace();
                 $state.go('apps.editor.list');
               });
             }

--- a/web/scripts/common/directives/dtv-page-title.js
+++ b/web/scripts/common/directives/dtv-page-title.js
@@ -1,0 +1,116 @@
+'use strict';
+
+angular.module('risevision.apps.directives')
+  .directive('pageTitle', ['$rootScope', '$state', '$timeout',
+    function($rootScope, $state, $timeout) {
+      return {
+        link: function($scope, element) {
+
+          var _getTitle = function(stateName) {
+            switch ($state.current.name)  {
+
+            // userstate routes:
+            case 'common':
+            case 'common.auth':
+            case 'common.auth.unauthorized':
+              return 'Sign In';
+
+            case 'common.auth.createaccount':
+            case 'common.auth.joinaccount':
+              return 'Sign Up';
+
+            case 'common.auth.requestpasswordreset':
+            case 'common.auth.resetpassword':
+              return 'Reset Password';
+
+            case 'common.auth.confirmaccount':
+              return 'Confirm Account';
+
+            case 'common.auth.unsubscribe':
+              return 'Unsubscribe';
+
+            // Apps auth routes:
+            case 'common.auth.signin':
+              return 'Sign In';
+
+            case 'common.auth.signup':
+            case 'common.auth.unregistered':
+              return 'Sign Up';
+
+            // Apps routes:
+            case 'apps':
+            case 'apps.launcher':
+            case 'apps.launcher.home':
+              return 'Home';
+
+            case 'apps.launcher.onboarding':
+              return 'Onboarding';
+
+            case 'apps.billing':
+            case 'apps.billing.home':
+              return 'Billing';
+
+            case 'apps.schedules':
+            case 'apps.schedules.list':
+              return 'Schedules';
+
+            case 'apps.schedules.details':
+              return 'Edit Schedule';
+
+            case 'apps.schedules.add':
+              return 'Add Schedule';
+
+            case 'apps.displays':
+            case 'apps.displays.list':
+              return 'Displays';
+
+            case 'apps.displays.change':
+            case 'apps.displays.details':
+              return 'Display Settings';
+
+            case 'apps.displays.alerts':
+              return 'Alert Settings';
+
+            case 'apps.editor':
+            case 'apps.editor.home':
+            case 'apps.editor.list':
+            case 'apps.editor.add':
+              return 'Presentations';
+
+            case 'apps.editor.workspace':
+            case 'apps.editor.workspace.artboard':
+            case 'apps.editor.workspace.htmleditor':
+              return 'Edit Presentation';
+
+            case 'apps.editor.templates':
+            case 'apps.editor.templates.edit':
+              return 'Edit HTML Presentation';
+
+            case 'apps.storage':
+            case 'apps.storage.home':
+              return 'Storage';
+
+            default:
+              return;
+            }
+
+          };
+
+          var _updateTitle = function() {
+            var title = _getTitle();
+            title = title ? (title + ' | ') : '';
+
+            $timeout(function() {
+              element.text(title + 'Rise Vision Apps');
+            }, 0, false);
+          };
+
+          _updateTitle();
+
+          $rootScope.$on('$stateChangeSuccess', function () {
+            _updateTitle();
+          });
+        }
+      };
+    }
+  ]);


### PR DESCRIPTION
## Description
Dynamic page titles for Apps
Page title based on the page/section that is shown

Use .replace to fix double history tokens

Add CID to billing link

[stage-18]

## Motivation and Context
This was flagged as a weekly improvement. Page named reviewed by PO.
Using a directive for the title helps not show curly brackets on page load.
Timeout necessary to fix some history issues where the title of the previous page was set as well as the new page.

Fix some small issues with history tokens.

## How Has This Been Tested?
Tested in the local environment. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No