### PR TITLE
Add multiple Presentations to a Schedule

### DIFF
--- a/test/e2e/schedules/cases/add-presentation.js
+++ b/test/e2e/schedules/cases/add-presentation.js
@@ -59,7 +59,7 @@ var AddPresentationScenarios = function() {
         describe('Given a user clicks on the Presentation button', function () {
           before(function () {
             scheduleAddPage.getAddPresentationItemButton().click();
-            helper.wait(presentationModalPage.getAddPresentationModal(), 'Add Presentation Modal');
+            helper.wait(presentationModalPage.getAddPresentationModal(), 'Add Presentations Modal');
           });
 
           it('should open the Add Presentation Modal', function () {
@@ -68,7 +68,7 @@ var AddPresentationScenarios = function() {
 
           it('should show modal title', function () {
 
-            expect(presentationModalPage.getModalTitle().getText()).to.eventually.equal('Select Presentation');
+            expect(presentationModalPage.getModalTitle().getText()).to.eventually.equal('Select Presentations');
           });
 
           it('should show a search box', function () {
@@ -95,20 +95,14 @@ var AddPresentationScenarios = function() {
                 presentationModalPage.getPresentationItems().get(0).click();
               });
             });
-            it('should show the playlist item dialog', function () {
-              helper.wait(playlistItemModalPage.getPlaylistItemModal(), 'Playlist Item Modal').then(function () {
-                expect(playlistItemModalPage.getPlaylistItemModal().isDisplayed()).to.eventually.be.true;
-                expect(playlistItemModalPage.getModalTitle().getText()).to.eventually.equal('Add Playlist Item');
-                expect(playlistItemModalPage.getNameTextbox().getAttribute('value')).to.eventually.equal(presentationItemName);
-                helper.wait(playlistItemModalPage.getPresentationNameField(), 'Playlist Item Modal').then(function () {
-                  expect(playlistItemModalPage.getPresentationNameField().getText()).to.eventually.equal(presentationItemName);
-                });
-              });
+
+            it('should select the presentation and close modal', function() {
+              presentationModalPage.getSelectPresentationsButton().click();
+
+              helper.waitDisappear(presentationModalPage.getAddPresentationModal(), 'Add Presentations Modal');
             });
 
             it('should add the playlist item', function () {
-              playlistItemModalPage.getSaveButton().click();
-
               expect(scheduleAddPage.getPlaylistItems().get(0).isDisplayed()).to.eventually.be.true;
               expect(playlistPage.getPresentationNameCell().get(0).getText()).to.eventually.equal(presentationItemName);
             });

--- a/test/e2e/schedules/pages/presentationModalPage.js
+++ b/test/e2e/schedules/pages/presentationModalPage.js
@@ -7,6 +7,7 @@ var PresentationModalPage = function() {
   var presentationItems = element.all(by.repeater('presentation in factory.items.list'));
   var presentationListLoader = element(by.xpath('//div[@spinner-key="presentation-list-loader"]'));
   var presentationNames = element.all(by.css('#addPresentationModal #presentationName'));
+  var selectPresentationsButton = element(by.id('selectPresentations'));
   var closeButton = element(by.css('#addPresentationModal > div.modal-header > button'));
 
   this.getAddPresentationModal = function() {
@@ -35,6 +36,10 @@ var PresentationModalPage = function() {
   
   this.getPresentationNames = function() {
     return presentationNames;
+  };
+
+  this.getSelectPresentationsButton = function() {
+    return selectPresentationsButton;
   };
   
   this.getCloseButton = function() {

--- a/test/unit/editor/controllers/ctr-presentation-multi-selector-modal.tests.js
+++ b/test/unit/editor/controllers/ctr-presentation-multi-selector-modal.tests.js
@@ -1,0 +1,107 @@
+'use strict';
+
+describe('controller: Presentation Multi Selector Modal', function() {
+  beforeEach(module('risevision.editor.controllers'));
+  beforeEach(module(function ($provide) {
+    $provide.service('$modalInstance',function(){
+      return {
+        close: sinon.spy(),
+        dismiss: sinon.spy()
+      };
+    });
+
+  }));
+  var $scope, $modalInstance;
+
+  beforeEach(function(){
+    inject(function($injector, $rootScope, $controller){
+      $scope = $rootScope.$new();
+      $modalInstance = $injector.get('$modalInstance');
+      $controller('PresentationMultiSelectorModal', {
+        $scope : $scope,
+        $modalInstance : $modalInstance
+      });
+      $scope.$digest();
+    });
+  });
+
+  it('should exist',function(){
+    expect($scope).to.be.ok;
+
+    expect($scope.togglePresentation).to.be.a('function');
+    expect($scope.isSelected).to.be.a("function");
+
+    expect($scope.add).to.be.a('function');
+    expect($scope.dismiss).to.be.a('function');
+
+    expect($scope.selected).to.be.a('array');
+
+  });
+
+  describe('togglePresentation:', function() {
+    it("should add display to distribution",function(done){
+      $scope.togglePresentation({id: 'presentationId'});
+      $scope.$digest();
+
+      setTimeout(function(){
+        expect($scope.selected).to.contain({id: 'presentationId'});
+
+        done();
+      },10);
+    });
+
+    it("should remove display from distribution if it was there before",function(done){
+      $scope.togglePresentation({id: 'presentationId'});
+      $scope.togglePresentation({id: 'presentationId'});
+      $scope.$digest();
+
+      setTimeout(function(){
+        expect($scope.selected).to.not.contain({id: 'presentationId'});
+
+        done();
+      },10);
+    });
+    
+  });
+
+  describe('isSelected:', function() {
+    it("should return true if a display is already on the distribution",function(done){
+      $scope.togglePresentation({id: 'presentationId'});
+      var actual = $scope.isSelected("presentationId");
+      $scope.$digest();
+
+      setTimeout(function(){
+        expect(actual).to.be.true;
+
+        done();
+      },10);
+    });
+
+    it("should return false if a display is not on the distribution",function(done){
+      var actual = $scope.isSelected("presentationId");
+      $scope.$digest();
+
+      setTimeout(function(){
+        expect(actual).to.be.false;
+
+        done();
+      },10);
+    });
+
+  });
+
+  it('should close modal when clicked on add',function(){
+    $scope.togglePresentation({id: 'presentationId'});
+
+    $scope.add();
+
+    $modalInstance.close.should.have.been.calledWith($scope.selected);
+  });
+
+  it('should dismiss modal when clicked on close with no action',function(){
+    $scope.dismiss();
+
+    $modalInstance.dismiss.should.have.been.called;
+  });
+
+});

--- a/test/unit/editor/services/svc-editor-factory.tests.js
+++ b/test/unit/editor/services/svc-editor-factory.tests.js
@@ -144,10 +144,8 @@ describe('service: editorFactory:', function() {
     $provide.service('processErrorCode', function() {
       return processErrorCode = sinon.spy(function() { return 'error'; });
     });
-    $provide.service('scheduleFactory', function() {
-      return {
-        createFirstSchedule: sinon.stub()
-      };
+    $provide.service('createFirstSchedule', function() {
+      return sinon.stub();
     });
     $provide.service('$window', function() {
       return {
@@ -165,7 +163,7 @@ describe('service: editorFactory:', function() {
     });
   }));
   var editorFactory, trackerCalled, updatePresentation, currentState, $state, stateParams,
-    presentationParser, distributionParser, $window, $modal, processErrorCode, scheduleFactory, userAuthFactory,
+    presentationParser, distributionParser, $window, $modal, processErrorCode, createFirstSchedule, userAuthFactory,
     $rootScope, storeProduct, showLegacyWarning;
   beforeEach(function(){
     trackerCalled = undefined;
@@ -180,7 +178,7 @@ describe('service: editorFactory:', function() {
       $modal = $injector.get('$modal');
       $state = $injector.get('$state');
       showLegacyWarning = $injector.get('showLegacyWarning');
-      scheduleFactory = $injector.get('scheduleFactory');
+      createFirstSchedule = $injector.get('createFirstSchedule');
       userAuthFactory = $injector.get('userAuthFactory');
       $rootScope = $injector.get('$rootScope');
     });
@@ -341,7 +339,7 @@ describe('service: editorFactory:', function() {
       editorFactory.addPresentation();
 
       setTimeout(function(){
-        scheduleFactory.createFirstSchedule.should.have.been.calledWith(sinon.match.object);
+        createFirstSchedule.should.have.been.calledWith(sinon.match.object);
 
         done();
       },100);

--- a/test/unit/editor/services/svc-presentation-factory.tests.js
+++ b/test/unit/editor/services/svc-presentation-factory.tests.js
@@ -29,7 +29,7 @@ describe('service: presentationFactory: ', function() {
     returnPresentation = true;
     apiCalls = 0;
     
-    inject(function($injector){  
+    inject(function($injector){
       presentationFactory = $injector.get('presentationFactory');
     });
   });
@@ -37,10 +37,51 @@ describe('service: presentationFactory: ', function() {
   it('should exist',function(){
     expect(presentationFactory).to.be.ok;
     
+    expect(presentationFactory.setPresentation).to.be.a('function');
     expect(presentationFactory.getPresentationCached).to.be.a('function');
     expect(presentationFactory.loadingPresentation).to.be.false;
   });
   
+  describe('setPresentation:', function() {
+    it('should return cached presentation', function(done) {
+      var presentation = {
+        id: 'presentationId',
+        name: 'some presentation',
+        revisionStatus: 0
+      };
+
+      presentationFactory.setPresentation(presentation);
+
+      presentationFactory.getPresentationCached('presentationId')
+        .then(function(result) {
+          expect(result).to.equal(presentation);
+
+          expect(apiCalls).to.equal(0);
+
+          done();
+        });
+    });
+
+    it('should not add presentation if already exists', function(done) {
+      var presentation = {
+        id: 'presentationId',
+        name: 'some presentation',
+        revisionStatus: 0
+      };
+
+      presentationFactory.setPresentation(presentation);
+      presentationFactory.setPresentation({id: 'presentationId'});
+
+      presentationFactory.getPresentationCached('presentationId')
+        .then(function(result) {
+          expect(result).to.equal(presentation);
+
+          done();
+        });
+    });
+
+  });
+
   describe('getPresentationCached: ', function() {
     it('should get the presentation',function(done){
       presentationFactory.getPresentationCached('presentationId')

--- a/test/unit/schedules/directives/dtv-schedule-fields.tests.js
+++ b/test/unit/schedules/directives/dtv-schedule-fields.tests.js
@@ -1,6 +1,6 @@
 'use strict';
 describe('directive: scheduleFields', function() {
-  var $scope, $rootScope;
+  var $scope, $rootScope, playlistFactory, $modal;
   var classicPres1 = { name: 'classic1' };
   var classicPres2 = { name: 'classic2' };
   var htmlPres1 = { name: 'html1', presentationType: 'HTML Template' };
@@ -13,22 +13,28 @@ describe('directive: scheduleFields', function() {
   beforeEach(module(function ($provide) {
     $provide.service('$modal', function() {
       return {
-        open: function() {
-        }
+        open: sinon.stub()
       };
     });
     $provide.service('playlistFactory', function() {
       return {
+        getNewUrlItem: sinon.stub().returns('urlItem'),
+        addPresentationItems: sinon.spy()
       };
     });
     $provide.service('scheduleFactory', function() {
       return {
-        getPreviewUrl: function () {}
+        getPreviewUrl: function () {
+          return 'previewUrl';
+        }
       };
     });
   }));
 
-  beforeEach(inject(function($compile, _$rootScope_, $templateCache){
+  beforeEach(inject(function($compile, _$rootScope_, $templateCache, $injector){
+    $modal = $injector.get('$modal');
+    playlistFactory = $injector.get('playlistFactory');
+
     $templateCache.put('partials/schedules/schedule-fields.html', '<p>mock</p>');
     $rootScope = _$rootScope_;
     $scope = $rootScope.$new();
@@ -37,6 +43,46 @@ describe('directive: scheduleFields', function() {
     element = $compile('<schedule-fields></schedule-fields>')($scope);
     $rootScope.$digest();
   }));
+
+  it('should exist', function() {
+    expect($scope).to.be.ok;
+
+    expect($scope.addUrlItem).to.be.a('function');
+    expect($scope.addPresentationItem).to.be.a("function");
+    expect($scope.isPreviewAvailable).to.be.a('function');
+
+    expect($scope.previewUrl).to.equal('previewUrl');
+  });
+
+  it('addUrlItem:', function() {
+    $scope.addUrlItem();
+
+    $modal.open.should.have.been.calledWithMatch({
+      templateUrl: 'partials/schedules/playlist-item.html',
+      controller: 'playlistItemModal',
+      size: 'md'
+    });
+
+    expect($modal.open.getCall(0).args[0].resolve.playlistItem()).to.equal('urlItem');
+  });
+
+  it('addPresentationItem:', function(done) {
+    $modal.open.returns({result: Q.resolve('presentations')});
+
+    $scope.addPresentationItem();
+
+    $modal.open.should.have.been.calledWithMatch({
+      templateUrl: 'partials/editor/presentation-multi-selector-modal.html',
+      controller: 'PresentationMultiSelectorModal'
+    });
+
+    setTimeout(function() {
+      playlistFactory.addPresentationItems.should.have.been.calledWith('presentations');
+
+      done();
+    }, 10);
+
+  });
 
   describe('isPreviewAvailable:', function() {
     it('should have Preview button available', function() {

--- a/test/unit/schedules/services/svc-create-first-schedule.tests.js
+++ b/test/unit/schedules/services/svc-create-first-schedule.tests.js
@@ -1,0 +1,147 @@
+'use strict';
+describe('service: createFirstSchedule:', function() {
+  beforeEach(module('risevision.schedules.services'));
+  beforeEach(module(function ($provide) {
+    $provide.service('$q', function() {return Q;});
+
+    $provide.service('scheduleFactory',function () {
+      return {
+        checkFirstSchedule: sinon.stub().returns(Q.resolve()),
+        newSchedule: sinon.spy(),
+        addSchedule: sinon.stub().returns(Q.resolve()),
+        schedule: {}
+      };
+    });
+    $provide.service('playlistFactory', function() {
+      return {
+        addPresentationItem: sinon.stub().returns(Q.resolve())
+      }
+    })
+    $provide.service('$state',function(){
+      return {
+        go : sinon.stub()
+      }
+    });
+    $provide.service('$modal',function(){
+      return {
+        open: sinon.stub()
+      };
+    });
+    $provide.service('onboardingFactory', function() {
+      return {
+        isTemplateOnboarding: sinon.stub().returns(false)
+      };
+    });
+    $provide.service('blueprintFactory', function() {
+      return {
+        isPlayUntilDone: sinon.stub()
+      };
+    });
+
+  }));
+  var createFirstSchedule, $state, scheduleFactory, playlistFactory, $modal;
+  var onboardingFactory, blueprintFactory;
+  beforeEach(function(){
+
+    inject(function($injector){
+      createFirstSchedule = $injector.get('createFirstSchedule');
+
+      $modal = $injector.get('$modal');
+      $state = $injector.get('$state');
+      scheduleFactory = $injector.get('scheduleFactory');
+      playlistFactory = $injector.get('playlistFactory');
+      onboardingFactory = $injector.get('onboardingFactory');
+      blueprintFactory = $injector.get('blueprintFactory');
+    });
+  });
+
+  it('should exist',function(){
+    expect(createFirstSchedule).to.be.ok;
+    expect(createFirstSchedule).to.be.a('function');
+  });
+
+  var samplePresentation, firstScheduleSample;
+
+  beforeEach(function() {
+    samplePresentation = {
+      name: 'presentationName',
+      id: 'presentationId'
+    };
+    firstScheduleSample = {
+      name: 'All Displays - 24/7',
+      content: [{
+        name: 'presentationName',
+        objectReference: 'presentationId',
+        playUntilDone: false,
+        duration: 10,
+        timeDefined: false,
+        type: 'presentation'
+      }],
+      distributeToAll: true,
+      timeDefined: false
+    };
+    
+  });
+
+  it('should create first schedule and show modal', function(done) {
+    createFirstSchedule(samplePresentation)
+      .then(function(){
+        scheduleFactory.checkFirstSchedule.should.have.been.called;
+        scheduleFactory.newSchedule.should.have.been.calledWith(true);
+
+        expect(scheduleFactory.schedule.name).to.equal('All Displays - 24/7');
+        expect(scheduleFactory.schedule.distributeToAll).to.be.true;
+
+        playlistFactory.addPresentationItem.should.have.been.calledWith(samplePresentation);
+
+        scheduleFactory.addSchedule.should.have.been.called;
+
+        $state.go.should.not.have.been.called;
+        $modal.open.should.have.been.called;
+
+        expect($modal.open.getCall(0).args[0].templateUrl).to.equal('partials/schedules/auto-schedule-modal.html');
+        expect($modal.open.getCall(0).args[0].controller).to.equal('AutoScheduleModalController');
+        expect($modal.open.getCall(0).args[0].resolve.presentationName()).to.equal('presentationName');
+
+        done();
+      });
+  });
+
+  it('should create first schedule and redirect to onboarding', function(done) {
+    onboardingFactory.isTemplateOnboarding.returns(true);
+    createFirstSchedule(samplePresentation)
+      .then(function(){
+        $state.go.should.have.been.calledWith('apps.launcher.onboarding');
+        $modal.open.should.not.have.been.called;
+
+        done();
+      });
+  });
+
+  it('should not create twice, checkFirstSchedule reject', function(done) {
+    scheduleFactory.checkFirstSchedule.returns(Q.reject());
+
+    createFirstSchedule(samplePresentation)
+      .then(function(){
+        done("Error: schedule created again");
+      },function(){
+        scheduleFactory.addSchedule.should.not.have.been.called;
+
+        done();
+      });
+  });
+
+  it('should handle failure to create schedule, addSchedule returns error', function(done) {
+    scheduleFactory.errorMessage = 'Failed to create schedule';
+
+    createFirstSchedule()
+      .then(function(){
+        done("Error: schedule created again");
+      },function(err){
+        expect(err).to.equal('Failed to create schedule');
+
+        done();
+      });
+  });
+
+});

--- a/test/unit/schedules/services/svc-playlist-factory.tests.js
+++ b/test/unit/schedules/services/svc-playlist-factory.tests.js
@@ -27,13 +27,24 @@ describe('service: playlistFactory:', function() {
     $provide.service('scheduleFactory',function () {
       return scheduleFactory;
     });
+    $provide.service('blueprintFactory', function() {
+      return {
+       isPlayUntilDone: sinon.stub().returns(Q.resolve(true))
+      };
+    });
+    $provide.service('presentationFactory', function() {
+      return {
+        setPresentation: sinon.spy()
+      };
+    });
     $provide.service('scheduleTracker', function() { 
       return function(name) {
         trackerCalled = name;
       };
     });
   }));
-  var playlist, playlistItem, playlistItem0, playlistItem2, playlistFactory, trackerCalled, updateSchedule, currentState;
+  var playlist, playlistItem, playlistItem0, playlistItem2, playlistFactory, blueprintFactory, presentationFactory;
+  var trackerCalled, updateSchedule, currentState;
   var scheduleFactory;
   beforeEach(function(){
     trackerCalled = undefined;
@@ -42,16 +53,17 @@ describe('service: playlistFactory:', function() {
     
     inject(function($injector){  
       playlistFactory = $injector.get('playlistFactory');
+      blueprintFactory = $injector.get('blueprintFactory');
+      presentationFactory = $injector.get('presentationFactory');
     });
   });
 
   it('should exist',function(){
-    expect(playlistFactory).to.be.truely;
+    expect(playlistFactory).to.be.ok;
     
     expect(playlistFactory.getPlaylist).to.be.a('function');
     expect(playlistFactory.isNew).to.be.a('function');    
     expect(playlistFactory.getNewUrlItem).to.be.a('function');    
-    expect(playlistFactory.getNewPresentationItem).to.be.a('function');
     expect(playlistFactory.removePlaylistItem).to.be.a('function');
     expect(playlistFactory.duplicatePlaylistItem).to.be.a('function');    
     expect(playlistFactory.updatePlaylistItem).to.be.a('function');
@@ -89,13 +101,146 @@ describe('service: playlistFactory:', function() {
     expect(playlistItem.type).to.equal('url');
     expect(playlistItem.name).to.equal('URL Item');
   });
-  
-  it('getNewPresentationItem: ', function() {
-    var playlistItem = playlistFactory.getNewPresentationItem();
-    
-    expect(trackerCalled).to.equal('Add Presentation to Schedule');
-    expect(playlistItem.duration).to.equal(10);
-    expect(playlistItem.type).to.equal('presentation');
+
+  describe('initPlayUntilDone:', function() {
+    var item;
+
+    beforeEach(function() {
+      item = {};
+    });
+
+    it('should resolve to true if item is not HTML_PRESENTATION_TYPE', function(done) {
+      playlistFactory.initPlayUntilDone(item, {presentationType: 'legacy'}, true)
+        .then(function(result) {
+          expect(result).to.be.true;
+
+          blueprintFactory.isPlayUntilDone.should.not.have.been.called;
+
+          done();
+        });
+    });
+
+    it('should resolve to true if HTML Template supports playUntilDone', function(done) {
+      playlistFactory.initPlayUntilDone(item, {presentationType: 'HTML Template', productCode: 'productCode'}, true)
+        .then(function(result) {
+          expect(result).to.be.true;
+          expect(item.playUntilDone).to.be.true;
+
+          blueprintFactory.isPlayUntilDone.should.have.been.calledWith('productCode');
+
+          done();
+        });
+    });
+
+    it('should not update item if existing', function(done) {
+      item.playUntilDone = false;
+
+      playlistFactory.initPlayUntilDone(item, {presentationType: 'HTML Template', productCode: 'productCode'}, false)
+        .then(function(result) {
+          expect(result).to.be.true;
+          expect(item.playUntilDone).to.be.false;
+
+          done();
+        });
+    });
+
+    it('should not overwrite if item playUntilDone is false', function(done) {
+      item.playUntilDone = false;
+
+      playlistFactory.initPlayUntilDone(item, {presentationType: 'HTML Template', productCode: 'productCode'}, false)
+        .then(function(result) {
+          expect(result).to.be.true;
+          expect(item.playUntilDone).to.be.false;
+
+          done();
+        });
+    });
+
+    it('should resolve to false if HTML Template does not support playUntilDone', function(done) {
+      blueprintFactory.isPlayUntilDone.returns(Q.resolve(false));
+
+      playlistFactory.initPlayUntilDone(item, {presentationType: 'HTML Template', productCode: 'productCode'}, true)
+        .then(function(result) {
+          expect(result).to.be.false;
+          expect(item.playUntilDone).to.be.false;
+
+          done();
+        });
+    });
+
+    it('should update to false if playUntilDone retrieval fails', function(done) {
+      item.playUntilDone = true;
+      blueprintFactory.isPlayUntilDone.returns(Q.reject('error'));
+
+      playlistFactory.initPlayUntilDone(item, {presentationType: 'HTML Template', productCode: 'productCode'}, false)
+        .then(function(result) {
+          expect(result).to.be.false;
+          expect(item.playUntilDone).to.be.false;
+
+          blueprintFactory.isPlayUntilDone.should.have.been.calledWith('productCode');
+
+          done();
+        });
+    });
+
+  });
+
+  describe('addPresentationItem:', function() {
+    var presentation, mockPlaylistItem;
+
+    beforeEach(function() {
+      presentation = {
+        id: 'presentationId',
+        name: 'presentationName',
+        presentationType: 'presentationType'
+      };
+      mockPlaylistItem = {
+        duration: 10,
+        type: 'presentation',
+        name: 'presentationName',
+        objectReference: 'presentationId',
+        presentationType: 'presentationType'
+      }
+
+
+      sinon.stub(playlistFactory, 'initPlayUntilDone').returns(Q.resolve());
+      sinon.stub(playlistFactory, 'updatePlaylistItem');      
+    });
+
+    it('should cache presentation', function() {
+      playlistFactory.addPresentationItem(presentation);
+
+      expect(trackerCalled).to.equal('Add Presentation to Schedule');
+
+      presentationFactory.setPresentation.should.have.been.calledWith(presentation);
+    });
+
+    it('should init playUntilDone', function() {
+      playlistFactory.addPresentationItem(presentation);
+
+      playlistFactory.initPlayUntilDone.should.have.been.calledWith(mockPlaylistItem, presentation, true);
+    });
+
+    it('should add item', function(done) {
+      playlistFactory.addPresentationItem(presentation)
+        .then(function() {
+          playlistFactory.updatePlaylistItem.should.have.been.calledWith(mockPlaylistItem);
+
+          done();
+        });
+    });
+
+  });
+
+  it('addPresentationItems:', function() {
+    sinon.stub(playlistFactory, 'addPresentationItem');
+
+    playlistFactory.addPresentationItems([1, 2]);
+
+    playlistFactory.addPresentationItem.should.have.been.calledTwice;
+
+    expect(playlistFactory.addPresentationItem.getCall(0).args[0]).to.equal(1);
+    expect(playlistFactory.addPresentationItem.getCall(1).args[0]).to.equal(2);
   });
 
   describe('removePlaylistItem: ',function(){

--- a/test/unit/schedules/services/svc-schedule-factory.tests.js
+++ b/test/unit/schedules/services/svc-schedule-factory.tests.js
@@ -1,4 +1,5 @@
 'use strict';
+
 describe('service: scheduleFactory:', function() {
   beforeEach(module('risevision.schedules.services'));
   beforeEach(module(function ($provide) {
@@ -7,8 +8,8 @@ describe('service: scheduleFactory:', function() {
     $provide.service('schedule',function () {
       return {
         _schedule: {
-          id: "scheduleId",
-          name: "some schedule"
+          id: 'scheduleId',
+          name: 'some schedule'
         },
         list: function() {
           var deferred = Q.defer();
@@ -64,18 +65,9 @@ describe('service: scheduleFactory:', function() {
     });
     $provide.service('$state',function(){
       return {
-        go : sinon.stub()
+        go : sinon.stub(),
+        current: {}
       }
-    });
-    $provide.service('$modal',function(){
-      return {
-        open: sinon.stub()
-      };
-    });
-    $provide.service('onboardingFactory', function() {
-      return {
-        isTemplateOnboarding: sinon.stub().returns(false)
-      };
     });
     $provide.service('blueprintFactory', function() {
       return {
@@ -89,8 +81,8 @@ describe('service: scheduleFactory:', function() {
     $provide.value('VIEWER_URL', 'http://rvaviewer-test.appspot.com');
 
   }));
-  var scheduleFactory, trackerCalled, updateSchedule, $state, returnList, scheduleListSpy, scheduleAddSpy, processErrorCode, $modal;
-  var $rootScope, onboardingFactory, blueprintFactory;
+  var scheduleFactory, trackerCalled, updateSchedule, $state, returnList, scheduleListSpy, scheduleAddSpy, processErrorCode;
+  var $rootScope, blueprintFactory;
   beforeEach(function(){
     trackerCalled = undefined;
     updateSchedule = true;
@@ -102,22 +94,20 @@ describe('service: scheduleFactory:', function() {
       scheduleListSpy = sinon.spy(schedule,'list');
       scheduleAddSpy = sinon.spy(schedule,'add');
 
-      $modal = $injector.get('$modal');
       $rootScope = $injector.get('$rootScope');
       sinon.spy($rootScope, '$emit');
       $state = $injector.get('$state');
-      onboardingFactory = $injector.get('onboardingFactory');
       blueprintFactory = $injector.get('blueprintFactory');
     });
   });
 
   it('should exist',function(){
-    expect(scheduleFactory).to.be.truely;
+    expect(scheduleFactory).to.be.ok;
 
-    expect(scheduleFactory.schedule).to.be.truely;
+    expect(scheduleFactory.schedule).to.be.ok;
     expect(scheduleFactory.loadingSchedule).to.be.false;
     expect(scheduleFactory.savingSchedule).to.be.false;
-    expect(scheduleFactory.apiError).to.not.be.truely;
+    expect(scheduleFactory.apiError).to.not.be.ok;
 
     expect(scheduleFactory.newSchedule).to.be.a('function');
     expect(scheduleFactory.getSchedule).to.be.a('function');
@@ -128,28 +118,34 @@ describe('service: scheduleFactory:', function() {
   });
 
   it('should initialize',function(){
-    expect(scheduleFactory.schedule).to.deep.equal({content: [], distributeToAll: false, distribution: []});
-    expect(scheduleFactory.scheduleId).to.not.be.truely;
+    expect(scheduleFactory.schedule).to.deep.equal({content: [], distributeToAll: false, distribution: [], timeDefined: false});
   });
 
-  it('newSchedule: should reset the schedule',function(){
-    scheduleFactory.schedule.id = 'scheduleId';
-    scheduleFactory.scheduleId = 'scheduleId';
+  describe('newSchedule:', function() {
+    it('should reset the schedule',function(){
+      scheduleFactory.schedule.id = 'scheduleId';
 
-    scheduleFactory.newSchedule();
+      scheduleFactory.newSchedule();
 
-    expect(trackerCalled).to.equal('Add Schedule');
+      expect(trackerCalled).to.equal('Add Schedule');
 
-    expect(scheduleFactory.schedule).to.deep.equal({content: [], distributeToAll: false, distribution: []});
-    expect(scheduleFactory.scheduleId).to.not.be.truely;
+      expect(scheduleFactory.schedule).to.deep.equal({content: [], distributeToAll: false, distribution: [], timeDefined: false});
+    });
+
+    it('should not call tracker if param is true',function(){
+      scheduleFactory.newSchedule(true);
+
+      expect(trackerCalled).to.not.be.ok;
+    });
+    
   });
 
   describe('getSchedule:',function(){
-    it("should get the schedule",function(done){
-      scheduleFactory.getSchedule("scheduleId")
+    it('should get the schedule',function(done){
+      scheduleFactory.getSchedule('scheduleId')
       .then(function() {
-        expect(scheduleFactory.schedule).to.be.truely;
-        expect(scheduleFactory.schedule.name).to.equal("some schedule");
+        expect(scheduleFactory.schedule).to.be.ok;
+        expect(scheduleFactory.schedule.name).to.equal('some schedule');
 
         setTimeout(function() {
           expect(scheduleFactory.loadingSchedule).to.be.false;
@@ -158,12 +154,12 @@ describe('service: scheduleFactory:', function() {
         }, 10);
       })
       .then(null, function() {
-        done("error");
+        done('error');
       })
       .then(null,done);
     });
 
-    it("should handle failure to get schedule correctly",function(done){
+    it('should handle failure to get schedule correctly',function(done){
       updateSchedule = false;
 
       scheduleFactory.getSchedule()
@@ -172,7 +168,7 @@ describe('service: scheduleFactory:', function() {
       })
       .then(null, function() {
         expect(scheduleFactory.errorMessage).to.be.ok;
-        expect(scheduleFactory.errorMessage).to.equal("Failed to get Schedule.");
+        expect(scheduleFactory.errorMessage).to.equal('Failed to get Schedule.');
         processErrorCode.should.have.been.calledWith('Schedule', 'get', sinon.match.object);
         expect(scheduleFactory.apiError).to.be.ok;
 
@@ -196,13 +192,26 @@ describe('service: scheduleFactory:', function() {
       expect(scheduleFactory.loadingSchedule).to.be.true;
 
       setTimeout(function(){
-        $state.go.should.have.been.calledWith('apps.schedules.details');
+        $state.go.should.not.have.been.called;
         $rootScope.$emit.should.have.been.calledWith('scheduleCreated');
         expect(trackerCalled).to.equal('Schedule Created');
         expect(scheduleFactory.savingSchedule).to.be.false;
         expect(scheduleFactory.loadingSchedule).to.be.false;
         expect(scheduleFactory.errorMessage).to.not.be.ok;
         expect(scheduleFactory.apiError).to.not.be.ok;
+
+        done();
+      },10);
+    });
+
+    it('should only redirect from apps.schedules.add',function(done){
+      $state.current.name = 'apps.schedules.add';
+      updateSchedule = true;
+
+      scheduleFactory.addSchedule();
+
+      setTimeout(function(){
+        $state.go.should.have.been.calledWith('apps.schedules.details');
 
         done();
       },10);
@@ -309,7 +318,7 @@ describe('service: scheduleFactory:', function() {
   it('getPreviewUrl: ', function(done) {
     expect(scheduleFactory.getPreviewUrl()).to.not.be.ok;
 
-    scheduleFactory.getSchedule("scheduleId")
+    scheduleFactory.getSchedule('scheduleId')
       .then(function() {
         expect(scheduleFactory.getPreviewUrl()).to.be.ok;
         expect(scheduleFactory.getPreviewUrl()).to.equal('http://rvaviewer-test.appspot.com/?type=schedule&id=scheduleId');
@@ -322,153 +331,89 @@ describe('service: scheduleFactory:', function() {
       .then(null,done);
   });
 
-  describe('createFirstSchedule:', function(){
-    var samplePresentation, firstScheduleSample;
+  describe('checkFirstSchedule:', function(){
 
-    beforeEach(function() {
-      samplePresentation = {
-        name: 'presentationName',
-        id: 'presentationId'
-      };
-      firstScheduleSample = {
-        name: 'All Displays - 24/7',
-        content: [{
-          name: 'presentationName',
-          objectReference: 'presentationId',
-          playUntilDone: false,
-          duration: 10,
-          timeDefined: false,
-          type: 'presentation'
-        }],
-        distributeToAll: true,
-        timeDefined: false
-      };
-      
-    });
-
-    it('should create first schedule and show modal', function(done) {
+    it('should check first schedule', function(done) {
       returnList = {};
-      scheduleFactory.createFirstSchedule(samplePresentation)
-      // .then(function(){
-      setTimeout(function() {
-        scheduleListSpy.should.have.been.calledWith({count:1});
+      scheduleFactory.checkFirstSchedule()
+        .then(function(){
+          scheduleListSpy.should.have.been.calledWith({count:1});
 
-        scheduleAddSpy.should.have.been.calledWith(firstScheduleSample);
-
-        $rootScope.$emit.should.have.been.calledWith('scheduleCreated');
-        expect(trackerCalled).to.equal('Schedule Created');
-
-        $state.go.should.not.have.been.called;
-        $modal.open.should.have.been.called;
-
-        expect($modal.open.getCall(0).args[0].templateUrl).to.equal('partials/schedules/auto-schedule-modal.html');
-        expect($modal.open.getCall(0).args[0].controller).to.equal('AutoScheduleModalController');
-        expect($modal.open.getCall(0).args[0].resolve.presentationName()).to.equal('presentationName');
-
-        done();
-      }, 100);
-    });
-
-    describe('HTML_PRESENTATION_TYPE:', function() {
-      beforeEach(function() {
-        samplePresentation.presentationType = 'HTML Template';
-        firstScheduleSample.content[0].presentationType = 'HTML Template';
-
-        blueprintFactory.isPlayUntilDone.returns(Q.resolve(false));
-      });
-
-      it('should set correct presentation type', function(done) {
-        returnList = {};
-        scheduleFactory.createFirstSchedule(samplePresentation)
-        // .then(function(){
-        setTimeout(function() {
-          scheduleAddSpy.should.have.been.calledWith(firstScheduleSample);
-
-          done();
-        }, 100);
-      });
-
-      it('should retrieve and update playUntilDone', function(done) {
-        blueprintFactory.isPlayUntilDone.returns(Q.resolve(true));
-        firstScheduleSample.content[0].playUntilDone = true;
-
-        returnList = {};
-        scheduleFactory.createFirstSchedule(samplePresentation)
-        // .then(function(){
-        setTimeout(function() {
-          scheduleAddSpy.should.have.been.calledWith(firstScheduleSample);
-
-          done();
-        }, 100);
-      });
-
-      it('should handle failure to retrieve blueprint', function(done) {
-        blueprintFactory.isPlayUntilDone.returns(Q.reject());
-
-        returnList = {};
-        scheduleFactory.createFirstSchedule(samplePresentation)
-        // .then(function(){
-        setTimeout(function() {
-          scheduleAddSpy.should.have.been.calledWith(firstScheduleSample);
-
-          done();
-        }, 100);
-      });
-    });
-
-    it('should create first schedule and redirect to onboarding', function(done) {
-      returnList = {};
-      onboardingFactory.isTemplateOnboarding.returns(true);
-      scheduleFactory.createFirstSchedule(samplePresentation)
-      .then(function(){
-        scheduleListSpy.should.have.been.calledWith({count:1});
-
-        scheduleAddSpy.should.have.been.calledWith(firstScheduleSample);
-
-        $rootScope.$emit.should.have.been.calledWith('scheduleCreated');
-        expect(trackerCalled).to.equal('Schedule Created');
-
-        $state.go.should.have.been.calledWith('apps.launcher.onboarding');
-        $modal.open.should.not.have.been.called;
-
-        done();
-      });
-    });
-
-    it('should not create twice', function(done) {
-      returnList = {};
-      scheduleFactory.createFirstSchedule(samplePresentation)
-      .then(function(){
-        scheduleListSpy.should.have.been.calledWith({count:1});
-
-        scheduleAddSpy.should.have.been.calledWith(firstScheduleSample);
-
-        $rootScope.$emit.should.have.been.calledWith('scheduleCreated');
-        expect(trackerCalled).to.equal('Schedule Created');
-
-        scheduleFactory.createFirstSchedule(samplePresentation).then(function(){
-          done("Error: schedule created again");
-        },function(){
-          scheduleListSpy.should.have.been.calledOnce;
-          scheduleAddSpy.should.have.been.calledOnce
           done();
         });
+    });
+
+    it('should reject (schedule exists) after Get', function(done) {
+      updateSchedule = true;
+
+      scheduleFactory.getSchedule()
+        .then(function() {
+          scheduleFactory.checkFirstSchedule()
+            .catch(function(){
+              scheduleListSpy.should.not.have.been.called;
+
+              done();
+            });
+        });
+    });
+
+    it('should reject (schedule exists) after Add', function(done) {
+      updateSchedule = true;
+
+      scheduleFactory.addSchedule()
+        .then(function() {
+          scheduleFactory.checkFirstSchedule()
+            .catch(function(){
+              scheduleListSpy.should.not.have.been.called;
+
+              done();
+            });
+        });
+    });
+
+    it('should get list after Delete', function(done) {
+      updateSchedule = true;
+      returnList = {};
+
+      // Add first
+      scheduleFactory.addSchedule()
+        .then(function() {
+          // Delete second
+          scheduleFactory.deleteSchedule()
+            .then(function() {
+              scheduleFactory.checkFirstSchedule()
+                .then(function(){
+                  scheduleListSpy.should.have.been.called;
+
+                  done();
+                });              
+            });
+        });
+    });
+
+    it('should reset after selectedCompanyChanged',function(done){
+      returnList = { items: [{name:'schedule'}] };
+      scheduleFactory.checkFirstSchedule()
+      .then(null, function(){
+        scheduleListSpy.should.have.been.calledWith({count:1});
+
+        $rootScope.$broadcast('risevision.company.selectedCompanyChanged');
+        $rootScope.$digest();
+
+        returnList = {};
+
+        scheduleFactory.checkFirstSchedule()
+          .then(function(){
+            scheduleListSpy.should.have.been.calledTwice;
+
+            done();
+          });
       });
     });
 
     it('should handle error loading list', function(done) {
       returnList = false;
-      scheduleFactory.createFirstSchedule(samplePresentation)
-      .then(null,function(){
-        scheduleListSpy.should.have.been.calledOnce;
-        done();
-      });
-    });
-
-    it('should handle error saving schedule', function(done) {
-      returnList = {};
-      updateSchedule = false;
-      scheduleFactory.createFirstSchedule(samplePresentation)
+      scheduleFactory.checkFirstSchedule()
       .then(null,function(){
         scheduleListSpy.should.have.been.calledOnce;
         done();
@@ -477,34 +422,11 @@ describe('service: scheduleFactory:', function() {
 
     it('should not create if already have schedules',function(done){
       returnList = { items: [{name:'schedule'}] };
-      scheduleFactory.createFirstSchedule(samplePresentation)
+      scheduleFactory.checkFirstSchedule()
       .then(null, function(){
         scheduleListSpy.should.have.been.calledWith({count:1});
-
-        scheduleAddSpy.should.not.have.been.called;
-
-        expect(trackerCalled).to.not.be.ok;
 
         done();
-      });
-    });
-
-    it('should cache result',function(done){
-      returnList = { items: [{name:'schedule'}] };
-      scheduleFactory.createFirstSchedule(samplePresentation)
-      .then(null, function(){
-        scheduleListSpy.should.have.been.calledWith({count:1});
-        scheduleAddSpy.should.not.have.been.called;
-        expect(trackerCalled).to.not.be.ok;
-
-        scheduleFactory.createFirstSchedule(samplePresentation).then(function(){
-          done("Error: schedule created again");
-        },function(){
-          scheduleListSpy.should.have.been.calledOnce;
-          scheduleAddSpy.should.not.have.been.called;
-          expect(trackerCalled).to.not.be.ok;
-          done();
-        });
       });
     });
 

--- a/test/unit/template-editor/services/svc-template-editor-factory.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-factory.tests.js
@@ -64,16 +64,14 @@ describe('service: templateEditorFactory:', function() {
       return presentationTracker;
     });
 
-    $provide.service('scheduleFactory', function() {
-      return {
-        createFirstSchedule: sandbox.stub()
-      };
+    $provide.service('createFirstSchedule', function() {
+      return sandbox.stub();
     });
 
   }));
 
   var $state, templateEditorFactory, templateEditorUtils, blueprintFactory, presentation, processErrorCode,
-    HTML_PRESENTATION_TYPE, storeProduct, plansFactory, scheduleFactory, brandingFactory;
+    HTML_PRESENTATION_TYPE, storeProduct, plansFactory, createFirstSchedule, brandingFactory;
 
   beforeEach(function() {
     inject(function($injector) {
@@ -82,7 +80,7 @@ describe('service: templateEditorFactory:', function() {
 
       presentation = $injector.get('presentation');
       plansFactory = $injector.get('plansFactory');
-      scheduleFactory = $injector.get('scheduleFactory');
+      createFirstSchedule = $injector.get('createFirstSchedule');
       brandingFactory = $injector.get('brandingFactory');
       storeProduct = $injector.get('storeProduct');
       templateEditorUtils = $injector.get('templateEditorUtils');
@@ -590,7 +588,7 @@ describe('service: templateEditorFactory:', function() {
 
   describe('publish: ', function() {
     beforeEach(function (done) {
-      scheduleFactory.createFirstSchedule.returns(Q.resolve());
+      createFirstSchedule.returns(Q.resolve());
       sandbox.stub(presentation, 'get').returns(Q.resolve({
         item: {
           id: 'presentationId',
@@ -704,7 +702,7 @@ describe('service: templateEditorFactory:', function() {
         templateEditorFactory.publish(templateEditorFactory)
           .then(function() {
             setTimeout(function() {
-              scheduleFactory.createFirstSchedule.should.have.been.calledWith(templateEditorFactory.presentation);
+              createFirstSchedule.should.have.been.calledWith(templateEditorFactory.presentation);
 
               done();
             });

--- a/web/index.html
+++ b/web/index.html
@@ -362,6 +362,7 @@
   <script src="scripts/schedules/services/svc-schedule.js"></script>
   <script src="scripts/schedules/services/svc-schedule-factory.js"></script>
   <script src="scripts/schedules/services/svc-playlist-factory.js"></script>
+  <script src="scripts/schedules/services/svc-create-first-schedule.js"></script>
 
   <script src="scripts/schedules/directives/dtv-schedule-fields.js"></script>
   <script src="scripts/schedules/directives/dtv-playlist.js"></script>
@@ -415,6 +416,7 @@
   <script src="scripts/editor/controllers/ctr-presentation-list.js"></script>
   <script src="scripts/editor/controllers/ctr-shared-templates-modal.js"></script>
   <script src="scripts/editor/controllers/ctr-presentation-selector-modal.js"></script>
+  <script src="scripts/editor/controllers/ctr-presentation-multi-selector-modal.js"></script>
 
   <script src="scripts/editor/services/svc-artboard-factory.js"></script>
   <script src="scripts/editor/services/svc-editor-factory.js"></script>

--- a/web/partials/editor/presentation-multi-selector-list.html
+++ b/web/partials/editor/presentation-multi-selector-list.html
@@ -1,0 +1,42 @@
+<div ng-controller="PresentationListController">
+  <search-filter filter-config="filterConfig" search="search" do-search="factory.doSearch"></search-filter>
+  <div class="panel u_margin-sm-top">
+    <div class="scrollable-list" 
+      scrolling-list="factory.load()"
+      rv-spinner rv-spinner-key="presentation-list-loader"
+      rv-spinner-start-active="1"
+      >
+      <table id="presentationListTable" class="table table--hover table--selector table--multiple-selector animated fadeIn">
+        <thead class="table-header">
+          <tr class="table-header__row">
+            <th id="tableHeaderName" ng-click="factory.sortBy('name')" class="table-header__cell u_clickable">
+              {{'editor-app.list.heading.name' | translate}}
+              <!-- ngIf: search.sortBy == 'name' -->
+              <i ng-if="search.sortBy == 'name'" class="fa" ng-class="{false: 'fa-long-arrow-up', true: 'fa-long-arrow-down'}[search.reverse]"></i>
+              <!-- end ngIf: search.sortBy == 'name' -->
+            </th>
+            <th id="tableHeaderStatus" class="table-header__cell text-right">
+              {{'editor-app.list.heading.status' | translate}}
+            </th>
+          </tr>
+        </thead>
+
+        <tbody class="table-body">
+          <tr class="table-body__row u_clickable" data-ng-click="togglePresentation(presentation);" data-ng-class="{'active' : isSelected(presentation.id)}" ng-repeat="presentation in factory.items.list">
+            <td id="presentationName" class="table-body__cell">{{presentation.name}}</td>
+            <td class="table-body__cell text-right"><span ng-class="{'text-danger': presentation.revisionStatus==1}">{{presentation.revisionStatusName | presentationStatus}}</span></td>
+          </tr>
+          <!-- If no presentation available -->
+          <tr class="table-body__row" ng-show="factory.items.list.length === 0 && !search.query">
+            <td colspan="3" class="text-center"><span translate>editor-app.list.empty</span></td>
+          </tr>
+          <!-- If no search results -->
+          <tr class="table-body__row" ng-show="factory.items.list.length === 0 && search.query">
+            <td colspan="3" class="text-center"><span translate>editor-app.list.no-results</span></td>
+          </tr>
+
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/web/partials/editor/presentation-multi-selector-modal.html
+++ b/web/partials/editor/presentation-multi-selector-modal.html
@@ -1,0 +1,15 @@
+<div id="addPresentationModal">
+  <div class="modal-header">
+    <button type="button" class="close" ng-click="dismiss()" aria-hidden="true">
+      <i class="fa fa-times"></i>
+    </button>
+    <h3 class="modal-title">Select Presentations</h3>
+  </div>
+  <div class="modal-body" stop-event="touchend" ng-include src="'partials/editor/presentation-multi-selector-list.html'">
+  </div>
+
+  <div class="modal-footer">
+    <button id="selectPresentations" class="btn btn-primary" ng-click="add()">Add Selected<i class="fa fa-check icon-right"></i></button>
+  </div>
+
+</div>

--- a/web/scripts/editor/controllers/ctr-presentation-multi-selector-modal.js
+++ b/web/scripts/editor/controllers/ctr-presentation-multi-selector-modal.js
@@ -1,0 +1,35 @@
+'use strict';
+
+angular.module('risevision.editor.controllers')
+  .controller('PresentationMultiSelectorModal', ['$scope', '$modalInstance',
+    function ($scope, $modalInstance) {
+      $scope.selected = [];
+
+      $scope.togglePresentation = function (presentation) {
+        var index = _.findIndex($scope.selected, {
+          id: presentation.id
+        });
+        if (index > -1) {
+          $scope.selected.splice(index, 1);
+        } else {
+          $scope.selected.push(presentation);
+        }
+      };
+
+      $scope.isSelected = function (presentationId) {
+        var presentation = _.find($scope.selected, {
+          id: presentationId
+        });
+
+        return !!presentation;
+      };
+
+      $scope.add = function () {
+        $modalInstance.close($scope.selected);
+      };
+
+      $scope.dismiss = function () {
+        $modalInstance.dismiss();
+      };
+    }
+  ]);

--- a/web/scripts/editor/services/svc-editor-factory.js
+++ b/web/scripts/editor/services/svc-editor-factory.js
@@ -10,13 +10,13 @@ angular.module('risevision.editor.services')
     'presentation', 'presentationParser', 'distributionParser',
     'presentationTracker', 'storeProduct', 'VIEWER_URL', 'REVISION_STATUS_REVISED',
     'REVISION_STATUS_PUBLISHED', 'DEFAULT_LAYOUT',
-    '$modal', '$rootScope', '$window', 'scheduleFactory', 'processErrorCode', 'messageBox',
+    '$modal', '$rootScope', '$window', 'createFirstSchedule', 'processErrorCode', 'messageBox',
     '$templateCache', '$log', 'presentationUtils', 'showLegacyWarning',
     function ($q, $state, userState, userAuthFactory, presentation,
       presentationParser, distributionParser, presentationTracker, storeProduct,
       VIEWER_URL, REVISION_STATUS_REVISED, REVISION_STATUS_PUBLISHED,
       DEFAULT_LAYOUT, $modal, $rootScope, $window,
-      scheduleFactory, processErrorCode, messageBox, $templateCache, $log,
+      createFirstSchedule, processErrorCode, messageBox, $templateCache, $log,
       presentationUtils, showLegacyWarning) {
       var factory = {};
       var JSON_PARSE_ERROR = 'JSON parse error';
@@ -192,7 +192,7 @@ angular.module('risevision.editor.services')
                 notify: false,
                 location: 'replace'
               }).then(function () {
-                scheduleFactory.createFirstSchedule(resp.item);
+                createFirstSchedule(resp.item);
               });
               deferred.resolve(resp.item.id);
             }

--- a/web/scripts/editor/services/svc-presentation-factory.js
+++ b/web/scripts/editor/services/svc-presentation-factory.js
@@ -9,10 +9,20 @@ angular.module('risevision.editor.services')
       factory.loadingPresentation = false;
       factory.apiError = '';
 
-      factory.getPresentationCached = function (presentationId) {
-        var presentation = _.find(_presentations, {
+      var _find = function (presentationId) {
+        return _.find(_presentations, {
           id: presentationId
         });
+      };
+
+      factory.setPresentation = function (presentation) {
+        if (presentation.id && !_find(presentation.id)) {
+          _presentations.push(presentation);
+        }
+      };
+
+      factory.getPresentationCached = function (presentationId) {
+        var presentation = _find(presentationId);
 
         if (presentation) {
           return $q.resolve(presentation);
@@ -29,7 +39,7 @@ angular.module('risevision.editor.services')
 
         presentation.get(presentationId)
           .then(function (result) {
-            _presentations.push(result.item);
+            factory.setPresentation(result.item);
 
             deferred.resolve(result.item);
           })

--- a/web/scripts/schedules/directives/dtv-schedule-fields.js
+++ b/web/scripts/schedules/directives/dtv-schedule-fields.js
@@ -28,17 +28,12 @@ angular.module('risevision.schedules.directives')
 
           $scope.addPresentationItem = function () {
             var modalInstance = $modal.open({
-              templateUrl: 'partials/editor/presentation-selector-modal.html',
-              controller: 'PresentationSelectorModal'
+              templateUrl: 'partials/editor/presentation-multi-selector-modal.html',
+              controller: 'PresentationMultiSelectorModal'
             });
 
-            modalInstance.result.then(function (presentationDetails) {
-              var playlistItem = playlistFactory.getNewPresentationItem();
-              playlistItem.objectReference = presentationDetails[0];
-              playlistItem.name = presentationDetails[1];
-              playlistItem.presentationType = presentationDetails[2];
-
-              openPlaylistModal(playlistItem);
+            modalInstance.result.then(function (presentations) {
+              playlistFactory.addPresentationItems(presentations);
             });
           };
 

--- a/web/scripts/schedules/services/svc-create-first-schedule.js
+++ b/web/scripts/schedules/services/svc-create-first-schedule.js
@@ -1,0 +1,45 @@
+'use strict';
+
+angular.module('risevision.schedules.services')
+  .factory('createFirstSchedule', ['$q', '$state', '$modal', 'scheduleFactory', 'playlistFactory',
+    'onboardingFactory',
+    function ($q, $state, $modal, scheduleFactory, playlistFactory, onboardingFactory) {
+
+      return function (presentation) {
+        return scheduleFactory.checkFirstSchedule()
+          .then(function () {
+            scheduleFactory.newSchedule(true);
+
+            scheduleFactory.schedule.name = 'All Displays - 24/7';
+            scheduleFactory.schedule.distributeToAll = true;
+
+            return playlistFactory.addPresentationItem(presentation);
+          })
+          .then(function () {
+            return scheduleFactory.addSchedule();
+          })
+          .then(function () {
+            if (scheduleFactory.errorMessage) {
+              return $q.reject(scheduleFactory.errorMessage);
+            }
+          })
+          .then(function () {
+            if (onboardingFactory.isTemplateOnboarding()) {
+              $state.go('apps.launcher.onboarding');
+            } else {
+              $modal.open({
+                templateUrl: 'partials/schedules/auto-schedule-modal.html',
+                size: 'md',
+                controller: 'AutoScheduleModalController',
+                resolve: {
+                  presentationName: function () {
+                    return presentation.name;
+                  }
+                }
+              });
+            }
+          });
+      };
+
+    }
+  ]);

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -3,11 +3,11 @@
 angular.module('risevision.template-editor.services')
   .constant('HTML_TEMPLATE_DOMAIN', 'https://widgets.risevision.com')
   .factory('templateEditorFactory', ['$q', '$log', '$state', '$rootScope', 'presentation',
-    'processErrorCode', 'userState', 'scheduleFactory',
+    'processErrorCode', 'userState', 'createFirstSchedule',
     'templateEditorUtils', 'brandingFactory', 'blueprintFactory', 'presentationTracker',
     'HTML_PRESENTATION_TYPE', 'REVISION_STATUS_REVISED', 'REVISION_STATUS_PUBLISHED',
     function ($q, $log, $state, $rootScope, presentation, processErrorCode, userState,
-      scheduleFactory, templateEditorUtils, brandingFactory, blueprintFactory,
+      createFirstSchedule, templateEditorUtils, brandingFactory, blueprintFactory,
       presentationTracker, HTML_PRESENTATION_TYPE, REVISION_STATUS_REVISED, REVISION_STATUS_PUBLISHED) {
       var factory = {
         hasUnsavedChanges: false
@@ -310,7 +310,7 @@ angular.module('risevision.template-editor.services')
       };
 
       var _createFirstSchedule = function () {
-        return scheduleFactory.createFirstSchedule(factory.presentation)
+        return createFirstSchedule(factory.presentation)
           .catch(function (err) {
             return err === 'Already have Schedules' ? $q.resolve() : $q.reject(err);
           });


### PR DESCRIPTION
## Description
Add multiple Presentations to a Schedule

Load blueprint to check PUD for HTML Templates
Moved functionality to factory

Split out first schedule creation factory
Helps use common code from scheduleFactory and playlistFactory

Minor improvement to Presentation caching
Minor improvements to has schedules check

[stage-2]

## Motivation and Context
Better user experience for selecting Presentations in a Schedule

Improvement based on #1494 post mortem.

## How Has This Been Tested?
Tested locally that multiple Presentations added to a Schedule have the correct Play Until Done setting.
Tested locally that the first schedule is created correctly for onboarding and non onboarding users.
Tested that schedule playlist items can be edited correctly.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
