### PR TITLE
Fix color picker selection saving [stage-8]

### DIFF
--- a/web/partials/template-editor/components/component-colors.html
+++ b/web/partials/template-editor/components/component-colors.html
@@ -1,9 +1,7 @@
 <div class="attribute-editor-component colors-container" >
   <div class="attribute-editor-row">
     <span class="colors-checkbox">
-      <input id="overrideBranding" type="checkbox"
-             ng-change="save()"
-             ng-model="override">
+      <input id="overrideBranding" type="checkbox" ng-change="saveOverride()" ng-model="override">
       <label class="control-label" for="overrideBranding">Override Branding</label>
     </span>
   </div>
@@ -13,22 +11,15 @@
 
   <label class="control-label" for="base-color">Base Color:</label>
   <p>Pick a dark color.</p>
-  <div class="input-group" colorpicker="rgba" colorpicker-position="bottom"
-       ng-model="baseColor">
-    <input id="base-color" type="text" class="form-control"
-           ng-model="baseColor"
-           placeholder="Enter a hex value, eg. #00FF00" ng-blur="save()">
+  <div class="input-group" colorpicker="rgba" colorpicker-position="bottom" ng-model="baseColor">
+    <input id="base-color" type="text" class="form-control" ng-model="baseColor" placeholder="Enter a hex value, eg. #00FF00">
     <span class="input-group-addon color-wheel"></span>
   </div>
 
   <label class="control-label u_margin-md-top" for="accent-color">Accent Color:</label>
   <p>Pick a light color.</p>
-  <div class="input-group" colorpicker="rgba" colorpicker-position="bottom"
-       ng-model="accentColor">
-    <input id="accent-color" type="text" class="form-control"
-           ng-model="accentColor"
-           placeholder="Enter a hex value, eg. #00FF00"
-           ng-blur="save()">
+  <div class="input-group" colorpicker="rgba" colorpicker-position="bottom" ng-model="accentColor">
+    <input id="accent-color" type="text" class="form-control" ng-model="accentColor" placeholder="Enter a hex value, eg. #00FF00">
     <span class="input-group-addon color-wheel"></span>
   </div>
 

--- a/web/scripts/template-editor/components/directives/dtv-component-colors.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-colors.js
@@ -10,13 +10,9 @@ angular.module('risevision.template-editor.directives')
         link: function ($scope, element) {
           $scope.factory = templateEditorFactory;
 
-          $scope.save = function () {
-            $scope.setAttributeData($scope.componentId, 'base', $scope.baseColor);
-            $scope.setAttributeData($scope.componentId, 'accent', $scope.accentColor);
+          $scope.saveOverride = function () {
             $scope.setAttributeData($scope.componentId, 'override', $scope.override);
           };
-
-          $scope.$on('colorpicker-selected', $scope.save);
 
           $scope.registerDirective({
             type: 'rise-data-colors',
@@ -34,6 +30,18 @@ angular.module('risevision.template-editor.directives')
             $scope.baseColor = $scope.getAvailableAttributeData($scope.componentId, 'base');
             $scope.accentColor = $scope.getAvailableAttributeData($scope.componentId, 'accent');
             $scope.override = $scope.getAvailableAttributeData($scope.componentId, 'override');
+
+            $scope.$watch('baseColor', function(newVal, oldVal) {
+              if ( newVal && newVal !== oldVal ) {
+                $scope.setAttributeData($scope.componentId, 'base', $scope.baseColor);
+              }
+            });
+
+            $scope.$watch('accentColor', function(newVal, oldVal) {
+              if ( newVal && newVal !== oldVal ) {
+                $scope.setAttributeData($scope.componentId, 'accent', $scope.accentColor);
+              }
+            });
           };
 
         }

--- a/web/scripts/template-editor/components/directives/dtv-component-colors.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-colors.js
@@ -16,6 +16,8 @@ angular.module('risevision.template-editor.directives')
             $scope.setAttributeData($scope.componentId, 'override', $scope.override);
           };
 
+          $scope.$on('colorpicker-selected', $scope.save);
+
           $scope.registerDirective({
             type: 'rise-data-colors',
             iconType: 'streamline',


### PR DESCRIPTION
## Description
Remove `ng-blur` handling on color pickers and omit listening for _colorpicker-selected_ event. Instead `$watch` on colorpicker instances model values to avoid the conflict with lifecycle of color picker selected event data and the $scope model value being updated. 

Ensuring to setup $watch handlers after setting initial model values to be able to avoid unnecessary saving to attribute data upon initial entry. 

## Motivation and Context
To save the colors selected to attribute data

## How Has This Been Tested?
Locally and on staging

https://apps-stage-8.risevision.com/templates/edit/ab1abbc8-b625-49e4-9220-e2297f0ce193/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
