### PR TITLE
Add caching for blueprint data

### DIFF
--- a/test/unit/template-editor/services/svc-template-editor-factory.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-factory.tests.js
@@ -47,7 +47,7 @@ describe('service: templateEditorFactory:', function() {
     $provide.factory('blueprintFactory', function() {
       return blueprintFactory = {
         blueprintData: {},
-        load: function() {
+        getBlueprintCached: function() {
           return Q.resolve(blueprintFactory.blueprintData);
         }
       };
@@ -487,7 +487,7 @@ describe('service: templateEditorFactory:', function() {
           templateAttributeData: '{ "attribute1": "value1" }'
         }
       }));
-      sandbox.stub(blueprintFactory, 'load').rejects();
+      sandbox.stub(blueprintFactory, 'getBlueprintCached').rejects();
 
       templateEditorFactory.getPresentation('presentationId')
       .then(function() {

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -60,7 +60,7 @@ angular.module('risevision.template-editor.services')
 
         presentationTracker('HTML Template Copied', productDetails.productCode, productDetails.name);
 
-        return blueprintFactory.load(factory.presentation.productCode)
+        return blueprintFactory.getBlueprintCached(factory.presentation.productCode)
           .then(null, function (e) {
             _showErrorMessage('add', e);
             return $q.reject(e);
@@ -161,7 +161,7 @@ angular.module('risevision.template-editor.services')
           .then(function (result) {
             _setPresentation(result.item);
 
-            return blueprintFactory.load(factory.presentation.productCode);
+            return blueprintFactory.getBlueprintCached(factory.presentation.productCode);
           })
           .then(function () {
             deferred.resolve();


### PR DESCRIPTION
## Description
Add caching for blueprint data
Works the same as presentationFactory cache

[stage-18]

## Motivation and Context
Improvement flagged as per #1500 

Blueprint data is requested on every HTML Presentation open and when adding a Template to the Schedule. Blueprint data is very rarely updated, and if it is updated with breaking changes, it is generally done via a new Template version.

## How Has This Been Tested?
Tested that blueprints are loaded correctly, and the cache is used for subsequent loads. Validated that other functionality in the blueprint factory still works as expected.

Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No