### PR TITLE
Lazy load images from Storage and Templates list

### DIFF
--- a/web/partials/editor/store-products-modal.html
+++ b/web/partials/editor/store-products-modal.html
@@ -23,7 +23,7 @@
                   <div class="product-grid_item panel panel-default">
 
                     <figure class="product-grid_image u_clickable">
-                      <img ng-src="{{product.imageUrl}}" class="img-responsive" alt="{{product.imageAlt || product.name}}">
+                      <img loading="lazy" ng-src="{{product.imageUrl}}" class="img-responsive" alt="{{product.imageAlt || product.name}}">
                     </figure> 
 
                     <div class="product-grid_details">
@@ -43,7 +43,7 @@
               <div class="col-sm-6 col-md-4 col-lg-3" ng-if="factory.search.category === 'Templates' && !factory.loadingItems">
                 <div class="product-grid_item panel panel-default">
                   <figure class="product-grid_image u_clickable" ui-sref="apps.editor.workspace.artboard" ng-click="dismiss();">
-                    <img class="img-responsive" src="https://s3.amazonaws.com/Rise-Images/UI/blank-landscape.png" alt="add blank presentation"> 
+                    <img loading="lazy" class="img-responsive" src="https://s3.amazonaws.com/Rise-Images/UI/blank-landscape.png" alt="add blank presentation"> 
                   </figure><!--template-image-->
                   <div class="product-grid_details">
                     <div class="row">

--- a/web/partials/storage/grid-view.html
+++ b/web/partials/storage/grid-view.html
@@ -10,9 +10,9 @@
    ng-if="storageFactory.storageFull || !storageUtils.fileIsTrash(file)" 
    title="{{file.name | fileNameFilter:filesFactory.folderPath}}{{ file.isThrottled? ' - '+('storage-client.error.blocked-file' | translate) : '' }}" data-toggle="tooltip" data-placement="top" tooltip>
 
-    <img class="list-item-icon" ng-if="isSvg" ng-src="{{imgSrc}}">
+    <img class="list-item-icon" ng-if="isSvg" loading="lazy" ng-src="{{imgSrc}}">
     
-    <img ng-if="!isSvg"  ng-src="{{imgSrc}}"/>
+    <img ng-if="!isSvg" loading="lazy" ng-src="{{imgSrc}}"/>
 
     <div ng-if="!file.metadata.thumbnail || file.isThrottled" class="list-item-label">
       {{file.name | fileNameFilter:filesFactory.folderPath}}

--- a/web/partials/template-editor/basic-storage-selector.html
+++ b/web/partials/template-editor/basic-storage-selector.html
@@ -15,7 +15,7 @@
         </div>
         <div class="file-entry" ng-if="!isFolder(item.name) && fileType != 'video'" ng-click="selectItem(item)">
           <a href="#">
-            <img src="{{ thumbnailFor(item) }}"></img>
+            <img loading="lazy" src="{{ thumbnailFor(item) }}"></img>
           </a>
         </div>
         <div class="video-entry" ng-if="!isFolder(item.name) && fileType == 'video'" ng-click="selectItem(item)">


### PR DESCRIPTION
## Description
Added a parameter for native lazy loading of images in Storage, Template Editor and Templates list.

## Motivation and Context
UX improvements epic.

## How Has This Been Tested?
Tested locally and on stage-1.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
