### PR TITLE
Fix Chrome crashing on e2e builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
             export STAGE_ENV=$(cat stage.txt)
             echo "Running tests on $STAGE_ENV";
             TEST_FILES=$(circleci tests glob "<< parameters.casesfile >>" | circleci tests split)
-            NODE_ENV=test XUNIT_FILE=~/rise-vision-apps/reports/angular-xunit.xml PROSHOT_DIR=~/rise-vision-apps/reports/screenshots DBUS_SESSION_BUS_ADDRESS=/dev/null xvfb-run node run-test.js $TEST_FILES
+            NODE_ENV=test XUNIT_FILE=~/rise-vision-apps/reports/angular-xunit.xml PROSHOT_DIR=~/rise-vision-apps/reports/screenshots DBUS_SESSION_BUS_ADDRESS=/dev/null xvfb-run -a --server-args="-screen 0 1280x800x24" node run-test.js $TEST_FILES
       - store_test_results:
           path: ~/rise-vision-apps/reports
       - store_artifacts:


### PR DESCRIPTION
## Description
Specify xvfb-run arguments to fix CCI Google Chrome crash.

## Motivation and Context
Correct build failure after Chrome 80 was released.

## How Has This Been Tested?
Build passes.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
