### PR TITLE
E2E improvement - Wait for spinner to disappear to prevent click failure 

### DIFF
--- a/test/e2e/registration/cases/checkout.js
+++ b/test/e2e/registration/cases/checkout.js
@@ -33,6 +33,10 @@
       });
 
       describe("checkout: ", function() {
+        before(function() {
+          helper.waitDisappear(homepage.getAppLauncherLoader(), 'App Launcher Loader');
+        });
+
         it("should show Subscribe button", function() {
           expect(purchaseFlowModalPage.getPlanSubscribeLink().isDisplayed()).to.eventually.be.true;
         });

--- a/test/e2e/registration/cases/checkout.js
+++ b/test/e2e/registration/cases/checkout.js
@@ -7,6 +7,7 @@
   var helper = require('rv-common-e2e').helper;
   var CommonHeaderPage = require('./../../common-header/pages/commonHeaderPage.js');
   var HomePage = require('./../../common-header/pages/homepage.js');
+  var LauncherPage = require('./../../common/pages/homepage.js');
   var SignInPage = require('./../../common/pages/signInPage.js');
   var PurchaseFlowModalPage = require('./../pages/purchaseFlowModalPage.js');
   var PricingComponentModalPage = require('./../pages/pricingComponentModalPage.js');
@@ -18,7 +19,8 @@
         homepage, 
         signInPage,
         purchaseFlowModalPage,
-        pricingComponentModalPage;
+        pricingComponentModalPage,
+        launcherPage;
                 
       before(function (){
         commonHeaderPage = new CommonHeaderPage();
@@ -26,6 +28,7 @@
         signInPage = new SignInPage();
         purchaseFlowModalPage = new PurchaseFlowModalPage();
         pricingComponentModalPage = new PricingComponentModalPage();
+        launcherPage = new LauncherPage();
 
         homepage.get();
 
@@ -34,7 +37,7 @@
 
       describe("checkout: ", function() {
         before(function() {
-          helper.waitDisappear(homepage.getAppLauncherLoader(), 'App Launcher Loader');
+          helper.waitDisappear(launcherPage.getAppLauncherLoader(), 'App Launcher Loader');
         });
 
         it("should show Subscribe button", function() {


### PR DESCRIPTION
## Description
E2E improvement -  Wait for spinner to disappear to prevent click failure when opening plan modal.

## Motivation and Context
E2E tests were failing often. Button to open Plan modal was behind a spinner and failed to trigger the modal when clicked.

## How Has This Been Tested?
E2E tests pass.
[stage-2]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
