### PR TITLE
Remove component title in Attribute Editor [stage-8]

### DIFF
--- a/test/e2e/template-editor/cases/components/counter.js
+++ b/test/e2e/template-editor/cases/components/counter.js
@@ -12,7 +12,7 @@ var CounterComponentScenarios = function () {
     var presentationsListPage;
     var templateEditorPage;
     var counterComponentPage;
-    var componentLabel = 'Count Down - Countdown Example';
+    var componentLabel = 'Countdown Example';
 
     before(function () {
       presentationsListPage = new PresentationListPage();

--- a/test/e2e/template-editor/cases/components/financial.js
+++ b/test/e2e/template-editor/cases/components/financial.js
@@ -12,6 +12,7 @@ var FinancialComponentScenarios = function () {
     var presentationsListPage;
     var templateEditorPage;
     var financialComponentPage;
+    var componentLabel = 'Currencies';
 
     before(function () {
       presentationsListPage = new PresentationListPage();
@@ -37,7 +38,7 @@ var FinancialComponentScenarios = function () {
       });
 
       it('should show one Financial Component', function () {
-        templateEditorPage.selectComponent("Financial - ");
+        templateEditorPage.selectComponent(componentLabel);
         expect(financialComponentPage.getInstrumentItems().count()).to.eventually.equal(3);
       });
 
@@ -67,7 +68,7 @@ var FinancialComponentScenarios = function () {
 
       it('should save the Presentation, reload it, and validate changes were saved', function () {
         presentationsListPage.loadPresentation(presentationName);
-        templateEditorPage.selectComponent("Financial - ");
+        templateEditorPage.selectComponent(componentLabel);
 
         expect(financialComponentPage.getInstrumentItems().count()).to.eventually.equal(4);
       });

--- a/test/e2e/template-editor/cases/components/image.js
+++ b/test/e2e/template-editor/cases/components/image.js
@@ -12,6 +12,7 @@ var ImageComponentScenarios = function () {
     var presentationsListPage;
     var templateEditorPage;
     var imageComponentPage;
+    var componentLabel = 'Test Instance';
 
     before(function () {
       presentationsListPage = new PresentationListPage();
@@ -31,7 +32,7 @@ var ImageComponentScenarios = function () {
 
     describe('basic operations', function () {
       it('should list the duration and images for the first Image Component', function () {
-        templateEditorPage.selectComponent('Image - ');
+        templateEditorPage.selectComponent(componentLabel);
         helper.wait(imageComponentPage.getListDurationComponent(), 'List Duration');
         expect(imageComponentPage.getSelectedImagesMain().count()).to.eventually.equal(4);
       });
@@ -111,7 +112,7 @@ var ImageComponentScenarios = function () {
     describe('save and validations', function () {
       it('should save the Presentation, reload it, and validate changes were saved', function () {
         presentationsListPage.loadPresentation(presentationName);
-        templateEditorPage.selectComponent('Image - ');
+        templateEditorPage.selectComponent(componentLabel);
 
         expect(imageComponentPage.getSelectedImagesMain().count()).to.eventually.equal(2);
       });
@@ -125,7 +126,7 @@ var ImageComponentScenarios = function () {
       });
 
       it('should list the duration and images for the first Image Component', function () {
-        templateEditorPage.selectComponent('Image - ');
+        templateEditorPage.selectComponent(componentLabel);
         helper.wait(imageComponentPage.getListDurationComponent(), 'List Duration');
         expect(imageComponentPage.getSelectedImagesMain().count()).to.eventually.equal(4);
 

--- a/test/e2e/template-editor/cases/components/rss.js
+++ b/test/e2e/template-editor/cases/components/rss.js
@@ -12,7 +12,7 @@ var RssComponentScenarios = function () {
     var presentationsListPage;
     var templateEditorPage;
     var rssComponentPage;
-    var componentLabel = 'RSS - Top left';
+    var componentLabel = 'Top left';
 
     before(function () {
       presentationsListPage = new PresentationListPage();

--- a/test/e2e/template-editor/cases/components/slides.js
+++ b/test/e2e/template-editor/cases/components/slides.js
@@ -12,7 +12,7 @@ var SlidesComponentScenarios = function () {
     var presentationsListPage;
     var templateEditorPage;
     var slidesComponentPage;
-    var componentLabel = "Google Slides - Slides with default URL";
+    var componentLabel = "Slides with default URL";
 
     before(function () {
       presentationsListPage = new PresentationListPage();

--- a/test/e2e/template-editor/cases/components/text.js
+++ b/test/e2e/template-editor/cases/components/text.js
@@ -13,6 +13,7 @@ var TextComponentScenarios = function () {
     var presentationsListPage;
     var templateEditorPage;
     var textComponentPage;
+    var componentLabel = "Title";
 
     before(function () {
       presentationsListPage = new PresentationListPage();
@@ -32,7 +33,7 @@ var TextComponentScenarios = function () {
 
     describe('basic operations', function () {
       it('should open properties of Text Component', function () {
-        templateEditorPage.selectComponent("Text - Title");
+        templateEditorPage.selectComponent(componentLabel);
 
         expect(textComponentPage.getTextInput().getAttribute('value')).to.eventually.equal("Financial Literacy");
       });
@@ -51,7 +52,7 @@ var TextComponentScenarios = function () {
       it('should reload the Presentation, and validate changes were saved', function () {
         presentationsListPage.loadPresentation(presentationName);
 
-        templateEditorPage.selectComponent("Text - Title");
+        templateEditorPage.selectComponent(componentLabel);
         expect(textComponentPage.getTextInput().isEnabled()).to.eventually.be.true;
         expect(textComponentPage.getTextInput().getAttribute('value')).to.eventually.equal("Changed Text");
       });

--- a/test/e2e/template-editor/cases/components/time-date.js
+++ b/test/e2e/template-editor/cases/components/time-date.js
@@ -12,7 +12,7 @@ var TimeDateComponentScenarios = function () {
     var presentationsListPage;
     var templateEditorPage;
     var timeDateComponentPage;
-    var componentLabel = ' Time and Date - Time and Date Example';
+    var componentLabel = 'Time and Date Example';
 
     before(function () {
       presentationsListPage = new PresentationListPage();

--- a/test/e2e/template-editor/cases/components/video.js
+++ b/test/e2e/template-editor/cases/components/video.js
@@ -20,6 +20,7 @@ var VideoComponentScenarios = function () {
     var presentationsListPage;
     var templateEditorPage;
     var videoComponentPage;
+    var componentLabel = 'Fullscreen';
 
     before(function () {
       presentationsListPage = new PresentationListPage();
@@ -38,7 +39,7 @@ var VideoComponentScenarios = function () {
 
     describe('basic operations', function () {
       it('should list the volume and videos for the first Video Component', function () {
-        templateEditorPage.selectComponent('Video - ');
+        templateEditorPage.selectComponent(componentLabel);
         helper.wait(videoComponentPage.getVolumeComponent(), 'Volume');
         expect(videoComponentPage.getSelectedVideosMain().count()).to.eventually.equal(2);
       });
@@ -114,7 +115,7 @@ var VideoComponentScenarios = function () {
     describe('save and validations', function () {
       it('should save the Presentation, reload it, and validate changes were saved', function () {
         presentationsListPage.loadPresentation(presentationName);
-        templateEditorPage.selectComponent('Video - ');
+        templateEditorPage.selectComponent(componentLabel);
 
         expect(videoComponentPage.getSelectedVideosMain().count()).to.eventually.equal(2);
       });
@@ -127,7 +128,7 @@ var VideoComponentScenarios = function () {
       });
 
       it('should list the volume and videos for the first Video Component', function () {
-        templateEditorPage.selectComponent('Video - ');
+        templateEditorPage.selectComponent(componentLabel);
         helper.wait(videoComponentPage.getVolumeComponent(), 'Volume');
         expect(videoComponentPage.getSelectedVideosMain().count()).to.eventually.equal(2);
 
@@ -220,7 +221,7 @@ var VideoComponentScenarios = function () {
             // Reload presentation so user agent is applied
 
             presentationsListPage.loadPresentation(presentationName);
-            templateEditorPage.selectComponent('Video - ');
+            templateEditorPage.selectComponent(componentLabel);
 
             videoComponentPage.getUploadInputMain().getAttribute('accept').then(accept => {
               expect(accept).to.equal('video/*')

--- a/test/e2e/template-editor/cases/components/weather.js
+++ b/test/e2e/template-editor/cases/components/weather.js
@@ -32,7 +32,7 @@ var WeatherComponentScenarios = function () {
     describe('basic operations', function () {
 
       it('should open properties of Weather Component', function () {
-        templateEditorPage.selectComponent("Weather - Weather Forecast");
+        templateEditorPage.selectComponent("Weather Forecast");
         expect(weatherComponentPage.getFarenheitOption().isSelected()).to.eventually.not.be.true;
         expect(weatherComponentPage.getCelsiusOption().isSelected()).to.eventually.be.true;
       });
@@ -51,7 +51,7 @@ var WeatherComponentScenarios = function () {
       it('should save the Presentation, reload it, and validate changes were saved', function () {
         //load presentation
         presentationsListPage.loadPresentation(presentationName);
-        templateEditorPage.selectComponent("Weather - Weather Forecast");
+        templateEditorPage.selectComponent("Weather Forecast");
 
         expect(weatherComponentPage.getFarenheitOption().isSelected()).to.eventually.be.true;
         expect(weatherComponentPage.getCelsiusOption().isSelected()).to.eventually.not.be.true;

--- a/test/e2e/template-editor/pages/templateEditorPage.js
+++ b/test/e2e/template-editor/pages/templateEditorPage.js
@@ -14,7 +14,7 @@ var TemplateEditorPage = function() {
   var deleteForeverButton = element(by.buttonText('Delete Forever'));
   var errorModal = element(by.xpath('//h4[contains(text(), "Failed to")]'));
   var publishButton = element(by.id('publishButtonDesktop'));
-  var imageComponentSelector = '//div[div/span[contains(text(), "Image - ")]]';
+  var imageComponentSelector = '//div[div/span[contains(text(), "Test Instance")]]';
   var imageComponent = element(by.xpath('(' + imageComponentSelector + ')[1]'));
   var imageComponentEdit = element(by.xpath('(' + imageComponentSelector + '/div/a)[1]'));
   var backToComponentsButton = element(by.css('[ng-click="onBackButton();"]'));
@@ -122,7 +122,7 @@ var TemplateEditorPage = function() {
         //wait for presentation to be auto-saved
         helper.waitDisappear(dirtyText);
         helper.waitDisappear(savingText, 'Template Editor auto-saving');
-        helper.wait(savedText, 'Template Editor auto-saved');        
+        helper.wait(savedText, 'Template Editor auto-saved');
       }
     });
   };

--- a/web/partials/template-editor/attribute-list.html
+++ b/web/partials/template-editor/attribute-list.html
@@ -26,7 +26,6 @@
     <div class="col-xs-10 pl-0 attribute-desc" ng-mouseover="highlightComponent(comp.id)">
       <component-icon icon="{{ getComponentIcon(comp) }}" type="{{ getComponentIconType(comp) }}"></component-icon>
       <span>
-        {{ getComponentTitle(comp) | translate }} -
         {{ comp.label }}
       </span>
     </div>

--- a/web/partials/template-editor/component.html
+++ b/web/partials/template-editor/component.html
@@ -15,10 +15,7 @@
                   type="{{ panelIconType }}"
                   class="component-icon">
   </component-icon>
-  <span ng-show="!panelTitle">
-    {{ factory.selected && getComponentTitle(factory.selected) | translate }} -
-    {{ factory.selected.label }}
-  </span>
+  <span ng-show="!panelTitle">{{ factory.selected.label }}</span>
   <span ng-show="panelTitle">{{ panelTitle }}</span>
 </div>
 <div class="component-container">

--- a/web/scripts/template-editor/directives/dtv-attribute-editor.js
+++ b/web/scripts/template-editor/directives/dtv-attribute-editor.js
@@ -76,16 +76,6 @@ angular.module('risevision.template-editor.directives')
               $scope.directives[component.type].iconType : '';
           };
 
-          $scope.getComponentTitle = function (component) {
-            var directive = $scope.directives[component.type];
-
-            if (directive.getTitle) {
-              return directive.getTitle(component);
-            }
-
-            return 'template.' + component.type;
-          };
-
           $scope.highlightComponent = function (componentId) {
             var message = {
               type: 'highlightComponent',


### PR DESCRIPTION
## Description
As per Creative request, no longer show the _title_ of the component. Only show [icon] _Label_.  

## Motivation and Context
The icon of the component is self explanatory to what it is. It was becoming redundant when the label associated with the instance also insinuates what it is. 

## How Has This Been Tested?
https://apps-stage-8.risevision.com/templates/edit/8592f2e6-c528-4fe4-9dc4-60ac4a85b8fa/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
Support, documentation - small low risk change, unnecessary. 
