### PR TITLE
Rename segmentAnalytics to analyticsTracker

### DIFF
--- a/test/unit/common-header/controllers/ctr-company-settings-spec.js
+++ b/test/unit/common-header/controllers/ctr-company-settings-spec.js
@@ -45,7 +45,7 @@ describe("controller: company settings", function() {
         return deferred.promise;
       };
     });
-    $provide.service("segmentAnalytics", function() {
+    $provide.service("analyticsFactory", function() {
       return {
         track: function(name) {
           trackerCalled = name;

--- a/test/unit/common-header/controllers/ctr-registration-modal-spec.js
+++ b/test/unit/common-header/controllers/ctr-registration-modal-spec.js
@@ -79,7 +79,7 @@ describe("controller: registration modal", function() {
       };
     });
 
-    $provide.service("segmentAnalytics", function() { 
+    $provide.service("analyticsFactory", function() { 
       return {
         track: function(name) {
           trackerCalled = name;

--- a/test/unit/common-header/services/svc-zendesk.spec.js
+++ b/test/unit/common-header/services/svc-zendesk.spec.js
@@ -32,7 +32,7 @@ describe("Services: Zendesk", function() {
       getUserCompanyName: function() { return "Rich Inc."; },
       getSelectedCompanyId: function() { return "abcdefg"; },
     });
-    $provide.service("segmentAnalytics", function() {
+    $provide.service("analyticsFactory", function() {
       return {
         identify: function() {},
       };

--- a/test/unit/components/logging/svc-company-tracker.tests.js
+++ b/test/unit/components/logging/svc-company-tracker.tests.js
@@ -15,7 +15,7 @@ describe('service: company tracker:', function() {
         _restoreState: function(){}
       }
     });
-    $provide.service('segmentAnalytics',function(){
+    $provide.service('analyticsFactory',function(){
       return {
         track: function(newEventName, newEventData) {
           eventName = newEventName;
@@ -47,7 +47,7 @@ describe('service: company tracker:', function() {
     expect(companyTracker).to.be.a('function');
   });
   
-  it('should call segment analytics service',function(){
+  it('should call analytics service',function(){
     companyTracker('Company Updated', 'companyId', 'companyName', true);
 
     expect(eventName).to.equal('Company Updated');
@@ -60,7 +60,7 @@ describe('service: company tracker:', function() {
     bQSpy.should.have.been.calledWith('Company Created', 'companyName', null, 'username', 'companyId');
   });
 
-  it('should not call segment w/ blank event',function(){
+  it('should not call w/ blank event',function(){
     companyTracker();
 
     expect(eventName).to.not.be.ok;

--- a/test/unit/components/logging/svc-display-tracker.tests.js
+++ b/test/unit/components/logging/svc-display-tracker.tests.js
@@ -12,7 +12,7 @@ describe('service: display tracker:', function() {
         _restoreState: function(){}
       }
     });
-    $provide.service('segmentAnalytics',function(){
+    $provide.service('analyticsFactory',function(){
       return {
         track: function(newEventName, newEventData) {
           eventName = newEventName;
@@ -44,7 +44,7 @@ describe('service: display tracker:', function() {
     expect(displayTracker).to.be.a('function');
   });
   
-  it('should call segment analytics service',function(){
+  it('should call analytics service',function(){
     displayTracker('Display Updated', 'displayId', 'displayName', 'downloadType');
 
     expect(eventName).to.equal('Display Updated');
@@ -62,7 +62,7 @@ describe('service: display tracker:', function() {
     bQSpy.should.have.been.calledWith('Display Created', 'displayId');
   });
 
-  it('should not call segment w/ blank event',function(){
+  it('should not call w/ blank event',function(){
     displayTracker();
 
     expect(eventName).to.not.be.ok;

--- a/test/unit/components/logging/svc-exception-handler.tests.js
+++ b/test/unit/components/logging/svc-exception-handler.tests.js
@@ -2,7 +2,7 @@
 
 describe("Services: $exceptionHandler", function() {
   beforeEach(module('risevision.common.components.logging'));
-  var $exceptionHandler, bigQueryLogging, segmentAnalytics;
+  var $exceptionHandler, bigQueryLogging, analyticsFactory;
 
   beforeEach(module(function($provide) {
     $provide.service("$q", function() {return Q;});
@@ -11,7 +11,7 @@ describe("Services: $exceptionHandler", function() {
         logEvent: sinon.stub()
       };
     }]);
-    $provide.factory("segmentAnalytics", [function () {
+    $provide.factory("analyticsFactory", [function () {
       return {
         track: sinon.stub()
       };
@@ -23,7 +23,7 @@ describe("Services: $exceptionHandler", function() {
     inject(function($injector){
       $exceptionHandler = $injector.get("$exceptionHandler");
       bigQueryLogging = $injector.get("bigQueryLogging");
-      segmentAnalytics = $injector.get("segmentAnalytics");
+      analyticsFactory = $injector.get("analyticsFactory");
     });
   });
 
@@ -36,7 +36,7 @@ describe("Services: $exceptionHandler", function() {
       $exceptionHandler("exception","details", true);
 
       bigQueryLogging.logEvent.should.have.been.calledWith('Exception', sinon.match.string);
-      segmentAnalytics.track.should.have.been.calledWith('Exception', sinon.match.object);
+      analyticsFactory.track.should.have.been.calledWith('Exception', sinon.match.object);
     });
 
     it("should handle uncaught exceptions",function() {

--- a/test/unit/components/logging/svc-launcher-tracker.tests.js
+++ b/test/unit/components/logging/svc-launcher-tracker.tests.js
@@ -12,7 +12,7 @@ describe('service: launcher tracker:', function() {
         _restoreState: function(){}
       }
     });
-    $provide.service('segmentAnalytics',function(){
+    $provide.service('analyticsFactory',function(){
       return {
         track: function(newEventName, newEventData) {
           eventName = newEventName;
@@ -37,14 +37,14 @@ describe('service: launcher tracker:', function() {
     expect(launcherTracker).to.be.a('function');
   });
   
-  it('should call segment analytics service',function(){
+  it('should call analytics service',function(){
     launcherTracker('Add Presentation');
 
     expect(eventName).to.equal('Add Presentation');
     expect(eventData).to.deep.equal({companyId: 'companyId'});
   });
 
-  it('should not call segment w/ blank event',function(){
+  it('should not call w/ blank event',function(){
     launcherTracker();
 
     expect(eventName).to.not.be.ok;

--- a/test/unit/components/logging/svc-presentation-tracker.tests.js
+++ b/test/unit/components/logging/svc-presentation-tracker.tests.js
@@ -12,7 +12,7 @@ describe('service: presentation tracker:', function() {
         _restoreState: function(){}
       }
     });
-    $provide.service('segmentAnalytics',function(){
+    $provide.service('analyticsFactory',function(){
       return {
         track: function(newEventName, newEventData) {
           eventName = newEventName;
@@ -44,7 +44,7 @@ describe('service: presentation tracker:', function() {
     expect(presentationTracker).to.be.a('function');
   });
   
-  it('should call segment analytics service',function(){
+  it('should call analytics service',function(){
     presentationTracker('Presentation Updated', 'presentationId', 'presentationName');
 
     expect(eventName).to.equal('Presentation Updated');
@@ -82,7 +82,7 @@ describe('service: presentation tracker:', function() {
     
   });
 
-  it('should not call segment w/ blank event',function(){
+  it('should not call w/ blank event',function(){
     presentationTracker();
 
     expect(eventName).to.not.be.ok;

--- a/test/unit/components/logging/svc-schedule-tracker.tests.js
+++ b/test/unit/components/logging/svc-schedule-tracker.tests.js
@@ -12,7 +12,7 @@ describe('service: schedule tracker:', function() {
         _restoreState: function(){}
       }
     });
-    $provide.service('segmentAnalytics',function(){
+    $provide.service('analyticsFactory',function(){
       return {
         track: function(newEventName, newEventData) {
           eventName = newEventName;
@@ -44,7 +44,7 @@ describe('service: schedule tracker:', function() {
     expect(scheduleTracker).to.be.a('function');
   });
   
-  it('should call segment analytics service',function(){
+  it('should call analytics service',function(){
     scheduleTracker('Schedule Updated', 'scheduleId', 'scheduleName');
 
     expect(eventName).to.equal('Schedule Updated');
@@ -57,7 +57,7 @@ describe('service: schedule tracker:', function() {
     bQSpy.should.have.been.calledWith('Schedule Created', 'scheduleId');
   });
 
-  it('should not call segment w/ blank event',function(){
+  it('should not call w/ blank event',function(){
     scheduleTracker();
 
     expect(eventName).to.not.be.ok;

--- a/test/unit/components/logging/svc-segment-analytics.tests.js
+++ b/test/unit/components/logging/svc-segment-analytics.tests.js
@@ -1,7 +1,7 @@
 /*jshint expr:true */
 "use strict";
 
-describe("Services: segment analytics", function() {
+describe("Services: analyticsFactory", function() {
 
   beforeEach(module("risevision.common.components.logging"));
   beforeEach(module(function ($provide) {
@@ -42,29 +42,29 @@ describe("Services: segment analytics", function() {
     }]);
   }));
   
-  var segmentAnalytics, analyticsEvents, $scope, companyId, $window;
+  var analyticsFactory, analyticsEvents, $scope, companyId, $window;
   beforeEach(function(){
     inject(function($rootScope, $injector){
       $scope = $rootScope;
       companyId = "companyId";
       
-      segmentAnalytics = $injector.get("segmentAnalytics");
+      analyticsFactory = $injector.get("analyticsFactory");
       $window = $injector.get("$window");
-      segmentAnalytics.load(true);
+      analyticsFactory.load(true);
       analyticsEvents = $injector.get("analyticsEvents");
       analyticsEvents.initialize();
     });
   });
   
   it("should exist, also methods", function() {
-    expect(segmentAnalytics.load).to.be.a('function');
-    expect(segmentAnalytics.track).to.be.a('function');
-    expect(segmentAnalytics.identify).to.be.a('function');
-    expect(segmentAnalytics.page).to.be.a('function');
+    expect(analyticsFactory.load).to.be.a('function');
+    expect(analyticsFactory.track).to.be.a('function');
+    expect(analyticsFactory.identify).to.be.a('function');
+    expect(analyticsFactory.page).to.be.a('function');
   });
 
   it("should identify user", function(done) {
-    var identifySpy = sinon.spy(segmentAnalytics, "identify");    
+    var identifySpy = sinon.spy(analyticsFactory, "identify");    
 
     analyticsEvents.identify();
     
@@ -89,7 +89,7 @@ describe("Services: segment analytics", function() {
   });
 
   it("should identify user when authorized", function(done) {
-    var identifySpy = sinon.spy(segmentAnalytics, "identify");    
+    var identifySpy = sinon.spy(analyticsFactory, "identify");    
 
     $scope.$broadcast("risevision.user.authorized");
     $scope.$digest();
@@ -109,7 +109,7 @@ describe("Services: segment analytics", function() {
   });
 
   it("should not send company information if company is undefined", function(done) {
-    var identifySpy = sinon.spy(segmentAnalytics, "identify");    
+    var identifySpy = sinon.spy(analyticsFactory, "identify");    
 
     companyId = null;
     
@@ -127,7 +127,7 @@ describe("Services: segment analytics", function() {
   });
   
   it("should track page views", function(done) {
-    var pageSpy = sinon.spy(segmentAnalytics, "page");
+    var pageSpy = sinon.spy(analyticsFactory, "page");
 
     $scope.$broadcast("$viewContentLoaded");
     $scope.$digest();
@@ -136,7 +136,7 @@ describe("Services: segment analytics", function() {
       var expectProperties = {url:"/somepath", path:"/somepath", referrer:""};
            
       pageSpy.should.have.been.calledWith(expectProperties);
-      expect(segmentAnalytics.location).to.equal("/somepath");
+      expect(analyticsFactory.location).to.equal("/somepath");
 
       expect($window.dataLayer[$window.dataLayer.length-1].event).to.equal("analytics.page");
       expect($window.dataLayer[$window.dataLayer.length-1].eventName).to.equal("page viewed");
@@ -148,7 +148,7 @@ describe("Services: segment analytics", function() {
 
   it("should track events", function() {
     var properties = {name:"name"};
-    segmentAnalytics.track("test", properties);
+    analyticsFactory.track("test", properties);
     
     expect($window.dataLayer[$window.dataLayer.length-1].event).to.equal("analytics.track");
     expect($window.dataLayer[$window.dataLayer.length-1].eventName).to.equal("test");

--- a/test/unit/components/logging/svc-user-tracker.tests.js
+++ b/test/unit/components/logging/svc-user-tracker.tests.js
@@ -12,7 +12,7 @@ describe('service: user tracker:', function() {
         _restoreState: function(){}
       }
     });
-    $provide.service('segmentAnalytics',function(){
+    $provide.service('analyticsFactory',function(){
       return {
         track: function(newEventName, newEventData) {
           eventName = newEventName;
@@ -44,7 +44,7 @@ describe('service: user tracker:', function() {
     expect(userTracker).to.be.a('function');
   });
   
-  it('should call segment analytics service',function(){
+  it('should call analytics service',function(){
     userTracker('User Updated', 'userId', true);
 
     expect(eventName).to.equal('User Updated');
@@ -52,7 +52,7 @@ describe('service: user tracker:', function() {
     bQSpy.should.not.have.been.called;
   });
 
-  it('should not call segment w/ blank event',function(){
+  it('should not call w/ blank event',function(){
     userTracker();
 
     expect(eventName).to.not.be.ok;

--- a/test/unit/launcher/services/svc-onboarding-factory.tests.js
+++ b/test/unit/launcher/services/svc-onboarding-factory.tests.js
@@ -28,7 +28,7 @@ describe('service: onboardingFactory:', function() {
       }
     });
 
-    $provide.service('segmentAnalytics',function(){
+    $provide.service('analyticsFactory',function(){
       return {
         track: sinon.stub()
       }
@@ -44,12 +44,12 @@ describe('service: onboardingFactory:', function() {
 
   }));
   
-  var onboardingFactory, userState, companyAssetsFactory, segmentAnalytics, updateUser, $rootScope, updateCompany;
+  var onboardingFactory, userState, companyAssetsFactory, analyticsFactory, updateUser, $rootScope, updateCompany;
   beforeEach(function() {
     inject(function($injector) {
       userState = $injector.get('userState');
       companyAssetsFactory = $injector.get('companyAssetsFactory');
-      segmentAnalytics = $injector.get('segmentAnalytics');
+      analyticsFactory = $injector.get('analyticsFactory');
       $rootScope = $injector.get('$rootScope');
       
       onboardingFactory = $injector.get('onboardingFactory');
@@ -332,7 +332,7 @@ describe('service: onboardingFactory:', function() {
         expect(onboardingFactory.isTabCompleted(3)).to.be.true;
         expect(onboardingFactory.alreadySubscribed).to.be.true;
 
-        expect(segmentAnalytics.track).to.have.been.calledWith('Onboarding Newsletter Signup Completed');
+        expect(analyticsFactory.track).to.have.been.calledWith('Onboarding Newsletter Signup Completed');
         expect(userState.updateCompanySettings).to.have.been.called;
         expect(userState.updateUserProfile).to.have.been.called;
         
@@ -362,7 +362,7 @@ describe('service: onboardingFactory:', function() {
         expect(onboardingFactory.isTabCompleted(3)).to.be.true;
         expect(onboardingFactory.alreadySubscribed).to.be.undefined;
 
-        expect(segmentAnalytics.track).to.have.been.calledWith('Onboarding Newsletter Signup Completed');
+        expect(analyticsFactory.track).to.have.been.calledWith('Onboarding Newsletter Signup Completed');
         expect(userState.updateCompanySettings).to.have.been.called;
         expect(userState.updateUserProfile).to.have.been.called;
 
@@ -390,7 +390,7 @@ describe('service: onboardingFactory:', function() {
         expect(onboardingFactory.isTabCompleted(3)).to.be.true;
         expect(onboardingFactory.alreadySubscribed).to.be.undefined;
 
-        expect(segmentAnalytics.track).to.have.been.calledWith('Onboarding Newsletter Signup Completed');
+        expect(analyticsFactory.track).to.have.been.calledWith('Onboarding Newsletter Signup Completed');
         expect(userState.updateCompanySettings).to.have.been.called;
         expect(userState.updateUserProfile).to.have.been.called;
         

--- a/web/index.html
+++ b/web/index.html
@@ -195,7 +195,7 @@
   <script src="scripts/components/logging/app.js"></script>
   <script src="scripts/components/logging/svc-external-logging.js"></script>
   <script src="scripts/components/logging/svc-big-query-logging.js"></script>
-  <script src="scripts/components/logging/svc-segment-analytics.js"></script>
+  <script src="scripts/components/logging/svc-analytics-factory.js"></script>
   <script src="scripts/components/logging/svc-hubspot.js"></script>
   <script src="scripts/components/logging/svc-exception-handler.js"></script>
   <script src="scripts/components/logging/svc-company-tracker.js"></script>

--- a/web/scripts/common-header/controllers/ctr-registration-modal.js
+++ b/web/scripts/common-header/controllers/ctr-registration-modal.js
@@ -5,12 +5,12 @@ angular.module('risevision.common.header')
     '$q', '$scope', '$rootScope', '$modalInstance',
     '$loading', 'addAccount', '$exceptionHandler',
     'userState', 'pick', 'uiFlowManager', 'messageBox', 'humanReadableError',
-    'agreeToTermsAndUpdateUser', 'account', 'segmentAnalytics',
+    'agreeToTermsAndUpdateUser', 'account', 'analyticsFactory',
     'bigQueryLogging', 'analyticsEvents', 'updateCompany', 'plansFactory',
     'COMPANY_INDUSTRY_FIELDS', 'urlStateService', 'getAccount',
     function ($q, $scope, $rootScope, $modalInstance, $loading, addAccount,
       $exceptionHandler, userState, pick, uiFlowManager, messageBox, humanReadableError,
-      agreeToTermsAndUpdateUser, account, segmentAnalytics, bigQueryLogging,
+      agreeToTermsAndUpdateUser, account, analyticsFactory, bigQueryLogging,
       analyticsEvents, updateCompany, plansFactory, COMPANY_INDUSTRY_FIELDS,
       urlStateService, getAccount) {
 
@@ -94,7 +94,7 @@ angular.module('risevision.common.header')
                   }
 
                   analyticsEvents.identify();
-                  segmentAnalytics.track('User Registered', {
+                  analyticsFactory.track('User Registered', {
                     'companyId': userState.getUserCompanyId(),
                     'companyName': userState.getUserCompanyName(),
                     'isNewCompany': $scope.newUser

--- a/web/scripts/common-header/dtv-common-header.js
+++ b/web/scripts/common-header/dtv-common-header.js
@@ -179,10 +179,10 @@ angular.module('risevision.common.header', [
     }
   ])
 
-  .run(['segmentAnalytics', 'analyticsEvents', 'TAG_MANAGER_CONTAINER_ID', 'TAG_MANAGER_AUTH', 'TAG_MANAGER_ENV',
-    function (segmentAnalytics, analyticsEvents, TAG_MANAGER_CONTAINER_ID, TAG_MANAGER_AUTH, TAG_MANAGER_ENV) {
+  .run(['analyticsFactory', 'analyticsEvents', 'TAG_MANAGER_CONTAINER_ID', 'TAG_MANAGER_AUTH', 'TAG_MANAGER_ENV',
+    function (analyticsFactory, analyticsEvents, TAG_MANAGER_CONTAINER_ID, TAG_MANAGER_AUTH, TAG_MANAGER_ENV) {
       analyticsEvents.initialize();
-      segmentAnalytics.load(TAG_MANAGER_CONTAINER_ID, TAG_MANAGER_AUTH, TAG_MANAGER_ENV);
+      analyticsFactory.load(TAG_MANAGER_CONTAINER_ID, TAG_MANAGER_AUTH, TAG_MANAGER_ENV);
     }
   ])
 

--- a/web/scripts/common-header/services/svc-zendesk.js
+++ b/web/scripts/common-header/services/svc-zendesk.js
@@ -7,9 +7,9 @@
     .value('ZENDESK_WEB_WIDGET_SCRIPT',
       'window.zE||(function(e,t,s){var n=window.zE=window.zEmbed=function(){n._.push(arguments)},a=n.s=e.createElement(t),r=e.getElementsByTagName(t)[0];n.set=function(e){n.set._.push(e)},n._=[],n.set._=[],a.async=true,a.setAttribute("charset","utf-8"),a.src="https://static.zdassets.com/ekr/asset_composer.js?key="+s,n.t=+new Date,a.type="text/javascript",r.parentNode.insertBefore(a,r)})(document,"script","b8d6bdba-10ea-4b88-b96c-9d3905b85d8f");'
     )
-    .factory('zendesk', ['$q', '$window', 'segmentAnalytics',
+    .factory('zendesk', ['$q', '$window', 'analyticsFactory',
       'userState', 'ZENDESK_WEB_WIDGET_SCRIPT',
-      function ($q, $window, segmentAnalytics, userState,
+      function ($q, $window, analyticsFactory, userState,
         ZENDESK_WEB_WIDGET_SCRIPT) {
 
         var loaded = false;
@@ -65,7 +65,7 @@
               'rise_vision_company_id': userState.getUserCompanyId(),
             };
 
-            segmentAnalytics.identify(username, properties);
+            analyticsFactory.identify(username, properties);
 
             deferred.resolve();
           });

--- a/web/scripts/components/logging/svc-analytics-factory.js
+++ b/web/scripts/components/logging/svc-analytics-factory.js
@@ -3,7 +3,7 @@
   'use strict';
 
   angular.module('risevision.common.components.logging')
-    .factory('segmentAnalytics', ['$rootScope', '$window', '$log', '$location',
+    .factory('analyticsFactory', ['$rootScope', '$window', '$log', '$location',
       function ($rootScope, $window, $log, $location) {
         var service = {};
         var loaded;
@@ -62,7 +62,7 @@
               j.async = true;
               j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
               if (gtmAuth && gtmEnv) {
-                j.src += '&gtm_auth='+gtmAuth+'&gtm_preview='+gtmEnv+'&gtm_cookies_win=x';
+                j.src += '&gtm_auth=' + gtmAuth + '&gtm_preview=' + gtmEnv + '&gtm_cookies_win=x';
               }
               f.parentNode.insertBefore(j, f);
             })($window, $window.document, 'script', 'dataLayer', gtmContainerId);
@@ -92,9 +92,9 @@
       }
     ])
 
-    .factory('analyticsEvents', ['$rootScope', 'segmentAnalytics',
+    .factory('analyticsEvents', ['$rootScope', 'analyticsFactory',
       'userState',
-      function ($rootScope, segmentAnalytics, userState) {
+      function ($rootScope, analyticsFactory, userState) {
         var service = {};
 
         service.identify = function () {
@@ -119,7 +119,7 @@
               };
             }
 
-            segmentAnalytics.identify(userState.getUsername(), properties);
+            analyticsFactory.identify(userState.getUsername(), properties);
           }
         };
 

--- a/web/scripts/components/logging/svc-company-tracker.js
+++ b/web/scripts/components/logging/svc-company-tracker.js
@@ -4,13 +4,13 @@ angular.module('risevision.common.components.logging')
   .value('COMPANY_EVENTS_TO_BQ', [
     'Company Created'
   ])
-  .factory('companyTracker', ['userState', 'segmentAnalytics',
+  .factory('companyTracker', ['userState', 'analyticsFactory',
     'bigQueryLogging', 'COMPANY_EVENTS_TO_BQ',
-    function (userState, segmentAnalytics, bigQueryLogging,
+    function (userState, analyticsFactory, bigQueryLogging,
       COMPANY_EVENTS_TO_BQ) {
       return function (eventName, companyId, companyName, isUserCompany) {
         if (eventName) {
-          segmentAnalytics.track(eventName, {
+          analyticsFactory.track(eventName, {
             companyId: companyId,
             companyName: companyName,
             isUserCompany: isUserCompany

--- a/web/scripts/components/logging/svc-display-tracker.js
+++ b/web/scripts/components/logging/svc-display-tracker.js
@@ -5,13 +5,13 @@ angular.module('risevision.common.components.logging')
     'Display Created',
     'Player Download'
   ])
-  .factory('displayTracker', ['userState', 'segmentAnalytics',
+  .factory('displayTracker', ['userState', 'analyticsFactory',
     'bigQueryLogging', 'DISPLAY_EVENTS_TO_BQ',
-    function (userState, segmentAnalytics, bigQueryLogging,
+    function (userState, analyticsFactory, bigQueryLogging,
       DISPLAY_EVENTS_TO_BQ) {
       return function (eventName, displayId, displayName, downloadType) {
         if (eventName) {
-          segmentAnalytics.track(eventName, {
+          analyticsFactory.track(eventName, {
             displayId: displayId,
             displayName: displayName,
             companyId: userState.getSelectedCompanyId(),

--- a/web/scripts/components/logging/svc-exception-handler.js
+++ b/web/scripts/components/logging/svc-exception-handler.js
@@ -25,7 +25,7 @@ angular.module('risevision.common.components.logging')
         // Prevents circular reference
         // https://stackoverflow.com/questions/22332130/injecting-http-into-angular-factoryexceptionhandler-results-in-a-circular-de
         var bigQueryLogging = $injector.get('bigQueryLogging');
-        var segmentAnalytics = $injector.get('segmentAnalytics');
+        var analyticsFactory = $injector.get('analyticsFactory');
 
         var error = getError(exception);
         var eventName = caught ? 'Exception' : 'Uncaught Exception';
@@ -43,7 +43,7 @@ angular.module('risevision.common.components.logging')
           message += '; cause: ' + _stringify(cause);
         }
 
-        segmentAnalytics.track(eventName, {
+        analyticsFactory.track(eventName, {
           message: message
         });
         bigQueryLogging.logEvent(eventName, message);

--- a/web/scripts/components/logging/svc-launcher-tracker.js
+++ b/web/scripts/components/logging/svc-launcher-tracker.js
@@ -1,11 +1,11 @@
 'use strict';
 
 angular.module('risevision.common.components.logging')
-  .factory('launcherTracker', ['userState', 'segmentAnalytics',
-    function (userState, segmentAnalytics) {
+  .factory('launcherTracker', ['userState', 'analyticsFactory',
+    function (userState, analyticsFactory) {
       return function (eventName) {
         if (eventName) {
-          segmentAnalytics.track(eventName, {
+          analyticsFactory.track(eventName, {
             companyId: userState.getSelectedCompanyId()
           });
         }

--- a/web/scripts/components/logging/svc-presentation-tracker.js
+++ b/web/scripts/components/logging/svc-presentation-tracker.js
@@ -7,13 +7,13 @@ angular.module('risevision.common.components.logging')
     'Template Copied',
     'HTML Template Copied'
   ])
-  .factory('presentationTracker', ['userState', 'segmentAnalytics',
+  .factory('presentationTracker', ['userState', 'analyticsFactory',
     'bigQueryLogging', 'PRESENTATION_EVENTS_TO_BQ',
-    function (userState, segmentAnalytics, bigQueryLogging,
+    function (userState, analyticsFactory, bigQueryLogging,
       PRESENTATION_EVENTS_TO_BQ) {
       return function (eventName, presentationId, presentationName) {
         if (eventName) {
-          segmentAnalytics.track(eventName, {
+          analyticsFactory.track(eventName, {
             presentationId: presentationId,
             presentationName: presentationName,
             companyId: userState.getSelectedCompanyId()

--- a/web/scripts/components/logging/svc-purchase-flow-tracker.js
+++ b/web/scripts/components/logging/svc-purchase-flow-tracker.js
@@ -1,12 +1,12 @@
 'use strict';
 
 angular.module('risevision.common.components.logging')
-  .factory('purchaseFlowTracker', ['segmentAnalytics',
-    function (segmentAnalytics) {
+  .factory('purchaseFlowTracker', ['analyticsFactory',
+    function (analyticsFactory) {
       var factory = {};
 
       factory.trackProductAdded = function (plan) {
-        segmentAnalytics.track('Product Added', {
+        analyticsFactory.track('Product Added', {
           id: plan.productCode,
           name: plan.name,
           price: plan.isMonthly ? plan.monthly.billAmount : plan.yearly.billAmount,
@@ -17,7 +17,7 @@ angular.module('risevision.common.components.logging')
       };
 
       factory.trackPlaceOrderClicked = function (estimate) {
-        segmentAnalytics.track('Place Order Clicked', {
+        analyticsFactory.track('Place Order Clicked', {
           amount: estimate.total,
           currency: estimate.currency,
           inApp: false
@@ -25,7 +25,7 @@ angular.module('risevision.common.components.logging')
       };
 
       factory.trackOrderPayNowClicked = function (estimate) {
-        segmentAnalytics.track('Order Pay Now Clicked', {
+        analyticsFactory.track('Order Pay Now Clicked', {
           amount: estimate.total,
           currency: estimate.currency,
           inApp: false

--- a/web/scripts/components/logging/svc-schedule-tracker.js
+++ b/web/scripts/components/logging/svc-schedule-tracker.js
@@ -4,13 +4,13 @@ angular.module('risevision.common.components.logging')
   .value('SCHEDULE_EVENTS_TO_BQ', [
     'Schedule Created'
   ])
-  .factory('scheduleTracker', ['userState', 'segmentAnalytics',
+  .factory('scheduleTracker', ['userState', 'analyticsFactory',
     'bigQueryLogging', 'SCHEDULE_EVENTS_TO_BQ',
-    function (userState, segmentAnalytics, bigQueryLogging,
+    function (userState, analyticsFactory, bigQueryLogging,
       SCHEDULE_EVENTS_TO_BQ) {
       return function (eventName, scheduleId, scheduleName) {
         if (eventName) {
-          segmentAnalytics.track(eventName, {
+          analyticsFactory.track(eventName, {
             scheduleId: scheduleId,
             scheduleName: scheduleName,
             companyId: userState.getSelectedCompanyId()

--- a/web/scripts/components/logging/svc-user-tracker.js
+++ b/web/scripts/components/logging/svc-user-tracker.js
@@ -2,13 +2,13 @@
 
 angular.module('risevision.common.components.logging')
   .value('USER_EVENTS_TO_BQ', [])
-  .factory('userTracker', ['userState', 'segmentAnalytics',
+  .factory('userTracker', ['userState', 'analyticsFactory',
     'bigQueryLogging', 'USER_EVENTS_TO_BQ',
-    function (userState, segmentAnalytics, bigQueryLogging,
+    function (userState, analyticsFactory, bigQueryLogging,
       USER_EVENTS_TO_BQ) {
       return function (eventName, userId, isSelf) {
         if (eventName) {
-          segmentAnalytics.track(eventName, {
+          analyticsFactory.track(eventName, {
             userId: userId,
             companyId: userState.getSelectedCompanyId(),
             isSelf: isSelf

--- a/web/scripts/launcher/services/svc-onboarding-factory.js
+++ b/web/scripts/launcher/services/svc-onboarding-factory.js
@@ -30,8 +30,8 @@ angular.module('risevision.apps.launcher.services')
     }
   ])
   .factory('onboardingFactory', ['$q', 'userState', 'companyAssetsFactory', 'updateUser', '$rootScope',
-    'segmentAnalytics', '$exceptionHandler', 'updateCompany',
-    function ($q, userState, companyAssetsFactory, updateUser, $rootScope, segmentAnalytics, $exceptionHandler,
+    'analyticsFactory', '$exceptionHandler', 'updateCompany',
+    function ($q, userState, companyAssetsFactory, updateUser, $rootScope, analyticsFactory, $exceptionHandler,
       updateCompany) {
       var factory = {};
       var onboarding = {
@@ -227,7 +227,7 @@ angular.module('risevision.apps.launcher.services')
               } else if (!resp[2]) {
                 _setCurrentStep('promotePlaybook');
                 _completeTabsUpTo(2);
-                segmentAnalytics.track('Onboarding Newsletter Signup Visited');
+                analyticsFactory.track('Onboarding Newsletter Signup Visited');
               } else {
                 factory.alreadySubscribed = true;
                 return _completeOnboarding(true);
@@ -274,7 +274,7 @@ angular.module('risevision.apps.launcher.services')
             _setCurrentStep('promoteTraining');
             _completeTabsUpTo(3);
 
-            segmentAnalytics.track('Onboarding Newsletter Signup Completed', {
+            analyticsFactory.track('Onboarding Newsletter Signup Completed', {
               subscribed: signupToNewsletter
             });
           })

--- a/web/storage-selector.html
+++ b/web/storage-selector.html
@@ -129,7 +129,7 @@
   <script src="scripts/components/logging/app.js"></script>
   <script src="scripts/components/logging/svc-external-logging.js"></script>
   <script src="scripts/components/logging/svc-big-query-logging.js"></script>
-  <script src="scripts/components/logging/svc-segment-analytics.js"></script>
+  <script src="scripts/components/logging/svc-analytics-factory.js"></script>
   <script src="scripts/components/logging/svc-hubspot.js"></script>
   <script src="scripts/components/logging/svc-exception-handler.js"></script>
   <script src="scripts/components/logging/svc-purchase-flow-tracker.js"></script>


### PR DESCRIPTION
## Description
Rename segmentAnalytics to analyticsTracker as Apps is no longer sending data directly to Segment.


## Motivation and Context
We now send data to Google Tag Manager, se we used a generic analytics factory in case we change again in future.
Related to Simplify Hubspot epic.

## How Has This Been Tested?
Manually tested locally and confirmed events are sent to GTM & Segment.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
