### PR TITLE
Add event category to GTM

### DIFF
--- a/test/unit/components/logging/svc-analytics-factory.tests.js
+++ b/test/unit/components/logging/svc-analytics-factory.tests.js
@@ -133,7 +133,7 @@ describe("Services: analyticsFactory", function() {
     $scope.$digest();
     
     setTimeout(function() {
-      var expectProperties = {url:"/somepath", path:"/somepath", referrer:""};
+      var expectProperties = {url:"/somepath", path:"/somepath", referrer:"", category: "apps"};
            
       pageSpy.should.have.been.calledWith(expectProperties);
       expect(analyticsFactory.location).to.equal("/somepath");
@@ -152,6 +152,7 @@ describe("Services: analyticsFactory", function() {
     
     expect($window.dataLayer[$window.dataLayer.length-1].event).to.equal("analytics.track");
     expect($window.dataLayer[$window.dataLayer.length-1].eventName).to.equal("test");
+    properties.category = "apps";
     expect($window.dataLayer[$window.dataLayer.length-1].analytics.event.properties).to.equal(properties);
   });
 

--- a/web/scripts/components/logging/svc-analytics-factory.js
+++ b/web/scripts/components/logging/svc-analytics-factory.js
@@ -11,6 +11,8 @@
         $window.dataLayer = $window.dataLayer || [];
 
         service.track = function (eventName, properties) {
+          properties = properties || {};
+          properties.category = "apps";
           $window.dataLayer.push({
             event: 'analytics.track',
             eventName: eventName,
@@ -35,6 +37,8 @@
         };
 
         service.page = function (properties) {
+          properties = properties || {};
+          properties.category = "apps";
           $window.dataLayer.push({
             event: 'analytics.page',
             eventName: 'page viewed',

--- a/web/scripts/components/logging/svc-analytics-factory.js
+++ b/web/scripts/components/logging/svc-analytics-factory.js
@@ -12,7 +12,7 @@
 
         service.track = function (eventName, properties) {
           properties = properties || {};
-          properties.category = "apps";
+          properties.category = 'apps';
           $window.dataLayer.push({
             event: 'analytics.track',
             eventName: eventName,
@@ -38,7 +38,7 @@
 
         service.page = function (properties) {
           properties = properties || {};
-          properties.category = "apps";
+          properties.category = 'apps';
           $window.dataLayer.push({
             event: 'analytics.page',
             eventName: 'page viewed',


### PR DESCRIPTION
## Description
Add event category and set it to "apps" when sending data to GTM, so that GTM/GA can identify the source of the event.

## Motivation and Context
Improvements around GTM integration.

## How Has This Been Tested?
Manually tested locally and on stage-1.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
