### PR TITLE
Feature/rise data twitter settings invoke oauth

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-twitter.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-twitter.tests.js
@@ -68,4 +68,20 @@ describe('directive: templateComponentTwitter', function() {
     });
   });
 
+  it('should detect failure when oauth service connection does not work', function(done) {
+    oauthService.authenticate = function() {
+      return Q.reject();
+    };
+
+    expect($scope.connected).to.be.false;
+    expect($scope.connectionFailure).to.be.false;
+
+    $scope.connectToTwitter().then( function() {
+      expect($scope.connected).to.be.false;
+      expect($scope.connectionFailure).to.be.true;
+
+      done();
+    });
+  });
+
 });

--- a/test/unit/template-editor/components/directives/dtv-component-twitter.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-twitter.tests.js
@@ -3,10 +3,12 @@
 describe('directive: templateComponentTwitter', function() {
   var $scope,
     element,
-    factory;
+    factory,
+    oauthService;
 
   beforeEach(function() {
     factory = { selected: { id: "TEST-ID" } };
+    oauthService = {};
   });
 
   beforeEach(module('risevision.template-editor.directives'));
@@ -17,6 +19,10 @@ describe('directive: templateComponentTwitter', function() {
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
       return factory;
+    });
+
+    $provide.service('TwitterOAuthService', function() {
+      return oauthService;
     });
   }));
 
@@ -44,6 +50,22 @@ describe('directive: templateComponentTwitter', function() {
     expect(directive.iconType).to.equal('streamline');
     expect(directive.icon).to.exist;
     expect(directive.show).to.be.a('function');
+  });
+
+  it('should set flags when oauth service connection works', function(done) {
+    oauthService.authenticate = function() {
+      return Q.resolve();
+    };
+
+    expect($scope.connected).to.be.false;
+    expect($scope.connectionFailure).to.be.false;
+
+    $scope.connectToTwitter().then( function() {
+      expect($scope.connected).to.be.true;
+      expect($scope.connectionFailure).to.be.false;
+
+      done();
+    });
   });
 
 });

--- a/web/scripts/template-editor/components/directives/dtv-component-twitter.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-twitter.js
@@ -13,8 +13,8 @@ angular.module('risevision.template-editor.directives')
           $scope.connectionFailure = false;
           $scope.connected = false;
 
-          $scope.connectToTwitter = function() {
-            TwitterOAuthService.authenticate()
+          $scope.connectToTwitter = function () {
+            return TwitterOAuthService.authenticate()
               .then(function (key) {
                 $scope.connected = true;
                 $scope.connectionFailure = false;

--- a/web/scripts/template-editor/components/directives/dtv-component-twitter.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-twitter.js
@@ -17,6 +17,7 @@ angular.module('risevision.template-editor.directives')
             TwitterOAuthService.authenticate()
               .then(function (key) {
                 $scope.connected = true;
+                $scope.connectionFailure = false;
               }, function () {
                 $scope.connected = false;
                 $scope.connectionFailure = true;

--- a/web/scripts/template-editor/components/directives/dtv-component-twitter.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-twitter.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
-  .directive('templateComponentTwitter', ['templateEditorFactory',
-    function (templateEditorFactory) {
+  .directive('templateComponentTwitter', ['templateEditorFactory', 'TwitterOAuthService',
+    function (templateEditorFactory, TwitterOAuthService) {
       return {
         restrict: 'E',
         scope: true,
@@ -10,12 +10,17 @@ angular.module('risevision.template-editor.directives')
         link: function ($scope, element) {
           $scope.factory = templateEditorFactory;
 
-          // temporarily set values to show all authenticate UI for validation
-          $scope.connectionFailure = true;
+          $scope.connectionFailure = false;
           $scope.connected = false;
 
           $scope.connectToTwitter = function() {
-            // TODO: coming soon
+            TwitterOAuthService.authenticate()
+              .then(function (key) {
+                $scope.connected = true;
+              }, function () {
+                $scope.connected = false;
+                $scope.connectionFailure = true;
+              });
           };
 
           $scope.registerDirective({


### PR DESCRIPTION
## Description
Invoke Twitter authentication from rise-twitter settings. 

## Motivation and Context
Is part of the twitter execution strategy

## How Has This Been Tested?
Tested locally here: https://apps-stage-9.risevision.com/templates/edit/ba52cc8e-88da-44b1-a882-268070649747/?cid=121ae986-1b89-40c8-b10b-a64c60fb9e03

When opening the presentation, connect button should show ( now it always shows as credential verification is still not implemented ):

![00-start](https://user-images.githubusercontent.com/33162690/74869902-72e5ab80-531e-11ea-982b-464f76b5e442.png)

When clicked it will pass to connected state, so the button will disappear ( in following tasks, inputs will be added ) -

![01-connected](https://user-images.githubusercontent.com/33162690/74869963-898c0280-531e-11ea-8a66-bbab94f2d61b.png)

Browser logs confirm that requests to oauth.io were successful:

![02-connection-logs](https://user-images.githubusercontent.com/33162690/74870009-9a3c7880-531e-11ea-9c90-60483124bd18.png)

But most important, credentials should have been added to GCS:

![03-credentials](https://user-images.githubusercontent.com/33162690/74870042-a58fa400-531e-11ea-90f4-c3ed69499598.png)

For now, we revoke them by using an auxiliary twitter widget presentation, that lets us manually revoke credentials on oauthtokenprovider. Once that is done, credentials are cleared and we can perform the test again:

![04-revoked](https://user-images.githubusercontent.com/33162690/74870119-cf48cb00-531e-11ea-9f1d-a4ca8643acdc.png)

Failing to revoke before authenticating again will generate oauthtokenprovider errors, until the following card is finished: https://trello.com/c/aDJUnkdg/7481-oauth-provider-clear-credentials-before-invoking-authentication-3

As another test, if authentication fails, the connect button is shown again, and the error message appears:

![10-error](https://user-images.githubusercontent.com/33162690/74870218-fdc6a600-531e-11ea-876c-29642fa8ae10.png)

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     - To be released before Friday
     - Manual and automated tests completed
     - Simple rollback is enough to undo changes, but as this component is not released yet, these changes are very low risk.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify support, no need to update documentation.
