### PR TITLE
Image Component Drag and Drop

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-image.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.tests.js
@@ -95,6 +95,7 @@ describe('directive: TemplateComponentImage', function() {
     expect($scope.factory).to.be.ok;
     expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" } });
     expect($scope.isEditingLogo).to.be.a('function');
+    expect($scope.sortItem).to.be.a('function');
 
     expect($scope.registerDirective).to.have.been.called;
 
@@ -438,4 +439,40 @@ describe('directive: TemplateComponentImage', function() {
       expect($scope.storageManager.isSingleFileSelector()).be.false;
     });
   });
+
+  describe('sortItem: ', function() {
+    var _callSort = function(oldIndex, newIndex) {
+      $scope.sortItem({
+        data: {
+          oldIndex: oldIndex,
+          newIndex: newIndex
+        }
+      });
+    };
+
+    beforeEach(function() {
+      $scope.selectedImages = [
+        'image0',
+        'image1',
+        'image2',
+        'image3'
+      ];
+    });
+
+    it('should move item up/down: ', function() {
+      _callSort(0, 1);
+
+      expect($scope.selectedImages.indexOf('image0')).to.equal(1);
+
+      _callSort(2, 1);
+
+      expect($scope.selectedImages.indexOf('image2')).to.equal(1);
+      expect($scope.selectedImages.indexOf('image0')).to.equal(2);
+
+      _callSort(2, 0);
+      expect($scope.selectedImages.indexOf('image0')).to.equal(0);
+    });
+
+  });
+
 });

--- a/test/unit/template-editor/directives/dtv-file-entry.tests.js
+++ b/test/unit/template-editor/directives/dtv-file-entry.tests.js
@@ -27,7 +27,7 @@ describe('directive: templateEditorFileEntry', function() {
       $rootScope.removeAction = removeAction;
 
       $templateCache.put('partials/template-editor/file-entry.html', '<p>mock</p>');
-      element = $compile('<template-editor-file-entry file-type="image" entry="entry" remove-action="removeAction"></template-editor-file-entry>')($rootScope);
+      element = $compile('<template-editor-file-entry file-type="image" entry="entry" remove-action="removeAction" show-grip-handle="true"></template-editor-file-entry>')($rootScope);
       $rootScope.$apply();
 
       $scope = element.isolateScope();
@@ -44,6 +44,7 @@ describe('directive: templateEditorFileEntry', function() {
       expect($scope.getStreamlineIcon).to.be.a.function;
       expect($scope.fileType).to.equal('image');
       expect($scope.entry).to.deep.equal(testEntry);
+      expect($scope.showGripHandle).to.be.true;
     });
 
     it('should have a file name', function () {

--- a/web/images/navigation-menu-vertical.svg
+++ b/web/images/navigation-menu-vertical.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="8px" height="24px" viewBox="0 0 8 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: sketchtool 61.2 (101010) - https://sketch.com -->
+    <title>A32F3B92-7C51-4EBC-ABD4-4695CB42B7BD@1.00x</title>
+    <desc>Created with sketchtool.</desc>
+    <g id="desktop/mockups/video-and-image" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="1.6" transform="translate(-20.000000, -465.000000)" fill="#999999" fill-rule="nonzero">
+            <g id="navigation-menu-vertical" transform="translate(20.000000, 465.000000)">
+                <circle id="Oval" cx="4" cy="3.25" r="3.25"></circle>
+                <circle id="Oval" cx="4" cy="12" r="3.25"></circle>
+                <circle id="Oval" cx="4" cy="20.75" r="3.25"></circle>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/web/partials/template-editor/basic-uploader.html
+++ b/web/partials/template-editor/basic-uploader.html
@@ -2,7 +2,7 @@
   <div id="upload-panel-{{uploaderId}}" class="storage-upload-panel" ng-show="activeUploadCount() > 0">
     <div class="storage-upload-body te-scrollable-container">
       <div ng-repeat="item in uploader.queue">
-        <div class="file-row">
+        <div class="storage-upload-file-row">
           <div class="file-entry" ng-class="{'is-error': item.isError}">
             <div class="file-text">
                 <div class="file-name">{{ fileNameOf(item.file.name) }}</div>

--- a/web/partials/template-editor/components/component-image/image-list.html
+++ b/web/partials/template-editor/components/component-image/image-list.html
@@ -13,13 +13,17 @@
 <div class="image-component-list file-component-list te-scrollable-container"
      ng-class="{'active-duration' : selectedImages.length > 1 && !isUploading}"
      rv-spinner rv-spinner-key="template-editor-loader">
-  <template-editor-file-entry
-    ng-repeat="image in selectedImages track by $index"
-    ng-show="selectedImages.length > 0 && !isUploading"
-    entry="image"
-    file-type="image"
-    remove-action="removeImageFromList">
-  </template-editor-file-entry>
+  <div rv-sortable on-sort="sortItem(evt)" append-to=".component-container" class="sortable-list">
+
+    <template-editor-file-entry
+      ng-repeat="image in selectedImages track by $index"
+      ng-show="selectedImages.length > 0 && !isUploading"
+      entry="image"
+      file-type="image"
+      remove-action="removeImageFromList"
+      show-grip-handle="selectedImages.length > 1">
+    </template-editor-file-entry>
+  </div>
 
   <template-editor-empty-file-list file-type="image" is-editing-logo="isEditingLogo"
      ng-hide="isUploading || selectedImages.length !== 0 || factory.loadingPresentation">

--- a/web/partials/template-editor/file-entry.html
+++ b/web/partials/template-editor/file-entry.html
@@ -1,4 +1,7 @@
-<div class="pl-0 file-row">
+<div class="pl-0 file-component-list-file-row rv-sortable-item">
+  <div class="list-grip pr-4 rv-sortable-handle" ng-if="showGripHandle">
+    <img class="img-responsive" src="../images/navigation-menu-vertical.svg">
+  </div>
   <div class="file-thumbnail">
     <div class="file-helper"></div>
     <img ng-src="{{ entry['thumbnail-url'] }}"

--- a/web/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-image.js
@@ -292,6 +292,14 @@ angular.module('risevision.template-editor.directives')
               _setSelectedImages(updatedMetadata);
             });
           };
+
+          $scope.sortItem = function (evt) {
+            var oldIndex = evt.data.oldIndex;
+            var newIndex = evt.data.newIndex;
+
+            $scope.selectedImages.splice(newIndex, 0, $scope.selectedImages.splice(oldIndex, 1)[0]);
+          };
+
         }
       };
     }

--- a/web/scripts/template-editor/directives/dtv-file-entry.js
+++ b/web/scripts/template-editor/directives/dtv-file-entry.js
@@ -5,10 +5,12 @@ angular.module('risevision.template-editor.directives')
     function (templateEditorFactory, templateEditorUtils) {
       return {
         restrict: 'E',
+        replace: true,
         scope: {
           fileType: '@',
           entry: '=',
-          removeAction: '='
+          removeAction: '=',
+          showGripHandle: '=',
         },
         templateUrl: 'partials/template-editor/file-entry.html',
         link: function ($scope) {

--- a/web/scss/sections/template-editor-layout.scss
+++ b/web/scss/sections/template-editor-layout.scss
@@ -836,18 +836,6 @@ $short-phone-height: 570px;
     float: right;
   }
 
-  .file-row {
-    @extend .template-editor-file-row;
-
-    flex-direction: column;
-    padding-top: 16px;
-    padding-bottom: 17px;
-
-    .file-entry {
-      width: 100%;
-    }
-  }
-
   .progress {
     height: 10px;
     box-shadow: none;
@@ -867,9 +855,19 @@ $short-phone-height: 570px;
   }
 }
 
-.file-component-list {
-  --thumbnail-width: 80px;
+.storage-upload-file-row {
+  @extend .template-editor-file-row;
 
+  flex-direction: column;
+  padding-top: 16px;
+  padding-bottom: 17px;
+
+  .file-entry {
+    width: 100%;
+  }
+}
+
+.file-component-list {
   overflow-x: hidden;
   overflow-y: auto;
   width: var(--sidebar-width);
@@ -877,11 +875,17 @@ $short-phone-height: 570px;
   @media (max-width: $screen-sm) {
     width: 100%;
   }
+}
 
-  .file-row {
-    @extend .template-editor-file-row;
+.file-component-list-file-row {
+  --thumbnail-width: 80px;
+
+  @extend .template-editor-file-row;
+
+  .list-grip {
+    cursor: move;
+    cursor: -webkit-grabbing;
   }
-
 }
 
 .file-component-list-action-button-bar {


### PR DESCRIPTION
## Description
Image Component Drag and Drop

Reorder Images in the component list via drag and drop

Split out class dependencies for file-row
Fixes issues with drag mirror being offset

Use directive replace: true
Drag and drop library requires elements to be directly
below parent element (ie. directive tag was in between)

[stage-2]

## Motivation and Context
Part of Apps UX Improvements epic

Allows users to reorder their Images in the Component without having to remove and add them again.

## How Has This Been Tested?
Tested drag and drop reordering in the local environment. Validated that the Upload styling is still working as expected.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
