### PR TITLE
Add video component file reorder

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-video.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-video.tests.js
@@ -52,6 +52,7 @@ describe('directive: templateComponentVideo', function() {
     expect($scope.factory).to.be.ok;
     expect($scope.factory).to.deep.equal({ selected: { id: 'TEST-ID' } })
     expect($scope.registerDirective).to.have.been.called;
+    expect($scope.sortItem).to.be.a('function');
 
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
@@ -430,6 +431,41 @@ describe('directive: templateComponentVideo', function() {
         'TEST-ID', 'volume', 100
       ), 'set volume attribute').to.be.true;
     });
+  });
+
+  describe('sortItem: ', function() {
+    var _callSort = function(oldIndex, newIndex) {
+      $scope.sortItem({
+        data: {
+          oldIndex: oldIndex,
+          newIndex: newIndex
+        }
+      });
+    };
+
+    beforeEach(function() {
+      $scope.selectedFiles = [
+        'file0',
+        'file1',
+        'file2',
+        'file3'
+      ];
+    });
+
+    it('should move item up/down: ', function() {
+      _callSort(0, 1);
+
+      expect($scope.selectedFiles.indexOf('file0')).to.equal(1);
+
+      _callSort(2, 1);
+
+      expect($scope.selectedFiles.indexOf('file2')).to.equal(1);
+      expect($scope.selectedFiles.indexOf('file0')).to.equal(2);
+
+      _callSort(2, 0);
+      expect($scope.selectedFiles.indexOf('file0')).to.equal(0);
+    });
+
   });
 
 });

--- a/web/partials/template-editor/components/component-video/video-list.html
+++ b/web/partials/template-editor/components/component-video/video-list.html
@@ -26,13 +26,17 @@
      rv-spinner-start-active="1"
      ng-class="{ 'not-empty': selectedFiles.length > 0 }"
 >
-  <template-editor-file-entry
-     ng-repeat="file in selectedFiles track by $index"
-     ng-show="showSettingsUI()"
-     entry="file"
-     file-type="video"
-     remove-action="removeFileFromList">
-  </template-editor-file-entry>
+  <div rv-sortable on-sort="sortItem(evt)" append-to=".component-container" class="sortable-list">
+
+    <template-editor-file-entry
+       ng-repeat="file in selectedFiles track by $index"
+       ng-show="showSettingsUI()"
+       entry="file"
+       file-type="video"
+       remove-action="removeFileFromList"
+       show-grip-handle="selectedFiles.length > 1">
+    </template-editor-file-entry>
+  </div>
 
   <template-editor-empty-file-list file-type="video"
      ng-hide="isUploading || selectedFiles.length !== 0 || factory.loadingPresentation">

--- a/web/scripts/template-editor/components/directives/dtv-component-video.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-video.js
@@ -206,6 +206,14 @@ angular.module('risevision.template-editor.directives')
           $scope.showSettingsUI = function () {
             return $scope.selectedFiles.length > 0 && !$scope.isUploading;
           };
+
+          $scope.sortItem = function (evt) {
+            var oldIndex = evt.data.oldIndex;
+            var newIndex = evt.data.newIndex;
+
+            $scope.selectedFiles.splice(newIndex, 0, $scope.selectedFiles.splice(oldIndex, 1)[0]);
+          };
+
         }
       };
     }


### PR DESCRIPTION
## Description
Add video component file reorder

[stage-2]

## Motivation and Context
Part of UX Improvements Epic
Allow user to reorder video files in the component

## How Has This Been Tested?
Validated changes in the local environment with the Full Screen Video template.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No