### PR TITLE
Fix failing Text component e2e test

### DIFF
--- a/test/e2e/template-editor/cases/components/text.js
+++ b/test/e2e/template-editor/cases/components/text.js
@@ -39,6 +39,7 @@ var TextComponentScenarios = function () {
       });
 
       it('should clear and update the component text', function () {
+        helper.wait(textComponentPage.getTextInput(), 'Text component input');
         // Note: Disconnect from Angular to prevent Autosave timeout from interrupting edits
         browser.waitForAngularEnabled(false);
         textComponentPage.getTextInput().clear();

--- a/test/e2e/template-editor/cases/components/text.js
+++ b/test/e2e/template-editor/cases/components/text.js
@@ -40,11 +40,8 @@ var TextComponentScenarios = function () {
 
       it('should clear and update the component text', function () {
         helper.wait(textComponentPage.getTextInput(), 'Text component input');
-        // Note: Disconnect from Angular to prevent Autosave timeout from interrupting edits
-        browser.waitForAngularEnabled(false);
         textComponentPage.getTextInput().clear();
         textComponentPage.getTextInput().sendKeys("Changed Text" + protractor.Key.ENTER);
-        browser.waitForAngularEnabled(true);
 
         //wait for presentation to be auto-saved
         templateEditorPage.waitForAutosave();


### PR DESCRIPTION
## Description
Removes calls to `waitForAngularEnabled`.

## Motivation and Context
Fixes a failing Text component e2e; these lines were added to fix a previous issue, which seems to be opposite of the current scenario (maybe a browser change?)

## How Has This Been Tested?
Tests pass on CCI.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No

@santiagonoguez @stulees please review
