### PR TITLE
Restore Transitions changeset

### DIFF
--- a/test/unit/schedules/controllers/ctr-schedule-add.tests.js
+++ b/test/unit/schedules/controllers/ctr-schedule-add.tests.js
@@ -11,7 +11,8 @@ describe('controller: schedule add', function() {
         loadingSchedule: true,
         addSchedule : function(){
           scheduleAdded = true;
-        }
+        },
+        logTransitionUsage: function() {}
       };
     });
     $provide.service('$loading',function(){

--- a/test/unit/schedules/controllers/ctr-schedule-details.tests.js
+++ b/test/unit/schedules/controllers/ctr-schedule-details.tests.js
@@ -15,7 +15,8 @@ describe('controller: schedule details', function() {
         },
         deleteSchedule: function() {
           deleteCalled = true;
-        }
+        },
+        logTransitionUsage: function() {}
       }
     });
     $provide.service('$state',function(){

--- a/test/unit/schedules/services/svc-schedule-factory.tests.js
+++ b/test/unit/schedules/services/svc-schedule-factory.tests.js
@@ -429,7 +429,47 @@ describe('service: scheduleFactory:', function() {
         done();
       });
     });
+  });
 
+  describe('scheduleHasTransitions', function() {
+    it('should return false if the schedule does not have transitions', function() {
+      expect(scheduleFactory.scheduleHasTransitions({})).to.be.false;
+      expect(scheduleFactory.scheduleHasTransitions({ content: [] })).to.be.false;
+      expect(scheduleFactory.scheduleHasTransitions({ content: [{}] })).to.be.false;
+      expect(scheduleFactory.scheduleHasTransitions({ content: [{ transitionType: 'normal' }] })).to.be.false;
+    });
+
+    it('should return true if the schedule has transitions', function() {
+      expect(scheduleFactory.scheduleHasTransitions({ content: [{ transitionType: 'fadeIn' }] })).to.be.true;
+    });
+  });
+
+  describe('logTransitionUsage', function() {
+    var presentationWithTransitions = { content: [{ transitionType: 'fadeIn' }] };
+
+    it('should not call scheduleTracker if transitions were not added', function() {
+      scheduleFactory.logTransitionUsage({}, {});
+
+      expect(trackerCalled).to.be.falsey;
+    });
+
+    it('should not call scheduleTracker if transitions existed and were not removed', function() {
+      scheduleFactory.logTransitionUsage(presentationWithTransitions, presentationWithTransitions);
+
+      expect(trackerCalled).to.be.falsey;
+    });
+
+    it('should call scheduleTracker if transitions were added', function() {
+      scheduleFactory.logTransitionUsage(presentationWithTransitions, {});
+
+      expect(trackerCalled).to.equal('Transitions Added');
+    });
+
+    it('should call scheduleTracker if transitions were removed', function() {
+      scheduleFactory.logTransitionUsage({}, presentationWithTransitions);
+
+      expect(trackerCalled).to.equal('Transitions Removed');
+    });
   });
 
 });

--- a/web/partials/schedules/playlist-item.html
+++ b/web/partials/schedules/playlist-item.html
@@ -67,6 +67,21 @@
         recurrence-days-of-week = "playlistItem.recurrenceDaysOfWeek"
         ></timeline-textbox>
       </div><!--form-group-->
+
+      <div class="form-group">
+        <label class="control-label">Transition</label>
+        <select class="form-control" ng-model="playlistItem.transitionType">
+          <option value="normal">No transition</option>
+          <option value="fadeIn">Fade in</option>
+          <option value="slideFromLeft">Slide from left</option>
+          <option value="slideFromRight">Slide from right</option>
+          <option value="slideFromTop">Slide from top</option>
+          <option value="slideFromBottom">Slide from bottom</option>
+          <option value="stripesHorizontal">Stripes horizontal</option>
+          <option value="stripesVertical">Stripes vertical</option>
+          <option value="zoomIn">Zoom in</option>
+        </select>
+      </div>
     </form>
   </div><!--modal-body-->
 

--- a/web/scripts/components/logging/svc-schedule-tracker.js
+++ b/web/scripts/components/logging/svc-schedule-tracker.js
@@ -2,7 +2,7 @@
 
 angular.module('risevision.common.components.logging')
   .value('SCHEDULE_EVENTS_TO_BQ', [
-    'Schedule Created'
+    'Schedule Created', 'Transitions Added', 'Transitions Removed'
   ])
   .factory('scheduleTracker', ['userState', 'analyticsFactory',
     'bigQueryLogging', 'SCHEDULE_EVENTS_TO_BQ',

--- a/web/scripts/schedules/controllers/ctr-schedule-add.js
+++ b/web/scripts/schedules/controllers/ctr-schedule-add.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.schedules.controllers')
-  .controller('scheduleAdd', ['$scope', 'scheduleFactory', '$loading', '$log',
-    function ($scope, scheduleFactory, $loading, $log) {
+  .controller('scheduleAdd', ['$scope', 'scheduleFactory', '$loading',
+    function ($scope, scheduleFactory, $loading) {
       $scope.factory = scheduleFactory;
       $scope.schedule = scheduleFactory.schedule;
 

--- a/web/scripts/schedules/controllers/ctr-schedule-details.js
+++ b/web/scripts/schedules/controllers/ctr-schedule-details.js
@@ -8,6 +8,8 @@ angular.module('risevision.schedules.controllers')
       $scope.factory = scheduleFactory;
       $scope.schedule = scheduleFactory.schedule;
 
+      var _oldSchedule = _.cloneDeep($scope.schedule);
+
       $scope.$watch('factory.loadingSchedule', function (loading) {
         if (loading) {
           $loading.start('schedule-loader');
@@ -85,7 +87,11 @@ angular.module('risevision.schedules.controllers')
 
           return $q.reject();
         } else {
-          return scheduleFactory.updateSchedule();
+          return scheduleFactory.updateSchedule()
+            .then(function () {
+              scheduleFactory.logTransitionUsage($scope.schedule, _oldSchedule);
+              _oldSchedule = _.cloneDeep($scope.schedule);
+            });
         }
       };
 

--- a/web/scripts/schedules/services/svc-schedule-factory.js
+++ b/web/scripts/schedules/services/svc-schedule-factory.js
@@ -129,6 +129,7 @@ angular.module('risevision.schedules.services')
               $rootScope.$emit('scheduleCreated');
 
               scheduleTracker('Schedule Created', resp.item.id, resp.item.name);
+              factory.logTransitionUsage(resp.item);
 
               if ($state.current.name === 'apps.schedules.add') {
                 $state.go('apps.schedules.details', {
@@ -202,6 +203,27 @@ angular.module('risevision.schedules.services')
           return VIEWER_URL + '/?type=schedule&id=' + _scheduleId;
         }
         return null;
+      };
+
+      factory.scheduleHasTransitions = function (schedule) {
+        var content = schedule && schedule.content;
+
+        return !!_.find(content || [], function (item) {
+          return item.transitionType && item.transitionType !== 'normal';
+        });
+      };
+
+      factory.logTransitionUsage = function (newSchedule, oldSchedule) {
+        var existingTransitions = factory.scheduleHasTransitions(oldSchedule);
+        var addedTransitions = factory.scheduleHasTransitions(newSchedule);
+
+        if (!existingTransitions && addedTransitions) {
+          scheduleTracker('Transitions Added', newSchedule.id, newSchedule.name);
+        } else if (existingTransitions && !addedTransitions) {
+          scheduleTracker('Transitions Removed', newSchedule.id, newSchedule.name);
+        }
+
+        return addedTransitions;
       };
 
       $rootScope.$on('risevision.company.selectedCompanyChanged', function () {


### PR DESCRIPTION
## Description
Restores the previously reverted Transitions logic. The changes in UI involve a single dropdown and its possible values, plus some logging for usage tracking.

## Motivation and Context
It was part of the latest Hackathon.

## How Has This Been Tested?
It can be tested here: https://apps-stage-7.risevision.com/schedules/details/e5b42687-c797-47f4-987b-9e148c39ca5a?cid=87977ab8-38b6-47fb-ad5e-256b8cc4b46d

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No

@andrecardoso please review
