### PR TITLE
Fix select all with query for storage

### DIFF
--- a/web/partials/storage/list-view.html
+++ b/web/partials/storage/list-view.html
@@ -3,7 +3,7 @@
     <tr class="table-header__row u_clickable">
       <th class="col-sm-6 table-header__cell">
         <input type="checkbox" class="u_margin-right" ng-model="selectAll">
-        <label ng-click="filesFactory.selectAllCheckboxes(query)" ng-show="storageFactory.isMultipleSelector()"></label>
+        <label ng-click="filesFactory.selectAllCheckboxes(search.query)" ng-show="storageFactory.isMultipleSelector()"></label>
         <span id="tableHeaderName" ng-click="sortBy(fileNameOrderFunction)">
           <span translate="common.file-name"></span>
           <!-- ngIf: search.sortBy = fileNameOrderFunction -->


### PR DESCRIPTION
## Description
Fix select all with query for storage

[stage-18]

## Motivation and Context
Fixes issue where the select all functionality does not take into account the search query.

## How Has This Been Tested?
Tested in the local environment.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No