### PR TITLE
Handle maxitems for Component Twitter UI

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-twitter.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-twitter.tests.js
@@ -245,7 +245,7 @@ describe('directive: templateComponentTwitter', function() {
         $scope.save();
 
         expect($scope.setAttributeData).to.have.been.called;
-        expect($scope.setAttributeData.lastCall.args[2]).to.equal('20');
+        expect($scope.setAttributeData.lastCall.args[2]).to.equal(20);
         expect($scope.maxitemsStatus).to.equal('VALID');
       });
 

--- a/test/unit/template-editor/components/directives/dtv-component-twitter.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-twitter.tests.js
@@ -160,51 +160,104 @@ describe('directive: templateComponentTwitter', function() {
   });
 
   describe('load', function () {
-    it('should load data and indicate the username is valid', function() {
-      var directive = $scope.registerDirective.getCall(0).args[0];
+    describe('username', function () {
+      it('should load data and indicate the username is valid', function() {
+        var directive = $scope.registerDirective.getCall(0).args[0];
 
-      $scope.getAvailableAttributeData = sandbox.stub().returns('@twitterHandle');
-      twitterCredentialsValidation.verifyCredentials = sandbox.stub().returns(Q.resolve(true));
+        $scope.getAvailableAttributeData = sandbox.stub().returns('@twitterHandle');
+        twitterCredentialsValidation.verifyCredentials = sandbox.stub().returns(Q.resolve(true));
 
-      directive.show();
+        directive.show();
 
-      expect($scope.username).to.equal('@twitterHandle');
-      expect($scope.usernameStatus).to.equal('VALID');
+        expect($scope.username).to.equal('@twitterHandle');
+        expect($scope.usernameStatus).to.equal('VALID');
+      });
+
+      it('should load data and indicate the username is not valid', function() {
+        var directive = $scope.registerDirective.getCall(0).args[0];
+
+        $scope.getAvailableAttributeData = sandbox.stub().returns('@twitterHandleButReallyLongAndNotValid');
+        twitterCredentialsValidation.verifyCredentials = sandbox.stub().returns(Q.resolve(true));
+
+        directive.show();
+
+        expect($scope.username).to.equal('@twitterHandleButReallyLongAndNotValid');
+        expect($scope.usernameStatus).to.equal('INVALID_USERNAME');
+      });
     });
 
-    it('should load data and indicate the username is not valid', function() {
-      var directive = $scope.registerDirective.getCall(0).args[0];
+    describe('maxitems', function () {
+      it('should load data and indicate maxitems is valid', function() {
+        var directive = $scope.registerDirective.getCall(0).args[0];
 
-      $scope.getAvailableAttributeData = sandbox.stub().returns('@twitterHandleButReallyLongAndNotValid');
-      twitterCredentialsValidation.verifyCredentials = sandbox.stub().returns(Q.resolve(true));
+        $scope.getAvailableAttributeData = sandbox.stub().returns('20');
+        twitterCredentialsValidation.verifyCredentials = sandbox.stub().returns(Q.resolve(true));
 
-      directive.show();
+        directive.show();
 
-      expect($scope.username).to.equal('@twitterHandleButReallyLongAndNotValid');
-      expect($scope.usernameStatus).to.equal('INVALID_USERNAME');
+        expect($scope.maxitems).to.equal('20');
+        expect($scope.maxitemsStatus).to.equal('VALID');
+      });
+
+      it('should load data and indicate maxitems is not valid', function() {
+        var directive = $scope.registerDirective.getCall(0).args[0];
+
+        $scope.getAvailableAttributeData = sandbox.stub().returns('300');
+        twitterCredentialsValidation.verifyCredentials = sandbox.stub().returns(Q.resolve(true));
+
+        directive.show();
+
+        expect($scope.maxitems).to.equal('300');
+        expect($scope.maxitemsStatus).to.equal('INVALID_RANGE');
+      });
     });
   });
 
   describe('save', function () {
-    it('should save data and indicate the username is valid', function() {
-      $scope.setAttributeData = sandbox.stub();
-      $scope.username = '@twitterHandle';
+    describe('username', function () {
+      it('should save data and indicate the username is valid', function() {
+        $scope.setAttributeData = sandbox.stub();
+        $scope.username = '@twitterHandle';
 
-      $scope.save();
+        $scope.save();
 
-      expect($scope.setAttributeData).to.have.been.called;
-      expect($scope.setAttributeData.lastCall.args[2]).to.equal('twitterHandle');
-      expect($scope.usernameStatus).to.equal('VALID');
+        expect($scope.setAttributeData).to.have.been.called;
+        expect($scope.setAttributeData.lastCall.args[2]).to.equal('twitterHandle');
+        expect($scope.usernameStatus).to.equal('VALID');
+      });
+
+      it('should load data and indicate the username is not valid', function() {
+        $scope.setAttributeData = sandbox.stub();
+        $scope.username = '@twitterHandleButReallyLongAndNotValid';
+
+        $scope.save();
+
+        expect($scope.setAttributeData).to.not.have.been.called;
+        expect($scope.usernameStatus).to.equal('INVALID_USERNAME');
+      });
     });
 
-    it('should load data and indicate the username is not valid', function() {
-      $scope.setAttributeData = sandbox.stub();
-      $scope.username = '@twitterHandleButReallyLongAndNotValid';
+    describe('maxitems', function () {
+      it('should save data and indicate maxitems is valid', function() {
+        $scope.setAttributeData = sandbox.stub();
+        $scope.maxitems = '20';
 
-      $scope.save();
+        $scope.save();
 
-      expect($scope.setAttributeData).to.not.have.been.called;
-      expect($scope.usernameStatus).to.equal('INVALID_USERNAME');
+        expect($scope.setAttributeData).to.have.been.called;
+        expect($scope.setAttributeData.lastCall.args[2]).to.equal('20');
+        expect($scope.maxitemsStatus).to.equal('VALID');
+      });
+
+      it('should load data and indicate maxitems is not valid', function() {
+        $scope.setAttributeData = sandbox.stub();
+        $scope.maxitems = '300';
+
+        $scope.save();
+
+        expect($scope.setAttributeData).to.not.have.been.called;
+        expect($scope.maxitemsStatus).to.equal('INVALID_RANGE');
+      });
     });
   });
 });

--- a/web/partials/template-editor/components/component-twitter.html
+++ b/web/partials/template-editor/components/component-twitter.html
@@ -11,11 +11,21 @@
   </div>
   <div class="attribute-editor-row" ng-show="connected">
     <div class="form-group has-feedback" ng-class="{ 'has-error': usernameStatus && usernameStatus !== 'VALID', 'has-success': usernameStatus === 'VALID' && username !== '' }">
-      <label class="control-label" for="twitter-username">Enter a username:</label>
-      <input type="text" id="twitter-username" class="form-control u_ellipsis" ng-model="username" placeholder="@RiseVision" ng-change="save()">
+      <label class="control-label" for="twitterUsername">Enter a username:</label>
+      <input type="text" id="twitterUsername"  class="form-control u_ellipsis" ng-model="username" placeholder="@RiseVision" ng-change="save()">
       <streamline-icon class="overlay-icon form-control-feedback" aria-hidden="true" name="{{usernameStatus && usernameStatus !== 'VALID' ? 'exclamation' : 'checkmark'}}" width="14" height="12"></streamline-icon>
       <p class="help-block" ng-switch on="usernameStatus">
         <span ng-switch-when="INVALID_USERNAME">Please provide a valid username.</span>
+      </p>
+    </div>
+  </div>
+  <div class="attribute-editor-row" ng-show="connected">
+    <div class="form-group has-feedback" ng-class="{ 'has-error': maxitemsStatus && maxitemsStatus !== 'VALID', 'has-success': maxitemsStatus === 'VALID' && maxitems }">
+      <label class="control-label" for="twitterMaxitems">Number of Tweets in queue:</label>
+      <input type="text" id="twitterMaxitems" class="form-control u_ellipsis" ng-model="maxitems" placeholder="Max 50" ng-change="save()">
+      <streamline-icon class="overlay-icon form-control-feedback" aria-hidden="true" name="{{maxitemsStatus && maxitemsStatus !== 'VALID' ? 'exclamation' : 'checkmark'}}" width="14" height="12"></streamline-icon>
+      <p class="help-block" ng-switch on="maxitemsStatus">
+        <span ng-switch-when="INVALID_RANGE">Please provide a number between 1 and 50.</span>
       </p>
     </div>
   </div>

--- a/web/partials/template-editor/components/component-twitter.html
+++ b/web/partials/template-editor/components/component-twitter.html
@@ -22,10 +22,10 @@
   <div class="attribute-editor-row" ng-show="connected">
     <div class="form-group has-feedback" ng-class="{ 'has-error': maxitemsStatus && maxitemsStatus !== 'VALID', 'has-success': maxitemsStatus === 'VALID' && maxitems }">
       <label class="control-label" for="twitterMaxitems">Number of Tweets in queue:</label>
-      <input type="text" id="twitterMaxitems" class="form-control u_ellipsis" ng-model="maxitems" placeholder="Max 50" ng-change="save()">
+      <input type="text" id="twitterMaxitems" class="form-control u_ellipsis" ng-model="maxitems" placeholder="Max {{MAX_ITEMS}}" ng-change="save()">
       <streamline-icon class="overlay-icon form-control-feedback" aria-hidden="true" name="{{maxitemsStatus && maxitemsStatus !== 'VALID' ? 'exclamation' : 'checkmark'}}" width="14" height="12"></streamline-icon>
       <p class="help-block" ng-switch on="maxitemsStatus">
-        <span ng-switch-when="INVALID_RANGE">Please provide a number between 1 and 50.</span>
+        <span ng-switch-when="INVALID_RANGE">Please provide a number between 1 and {{MAX_ITEMS}}.</span>
       </p>
     </div>
   </div>

--- a/web/scripts/template-editor/components/directives/dtv-component-twitter.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-twitter.js
@@ -10,6 +10,7 @@ angular.module('risevision.template-editor.directives')
         templateUrl: 'partials/template-editor/components/component-twitter.html',
         link: function ($scope, element) {
           $scope.factory = templateEditorFactory;
+          $scope.MAX_ITEMS = 100;
 
           $scope.$watch('spinner', function (loading) {
             if (loading) {
@@ -47,7 +48,7 @@ angular.module('risevision.template-editor.directives')
             }
 
             if (_validateMaxitems($scope.maxitems)) {
-              $scope.setAttributeData($scope.componentId, 'maxitems', $scope.maxitems);
+              $scope.setAttributeData($scope.componentId, 'maxitems', Number($scope.maxitems));
             }
           };
 
@@ -108,7 +109,7 @@ angular.module('risevision.template-editor.directives')
           }
 
           function _validateMaxitems(maxitems) {
-            if (maxitems && maxitems >= 1 && maxitems <= 50) {
+            if (maxitems && maxitems >= 1 && maxitems <= $scope.MAX_ITEMS) {
               $scope.maxitemsStatus = 'VALID';
               return true;
             } else if (maxitems) {

--- a/web/scripts/template-editor/components/directives/dtv-component-twitter.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-twitter.js
@@ -45,6 +45,10 @@ angular.module('risevision.template-editor.directives')
             if (_validateUsername($scope.username)) {
               $scope.setAttributeData($scope.componentId, 'username', $scope.username.replace('@', ''));
             }
+
+            if (_validateMaxitems($scope.maxitems)) {
+              $scope.setAttributeData($scope.componentId, 'maxitems', $scope.maxitems);
+            }
           };
 
           $scope.registerDirective({
@@ -62,9 +66,12 @@ angular.module('risevision.template-editor.directives')
 
           function _load() {
             var username = $scope.getAvailableAttributeData($scope.componentId, 'username');
+            var maxitems = $scope.getAvailableAttributeData($scope.componentId, 'maxitems');
 
             $scope.username = username && username.indexOf('@') === -1 ? '@' + username : username;
+            $scope.maxitems = maxitems;
             _validateUsername($scope.username);
+            _validateMaxitems($scope.maxitems);
           }
 
           function _handleConnectionFailure() {
@@ -96,6 +103,19 @@ angular.module('risevision.template-editor.directives')
               return true;
             } else {
               $scope.usernameStatus = 'INVALID_USERNAME';
+              return false;
+            }
+          }
+
+          function _validateMaxitems(maxitems) {
+            if (maxitems && maxitems >= 1 && maxitems <= 50) {
+              $scope.maxitemsStatus = 'VALID';
+              return true;
+            } else if (maxitems) {
+              $scope.maxitemsStatus = 'INVALID_RANGE';
+              return false;
+            } else {
+              $scope.maxitemsStatus = null;
               return false;
             }
           }


### PR DESCRIPTION
## Description
Adds support for `maxitems` field in Component Twitter UI.

I did not use `input type="number"` since it always provided `undefined` for non-numbers. This caused showing an error message as soon as entering the editor, when we only want to show the placeholder.

## Motivation and Context
It's part of our epic.

## How Has This Been Tested?
It can be tested here: https://apps-stage-7.risevision.com/templates/edit/dc974d01-4c04-4d7c-81cc-05d8e8b25144/?cid=87977ab8-38b6-47fb-ad5e-256b8cc4b46d

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No

@santiagonoguez @stulees please review