### PR TITLE
Add opaque background and border to mirror

### DIFF
--- a/web/scss/sections/template-editor-layout.scss
+++ b/web/scss/sections/template-editor-layout.scss
@@ -892,6 +892,11 @@ $short-phone-height: 570px;
     cursor: move;
     cursor: -webkit-grabbing;
   }
+
+  &.draggable-mirror {
+    border-top: 1px solid $madero-gray;
+    background: rgba(242, 242, 242, 0.85);
+  }
 }
 
 .file-component-list-folder-row {


### PR DESCRIPTION
## Description
Add opaque background and border to mirror
Improve visibility of Template Editor drag & drop mirror

[stage-2]

## Motivation and Context
Currently mirror is transparent and gets lost among other content. It is confusing to use.

## How Has This Been Tested?
Validated changes in the dev environment.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No