### PR TITLE
Split out radio/checkbox madero components

### DIFF
--- a/web/partials/template-editor/basic-storage-selector.html
+++ b/web/partials/template-editor/basic-storage-selector.html
@@ -15,7 +15,7 @@
   <div class="file-component-list" ng-show="folderItems.length > 0 && !isUploading" ng-if="basicStorageSelectorFactory.isListView">
     <div class="pl-0 file-component-list-header" ng-hide="filteredItems.length === 0">
       <div class="file-entry">
-        <div class="checkbox" ng-if="!storageManager.isSingleFileSelector()" ng-click="selectAllItems()">
+        <div class="madero-checkbox" ng-if="!storageManager.isSingleFileSelector()" ng-click="selectAllItems()">
           <input type="checkbox" ng-model="search.selectAll" tabindex="1">
           <label>
             <streamline-icon name="checkmark" width="14" height="12"></streamline-icon>
@@ -44,7 +44,7 @@
 
       <div class="pl-0 file-component-list-file-row u_clickable" ng-if="!isFolder(item.name)" ng-click="selectItem(item)">
         <div class="file-entry">
-          <div class="checkbox" ng-if="!storageManager.isSingleFileSelector()">
+          <div class="madero-checkbox" ng-if="!storageManager.isSingleFileSelector()">
             <input type="checkbox" ng-checked="isSelected(item)" tabindex="1">
             <label>
               <streamline-icon name="checkmark" width="14" height="12"></streamline-icon>

--- a/web/partials/template-editor/components/component-counter.html
+++ b/web/partials/template-editor/components/component-counter.html
@@ -2,7 +2,7 @@
   <div class="attribute-editor-row counter-container">
     <label ng-show="counterType == 'down'" class="u_margin-sm-top">Countdown to:</label>
     <label ng-show="counterType == 'up'" class="u_margin-sm-top">Count up from:</label>
-    <div class="radio" id="dateRadio">
+    <div class="madero-radio" id="dateRadio">
       <input type="radio" ng-model="targetUnit" value="targetDate" id="specificDate" name="specificDate" ng-change="save()" aria-required="true" tabindex="1" required>
       <label for="specificDate" id="specificDateLabel">
         A specific date and time:
@@ -46,7 +46,7 @@
       </div>
     </div>
 
-    <div class="radio" id="timeRadio">
+    <div class="madero-radio" id="timeRadio">
       <input type="radio" ng-model="targetUnit" value="targetTime" id="specificTime" name="specificTime" ng-change="save()" aria-required="true" tabindex="1" required>
       <label for="specificTime" id="specificTimeLabel">
         A specific time, every day:

--- a/web/partials/template-editor/components/component-time-date.html
+++ b/web/partials/template-editor/components/component-time-date.html
@@ -13,14 +13,14 @@
   <div class="attribute-editor-row" ng-show="type === 'timedate' || type === 'time'">
     <label class="u_margin-sm-top mb-0">Time format:</label>
 
-    <div class="radio" id="time12HoursRadio">
+    <div class="madero-radio" id="time12HoursRadio">
       <input type="radio" ng-model="timeFormat" value="Hours12" id="Hours12" name="Hours12" ng-change="save()" aria-required="true" required>
       <label for="Hours12" id="Hours12Label">
         12 hour.
       </label>
     </div>
 
-    <div class="radio" id="time24HoursRadio">
+    <div class="madero-radio" id="time24HoursRadio">
       <input type="radio" ng-model="timeFormat" value="Hours24" id="Hours24" name="Hours24" ng-change="save()" aria-required="true" required>
       <label for="Hours24" id="Hours24Label">
         24 hour.
@@ -31,14 +31,14 @@
   <div class="attribute-editor-row">
     <label class="u_margin-sm-top mb-0">Show the time and date according to:</label>
 
-    <div class="radio" id="displayTzRadio">
+    <div class="madero-radio" id="displayTzRadio">
       <input type="radio" ng-model="timezoneType" value="DisplayTz" id="DisplayTz" name="DisplayTz" ng-change="save()" aria-required="true" required>
       <label for="DisplayTz" id="DisplayTzLabel">
         The Display's time zone.
       </label>
     </div>
 
-    <div class="radio" id="specificTzRadio">
+    <div class="madero-radio" id="specificTzRadio">
       <input type="radio" ng-model="timezoneType" value="SpecificTz" id="SpecificTz" name="SpecificTz" ng-change="save()" aria-required="true" required>
       <label for="SpecificTz" id="SpecificTzLabel">
         A specific time zone.

--- a/web/partials/template-editor/components/component-weather.html
+++ b/web/partials/template-editor/components/component-weather.html
@@ -4,14 +4,14 @@
     <p ng-show="!hasValidAddress && canEditCompany">Set an address to see the weather. Navigate to <a href="" ng-click="companySettingsFactory.openCompanySettings()">Company Settings</a>, enter your address and click Save.</p>
     <p ng-show="hasValidAddress">This Template will show the weather for the Address of the Display it is playing on.</p>    
     <label class="u_margin-sm-top">Display weather in:</label>
-    <div class="radio">
+    <div class="madero-radio">
       <input type="radio" ng-model="scale" value="F" id="farenheit" name="farenheit" ng-change="save()" aria-required="true" tabindex="1" required>
       <label for="farenheit">
         Farenheit
       </label>
     </div>
 
-    <div class="radio">
+    <div class="madero-radio">
       <input type="radio" ng-model="scale" value="C" id="celsius" name="celsius" ng-change="save()" aria-required="true" tabindex="1" required>
       <label for="celsius">
         Celsius

--- a/web/scss/sections/template-editor-layout.scss
+++ b/web/scss/sections/template-editor-layout.scss
@@ -1042,86 +1042,6 @@ $short-phone-height: 570px;
     }
   } 
 
-  .radio, .checkbox {
-    margin-top: 0px;
-    margin-bottom: 0px;
-    min-height: 25px;
-  }
-
-  .radio label, .checkbox label {
-    padding-left: 0px;
-  }
-
-  input[type=radio], input[type=checkbox] {
-    position: absolute;
-    top: auto;
-    overflow: hidden;
-    clip: rect(1px 1px 1px 1px); /* IE 6/7 */
-    clip: rect(1px, 1px, 1px, 1px);
-    width: 1px;
-    height: 1px;
-    white-space: nowrap;
-  }
-
-  input[type=radio] + label, input[type=checkbox] + label {
-    display: block;
-    padding-top: 5px;
-
-    &:before {
-      content: '';
-      background: #fff;
-      border: .15em solid $madero-gray;
-      background-color: rgba(255, 255, 255, .8);
-      display: block;
-      box-sizing: border-box;
-      float: left;
-      width: 20px;
-      height: 20px;
-      vertical-align: top;
-      cursor: pointer;
-      text-align: center;
-      transition: all .1s ease-out;      
-    }
-  }
-
-  input[type=radio] + label:before {
-    border-radius: 100%;
-    margin-right: 10px;
-  }
-
-  input[type=radio]:checked + label:before {
-    background-color: $madero-light-blue;
-    border: .15em solid $madero-light-blue;
-    box-shadow: inset 0 0 0 0.23em rgba(255, 255, 255, .95);
-  }
-
-  // Requires checkmark svg in the label element
-  input[type=checkbox] + label {
-    margin-bottom: 7px;
-
-    &:before {
-      border-radius: 2px;
-      margin-right: -3px;
-    }
-  }
-
-  input[type=checkbox]:checked + label:before {
-    border: .15em solid $madero-light-blue;
-  }
-
-  input[type=checkbox] + label {
-    svg {
-      fill: #fff;
-      transform: translate(-14px, 2px);
-    }
-  }
-
-  input[type=checkbox]:checked + label {
-    svg {
-      fill: $madero-light-blue;
-    }
-  }
-
   input[type='range'] {
     margin: 0;
     outline: none;
@@ -1511,6 +1431,86 @@ $short-phone-height: 570px;
 
   .display-id {
     font-size: 18px;
+  }
+}
+
+.madero-radio, .madero-checkbox {
+  margin-top: 0px;
+  margin-bottom: 0px;
+  min-height: 25px;
+
+  & label, & label {
+    padding-left: 0px;
+  }
+
+  input[type=radio], input[type=checkbox] {
+    position: absolute;
+    top: auto;
+    overflow: hidden;
+    clip: rect(1px 1px 1px 1px); /* IE 6/7 */
+    clip: rect(1px, 1px, 1px, 1px);
+    width: 1px;
+    height: 1px;
+    white-space: nowrap;
+  }
+
+  input[type=radio] + label, input[type=checkbox] + label {
+    display: block;
+    padding-top: 5px;
+
+    &:before {
+      content: '';
+      background: #fff;
+      border: .15em solid $madero-gray;
+      background-color: rgba(255, 255, 255, .8);
+      display: block;
+      box-sizing: border-box;
+      float: left;
+      width: 20px;
+      height: 20px;
+      vertical-align: top;
+      cursor: pointer;
+      text-align: center;
+      transition: all .1s ease-out;      
+    }
+  }
+
+  input[type=radio] + label:before {
+    border-radius: 100%;
+    margin-right: 10px;
+  }
+
+  input[type=radio]:checked + label:before {
+    background-color: $madero-light-blue;
+    border: .15em solid $madero-light-blue;
+    box-shadow: inset 0 0 0 0.23em rgba(255, 255, 255, .95);
+  }
+
+  // Requires checkmark svg in the label element
+  input[type=checkbox] + label {
+    margin-bottom: 7px;
+
+    &:before {
+      border-radius: 2px;
+      margin-right: -3px;
+    }
+  }
+
+  input[type=checkbox]:checked + label:before {
+    border: .15em solid $madero-light-blue;
+  }
+
+  input[type=checkbox] + label {
+    svg {
+      fill: #fff;
+      transform: translate(-14px, 2px);
+    }
+  }
+
+  input[type=checkbox]:checked + label {
+    svg {
+      fill: $madero-light-blue;
+    }
   }
 }
 


### PR DESCRIPTION
## Description
Split out radio/checkbox madero components

Prevent conflicts with other checkbox classes
in the template editor

[stage-2]

## Motivation and Context
Fix issues where Financial component checkboxes have both styles applied.

## How Has This Been Tested?
Tested Financial & Image/Video file selector for Checkboxes
Tested Weather, Time & Date and Countdown for Radio buttons

Validated that styles are applied correctly. Validated that no checkbox/radio instances were not updated.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No