### PR TITLE
Open playlist item modal if only one presentation is selected

### DIFF
--- a/test/e2e/schedules/cases/add-presentation.js
+++ b/test/e2e/schedules/cases/add-presentation.js
@@ -102,7 +102,20 @@ var AddPresentationScenarios = function() {
               helper.waitDisappear(presentationModalPage.getAddPresentationModal(), 'Add Presentations Modal');
             });
 
+            it('should show the playlist item dialog', function () {
+              helper.wait(playlistItemModalPage.getPlaylistItemModal(), 'Playlist Item Modal').then(function () {
+                expect(playlistItemModalPage.getPlaylistItemModal().isDisplayed()).to.eventually.be.true;
+                expect(playlistItemModalPage.getModalTitle().getText()).to.eventually.equal('Add Playlist Item');
+                expect(playlistItemModalPage.getNameTextbox().getAttribute('value')).to.eventually.equal(presentationItemName);
+                helper.wait(playlistItemModalPage.getPresentationNameField(), 'Playlist Item Modal').then(function () {
+                  expect(playlistItemModalPage.getPresentationNameField().getText()).to.eventually.equal(presentationItemName);
+                });
+              });
+            });
+              
             it('should add the playlist item', function () {
+              playlistItemModalPage.getSaveButton().click();
+
               expect(scheduleAddPage.getPlaylistItems().get(0).isDisplayed()).to.eventually.be.true;
               expect(playlistPage.getPresentationNameCell().get(0).getText()).to.eventually.equal(presentationItemName);
             });

--- a/test/unit/schedules/directives/dtv-schedule-fields.tests.js
+++ b/test/unit/schedules/directives/dtv-schedule-fields.tests.js
@@ -19,6 +19,7 @@ describe('directive: scheduleFields', function() {
     $provide.service('playlistFactory', function() {
       return {
         getNewUrlItem: sinon.stub().returns('urlItem'),
+        newPresentationItem: sinon.stub().returns('presentationItem'),
         addPresentationItems: sinon.spy()
       };
     });
@@ -66,22 +67,58 @@ describe('directive: scheduleFields', function() {
     expect($modal.open.getCall(0).args[0].resolve.playlistItem()).to.equal('urlItem');
   });
 
-  it('addPresentationItem:', function(done) {
-    $modal.open.returns({result: Q.resolve('presentations')});
 
-    $scope.addPresentationItem();
+  describe('addPresentationItem:', function() {
 
-    $modal.open.should.have.been.calledWithMatch({
-      templateUrl: 'partials/editor/presentation-multi-selector-modal.html',
-      controller: 'PresentationMultiSelectorModal'
+    it('should open the Playlist Item modal for a single item', function(done) {
+      $modal.open.returns({result: Q.resolve(['presentation1'])});
+
+      $scope.addPresentationItem();
+
+      $modal.open.should.have.been.calledOnce;
+      $modal.open.should.have.been.calledWithMatch({
+        templateUrl: 'partials/editor/presentation-multi-selector-modal.html',
+        controller: 'PresentationMultiSelectorModal'
+      });
+
+      setTimeout(function() {
+        $modal.open.should.have.been.calledTwice;
+        $modal.open.should.have.been.calledWithMatch({
+          templateUrl: 'partials/schedules/playlist-item.html',
+          controller: 'playlistItemModal',
+          size: 'md'
+        });
+
+        expect($modal.open.getCall(1).args[0].resolve.playlistItem()).to.equal('presentationItem');
+
+        playlistFactory.addPresentationItems.should.not.have.been.called;
+
+        done();
+      }, 10);
+
     });
 
-    setTimeout(function() {
-      playlistFactory.addPresentationItems.should.have.been.calledWith('presentations');
+    it('should add multiple items to the list', function(done) {
+      var presentations = ['presentation1', 'presentation2'];
+      $modal.open.returns({result: Q.resolve(presentations)});
 
-      done();
-    }, 10);
+      $scope.addPresentationItem();
 
+      $modal.open.should.have.been.calledOnce;
+      $modal.open.should.have.been.calledWithMatch({
+        templateUrl: 'partials/editor/presentation-multi-selector-modal.html',
+        controller: 'PresentationMultiSelectorModal'
+      });
+
+      setTimeout(function() {
+        $modal.open.should.have.been.calledOnce;
+
+        playlistFactory.addPresentationItems.should.have.been.calledWith(presentations);
+
+        done();
+      }, 10);
+
+    });
   });
 
   describe('isPreviewAvailable:', function() {

--- a/test/unit/schedules/services/svc-playlist-factory.tests.js
+++ b/test/unit/schedules/services/svc-playlist-factory.tests.js
@@ -60,10 +60,14 @@ describe('service: playlistFactory:', function() {
 
   it('should exist',function(){
     expect(playlistFactory).to.be.ok;
-    
+
+    expect(playlistFactory.newPresentationItem).to.be.a('function');    
+    expect(playlistFactory.initPlayUntilDone).to.be.a('function');
+    expect(playlistFactory.addPresentationItem).to.be.a('function');
+    expect(playlistFactory.addPresentationItems).to.be.a('function');
     expect(playlistFactory.getPlaylist).to.be.a('function');
     expect(playlistFactory.isNew).to.be.a('function');    
-    expect(playlistFactory.getNewUrlItem).to.be.a('function');    
+    expect(playlistFactory.getNewUrlItem).to.be.a('function');
     expect(playlistFactory.removePlaylistItem).to.be.a('function');
     expect(playlistFactory.duplicatePlaylistItem).to.be.a('function');    
     expect(playlistFactory.updatePlaylistItem).to.be.a('function');
@@ -102,90 +106,8 @@ describe('service: playlistFactory:', function() {
     expect(playlistItem.name).to.equal('URL Item');
   });
 
-  describe('initPlayUntilDone:', function() {
-    var item;
 
-    beforeEach(function() {
-      item = {};
-    });
-
-    it('should resolve to true if item is not HTML_PRESENTATION_TYPE', function(done) {
-      playlistFactory.initPlayUntilDone(item, {presentationType: 'legacy'}, true)
-        .then(function(result) {
-          expect(result).to.be.true;
-
-          blueprintFactory.isPlayUntilDone.should.not.have.been.called;
-
-          done();
-        });
-    });
-
-    it('should resolve to true if HTML Template supports playUntilDone', function(done) {
-      playlistFactory.initPlayUntilDone(item, {presentationType: 'HTML Template', productCode: 'productCode'}, true)
-        .then(function(result) {
-          expect(result).to.be.true;
-          expect(item.playUntilDone).to.be.true;
-
-          blueprintFactory.isPlayUntilDone.should.have.been.calledWith('productCode');
-
-          done();
-        });
-    });
-
-    it('should not update item if existing', function(done) {
-      item.playUntilDone = false;
-
-      playlistFactory.initPlayUntilDone(item, {presentationType: 'HTML Template', productCode: 'productCode'}, false)
-        .then(function(result) {
-          expect(result).to.be.true;
-          expect(item.playUntilDone).to.be.false;
-
-          done();
-        });
-    });
-
-    it('should not overwrite if item playUntilDone is false', function(done) {
-      item.playUntilDone = false;
-
-      playlistFactory.initPlayUntilDone(item, {presentationType: 'HTML Template', productCode: 'productCode'}, false)
-        .then(function(result) {
-          expect(result).to.be.true;
-          expect(item.playUntilDone).to.be.false;
-
-          done();
-        });
-    });
-
-    it('should resolve to false if HTML Template does not support playUntilDone', function(done) {
-      blueprintFactory.isPlayUntilDone.returns(Q.resolve(false));
-
-      playlistFactory.initPlayUntilDone(item, {presentationType: 'HTML Template', productCode: 'productCode'}, true)
-        .then(function(result) {
-          expect(result).to.be.false;
-          expect(item.playUntilDone).to.be.false;
-
-          done();
-        });
-    });
-
-    it('should update to false if playUntilDone retrieval fails', function(done) {
-      item.playUntilDone = true;
-      blueprintFactory.isPlayUntilDone.returns(Q.reject('error'));
-
-      playlistFactory.initPlayUntilDone(item, {presentationType: 'HTML Template', productCode: 'productCode'}, false)
-        .then(function(result) {
-          expect(result).to.be.false;
-          expect(item.playUntilDone).to.be.false;
-
-          blueprintFactory.isPlayUntilDone.should.have.been.calledWith('productCode');
-
-          done();
-        });
-    });
-
-  });
-
-  describe('addPresentationItem:', function() {
+  describe('presentationItem', function() {
     var presentation, mockPlaylistItem;
 
     beforeEach(function() {
@@ -200,47 +122,141 @@ describe('service: playlistFactory:', function() {
         name: 'presentationName',
         objectReference: 'presentationId',
         presentationType: 'presentationType'
-      }
-
-
-      sinon.stub(playlistFactory, 'initPlayUntilDone').returns(Q.resolve());
-      sinon.stub(playlistFactory, 'updatePlaylistItem');      
+      };
     });
 
-    it('should cache presentation', function() {
-      playlistFactory.addPresentationItem(presentation);
+    describe('newPresentationItem:', function() {
+      it('should cache presentation', function() {
+        playlistFactory.newPresentationItem(presentation);
 
-      expect(trackerCalled).to.equal('Add Presentation to Schedule');
+        expect(trackerCalled).to.equal('Add Presentation to Schedule');
 
-      presentationFactory.setPresentation.should.have.been.calledWith(presentation);
+        presentationFactory.setPresentation.should.have.been.calledWith(presentation);
+      });
+
+      it('should return playlistItem', function() {
+        expect(playlistFactory.newPresentationItem(presentation)).to.deep.equal(mockPlaylistItem);
+      });
+
     });
 
-    it('should init playUntilDone', function() {
-      playlistFactory.addPresentationItem(presentation);
+    describe('initPlayUntilDone:', function() {
+      var item;
 
-      playlistFactory.initPlayUntilDone.should.have.been.calledWith(mockPlaylistItem, presentation, true);
+      beforeEach(function() {
+        item = {};
+      });
+
+      it('should resolve to true if item is not HTML_PRESENTATION_TYPE', function(done) {
+        playlistFactory.initPlayUntilDone(item, {presentationType: 'legacy'}, true)
+          .then(function(result) {
+            expect(result).to.be.true;
+
+            blueprintFactory.isPlayUntilDone.should.not.have.been.called;
+
+            done();
+          });
+      });
+
+      it('should resolve to true if HTML Template supports playUntilDone', function(done) {
+        playlistFactory.initPlayUntilDone(item, {presentationType: 'HTML Template', productCode: 'productCode'}, true)
+          .then(function(result) {
+            expect(result).to.be.true;
+            expect(item.playUntilDone).to.be.true;
+
+            blueprintFactory.isPlayUntilDone.should.have.been.calledWith('productCode');
+
+            done();
+          });
+      });
+
+      it('should not update item if existing', function(done) {
+        item.playUntilDone = false;
+
+        playlistFactory.initPlayUntilDone(item, {presentationType: 'HTML Template', productCode: 'productCode'}, false)
+          .then(function(result) {
+            expect(result).to.be.true;
+            expect(item.playUntilDone).to.be.false;
+
+            done();
+          });
+      });
+
+      it('should not overwrite if item playUntilDone is false', function(done) {
+        item.playUntilDone = false;
+
+        playlistFactory.initPlayUntilDone(item, {presentationType: 'HTML Template', productCode: 'productCode'}, false)
+          .then(function(result) {
+            expect(result).to.be.true;
+            expect(item.playUntilDone).to.be.false;
+
+            done();
+          });
+      });
+
+      it('should resolve to false if HTML Template does not support playUntilDone', function(done) {
+        blueprintFactory.isPlayUntilDone.returns(Q.resolve(false));
+
+        playlistFactory.initPlayUntilDone(item, {presentationType: 'HTML Template', productCode: 'productCode'}, true)
+          .then(function(result) {
+            expect(result).to.be.false;
+            expect(item.playUntilDone).to.be.false;
+
+            done();
+          });
+      });
+
+      it('should update to false if playUntilDone retrieval fails', function(done) {
+        item.playUntilDone = true;
+        blueprintFactory.isPlayUntilDone.returns(Q.reject('error'));
+
+        playlistFactory.initPlayUntilDone(item, {presentationType: 'HTML Template', productCode: 'productCode'}, false)
+          .then(function(result) {
+            expect(result).to.be.false;
+            expect(item.playUntilDone).to.be.false;
+
+            blueprintFactory.isPlayUntilDone.should.have.been.calledWith('productCode');
+
+            done();
+          });
+      });
+
     });
 
-    it('should add item', function(done) {
-      playlistFactory.addPresentationItem(presentation)
-        .then(function() {
-          playlistFactory.updatePlaylistItem.should.have.been.calledWith(mockPlaylistItem);
+    describe('addPresentationItem:', function() {
+      beforeEach(function() {
+        sinon.stub(playlistFactory, 'initPlayUntilDone').returns(Q.resolve());
+        sinon.stub(playlistFactory, 'updatePlaylistItem');      
+      });
 
-          done();
-        });
+      it('should init playUntilDone', function() {
+        playlistFactory.addPresentationItem(presentation);
+
+        playlistFactory.initPlayUntilDone.should.have.been.calledWith(mockPlaylistItem, presentation, true);
+      });
+
+      it('should add item', function(done) {
+        playlistFactory.addPresentationItem(presentation)
+          .then(function() {
+            playlistFactory.updatePlaylistItem.should.have.been.calledWith(mockPlaylistItem);
+
+            done();
+          });
+      });
+
     });
 
-  });
+    it('addPresentationItems:', function() {
+      sinon.stub(playlistFactory, 'addPresentationItem');
 
-  it('addPresentationItems:', function() {
-    sinon.stub(playlistFactory, 'addPresentationItem');
+      playlistFactory.addPresentationItems([1, 2]);
 
-    playlistFactory.addPresentationItems([1, 2]);
+      playlistFactory.addPresentationItem.should.have.been.calledTwice;
 
-    playlistFactory.addPresentationItem.should.have.been.calledTwice;
+      expect(playlistFactory.addPresentationItem.getCall(0).args[0]).to.equal(1);
+      expect(playlistFactory.addPresentationItem.getCall(1).args[0]).to.equal(2);
+    });
 
-    expect(playlistFactory.addPresentationItem.getCall(0).args[0]).to.equal(1);
-    expect(playlistFactory.addPresentationItem.getCall(1).args[0]).to.equal(2);
   });
 
   describe('removePlaylistItem: ',function(){

--- a/web/scripts/schedules/directives/dtv-schedule-fields.js
+++ b/web/scripts/schedules/directives/dtv-schedule-fields.js
@@ -33,7 +33,11 @@ angular.module('risevision.schedules.directives')
             });
 
             modalInstance.result.then(function (presentations) {
-              playlistFactory.addPresentationItems(presentations);
+              if (presentations && presentations.length === 1) {
+                openPlaylistModal(playlistFactory.newPresentationItem(presentations[0]));
+              } else {
+                playlistFactory.addPresentationItems(presentations);                
+              }
             });
           };
 

--- a/web/scripts/schedules/services/svc-playlist-factory.js
+++ b/web/scripts/schedules/services/svc-playlist-factory.js
@@ -10,14 +10,20 @@ angular.module('risevision.schedules.services')
       var DEFAULT_DURATION = 10;
       var factory = {};
 
-      var _newPresentationItem = function () {
+      factory.newPresentationItem = function (presentation) {
         scheduleTracker('Add Presentation to Schedule',
           scheduleFactory.schedule.id, scheduleFactory.schedule.name
         );
 
+        // Cache presentation to avoid API call for the name
+        presentationFactory.setPresentation(presentation);
+
         return {
           duration: DEFAULT_DURATION,
-          type: TYPE_PRESENTATION
+          type: TYPE_PRESENTATION,
+          objectReference: presentation.id,
+          name: presentation.name,
+          presentationType: presentation.presentationType
         };
       };
 
@@ -48,14 +54,7 @@ angular.module('risevision.schedules.services')
       };
 
       factory.addPresentationItem = function (presentation) {
-        var playlistItem = _newPresentationItem(presentation);
-
-        // Cache presentation to avoid API call for the name
-        presentationFactory.setPresentation(presentation);
-
-        playlistItem.objectReference = presentation.id;
-        playlistItem.name = presentation.name;
-        playlistItem.presentationType = presentation.presentationType;
+        var playlistItem = factory.newPresentationItem(presentation);
 
         return factory.initPlayUntilDone(playlistItem, presentation, true)
           .then(function () {


### PR DESCRIPTION
## Description
Open playlist item modal if only one presentation is selected

[stage-2]

## Motivation and Context
Improved user experience to allow them to edit the item

## How Has This Been Tested?
Tested adding both a Single Item and Multiple Items to a Schedule Playlist.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
