### PR TITLE
Add education specific roles for users

### DIFF
--- a/test/unit/common-header/controllers/ctr-user-add-spec.js
+++ b/test/unit/common-header/controllers/ctr-user-add-spec.js
@@ -88,7 +88,8 @@ describe("controller: user add", function() {
         },
         isSelectedCompanyChargebee: function () {
           return false;
-        }
+        },
+        isEducationCustomer: sinon.stub().returns(true)
       };
     };
     inject(function($injector,$rootScope, $controller){
@@ -124,6 +125,12 @@ describe("controller: user add", function() {
     expect($scope.COMPANY_ROLE_FIELDS).to.exist;
 
     expect($scope.isUserAdmin).to.be.true;
+  });
+
+  it("should configure company roles by checking if customer is education", function() {
+    userState.isEducationCustomer.should.have.been.called;
+
+    expect($scope.COMPANY_ROLE_FIELDS[0]).to.deep.equal(['IT', 'education_it']);
   });
   
   describe("save: ",function(){

--- a/test/unit/common-header/controllers/ctr-user-settings-spec.js
+++ b/test/unit/common-header/controllers/ctr-user-settings-spec.js
@@ -89,9 +89,9 @@ describe("controller: user settings", function() {
     savedUser = userProfile;
     userState = function(){
       return {
-        checkUsername: function(username){
+        checkUsername: sinon.spy(function(username) {
           return username === "user@example.io";
-        },
+        }),
         getAccessToken : function(){
           return{access_token: "TEST_TOKEN"};
         },
@@ -121,6 +121,7 @@ describe("controller: user settings", function() {
         isSelectedCompanyChargebee: function () {
           return false;
         },
+        isEducationCustomer: sinon.stub().returns(true),
         _state: {}
       };
     };
@@ -164,6 +165,13 @@ describe("controller: user settings", function() {
     expect($scope.deleteUser).to.exist;
     expect($scope.editRoleAllowed).to.exist;
     expect($scope.editRoleVisible).to.exist;
+  });
+
+  it("should configure company roles by checking if customer is education", function() {
+    userState.checkUsername.should.have.been.calledWith('user@example.io');
+    userState.isEducationCustomer.should.have.been.calledWith(true);
+
+    expect($scope.COMPANY_ROLE_FIELDS[0]).to.deep.equal(['IT', 'education_it']);
   });
 
   it("should load current user",function(done){

--- a/test/unit/components/userstate/services/svc-companystate.tests.js
+++ b/test/unit/components/userstate/services/svc-companystate.tests.js
@@ -325,6 +325,16 @@ describe("Services: company state", function() {
 
         expect(companyState.isEducationCustomer()).to.be.false;
       });    
+
+      it("should use own company if parameter is true", function() {
+        companyWithNewSettings.companyIndustry = "HIGHER_EDUCATION";
+        subCompanyWithNewSettings.companyIndustry = "MARKETING";
+        
+        companyState.updateCompanySettings(companyWithNewSettings);
+        companyState.updateCompanySettings(subCompanyWithNewSettings);
+
+        expect(companyState.isEducationCustomer(true)).to.be.true;
+      });
     });
   });
 });

--- a/web/scripts/common-header/controllers/ctr-user-add-modal.js
+++ b/web/scripts/common-header/controllers/ctr-user-add-modal.js
@@ -4,13 +4,18 @@ angular.module('risevision.common.header')
   .controller('AddUserModalCtrl', ['$scope', '$filter', 'addUser',
     '$modalInstance', 'companyId', 'userState', 'userRoleMap',
     'humanReadableError', 'messageBox', '$loading', 'userTracker',
-    'COMPANY_ROLE_FIELDS',
+    'COMPANY_ROLE_FIELDS', 'EDUCATION_COMPANY_ROLE_FIELDS',
     function ($scope, $filter, addUser, $modalInstance, companyId,
       userState, userRoleMap, humanReadableError, messageBox, $loading,
-      userTracker, COMPANY_ROLE_FIELDS) {
+      userTracker, COMPANY_ROLE_FIELDS, EDUCATION_COMPANY_ROLE_FIELDS) {
       $scope.isAdd = true;
-      $scope.COMPANY_ROLE_FIELDS = COMPANY_ROLE_FIELDS;
       $scope.isUserAdmin = userState.isUserAdmin();
+
+      if (userState.isEducationCustomer()) {
+        $scope.COMPANY_ROLE_FIELDS = EDUCATION_COMPANY_ROLE_FIELDS;
+      } else {
+        $scope.COMPANY_ROLE_FIELDS = COMPANY_ROLE_FIELDS;        
+      }
 
       //push roles into array
       $scope.availableRoles = [];

--- a/web/scripts/common-header/controllers/ctr-user-settings-modal.js
+++ b/web/scripts/common-header/controllers/ctr-user-settings-modal.js
@@ -6,15 +6,18 @@ angular.module('risevision.common.header')
     '$scope', '$filter', '$modalInstance', 'updateUser', 'getUserProfile',
     'deleteUser', 'username', 'userRoleMap', '$log', '$loading', 'userState',
     'userAuthFactory', 'uiFlowManager', 'humanReadableError', 'messageBox', 'confirmModal',
-    '$rootScope', 'userTracker', 'userauth', '$q', 'COMPANY_ROLE_FIELDS',
+    '$rootScope', 'userTracker', 'userauth', '$q',
+    'COMPANY_ROLE_FIELDS', 'EDUCATION_COMPANY_ROLE_FIELDS',
     function ($scope, $filter, $modalInstance, updateUser, getUserProfile,
       deleteUser, username, userRoleMap, $log, $loading, userState,
       userAuthFactory, uiFlowManager, humanReadableError, messageBox, confirmModal,
-      $rootScope, userTracker, userauth, $q, COMPANY_ROLE_FIELDS) {
+      $rootScope, userTracker, userauth, $q,
+      COMPANY_ROLE_FIELDS, EDUCATION_COMPANY_ROLE_FIELDS) {
       $scope.user = {};
       $scope.userPassword = {};
       $scope.showChangePassword = false;
       $scope.isRiseAuthUser = userState.isRiseAuthUser();
+      $scope.editingYourself = userState.checkUsername(username);
       $scope.$watch('loading', function (loading) {
         if (loading) {
           $loading.start('user-settings-modal');
@@ -31,7 +34,12 @@ angular.module('risevision.common.header')
           name: v
         });
       });
-      $scope.COMPANY_ROLE_FIELDS = COMPANY_ROLE_FIELDS;
+
+      if (userState.isEducationCustomer($scope.editingYourself)) {
+        $scope.COMPANY_ROLE_FIELDS = EDUCATION_COMPANY_ROLE_FIELDS;
+      } else {
+        $scope.COMPANY_ROLE_FIELDS = COMPANY_ROLE_FIELDS;        
+      }
 
       // convert string to numbers
       $scope.$watch('user.status', function (status) {
@@ -52,8 +60,6 @@ angular.module('risevision.common.header')
       $scope.loading = true;
       getUserProfile(username).then(function (user) {
         $scope.user = user;
-        $scope.editingYourself = userState.checkUsername(user.username);
-
       }).finally(function () {
         $scope.loading = false;
       });

--- a/web/scripts/common-header/services/svc-company-icp.js
+++ b/web/scripts/common-header/services/svc-company-icp.js
@@ -14,6 +14,21 @@ angular.module('risevision.common.header')
     ['Developer', 'developer'],
     ['Other', 'other']
   ])
+  .value('EDUCATION_COMPANY_ROLE_FIELDS', [
+    ['IT', 'education_it'],
+    ['Librarian', 'education_librarian'],
+    ['Marketing/Communications', 'education_marketing_communications'],
+    ['Other', 'education_other'],
+    ['Principal', 'education_principal'],
+    ['Media Specialist', 'education_media_specialist'],
+    ['Learning/Technology Coach', 'education_learning_technology_coach'],
+    ['Receptionist/Admin', 'education_receptionist_admin'],
+    ['Superintendent', 'education_superintendent'],
+    ['Teacher', 'education_teacher'],
+    ['Professor', 'education_professor'],
+    ['Dean', 'education_dean'],
+    ['Student', 'education_student']
+  ])
   .value('COMPANY_INDUSTRY_FIELDS', [
     ['K-12 Education', 'PRIMARY_SECONDARY_EDUCATION',
       'https://cdn2.hubspot.net/hubfs/2700250/Assets%20May%5B17%5D/university.svg'

--- a/web/scripts/components/userstate/services/svc-companystate.js
+++ b/web/scripts/components/userstate/services/svc-companystate.js
@@ -171,9 +171,11 @@
           isSelectedCompanyChargebee: function () {
             return _state.selectedCompany && _state.selectedCompany.origin === 'Chargebee';
           },
-          isEducationCustomer: function () {
-            return _state.selectedCompany && (_state.selectedCompany.companyIndustry ===
-              'PRIMARY_SECONDARY_EDUCATION' || _state.selectedCompany.companyIndustry === 'HIGHER_EDUCATION');
+          isEducationCustomer: function (checkUserCompany) {
+            var company = checkUserCompany ? _state.userCompany : _state.selectedCompany;
+
+            return company && (company.companyIndustry === 'PRIMARY_SECONDARY_EDUCATION' || 
+              company.companyIndustry === 'HIGHER_EDUCATION');
           }
         };
 


### PR DESCRIPTION
## Description
Add education specific roles for users

[stage-2]

## Motivation and Context
Tailored user roles for Education

## How Has This Been Tested?
Tested locally the roles are updated correctly. Tested non-Education role being saved as is (the role persists) and being replaced by an Education role.

Added roles to Hubspot (sandbox) property. Ensured property is updated with the correct role.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
