### PR TITLE
Use multiline flag to conditionally show text area for Text Component

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-text.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-text.tests.js
@@ -26,6 +26,8 @@ describe('directive: templateComponentText', function() {
 
     $scope.registerDirective = sinon.stub();
     $scope.setAttributeData = sinon.stub();
+    $scope.getAvailableAttributeData = sinon.stub().returns('data');
+    $scope.getBlueprintData = sinon.stub().returns(false);
 
     element = $compile("<template-component-text></template-component-text>")($scope);
     $scope = element.scope();
@@ -49,10 +51,7 @@ describe('directive: templateComponentText', function() {
   it('should load text from attribute data', function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     var sampleValue = "test text";
-
-    $scope.getAvailableAttributeData = function() {
-      return sampleValue;
-    }
+    $scope.getAvailableAttributeData.returns(sampleValue);
 
     directive.show();
 
@@ -60,13 +59,20 @@ describe('directive: templateComponentText', function() {
     expect($scope.value).to.equal(sampleValue);
   });
 
+  it('should load multiline attribute from blueprint', function() {
+    $scope.getBlueprintData.returns(true);
+    var directive = $scope.registerDirective.getCall(0).args[0];
+
+    directive.show();
+
+    expect($scope.getBlueprintData).to.have.been.calledWith('TEST-ID', 'multiline');
+    expect($scope.isMultiline).to.be.true;
+  });
+
   it('should save text to attribute data', function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     var sampleValue = "test text";
-
-    $scope.getAvailableAttributeData = function() {
-      return sampleValue;
-    }
+    $scope.getAvailableAttributeData.returns(sampleValue);
 
     directive.show();
 

--- a/web/partials/template-editor/components/component-text.html
+++ b/web/partials/template-editor/components/component-text.html
@@ -1,9 +1,9 @@
 <div class="attribute-editor-component">
   <div class="attribute-editor-row">
     <label>Text:</label>
-    <input ng-if="!isMultiline" id="text-component-input" type="text" class="form-control" ng-model="value" placeholder="Enter your text" ng-change="save()">
-    <p ng-if="isMultiline" class="text-sm">Hit enter to add a line break.</p>
-    <div ng-if="isMultiline" class="row">
+    <input ng-hide="isMultiline" id="text-component-input" type="text" class="form-control" ng-model="value" placeholder="Enter your text" ng-change="save()">
+    <p ng-show="isMultiline" class="text-sm">Hit enter to add a line break.</p>
+    <div ng-show="isMultiline" class="row">
       <div class="col-xs-12">
         ​<textarea id="text-component-input-multiline" class="form-control" rows="2" ng-model="value" placeholder="Enter your text" ng-change="save()"></textarea>
       </div>

--- a/web/partials/template-editor/components/component-text.html
+++ b/web/partials/template-editor/components/component-text.html
@@ -1,10 +1,11 @@
 <div class="attribute-editor-component">
   <div class="attribute-editor-row">
     <label>Text:</label>
-    <p class="text-sm">Hit enter to add a line break.</p>
-    <div class="row">
+    <input ng-if="!isMultiline" id="text-component-input" type="text" class="form-control" ng-model="value" placeholder="Enter your text" ng-change="save()">
+    <p ng-if="isMultiline" class="text-sm">Hit enter to add a line break.</p>
+    <div ng-if="isMultiline" class="row">
       <div class="col-xs-12">
-        ​<textarea id="text-component-input" class="form-control" rows="2" ng-model="value" placeholder="Enter your text" ng-change="save()"></textarea>
+        ​<textarea id="text-component-input-multiline" class="form-control" rows="2" ng-model="value" placeholder="Enter your text" ng-change="save()"></textarea>
       </div>
     </div>
   </div>

--- a/web/partials/template-editor/components/component-text.html
+++ b/web/partials/template-editor/components/component-text.html
@@ -1,9 +1,10 @@
 <div class="attribute-editor-component">
   <div class="attribute-editor-row">
     <label>Text:</label>
+    <p class="text-sm">Hit enter to add a line break.</p>
     <div class="row">
       <div class="col-xs-12">
-        <input id="text-component-input" type="text" class="form-control" ng-model="value" placeholder="Enter your text" ng-change="save()">
+        ​<textarea id="text-component-input" class="form-control" rows="2" ng-model="value" placeholder="Enter your text" ng-change="save()"></textarea>
       </div>
     </div>
   </div>

--- a/web/scripts/template-editor/components/directives/dtv-component-text.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-text.js
@@ -15,6 +15,7 @@ angular.module('risevision.template-editor.directives')
           };
 
           function _load() {
+            $scope.isMultiline = $scope.getBlueprintData($scope.componentId, 'multiline');
             var value = $scope.getAvailableAttributeData($scope.componentId, 'value');
             var fontsize = $scope.getAvailableAttributeData($scope.componentId, 'fontsize');
             var minfontsize = $scope.getAvailableAttributeData($scope.componentId, 'minfontsize');

--- a/web/scss/sections/template-editor-layout.scss
+++ b/web/scss/sections/template-editor-layout.scss
@@ -1226,6 +1226,11 @@ $short-phone-height: 570px;
     }
   }
 
+  textarea.form-control {
+    height: auto;
+    display: initial;
+  }
+
   .control-label {
     font-weight: bold;
     color: $madero-black;


### PR DESCRIPTION
## Description
Use `multiline` flag to conditionally show text area for Text Component.

## Motivation and Context
Apps UX Improvements epic.

## How Has This Been Tested?
As per https://github.com/Rise-Vision/rise-text/pull/34.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
