### PR TITLE
Don't allow horizontal resize of text component text area

### DIFF
--- a/web/partials/template-editor/components/component-text.html
+++ b/web/partials/template-editor/components/component-text.html
@@ -5,7 +5,7 @@
     <p ng-show="isMultiline" class="text-sm">Hit enter to add a line break.</p>
     <div ng-show="isMultiline" class="row">
       <div class="col-xs-12">
-        ​<textarea id="text-component-input-multiline" class="form-control" rows="2" ng-model="value" placeholder="Enter your text" ng-change="save()"></textarea>
+        ​<textarea id="text-component-input-multiline" class="form-control resize-vertical" rows="2" ng-model="value" placeholder="Enter your text" ng-change="save()"></textarea>
       </div>
     </div>
   </div>

--- a/web/scss/sections/template-editor-layout.scss
+++ b/web/scss/sections/template-editor-layout.scss
@@ -1229,6 +1229,10 @@ $short-phone-height: 570px;
   textarea.form-control {
     height: auto;
     display: initial;
+
+    &.resize-vertical {
+      resize: vertical;
+    }
   }
 
   .control-label {


### PR DESCRIPTION
## Description
Don't allow horizontal resize of text component text area.

## Motivation and Context
Users could expand textarea into Template Preview area. Limiting it to vertical resize only.

## How Has This Been Tested?
Locally and on [stage-1](https://apps-stage-1.risevision.com/templates/edit/25c99d9e-dc5b-47c1-992b-d37b622d5401/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443).

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
