### PR TITLE
Update trial period to 90 days

### DIFF
--- a/web/scripts/components/plans/svc-plans-factory.js
+++ b/web/scripts/components/plans/svc-plans-factory.js
@@ -39,7 +39,7 @@
         billAmount: 110,
         save: 10
       },
-      trialPeriod: 14,
+      trialPeriod: 90,
       discountIndustries: [
         'PRIMARY_SECONDARY_EDUCATION',
         'HIGHER_EDUCATION',
@@ -67,7 +67,7 @@
         billAmount: 110,
         save: 10
       },
-      trialPeriod: 14,
+      trialPeriod: 90,
       discountIndustries: [
         'PRIMARY_SECONDARY_EDUCATION',
         'HIGHER_EDUCATION',


### PR DESCRIPTION
## Description
Update trial period to 90 days

[stage-2]

## Motivation and Context
Temporary increase of trial duration for new customers.

## How Has This Been Tested?
Updated the Store Products spreadsheet with this period of 90 days for Display License and Display License for Education plans. This has been updated on Test only. On deployment I will update in Production as well.

Validated for both Ed and non Ed customers that the 90 day trial is being applied both in App when the trial is started (on registration) and in Chargebee/Store/Core and back to Apps when the Plan is retrieved.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
