### PR TITLE
Prevent multiple calls of 'logged in' event on registration

### DIFF
--- a/test/unit/common-header/controllers/ctr-registration-modal-spec.js
+++ b/test/unit/common-header/controllers/ctr-registration-modal-spec.js
@@ -103,13 +103,6 @@ describe("controller: registration modal", function() {
       };
     });
 
-    $provide.service("analyticsEvents", function() { 
-      return {
-        initialize: function() {},
-        identify: function() {}
-      };
-    });
-
     $provide.factory("customLoader", function ($q) {
       return function () {
         var deferred = $q.defer();
@@ -125,7 +118,7 @@ describe("controller: registration modal", function() {
         
   }));
   var $scope, userProfile, userState, $modalInstance, newUser;
-  var registerUser, account, analyticsFactory, bqCalled, identifySpy,
+  var registerUser, account, analyticsFactory, bqCalled,
     updateCompanyCalled, plansFactory;
   
   beforeEach(function() {
@@ -142,8 +135,6 @@ describe("controller: registration modal", function() {
     inject(function($injector,$rootScope, $controller){
       $scope = $rootScope.$new();
       $modalInstance = $injector.get("$modalInstance");
-      var analyticsEvents = $injector.get("analyticsEvents");
-      identifySpy = sinon.spy(analyticsEvents,"identify");
       analyticsFactory = $injector.get("analyticsFactory");
       userState = $injector.get("userState");
       $controller("RegistrationModalCtrl", {
@@ -207,7 +198,6 @@ describe("controller: registration modal", function() {
       setTimeout(function() {
         expect(newUser).to.be.true;
         plansFactory.initVolumePlanTrial.should.have.been.called;
-        identifySpy.should.have.been.called;
         expect(analyticsFactory.track).to.have.been.calledWith("User Registered",{
           companyId: "some_company_id",
           companyName: "company_name",
@@ -236,7 +226,6 @@ describe("controller: registration modal", function() {
       setTimeout(function(){
         expect(newUser).to.be.true;
         plansFactory.initVolumePlanTrial.should.not.have.been.called;
-        identifySpy.should.not.have.been.called;
         expect(analyticsFactory.track).to.not.have.been.called;
         expect(bqCalled).to.not.be.ok;
         expect($scope.registering).to.be.false;
@@ -270,7 +259,6 @@ describe("controller: registration modal", function() {
       setTimeout(function() {
         expect(newUser).to.be.false;
         plansFactory.initVolumePlanTrial.should.not.have.been.called;
-        identifySpy.should.have.been.called;
         expect(analyticsFactory.track).to.have.been.calledWithMatch("User Registered",{
           companyId: "some_company_id",
           companyName: "company_name",

--- a/test/unit/components/logging/svc-analytics-factory.tests.js
+++ b/test/unit/components/logging/svc-analytics-factory.tests.js
@@ -8,7 +8,7 @@ describe("Services: analyticsFactory", function() {
     $provide.factory("userState", [function () {
       return {
         getCopyOfProfile: function() {
-          return {};
+          return profile;
         },
         getUsername: function() {
           return "username";
@@ -43,11 +43,14 @@ describe("Services: analyticsFactory", function() {
     }]);
   }));
   
-  var analyticsFactory, analyticsEvents, $scope, companyId, $window;
+  var analyticsFactory, analyticsEvents, $scope, companyId, $window, profile;
   beforeEach(function(){
     inject(function($rootScope, $injector){
       $scope = $rootScope;
       companyId = "companyId";
+      profile = {
+        termsAcceptanceDate: "2020-01-01"
+      };
       
       analyticsFactory = $injector.get("analyticsFactory");
       $window = $injector.get("$window");
@@ -81,6 +84,7 @@ describe("Services: analyticsFactory", function() {
         email: undefined,
         firstName: "",
         lastName: "",
+        registeredDate: "2020-01-01",
         subscriptionRenewalDate: undefined,
         subscriptionStatus: "Free",
         subscriptionTrialExpiryDate: undefined
@@ -103,6 +107,38 @@ describe("Services: analyticsFactory", function() {
     }, 10);
   });
 
+  it("should identify user but not send 'logged in' event if user has not finalized registration", function(done) {
+    var identifySpy = sinon.spy(analyticsFactory, "identify");
+    var trackSpy = sinon.spy(analyticsFactory, "track");
+
+    profile.termsAcceptanceDate = undefined;
+
+    analyticsEvents.identify();
+    
+    setTimeout(function() {
+      var expectProperties = {
+        company: { id: "companyId", name: "companyName", companyIndustry: "K-12 Education", parentId: "parent123" },
+        companyId: "companyId",
+        companyName: "companyName",
+        companyIndustry: "K-12 Education",
+        parentId: "parent123",
+        userId: "username",
+        email: undefined,
+        firstName: "",
+        lastName: "",
+        registeredDate: undefined,
+        subscriptionRenewalDate: undefined,
+        subscriptionStatus: "Free",
+        subscriptionTrialExpiryDate: undefined
+      };
+      identifySpy.should.have.been.calledWith("username",expectProperties);
+
+      trackSpy.should.not.have.been.called;
+      
+      done();
+    }, 10);
+  });
+
   it("should identify user when authorized and track logged in event", function(done) {
     var identifySpy = sinon.spy(analyticsFactory, "identify");
     var trackSpy = sinon.spy(analyticsFactory, "track");
@@ -121,6 +157,7 @@ describe("Services: analyticsFactory", function() {
         email: undefined,
         firstName: "",
         lastName: "",
+        registeredDate: "2020-01-01",
         subscriptionRenewalDate: undefined,
         subscriptionStatus: "Free",
         subscriptionTrialExpiryDate: undefined
@@ -147,7 +184,8 @@ describe("Services: analyticsFactory", function() {
         userId: "username",
         email: undefined,
         firstName: "",
-        lastName: ""
+        lastName: "",
+        registeredDate: "2020-01-01"
       });
       done();
     }, 10);

--- a/web/scripts/common-header/controllers/ctr-registration-modal.js
+++ b/web/scripts/common-header/controllers/ctr-registration-modal.js
@@ -6,13 +6,12 @@ angular.module('risevision.common.header')
     '$loading', 'addAccount', '$exceptionHandler',
     'userState', 'pick', 'uiFlowManager', 'messageBox', 'humanReadableError',
     'agreeToTermsAndUpdateUser', 'account', 'analyticsFactory',
-    'bigQueryLogging', 'analyticsEvents', 'updateCompany', 'plansFactory',
+    'bigQueryLogging', 'updateCompany', 'plansFactory',
     'COMPANY_INDUSTRY_FIELDS', 'urlStateService', 'getAccount',
     function ($q, $scope, $rootScope, $modalInstance, $loading, addAccount,
       $exceptionHandler, userState, pick, uiFlowManager, messageBox, humanReadableError,
       agreeToTermsAndUpdateUser, account, analyticsFactory, bigQueryLogging,
-      analyticsEvents, updateCompany, plansFactory, COMPANY_INDUSTRY_FIELDS,
-      urlStateService, getAccount) {
+      updateCompany, plansFactory, COMPANY_INDUSTRY_FIELDS, urlStateService, getAccount) {
 
       $scope.newUser = !account;
       $scope.DROPDOWN_INDUSTRY_FIELDS = COMPANY_INDUSTRY_FIELDS;
@@ -93,7 +92,6 @@ angular.module('risevision.common.header')
                     plansFactory.initVolumePlanTrial();
                   }
 
-                  analyticsEvents.identify();
                   var userCompany = userState.getCopyOfUserCompany();
                   var userProfile = userState.getCopyOfProfile();
                   analyticsFactory.track('User Registered', {

--- a/web/scripts/components/logging/svc-analytics-factory.js
+++ b/web/scripts/components/logging/svc-analytics-factory.js
@@ -110,6 +110,7 @@
               email: profile.email,
               firstName: profile.firstName ? profile.firstName : '',
               lastName: profile.lastName ? profile.lastName : '',
+              registeredDate: profile.termsAcceptanceDate
             };
             if (userState.getUserCompanyId()) {
               var company = userState.getCopyOfUserCompany();
@@ -132,9 +133,12 @@
 
             analyticsFactory.identify(userState.getUsername(), properties);
 
-            var loggedInProperties = angular.copy(properties);
-            loggedInProperties.loginDate = new Date();
-            analyticsFactory.track('logged in', loggedInProperties);
+            //send 'logged in' event only if user has finalized sign up
+            if (profile.termsAcceptanceDate) {
+              var loggedInProperties = angular.copy(properties);
+              loggedInProperties.loginDate = new Date();
+              analyticsFactory.track('logged in', loggedInProperties);
+            }
           }
         };
 


### PR DESCRIPTION
## Description
Improve `logged in` event tracking to prevent multiple calls on registration.
Add `registeredDate` to identify() and 'logged in' event.

## Motivation and Context
Simplify Hubspot epic.

## How Has This Been Tested?
Manually tested locally and on stage-1.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
