### PR TITLE
Feature/send presentation id to preview

### DIFF
--- a/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
+++ b/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
@@ -63,13 +63,6 @@ describe('directive: TemplateEditorPreviewHolder', function() {
     $provide.service('userState', function() {
       return userState;
     });
-    $provide.service('$sce', function() {
-      return {
-        trustAsResourceUrl: function(url) {
-          return url;
-        }
-      };
-    });
   }));
 
   beforeEach(inject(function($compile, $rootScope, $templateCache, $window, _$timeout_,$injector){
@@ -294,7 +287,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
     it('should include presentation id in template URL', function() {
       var url = $scope.getEditorPreviewUrl('AAAA');
 
-      expect(url).to.equal('https://widgets.risevision.com/staging/templates/AAAA/src/template.html?presentationId=xxxxyyyy');
+      expect(url.toString()).to.equal('https://widgets.risevision.com/staging/templates/AAAA/src/template.html?presentationId=xxxxyyyy');
     });
   });
 

--- a/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
+++ b/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
@@ -38,6 +38,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
     $provide.service('templateEditorFactory', function() {
       return {
         presentation: {
+          id: 'xxxxyyyy',
           templateAttributeData: {
             components: [
               {id:'image', metadata: 'originalMetadata1'},
@@ -61,7 +62,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
     });
     $provide.service('userState', function() {
       return userState;
-    });    
+    });
   }));
 
   beforeEach(inject(function($compile, $rootScope, $templateCache, $window, _$timeout_,$injector){
@@ -130,7 +131,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
 
         done();
       },10);
-    });    
+    });
 
     it('posts display data when branding colors have changed', function(done) {
       iframe.onload();
@@ -146,7 +147,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
 
         done();
       },10);
-    });    
+    });
   });
 
   describe('_updateLogoData', function() {
@@ -272,13 +273,21 @@ describe('directive: TemplateEditorPreviewHolder', function() {
     it('should setup components on load',function(){
 
       iframe.onload();
-      
+
       //send attributes data
       expect(iframe.contentWindow.postMessage.getCall(0).args).to.deep.equal([ '{"type":"attributeData","value":{"components":[{"id":"image","metadata":"originalMetadata1"},{"id":"logo","metadata":"logoMetadata"}]}}', 'https://widgets.risevision.com' ]);
       //send start event
       expect(iframe.contentWindow.postMessage.getCall(1).args).to.deep.equal([ '{"type":"sendStartEvent"}', 'https://widgets.risevision.com' ]);
       //send display data
       expect(iframe.contentWindow.postMessage.getCall(2).args).to.deep.equal([ '{"type":"displayData","value":{"displayAddress":{},"companyBranding":{"baseColor":"baseColor","accentColor":"accentColor"}}}', 'https://widgets.risevision.com' ]);
+    });
+  });
+
+  describe('getDesktopWidth', function() {
+    it('should include presentation id in template URL', function() {
+      var url = $scope.getEditorPreviewUrl('AAAA');
+
+      expect(url).to.equal('https://widgets.risevision.com/staging/templates/AAAA/src/template.html?presentationId=xxxxyyyy');
     });
   });
 

--- a/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
+++ b/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
@@ -63,6 +63,13 @@ describe('directive: TemplateEditorPreviewHolder', function() {
     $provide.service('userState', function() {
       return userState;
     });
+    $provide.service('templateEditorFactory', function() {
+      return {
+        trustAsResourceUrl: function(url) {
+          return url;
+        }
+      };
+    });
   }));
 
   beforeEach(inject(function($compile, $rootScope, $templateCache, $window, _$timeout_,$injector){

--- a/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
+++ b/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
@@ -283,7 +283,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
     });
   });
 
-  describe('getDesktopWidth', function() {
+  describe('getEditorPreviewUrl', function() {
     it('should include presentation id in template URL', function() {
       var url = $scope.getEditorPreviewUrl('AAAA');
 

--- a/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
+++ b/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
@@ -63,7 +63,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
     $provide.service('userState', function() {
       return userState;
     });
-    $provide.service('templateEditorFactory', function() {
+    $provide.service('$sce', function() {
       return {
         trustAsResourceUrl: function(url) {
           return url;

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -38,7 +38,9 @@ angular.module('risevision.template-editor.directives')
           };
 
           $scope.getEditorPreviewUrl = function (productCode) {
-            var url = HTML_TEMPLATE_URL.replace('PRODUCT_CODE', productCode);
+            var presentationId = $scope.factory.presentation && $scope.factory.presentation.id;
+
+            var url = HTML_TEMPLATE_URL.replace('PRODUCT_CODE', productCode) + "?presentationId=" + presentationId;
 
             return $sce.trustAsResourceUrl(url);
           };

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -40,7 +40,7 @@ angular.module('risevision.template-editor.directives')
           $scope.getEditorPreviewUrl = function (productCode) {
             var presentationId = $scope.factory.presentation && $scope.factory.presentation.id;
 
-            var url = HTML_TEMPLATE_URL.replace('PRODUCT_CODE', productCode) + "?presentationId=" + presentationId;
+            var url = HTML_TEMPLATE_URL.replace('PRODUCT_CODE', productCode) + '?presentationId=' + presentationId;
 
             return $sce.trustAsResourceUrl(url);
           };

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -38,7 +38,8 @@ angular.module('risevision.template-editor.directives')
           };
 
           $scope.getEditorPreviewUrl = function (productCode) {
-            var presentationId = $scope.factory.presentation && $scope.factory.presentation.id;
+            var presentationId =
+              $scope.factory.presentation && $scope.factory.presentation.id;
 
             var url = HTML_TEMPLATE_URL.replace('PRODUCT_CODE', productCode) + '?presentationId=' + presentationId;
 


### PR DESCRIPTION
## Description
Send presentation id to preview

## Motivation and Context
Presentation id will be needed for Twitter service requests.

## How Has This Been Tested?
Manually tested here:
https://apps-stage-9.risevision.com/templates/edit/9d5c5d6d-8e03-4fd3-b4b3-25dc98db2270/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

And the template now recognized the presentation id, in console:
```
RisePlayerConfiguration.getPresentationId()
```

A unit test was also added.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
