### PR TITLE
Move blank template to the top for non-education

### DIFF
--- a/web/partials/editor/blank-presentation.html
+++ b/web/partials/editor/blank-presentation.html
@@ -1,0 +1,20 @@
+<div class="col-sm-6 col-md-4 col-lg-3" ng-if="factory.search.category === 'Templates' && !factory.loadingItems">
+  <div class="product-grid_item panel panel-default">
+    <figure class="product-grid_image u_clickable" ui-sref="apps.editor.workspace.artboard" ng-click="dismiss();">
+      <img loading="lazy" class="img-responsive" src="https://s3.amazonaws.com/Rise-Images/UI/blank-landscape.png" alt="add blank presentation"> 
+    </figure><!--template-image-->
+    <div class="product-grid_details">
+      <div class="row">
+        <div class="col-xs-8">
+          <h4>{{'editor-app.storeProduct.templates.blank' | translate}}</h4>
+        </div><!-- end col -->
+        <div class="col-xs-4">
+          <button class="btn btn-primary btn-sm btn-block" id="newPresentationButton" ui-sref="apps.editor.workspace.artboard" ng-click="dismiss();">
+            Add
+          </button>
+        </div><!-- end col -->
+      </div><!-- end row -->
+      
+    </div>
+  </div><!--product-grid-item-->
+</div>

--- a/web/partials/editor/store-products-modal.html
+++ b/web/partials/editor/store-products-modal.html
@@ -42,6 +42,8 @@
           <div class="product-grid">
             <div class="row">
 
+              <ng-include ng-if="!isEducationCustomer" src="'partials/editor/blank-presentation.html'"></ng-include>
+
               <ng-repeat ng-repeat="product in factory.items.list | filter: getTemplatesFilter()">
                 <div id="storeProduct" class="col-sm-6 col-md-4 col-lg-3" ng-click="select(product)">
                   <div class="product-grid_item panel panel-default">
@@ -64,26 +66,7 @@
                 </div>
               </ng-repeat>
 
-              <div class="col-sm-6 col-md-4 col-lg-3" ng-if="factory.search.category === 'Templates' && !factory.loadingItems">
-                <div class="product-grid_item panel panel-default">
-                  <figure class="product-grid_image u_clickable" ui-sref="apps.editor.workspace.artboard" ng-click="dismiss();">
-                    <img loading="lazy" class="img-responsive" src="https://s3.amazonaws.com/Rise-Images/UI/blank-landscape.png" alt="add blank presentation"> 
-                  </figure><!--template-image-->
-                  <div class="product-grid_details">
-                    <div class="row">
-                      <div class="col-xs-8">
-                        <h4>{{'editor-app.storeProduct.templates.blank' | translate}}</h4>
-                      </div><!-- end col -->
-                      <div class="col-xs-4">
-                        <button class="btn btn-primary btn-sm btn-block" id="newPresentationButton" ui-sref="apps.editor.workspace.artboard" ng-click="dismiss();">
-                          Add
-                        </button>
-                      </div><!-- end col -->
-                    </div><!-- end row -->
-                    
-                  </div>
-                </div><!--product-grid-item-->
-              </div>
+              <ng-include ng-if="isEducationCustomer" src="'partials/editor/blank-presentation.html'"></ng-include>
 
               <!-- If no search results -->
               <div class="col-sm-12" ng-show="factory.items.list.length === 0 && search.query && !factory.loadingItems">


### PR DESCRIPTION
## Description
Move the blank template to the top for non-education.

## Motivation and Context
Apps Changes epic.

## How Has This Been Tested?
Locally and on stage-1.

Education company - Blank at the end: https://apps-stage-1.risevision.com/editor/list?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443
Non Education company - Blank at the top: https://apps-stage-1.risevision.com/editor/list?cid=fbed0120-e89c-4927-b96a-bffa38e4b212

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
