### PR TITLE
Update “No Templates Found” label

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-playlist.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-playlist.tests.js
@@ -6,6 +6,7 @@ describe("directive: templateComponentPlaylist", function() {
       $loading,
       element,
       factory,
+      editorFactory,
       sampleAttributeData,
       sampleSelectedTemplates,
       sampleTemplatesFactory;
@@ -82,12 +83,20 @@ describe("directive: templateComponentPlaylist", function() {
         stop: sandbox.stub()
       };
     });
+
+    $provide.service("editorFactory", function() {
+      return {
+        addPresentationModal: sandbox.stub()
+      };
+    });
+  
   }));
 
   beforeEach(inject(function($injector, $compile, $rootScope, $templateCache){
     $templateCache.put("partials/template-editor/components/component-playlist.html", "<p>mock</p>");
     $scope = $rootScope.$new();
     $loading = $injector.get('$loading');
+    editorFactory = $injector.get('editorFactory');
 
     $scope.registerDirective = sinon.stub();
     $scope.setAttributeData = sinon.stub();
@@ -333,6 +342,12 @@ describe("directive: templateComponentPlaylist", function() {
     expect($scope.selectedTemplates[0]["duration"]).to.equal(30);
     expect($scope.selectedTemplates[0]["transition-type"]).to.equal("some-transition");
     expect($scope.save).to.be.calledOnce;
+  });
+
+  it("should call editorFactory.addPresentationModal()", function() {
+    $scope.createNewTemplate();
+
+    expect(editorFactory.addPresentationModal).to.be.calledOnce;
   });
 
 });

--- a/web/partials/template-editor/components/component-playlist.html
+++ b/web/partials/template-editor/components/component-playlist.html
@@ -65,7 +65,7 @@
     <div class="templates-selector te-scrollable-container"
     scrolling-list="templatesFactory.load()">
       <div class="templates-selector-no-results" ng-show="!(templatesFactory.items.list.length > 0)">
-        No Results Found
+        No Templates found. To create a new Template <a ng-click="createNewTemplate()">click here</a>. 
       </div>
 
       <div class="row templates-row" ng-show="templatesFactory.items.list.length > 0"

--- a/web/scripts/template-editor/components/directives/dtv-component-playlist.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-playlist.js
@@ -3,9 +3,9 @@
 angular.module('risevision.template-editor.directives')
   .constant('FILTER_HTML_TEMPLATES', 'presentationType:"HTML Template"')
   .directive('templateComponentPlaylist', ['templateEditorFactory', 'presentation', '$loading',
-  'FILTER_HTML_TEMPLATES', 'ScrollingListService',
+  'FILTER_HTML_TEMPLATES', 'ScrollingListService', 'editorFactory',
     function (templateEditorFactory, presentation, $loading,
-      FILTER_HTML_TEMPLATES, ScrollingListService) {
+      FILTER_HTML_TEMPLATES, ScrollingListService, editorFactory) {
       return {
         restrict: 'E',
         scope: true,
@@ -223,6 +223,9 @@ angular.module('risevision.template-editor.directives')
             $scope.save();
           };
 
+          $scope.createNewTemplate = function () {
+            editorFactory.addPresentationModal();
+          };
         }
       };
     }

--- a/web/scss/sections/components/playlist.scss
+++ b/web/scss/sections/components/playlist.scss
@@ -228,33 +228,8 @@
   font-size: 0.9em;
   margin: 20px;
 
-  & > div {
-    margin: 0 0 10px;
-  }
-
-  & > h2 {
-    font-size: 1.2em;
-    font-weight: 700;
-    padding: 20px 0px;
-    margin-top: 0px;
-  }
-
-  & > div:first-of-type {
-    font-weight: bold;
-  }
-
-  & i {
-    font-size: 15pt;
-    color: $rise-green;
-    margin-right: 5px;
-  }
-
   & a {
-    color: $dark-gray;
-
-    &:hover > span {
-      text-decoration: underline;
-    }
+    color: $rise-blue;
   }
 
 }


### PR DESCRIPTION
## Description
- Update “No Templates Found” label. 
- Open Add Template modal on click.

## Motivation and Context
This is a simplification of the "Hmm... You don't have any templates..." [use case](https://app.abstract.com/share/422f0953-788a-48b2-bf55-06880a27fcd3?collectionId=1eba19f7-14c3-492f-9e7c-7488289cf2e1&collectionLayerId=9dcc5815-1ad6-4857-9496-965318ab3be3&present=true&preview=false&sha=c89d1ef5d90f61311b6a8e72a8a1f4ab7770a461)

## How Has This Been Tested?
Manually and with unit test.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
