### PR TITLE
Use case: if template is PUD then it is added to the schedule as PUD

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-playlist.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-playlist.tests.js
@@ -92,7 +92,12 @@ describe("directive: templateComponentPlaylist", function() {
         addPresentationModal: sandbox.stub()
       };
     });
-  
+
+    $provide.service("blueprintFactory", function() {
+      return {
+        isPlayUntilDone: function() {return Q.resolve(true)}
+      };
+    });
   }));
 
   beforeEach(inject(function($injector, $compile, $rootScope, $templateCache){
@@ -269,7 +274,7 @@ describe("directive: templateComponentPlaylist", function() {
     expect($scope.canAddTemplates).to.equal(false);
   });
 
-  it("should add selected templates to playlist", function() {
+  it("should add selected templates to playlist and assign default PUD value", function(done) {
     $scope.templatesFactory = sampleTemplatesFactory;
     $scope.selectedTemplates = [];
     sandbox.stub($scope, "save");
@@ -279,8 +284,20 @@ describe("directive: templateComponentPlaylist", function() {
 
     $scope.addTemplates();
 
-    expect($scope.selectedTemplates.length).to.equal(1);
-    expect($scope.selectedTemplates[0].id).to.equal("id2");
+    setTimeout(function() {
+      // Propagate $q.all promise resolution using $apply()
+      $scope.$apply();
+
+      expect($scope.selectedTemplates.length).to.equal(1);
+      expect($scope.selectedTemplates[0].id).to.equal("id2");
+
+      //confirm PUD value is copied from the blueprint
+      expect($scope.selectedTemplates[0]["play-until-done"]).to.equal(true);
+
+      expect($loading.start).to.be.calledOnce;
+      expect($loading.stop).to.be.calledOnce;
+      done();
+    }, 10);
   });
 
   it("should remove templates from playlist", function() {


### PR DESCRIPTION
## Description
Implementation of the use case "As a User, when I schedule an HTML Template that contains one or more HTML Templates configured for Play Until Done, I can see that the duration of the scheduled playlist item is set to Play Until Done, so that I know my content will play all the way through before moving onto the next item"

## Motivation and Context
This is an Epic requirement.

## How Has This Been Tested?
Updated unit test and also manually verified that if a template is PUD then it is added to the schedule as PUD.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
