### PR TITLE
Show spinner while loading template names

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-playlist.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-playlist.tests.js
@@ -135,9 +135,12 @@ describe("directive: templateComponentPlaylist", function() {
       return sampleAttributeData[attributeName];
     };
 
+    $scope.selectedTemplates = sampleSelectedTemplates; //some garbage data from past session
+
     directive.show();
 
     expect($scope.componentId).to.equal("TEST-ID");
+    expect($scope.selectedTemplates).to.eql([]);
 
     setTimeout(function() {
 

--- a/web/partials/template-editor/components/component-playlist.html
+++ b/web/partials/template-editor/components/component-playlist.html
@@ -1,7 +1,8 @@
-<div class="rise-playlist-container">
+<div class="rise-playlist-container attribute-editor-component"
+rv-spinner rv-spinner-key="rise-playlist-templates-loader" rv-spinner-start-active="1">
 
   <!-- default view -->
-  <div ng-show="!view" class="attribute-editor-component">
+  <div ng-show="!view">
     <div class="templates-selector te-scrollable-container" ng-show="selectedTemplates.length">
       <div class="selected-templates-label">
         <label>Embedded Templates:</label>
@@ -45,8 +46,7 @@
   </div>
 
   <!-- "add-templates" view -->
-  <div class="attribute-editor-component" ng-show="view === 'add-templates'"
-  rv-spinner rv-spinner-key="rise-playlist-templates-loader" rv-spinner-start-active="1">
+  <div ng-show="view === 'add-templates'">
     <div class="templates-selector-search-label">
       <label>Choose A Template</label>
     </div>
@@ -100,7 +100,7 @@
   </div>
 
   <!-- "edit" view -->
-  <div class="attribute-editor-component" ng-show="view === 'edit'">
+  <div ng-show="view === 'edit'">
     <div class="form-group has-feedback">
 
       <div class="attribute-editor-row">

--- a/web/scripts/template-editor/components/directives/dtv-component-playlist.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-playlist.js
@@ -110,6 +110,8 @@ angular.module('risevision.template-editor.directives')
 
             var search = {filter: presentationIds.join(' OR ')};
 
+            $loading.start('rise-playlist-templates-loader');
+
             presentation.list(search)
             .then(function(res) {
               if (res.items) {
@@ -123,6 +125,10 @@ angular.module('risevision.template-editor.directives')
                 });
               }
               $scope.selectedTemplates = templates;
+              $loading.stop('rise-playlist-templates-loader');
+            })
+            .catch(function () {
+              $loading.stop('rise-playlist-templates-loader');
             });
           };
 

--- a/web/scripts/template-editor/components/directives/dtv-component-playlist.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-playlist.js
@@ -37,6 +37,7 @@ angular.module('risevision.template-editor.directives')
             element: element,
             show: function () {
               $scope.componentId = $scope.factory.selected.id;
+              $scope.selectedTemplates = [];
               _load();
             },
             onBackHandler: function () {


### PR DESCRIPTION
## Description
- Show spinner while loading template names
- Clear selected templates on directive open

## Motivation and Context
Just an enhancement to UX. Showing a spinner makes it clear for a user that they need to wait. Without a spinner user sees an empty list while selected templates are loading which could be confusing.

## How Has This Been Tested?
- Verified manually that spinner is shown. 
- Updated unit test to confirm that list of selected templates is cleared when directive opens.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
