### PR TITLE
Update staging preview links

### DIFF
--- a/test/e2e/editor/cases/shared-templates.js
+++ b/test/e2e/editor/cases/shared-templates.js
@@ -74,7 +74,7 @@ var SharedTemplatesScenarios = function() {
         oldWindowHandle = handles[0];
         newWindowHandle = handles[1];
         browser.switchTo().window(newWindowHandle).then(function () {
-          expect(browser.driver.getCurrentUrl()).to.eventually.contain('http://stage-test-dot-rvaviewer-test.appspot.com/?type=presentation&id=ebbb1b89-166e-41fb-9adb-d0052132b0df');
+          expect(browser.driver.getCurrentUrl()).to.eventually.contain('http://viewer-test.risevision.com/?type=presentation&id=ebbb1b89-166e-41fb-9adb-d0052132b0df');
 
           browser.driver.close();
           browser.switchTo().window(oldWindowHandle);

--- a/web/scripts/config/dev.js
+++ b/web/scripts/config/dev.js
@@ -29,7 +29,7 @@
       'https://store-dot-rvacore-test.appspot.com/_ah/api') // override default Store server value
     .value('STORE_SERVER_URL', 'https://store-dot-rvacore-test.appspot.com/')
     .value('RVA_URL', 'http://rva-test.appspot.com')
-    .value('VIEWER_URL', 'http://stage-test-dot-rvaviewer-test.appspot.com')
+    .value('VIEWER_URL', 'http://viewer-test.risevision.com')
     .value('ALERTS_WS_URL',
       'https://rvacore-test.appspot.com/alerts/cap')
     .value('TAG_MANAGER_CONTAINER_ID', null)

--- a/web/scripts/config/stage.js
+++ b/web/scripts/config/stage.js
@@ -28,7 +28,7 @@
       'https://store-dot-rvacore-test.appspot.com/_ah/api') // override default Store server value
     .value('STORE_SERVER_URL', 'https://store-dot-rvacore-test.appspot.com/')
     .value('RVA_URL', 'http://rva-test.appspot.com')
-    .value('VIEWER_URL', 'http://stage-test-dot-rvaviewer-test.appspot.com')
+    .value('VIEWER_URL', 'http://viewer-test.risevision.com')
     .value('ALERTS_WS_URL',
       'https://rvacore-test.appspot.com/alerts/cap')
     .value('TAG_MANAGER_CONTAINER_ID', 'GTM-MMTK3JH')

--- a/web/scripts/config/test.js
+++ b/web/scripts/config/test.js
@@ -29,7 +29,7 @@
       'https://store-dot-rvacore-test.appspot.com/_ah/api') // override default Store server value
     .value('STORE_SERVER_URL', 'https://store-dot-rvacore-test.appspot.com/')
     .value('RVA_URL', 'http://rva-test.appspot.com')
-    .value('VIEWER_URL', 'http://stage-test-dot-rvaviewer-test.appspot.com')
+    .value('VIEWER_URL', 'http://viewer-test.risevision.com')
     .value('ALERTS_WS_URL',
       'https://rvacore-test.appspot.com/alerts/cap')
     .value('TAG_MANAGER_CONTAINER_ID', null)


### PR DESCRIPTION
## Description
Update staging preview links

point to risevision.com domain

[stage-2]

## Motivation and Context
Current preview link is pointing to a very old version that is not being maintained.
viewer-test.risevision.com points to rvaviewer-test.appspot.com default version.
*.risevision.com domains are required for some functionality to work correctly.

## How Has This Been Tested?
Verified that Apps staging previews point to this version, both for Presentations and Schedules.

Config change only applies to staging/dev/test environments, not production.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
