### PR TITLE
Fix radio label font weight [stage-8]

### DIFF
--- a/web/scss/sections/components/playlist.scss
+++ b/web/scss/sections/components/playlist.scss
@@ -286,4 +286,10 @@
   }
 }
 
+  .madero-radio {
+    label {
+      font-weight: normal;
+    }
+  }
+
 }


### PR DESCRIPTION
## Description
Make the radio button labels in _edit_ view a normal font weight

## Motivation and Context
Fixing styling issues as per list on https://trello.com/c/Zv0YbfzF/7581-meet-ui-specs-3

## How Has This Been Tested?
Locally and on stage 8

https://apps-stage-8.risevision.com/templates/edit/c27830e2-b426-42fb-afcc-901de06c6955/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
