### PR TITLE
Split template-editor2.cases [stage-4]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,6 +279,12 @@ workflows:
           filters:
             branches:
               ignore: /(stage).*/
+      - e2e_template_editor3:
+          requires:
+            - test_build
+          filters:
+            branches:
+              ignore: /(stage).*/
       - test_e2e:
           requires:
             - e2e_schedules

--- a/test/e2e/apps.scenarios.js
+++ b/test/e2e/apps.scenarios.js
@@ -5,5 +5,6 @@ require('./storage/storage.cases.js');
 require('./common/common.cases.js');
 require('./template-editor/template-editor.cases');
 require('./template-editor/template-editor2.cases');
+require('./template-editor/template-editor3.cases');
 require('./common-header/common-header.cases');
 require('./registration/registration.cases');

--- a/test/e2e/template-editor/template-editor3.cases.js
+++ b/test/e2e/template-editor/template-editor3.cases.js
@@ -4,16 +4,12 @@
   var CommonHeaderPage = require('./../common-header/pages/commonHeaderPage.js');
   var PresentationListPage = require('./pages/presentationListPage.js');
 
-  var ImageComponentScenarios = require('./cases/components/image.js');
-  var SlidesComponentScenarios = require('./cases/components/slides.js');
-  var VideoComponentScenarios = require('./cases/components/video.js');
-  var RssComponentScenarios = require('./cases/components/rss.js');
-  var CounterComponentScenarios = require('./cases/components/counter.js');
-  var TimeDateComponentScenarios = require('./cases/components/time-date.js');
+  var PlaylistComponentScenarios = require('./cases/components/playlist.js');
+  var TwitterComponentScenarios = require('./cases/components/twitter.js');
 
-  describe('Template Editor 2', function() {
+  describe('Template Editor 3', function() {
 
-    var subCompanyName = 'E2E TEST SUBCOMPANY - TEMPLATE EDITOR 2';
+    var subCompanyName = 'E2E TEST SUBCOMPANY - TEMPLATE EDITOR 3';
     var commonHeaderPage;
     var presentationsListPage;
 
@@ -32,12 +28,8 @@
       commonHeaderPage.selectSubCompany(subCompanyName);
     });
 
-    var imageComponentScenarios = new ImageComponentScenarios();
-    var slidesComponentScenarios = new SlidesComponentScenarios();
-    var videoComponentScenarios = new VideoComponentScenarios();
-    var rssComponentScenarios = new RssComponentScenarios();
-    var counterComponentScenarios = new CounterComponentScenarios();
-    var timeDateComponentScenarios = new TimeDateComponentScenarios();
+    var playlistComponentScenarios = new PlaylistComponentScenarios();
+    var twitterComponentScenarios = new TwitterComponentScenarios();
 
     after(function() {
       // Loading the Presentation List is a workaround to a Chrome Driver issue that has it fail to click on elements over the Preview iframe


### PR DESCRIPTION
## Description
`template-editor2.cases` is getting too big and it's taking too long to build on CCI. It's time to split it. Before this change the build time was ~9 min. After the this change the build time for `template-editor2.cases` is ~6 min.

## Motivation and Context
Splitting `template-editor2.cases` should speed up the Apps build. The less tests we have in one group, the less chances for this group to fail which in turns improves build reliability.

## How Has This Been Tested?
Checked the build times in CCI.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
