### PR TITLE
Indicate in UI of embedded template item when it is not available

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-playlist.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-playlist.tests.js
@@ -37,18 +37,6 @@ describe("directive: templateComponentPlaylist", function() {
           },
           "play-until-done": true,
           "transition-type": "fadeIn"
-        },
-        {
-          "duration": 10,
-          "element": {
-            "attributes": {
-              "presentation-id": "presentation-id-2",
-              "template-id": "template-id-2"
-            },
-            "tagName": "rise-embedded-template"
-          },
-          "play-until-done": true,
-          "transition-type": "fadeIn"
         }
       ]
     };
@@ -59,12 +47,6 @@ describe("directive: templateComponentPlaylist", function() {
       "transition-type": "fadeIn",
       "id": "presentation-id-1",
       "productCode": "template-id-1"
-    },{
-      "duration": 20,
-      "play-until-done": true,
-      "transition-type": "fadeIn",
-      "id": "presentation-id-2",
-      "productCode": "template-id-2"
     }];
 
     sampleTemplatesFactory = {
@@ -177,13 +159,36 @@ describe("directive: templateComponentPlaylist", function() {
   });
 
   it("should indicate any templates that are now 'Unknown' from being deleted", function() {
-    var directive = $scope.registerDirective.getCall(0).args[0];
+    var directive = $scope.registerDirective.getCall(0).args[0],
+      copySampleAttributeData = JSON.parse(JSON.stringify(sampleAttributeData)),
+      copySelectedTemplates = sampleSelectedTemplates.slice();
+
+    copySampleAttributeData.items.push({
+      "duration": 10,
+      "element": {
+        "attributes": {
+          "presentation-id": "presentation-id-2",
+          "template-id": "template-id-2"
+        },
+        "tagName": "rise-embedded-template"
+      },
+      "play-until-done": true,
+      "transition-type": "fadeIn"
+    });
+
+    copySelectedTemplates.push({
+      "duration": 20,
+      "play-until-done": true,
+      "transition-type": "fadeIn",
+      "id": "presentation-id-2",
+      "productCode": "template-id-2"
+    });
 
     $scope.getAvailableAttributeData = function(componentId, attributeName) {
-      return sampleAttributeData[attributeName];
+      return copySampleAttributeData[attributeName];
     };
 
-    $scope.selectedTemplates = sampleSelectedTemplates;
+    $scope.selectedTemplates = copySelectedTemplates;
 
     directive.show();
 

--- a/test/unit/template-editor/components/directives/dtv-component-playlist.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-playlist.tests.js
@@ -158,6 +158,27 @@ describe("directive: templateComponentPlaylist", function() {
 
   });
 
+  it("should indicate in UI any items that are unknown", function() {
+    var directive = $scope.registerDirective.getCall(0).args[0];
+
+    $scope.getAvailableAttributeData = function(componentId, attributeName) {
+      return [];
+    };
+
+    $scope.selectedTemplates = sampleSelectedTemplates; //some garbage data from past session
+
+    directive.show();
+
+    setTimeout(function() {
+
+      expect($scope.selectedTemplates[0]["name"]).to.equal("Unknown");
+      expect($scope.selectedTemplates[0]["revisionStatusName"]).to.equal("Template not found.");
+      expect($scope.selectedTemplates[0]["removed"]).to.be.true;
+
+      done();
+    }, 10);
+  });
+
   it("should save items to attribute data", function() {
     $scope.componentId = "TEST-ID";
     sandbox.stub($scope, "selectedTemplatesToJson").callsFake(function(){ return "fake data"; });

--- a/test/unit/template-editor/components/directives/dtv-component-playlist.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-playlist.tests.js
@@ -13,8 +13,8 @@ describe("directive: templateComponentPlaylist", function() {
 
   //add polyfill for Number.isInteger if phantomjs does not have it
   Number.isInteger = Number.isInteger || function(value) {
-    return typeof value === "number" && 
-      isFinite(value) && 
+    return typeof value === "number" &&
+      isFinite(value) &&
       Math.floor(value) === value;
   };
 
@@ -37,16 +37,34 @@ describe("directive: templateComponentPlaylist", function() {
           },
           "play-until-done": true,
           "transition-type": "fadeIn"
+        },
+        {
+          "duration": 10,
+          "element": {
+            "attributes": {
+              "presentation-id": "presentation-id-2",
+              "template-id": "template-id-2"
+            },
+            "tagName": "rise-embedded-template"
+          },
+          "play-until-done": true,
+          "transition-type": "fadeIn"
         }
       ]
     };
 
     sampleSelectedTemplates = [{
-      "duration": 20, 
-      "play-until-done": true, 
+      "duration": 20,
+      "play-until-done": true,
       "transition-type": "fadeIn",
-      "id": "presentation-id-1", 
+      "id": "presentation-id-1",
       "productCode": "template-id-1"
+    },{
+      "duration": 20,
+      "play-until-done": true,
+      "transition-type": "fadeIn",
+      "id": "presentation-id-2",
+      "productCode": "template-id-2"
     }];
 
     sampleTemplatesFactory = {
@@ -56,7 +74,7 @@ describe("directive: templateComponentPlaylist", function() {
           {id: "id2"}
         ]
       }
-    };;
+    };
   });
 
   beforeEach(module("risevision.template-editor.directives"));
@@ -158,22 +176,23 @@ describe("directive: templateComponentPlaylist", function() {
 
   });
 
-  it("should indicate in UI any items that are unknown", function() {
+  it("should indicate any templates that are now 'Unknown' from being deleted", function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
 
     $scope.getAvailableAttributeData = function(componentId, attributeName) {
-      return [];
+      return sampleAttributeData[attributeName];
     };
 
-    $scope.selectedTemplates = sampleSelectedTemplates; //some garbage data from past session
+    $scope.selectedTemplates = sampleSelectedTemplates;
 
     directive.show();
 
     setTimeout(function() {
-
-      expect($scope.selectedTemplates[0]["name"]).to.equal("Unknown");
-      expect($scope.selectedTemplates[0]["revisionStatusName"]).to.equal("Template not found.");
-      expect($scope.selectedTemplates[0]["removed"]).to.be.true;
+      expect($scope.selectedTemplates[1]["id"]).to.equal("presentation-id-2");
+      expect($scope.selectedTemplates[1]["productCode"]).to.equal("template-id-2");
+      expect($scope.selectedTemplates[1]["name"]).to.equal("Unknown");
+      expect($scope.selectedTemplates[1]["revisionStatusName"]).to.equal("Template not found.");
+      expect($scope.selectedTemplates[1]["removed"]).to.be.true;
 
       done();
     }, 10);
@@ -276,7 +295,7 @@ describe("directive: templateComponentPlaylist", function() {
   it("should search templates when user presses enter", function() {
     sandbox.stub($scope, "searchTemplates");
 
-    $scope.searchKeyPressed({which: 13}); 
+    $scope.searchKeyPressed({which: 13});
 
     expect($scope.searchTemplates).to.be.calledOnce;
   });
@@ -366,7 +385,7 @@ describe("directive: templateComponentPlaylist", function() {
 
   it("should edit properties of a playlist item", function() {
     $scope.selectedTemplates = sampleSelectedTemplates;
-    
+
     $scope.editProperties(0);
 
     expect($scope.selectedItem["key"]).to.equal(0);
@@ -383,7 +402,7 @@ describe("directive: templateComponentPlaylist", function() {
       "play-until-done": false,
       "transition-type": "some-transition"
     };
-    
+
     sandbox.stub($scope, "save");
 
     $scope.saveProperties();

--- a/test/unit/template-editor/components/directives/dtv-component-playlist.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-playlist.tests.js
@@ -158,11 +158,11 @@ describe("directive: templateComponentPlaylist", function() {
 
   });
 
-  it("should indicate any templates that are now 'Unknown' from being deleted", function() {
+  it("should indicate any templates that are now 'Unknown' from being deleted", function(done) {
     var directive = $scope.registerDirective.getCall(0).args[0],
-      copySampleAttributeData = JSON.parse(JSON.stringify(sampleAttributeData)),
-      copySelectedTemplates = sampleSelectedTemplates.slice();
+        copySampleAttributeData = angular.copy(sampleAttributeData);
 
+    // add deleted item
     copySampleAttributeData.items.push({
       "duration": 10,
       "element": {
@@ -176,19 +176,9 @@ describe("directive: templateComponentPlaylist", function() {
       "transition-type": "fadeIn"
     });
 
-    copySelectedTemplates.push({
-      "duration": 20,
-      "play-until-done": true,
-      "transition-type": "fadeIn",
-      "id": "presentation-id-2",
-      "productCode": "template-id-2"
-    });
-
     $scope.getAvailableAttributeData = function(componentId, attributeName) {
       return copySampleAttributeData[attributeName];
     };
-
-    $scope.selectedTemplates = copySelectedTemplates;
 
     directive.show();
 

--- a/web/partials/template-editor/components/component-playlist.html
+++ b/web/partials/template-editor/components/component-playlist.html
@@ -16,13 +16,13 @@ rv-spinner rv-spinner-key="rise-playlist-templates-loader">
           <div class="col-xs-10 pl-0 pr-0">
             <span class="playlist-item-name">
               <div class="templates-name">{{ value.name }}</div>
-              <div class="templates-status templates-status-inline" ng-class="{'templates-status-revised' : value.revisionStatusName === 'Revised'}">{{ value.revisionStatusName }}</div>
-              <div class="templates-status templates-status-inline" > • {{ durationToText(value) }}</div>
+              <div class="templates-status templates-status-inline" ng-class="{'templates-status-revised' : value.revisionStatusName === 'Revised' || value.removed}">{{ value.revisionStatusName }}</div>
+              <div class="templates-status templates-status-inline" ng-hide="value.removed"> • {{ durationToText(value) }}</div>
             </span>
           </div>
           <div class="col-xs-2 pr-0 playlist-item-actions">
             <a href="#"
-               ng-click="editProperties(key)">
+               ng-click="editProperties(key)" ng-hide="value.removed">
                <streamline-icon class="u_margin-left streamline-component-icon" name="edit" width="16" height="16"></streamline-icon>
             </a>
             <a href="#"

--- a/web/scripts/template-editor/components/directives/dtv-component-playlist.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-playlist.js
@@ -117,12 +117,22 @@ angular.module('risevision.template-editor.directives')
             .then(function(res) {
               if (res.items) {
                 _.forEach(templates, function (template) {
+                  var found = false;
+
                   _.forEach(res.items, function (item) {
                     if (template.id === item.id) {
+                      found = true;
                       template.name = item.name;
                       template.revisionStatusName = item.revisionStatusName;
+                      template.removed = false;
                     }
                   });
+
+                  if (!found) {
+                    template.name = "Unknown";
+                    template.revisionStatusName = "Template not found.";
+                    template.removed = true;
+                  }
                 });
               }
               $scope.selectedTemplates = templates;
@@ -136,7 +146,7 @@ angular.module('risevision.template-editor.directives')
           $scope.searchTemplates = function () {
 
             $scope.templatesSearch.filter = presentation.buildFilterString($scope.searchKeyword, FILTER_HTML_TEMPLATES);
- 
+
             //exclude a template that is being edited
             $scope.templatesSearch.filter += ' AND NOT id:' + $scope.factory.presentation.id;
 
@@ -163,7 +173,7 @@ angular.module('risevision.template-editor.directives')
 
             $scope.templatesFactory = new ScrollingListService(presentation.list, $scope.templatesSearch);
 
-            $scope.$watch('templatesFactory.loadingItems', 
+            $scope.$watch('templatesFactory.loadingItems',
             function (loading) {
               if (loading) {
                 $loading.start('rise-playlist-templates-loader');

--- a/web/scripts/template-editor/components/directives/dtv-component-playlist.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-playlist.js
@@ -3,7 +3,7 @@
 angular.module('risevision.template-editor.directives')
   .constant('FILTER_HTML_TEMPLATES', 'presentationType:"HTML Template"')
   .directive('templateComponentPlaylist', ['templateEditorFactory', 'presentation', '$loading',
-  '$q', 'FILTER_HTML_TEMPLATES', 'ScrollingListService', 'editorFactory', 'blueprintFactory',
+    '$q', 'FILTER_HTML_TEMPLATES', 'ScrollingListService', 'editorFactory', 'blueprintFactory',
     function (templateEditorFactory, presentation, $loading,
       $q, FILTER_HTML_TEMPLATES, ScrollingListService, editorFactory, blueprintFactory) {
       return {
@@ -57,8 +57,10 @@ angular.module('risevision.template-editor.directives')
                   'duration': item.duration,
                   'play-until-done': item['play-until-done'],
                   'transition-type': item['transition-type'],
-                  'id': item.element && item.element.attributes ? item.element.attributes['presentation-id'] : undefined,
-                  'productCode': item.element && item.element.attributes ? item.element.attributes['template-id'] : undefined
+                  'id': item.element && item.element.attributes ? item.element.attributes['presentation-id'] :
+                    undefined,
+                  'productCode': item.element && item.element.attributes ? item.element.attributes[
+                    'template-id'] : undefined
                 };
               });
             }
@@ -109,43 +111,46 @@ angular.module('risevision.template-editor.directives')
               return 'id:' + item.id;
             });
 
-            var search = {filter: presentationIds.join(' OR ')};
+            var search = {
+              filter: presentationIds.join(' OR ')
+            };
 
             $loading.start('rise-playlist-templates-loader');
 
             presentation.list(search)
-            .then(function(res) {
-              if (res.items) {
-                _.forEach(templates, function (template) {
-                  var found = false;
+              .then(function (res) {
+                if (res.items) {
+                  _.forEach(templates, function (template) {
+                    var found = false;
 
-                  _.forEach(res.items, function (item) {
-                    if (template.id === item.id) {
-                      found = true;
-                      template.name = item.name;
-                      template.revisionStatusName = item.revisionStatusName;
-                      template.removed = false;
+                    _.forEach(res.items, function (item) {
+                      if (template.id === item.id) {
+                        found = true;
+                        template.name = item.name;
+                        template.revisionStatusName = item.revisionStatusName;
+                        template.removed = false;
+                      }
+                    });
+
+                    if (!found) {
+                      template.name = 'Unknown';
+                      template.revisionStatusName = 'Template not found.';
+                      template.removed = true;
                     }
                   });
-
-                  if (!found) {
-                    template.name = "Unknown";
-                    template.revisionStatusName = "Template not found.";
-                    template.removed = true;
-                  }
-                });
-              }
-              $scope.selectedTemplates = templates;
-              $loading.stop('rise-playlist-templates-loader');
-            })
-            .catch(function () {
-              $loading.stop('rise-playlist-templates-loader');
-            });
+                }
+                $scope.selectedTemplates = templates;
+                $loading.stop('rise-playlist-templates-loader');
+              })
+              .catch(function () {
+                $loading.stop('rise-playlist-templates-loader');
+              });
           };
 
           $scope.searchTemplates = function () {
 
-            $scope.templatesSearch.filter = presentation.buildFilterString($scope.searchKeyword, FILTER_HTML_TEMPLATES);
+            $scope.templatesSearch.filter = presentation.buildFilterString($scope.searchKeyword,
+              FILTER_HTML_TEMPLATES);
 
             //exclude a template that is being edited
             $scope.templatesSearch.filter += ' AND NOT id:' + $scope.factory.presentation.id;
@@ -174,17 +179,18 @@ angular.module('risevision.template-editor.directives')
             $scope.templatesFactory = new ScrollingListService(presentation.list, $scope.templatesSearch);
 
             $scope.$watch('templatesFactory.loadingItems',
-            function (loading) {
-              if (loading) {
-                $loading.start('rise-playlist-templates-loader');
-              } else {
-                $loading.stop('rise-playlist-templates-loader');
-              }
-            });
+              function (loading) {
+                if (loading) {
+                  $loading.start('rise-playlist-templates-loader');
+                } else {
+                  $loading.stop('rise-playlist-templates-loader');
+                }
+              });
           };
 
           $scope.selectTemplate = function (key) {
-            $scope.templatesFactory.items.list[key].isSelected = !$scope.templatesFactory.items.list[key].isSelected;
+            $scope.templatesFactory.items.list[key].isSelected = !$scope.templatesFactory.items.list[key]
+              .isSelected;
             $scope.canAddTemplates = _.some($scope.templatesFactory.items.list, function (item) {
               return item.isSelected;
             });
@@ -205,22 +211,22 @@ angular.module('risevision.template-editor.directives')
             $loading.start('rise-playlist-templates-loader');
 
             $q.all(promises)
-            .then(function (playUntilDoneValues) {
+              .then(function (playUntilDoneValues) {
 
-              for (var i = 0; i < playUntilDoneValues.length; i++) {
-                itemsToAdd[i]['play-until-done'] = playUntilDoneValues[i];
-              }
+                for (var i = 0; i < playUntilDoneValues.length; i++) {
+                  itemsToAdd[i]['play-until-done'] = playUntilDoneValues[i];
+                }
 
-              $scope.selectedTemplates = $scope.selectedTemplates.concat(itemsToAdd);
-              $scope.save();
+                $scope.selectedTemplates = $scope.selectedTemplates.concat(itemsToAdd);
+                $scope.save();
 
-              $loading.stop('rise-playlist-templates-loader');
+                $loading.stop('rise-playlist-templates-loader');
 
-              $scope.showSelectedTemplates();
+                $scope.showSelectedTemplates();
               })
-            .catch(function (e) {
-              $loading.stop('rise-playlist-templates-loader');
-            });
+              .catch(function (e) {
+                $loading.stop('rise-playlist-templates-loader');
+              });
           };
 
           $scope.removeTemplate = function (key) {
@@ -248,9 +254,11 @@ angular.module('risevision.template-editor.directives')
             $scope.selectedItem.key = key;
 
             //set default values
-            $scope.selectedItem.duration = Number.isInteger($scope.selectedItem.duration) ? $scope.selectedItem.duration : 10;
+            $scope.selectedItem.duration = Number.isInteger($scope.selectedItem.duration) ? $scope.selectedItem
+              .duration : 10;
             $scope.selectedItem['play-until-done'] = $scope.selectedItem['play-until-done'] ? 'true' : 'false';
-            $scope.selectedItem['transition-type'] = $scope.selectedItem['transition-type'] ? $scope.selectedItem['transition-type'] : 'normal';
+            $scope.selectedItem['transition-type'] = $scope.selectedItem['transition-type'] ? $scope.selectedItem[
+              'transition-type'] : 'normal';
 
             $scope.showProperties();
           };


### PR DESCRIPTION
## Description
Indicate in the UI of a selected embedded template item that the item is _Unknown_ when it has been deleted from the users presentations. 

## Motivation and Context
Provide the user a visual indication that a template(s) in their selected embedded templates list is not available due to being deleted (or for some other reason).

## How Has This Been Tested?
Tested locally and and on stage-8 with this presentation:

https://apps-stage-8.risevision.com/templates/edit/c27830e2-b426-42fb-afcc-901de06c6955/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
