### PR TITLE
Account for deleting last template in company and it was embedded

### DIFF
--- a/web/scripts/template-editor/components/directives/dtv-component-playlist.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-playlist.js
@@ -25,6 +25,12 @@ angular.module('risevision.template-editor.directives')
             $scope.loadTemplateNames(itemsArray);
           }
 
+          function _configureUnknown(template) {
+            template.name = 'Unknown';
+            template.revisionStatusName = 'Template not found.';
+            template.removed = true;
+          }
+
           $scope.save = function () {
             var itemsJson = $scope.selectedTemplatesToJson();
             $scope.setAttributeData($scope.componentId, 'items', itemsJson);
@@ -133,10 +139,12 @@ angular.module('risevision.template-editor.directives')
                     });
 
                     if (!found) {
-                      template.name = 'Unknown';
-                      template.revisionStatusName = 'Template not found.';
-                      template.removed = true;
+                      _configureUnknown(template);
                     }
+                  });
+                } else {
+                  _.forEach(templates, function (template) {
+                    _configureUnknown(template);
                   });
                 }
                 $scope.selectedTemplates = templates;

--- a/web/scripts/template-editor/components/directives/dtv-component-playlist.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-playlist.js
@@ -25,12 +25,6 @@ angular.module('risevision.template-editor.directives')
             $scope.loadTemplateNames(itemsArray);
           }
 
-          function _configureUnknown(template) {
-            template.name = 'Unknown';
-            template.revisionStatusName = 'Template not found.';
-            template.removed = true;
-          }
-
           $scope.save = function () {
             var itemsJson = $scope.selectedTemplatesToJson();
             $scope.setAttributeData($scope.componentId, 'items', itemsJson);
@@ -125,10 +119,10 @@ angular.module('risevision.template-editor.directives')
 
             presentation.list(search)
               .then(function (res) {
-                if (res.items) {
-                  _.forEach(templates, function (template) {
-                    var found = false;
+                _.forEach(templates, function (template) {
+                  var found = false;
 
+                  if (res.items) {
                     _.forEach(res.items, function (item) {
                       if (template.id === item.id) {
                         found = true;
@@ -137,16 +131,14 @@ angular.module('risevision.template-editor.directives')
                         template.removed = false;
                       }
                     });
+                  }
 
-                    if (!found) {
-                      _configureUnknown(template);
-                    }
-                  });
-                } else {
-                  _.forEach(templates, function (template) {
-                    _configureUnknown(template);
-                  });
-                }
+                  if (!found) {
+                    template.name = 'Unknown';
+                    template.revisionStatusName = 'Template not found.';
+                    template.removed = true;
+                  }
+                });
                 $scope.selectedTemplates = templates;
                 $loading.stop('rise-playlist-templates-loader');
               })


### PR DESCRIPTION
## Description
Ensure to account for rare use case of user removing all their presentations in company and one or more were selected in embedded template component instance. 

## Motivation and Context
UI was not properly configured for the embedded template item in this specific scenario

## How Has This Been Tested?
Validated with deleting the only presentation in company that was used in embedded templates
https://apps-stage-8.risevision.com/templates/edit/a5f2c169-7915-4635-9622-1c64c6079a8a/?cid=dd474bee-b237-46e3-aa20-98e975679773

Re-validated when there are multiple templates still left to choose from
https://apps-stage-8.risevision.com/templates/edit/c27830e2-b426-42fb-afcc-901de06c6955/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
