### PR TITLE
Use blueprintFactory in readonly mode

### DIFF
--- a/test/unit/template-editor/services/svc-blueprint-factory.tests.js
+++ b/test/unit/template-editor/services/svc-blueprint-factory.tests.js
@@ -117,46 +117,32 @@ describe('service: blueprint factory', function() {
   });
 
   describe('isPlayUntilDone: ', function() {
-    beforeEach(function() {
-      sinon.stub(blueprintFactory, 'getBlueprintCached').returns(Q.resolve());
-    });
 
     it('should return a promise',function() {
+      sinon.stub(blueprintFactory, 'getBlueprintCached').returns(Q.resolve());
       expect(blueprintFactory.isPlayUntilDone('productCode').then).to.be.a('function');
 
-      blueprintFactory.getBlueprintCached.should.have.been.calledWith('productCode');
+      blueprintFactory.getBlueprintCached.should.have.been.calledWith('productCode', true);
     });
 
     it('should return false if blueprintData is not populated',function() {
+      sinon.stub(blueprintFactory, 'getBlueprintCached').returns(Q.resolve());
+
       return blueprintFactory.isPlayUntilDone().then(function(result) {
         expect(result).to.be.false;
       });
     });
 
-    it('should return true if blueprintData.playUntilDone is true',function() {
-      blueprintFactory.blueprintData = {
-        playUntilDone: true
-      };
+    it('should return true if blueprintData exists and playUntilDone is true',function() {
+      sinon.stub(blueprintFactory, 'getBlueprintCached').returns(Q.resolve({playUntilDone: true}));
 
       return blueprintFactory.isPlayUntilDone().then(function(result) {
         expect(result).to.be.true;
       });
     });
 
-    it('should return true if blueprintData.playUntilDone exists',function() {
-      blueprintFactory.blueprintData = {
-        playUntilDone: "something"
-      };
-
-      return blueprintFactory.isPlayUntilDone().then(function(result) {
-        expect(result).to.be.true;
-      });
-    });
-
-    it('should return false otherwise',function() {
-      blueprintFactory.blueprintData = {
-        playUntilDone: false
-      };
+    it('should return true if blueprintData exists and playUntilDone is not true',function() {
+      sinon.stub(blueprintFactory, 'getBlueprintCached').returns(Q.resolve({}));
 
       return blueprintFactory.isPlayUntilDone().then(function(result) {
         expect(result).to.be.false;

--- a/web/scripts/template-editor/services/svc-blueprint-factory.js
+++ b/web/scripts/template-editor/services/svc-blueprint-factory.js
@@ -8,19 +8,21 @@ angular.module('risevision.template-editor.services')
       var _blueprints = {};
       factory.loadingBlueprint = false;
 
-      factory.getBlueprintCached = function (productCode) {
+      factory.getBlueprintCached = function (productCode, readOnly) {
         var blueprint = _blueprints[productCode];
 
         if (blueprint) {
-          factory.blueprintData = blueprint;
+          if (!readOnly) {
+            factory.blueprintData = blueprint;
+          }
 
           return $q.resolve(blueprint);
         } else {
-          return _getBlueprint(productCode);
+          return _getBlueprint(productCode, readOnly);
         }
       };
 
-      var _getBlueprint = function (productCode) {
+      var _getBlueprint = function (productCode, readOnly) {
         var url = BLUEPRINT_URL.replace('PRODUCT_CODE', productCode);
 
         //show loading spinner
@@ -28,11 +30,13 @@ angular.module('risevision.template-editor.services')
 
         return $http.get(url)
           .then(function (response) {
-            factory.blueprintData = response.data;
+            if (!readOnly) {
+              factory.blueprintData = response.data;
+            }
 
-            _blueprints[productCode] = factory.blueprintData;
+            _blueprints[productCode] = response.data;
 
-            return factory.blueprintData;
+            return response.data;
           })
           .finally(function () {
             factory.loadingBlueprint = false;
@@ -40,9 +44,9 @@ angular.module('risevision.template-editor.services')
       };
 
       factory.isPlayUntilDone = function (productCode) {
-        return factory.getBlueprintCached(productCode)
-          .then(function () {
-            return !!(factory.blueprintData && factory.blueprintData.playUntilDone);
+        return factory.getBlueprintCached(productCode, true)
+          .then(function (result) {
+            return !!(result && result.playUntilDone);
           });
       };
 


### PR DESCRIPTION
## Description
This PR fixes the issue of Template Editor resizing when portrait template is added to the Playlist component. 

Changes: 
- Added `readOnly` parameter to some methods of the `blueprintFactory`. That allows the Playlist Component to call `blueprintFactory.isPlayUntilDone()` without changing value of the `blueprintFactory.blueprintData` field.

## Motivation and Context
[Trello card](https://trello.com/c/EbvDBO4j/7599-investigate-resizing-issue-when-mixing-landscape-and-portrait-templates-2).

The Playlist Component calls `blueprintFactory.isPlayUntilDone()` method and unintentionally resets the public property `blueprintFactory.blueprintData`. It breaks the functionality of the Template Editor that expects the `blueprintFactory.blueprintData` to not change as long as Template Editor stays open.

## How Has This Been Tested?

- Unit tests are updated. 
- Confirmed on stage-4 that adding landscape and portrait templates to the component does not affect the size of the preview window in Template Editor.
- Confirmed on stage-4 that adding templates (both PUD and non-PUD) to a Schedule works as expected.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
