### PR TITLE
Prepare for upcoming changes on how logo is provided to Rise Image

### DIFF
--- a/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
+++ b/test/unit/template-editor/directives/dtv-editor-preview-holder.tests.js
@@ -56,6 +56,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
         brandingSettings: {
           baseColor: 'baseColor',
           accentColor: 'accentColor',
+          logoFile: 'logoFile',
           logoFileMetadata: 'logoMetadata'
         }
       };
@@ -112,7 +113,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
 
       setTimeout(function(){
         iframe.contentWindow.postMessage.should.have.been.called;
-        expect(iframe.contentWindow.postMessage.getCall(0).args).to.deep.equal(['{"type":"displayData","value":{"displayAddress":{},"companyBranding":{"baseColor":"baseColor","accentColor":"accentColor"}}}', 'https://widgets.risevision.com']);
+        expect(iframe.contentWindow.postMessage.getCall(0).args).to.deep.equal(['{"type":"displayData","value":{"displayAddress":{},"companyBranding":{"logoFile":"logoFile","baseColor":"baseColor","accentColor":"accentColor"}}}', 'https://widgets.risevision.com']);
 
         done();
       },10);
@@ -127,7 +128,7 @@ describe('directive: TemplateEditorPreviewHolder', function() {
 
       setTimeout(function(){
         iframe.contentWindow.postMessage.should.have.been.called;
-        expect(iframe.contentWindow.postMessage.getCall(0).args).to.deep.equal(['{"type":"displayData","value":{"displayAddress":{},"companyBranding":{"baseColor":"baseColor","accentColor":"accentColor"}}}', 'https://widgets.risevision.com']);
+        expect(iframe.contentWindow.postMessage.getCall(0).args).to.deep.equal(['{"type":"displayData","value":{"displayAddress":{},"companyBranding":{"logoFile":"logoFile","baseColor":"baseColor","accentColor":"accentColor"}}}', 'https://widgets.risevision.com']);
 
         done();
       },10);
@@ -143,7 +144,22 @@ describe('directive: TemplateEditorPreviewHolder', function() {
 
       setTimeout(function(){
         iframe.contentWindow.postMessage.should.have.been.called;
-        expect(iframe.contentWindow.postMessage.getCall(0).args).to.deep.equal(['{"type":"displayData","value":{"displayAddress":{},"companyBranding":{"baseColor":"newBaseColor","accentColor":"newAccentColor"}}}', 'https://widgets.risevision.com']);
+        expect(iframe.contentWindow.postMessage.getCall(0).args).to.deep.equal(['{"type":"displayData","value":{"displayAddress":{},"companyBranding":{"logoFile":"logoFile","baseColor":"newBaseColor","accentColor":"newAccentColor"}}}', 'https://widgets.risevision.com']);
+
+        done();
+      },10);
+    });
+
+    it('posts display data when logo has changed', function(done) {
+      iframe.onload();
+      iframe.contentWindow.postMessage.reset();
+      brandingFactory.brandingSettings.logoFile = "newLogoFile";
+      $scope.$digest();
+      $timeout.flush();
+
+      setTimeout(function(){
+        iframe.contentWindow.postMessage.should.have.been.called;
+        expect(iframe.contentWindow.postMessage.getCall(0).args).to.deep.equal(['{"type":"displayData","value":{"displayAddress":{},"companyBranding":{"logoFile":"newLogoFile","baseColor":"baseColor","accentColor":"accentColor"}}}', 'https://widgets.risevision.com']);
 
         done();
       },10);
@@ -274,12 +290,12 @@ describe('directive: TemplateEditorPreviewHolder', function() {
 
       iframe.onload();
 
-      //send attributes data
-      expect(iframe.contentWindow.postMessage.getCall(0).args).to.deep.equal([ '{"type":"attributeData","value":{"components":[{"id":"image","metadata":"originalMetadata1"},{"id":"logo","metadata":"logoMetadata"}]}}', 'https://widgets.risevision.com' ]);
-      //send start event
-      expect(iframe.contentWindow.postMessage.getCall(1).args).to.deep.equal([ '{"type":"sendStartEvent"}', 'https://widgets.risevision.com' ]);
       //send display data
-      expect(iframe.contentWindow.postMessage.getCall(2).args).to.deep.equal([ '{"type":"displayData","value":{"displayAddress":{},"companyBranding":{"baseColor":"baseColor","accentColor":"accentColor"}}}', 'https://widgets.risevision.com' ]);
+      expect(iframe.contentWindow.postMessage.getCall(0).args).to.deep.equal([ '{"type":"displayData","value":{"displayAddress":{},"companyBranding":{"logoFile":"logoFile","baseColor":"baseColor","accentColor":"accentColor"}}}', 'https://widgets.risevision.com' ]);
+      //send attributes data
+      expect(iframe.contentWindow.postMessage.getCall(1).args).to.deep.equal([ '{"type":"attributeData","value":{"components":[{"id":"image","metadata":"originalMetadata1"},{"id":"logo","metadata":"logoMetadata"}]}}', 'https://widgets.risevision.com' ]);
+      //send start event
+      expect(iframe.contentWindow.postMessage.getCall(2).args).to.deep.equal([ '{"type":"sendStartEvent"}', 'https://widgets.risevision.com' ]);      
     });
   });
 

--- a/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
+++ b/web/scripts/template-editor/directives/dtv-editor-preview-holder.js
@@ -30,11 +30,12 @@ angular.module('risevision.template-editor.directives')
           iframe.onload = function () {
             iframeLoaded = true;
 
+            _postDisplayData();
+
             _postAttributeData();
 
             _postStartEvent();
 
-            _postDisplayData();
           };
 
           $scope.getEditorPreviewUrl = function (productCode) {
@@ -181,6 +182,7 @@ angular.module('risevision.template-editor.directives')
           }, true);
 
           $scope.$watchGroup([
+            'brandingFactory.brandingSettings.logoFile',
             'brandingFactory.brandingSettings.baseColor',
             'brandingFactory.brandingSettings.accentColor'
           ], function () {
@@ -250,6 +252,7 @@ angular.module('risevision.template-editor.directives')
                   postalCode: company.postalCode
                 },
                 companyBranding: {
+                  logoFile: brandingFactory.brandingSettings.logoFile,
                   baseColor: brandingFactory.brandingSettings.baseColor,
                   accentColor: brandingFactory.brandingSettings.accentColor
                 }


### PR DESCRIPTION
## Description
Prepare for upcoming changes on how logo is provided to Rise Image.
Apps will provide logo both as attributes data and as displays data.
Current rise-image receives it as attributes data and updated version will be able to handle it only as displayData.

## Motivation and Context
Shared Schedules epic.

## How Has This Been Tested?
Tested on stage-1 with both rise-image versions (Charles proxy), replacing and removing logo files.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
