### PR TITLE
Hide PUD option if it’s not supported by a template [stage-4]

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-playlist.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-playlist.tests.js
@@ -7,6 +7,7 @@ describe("directive: templateComponentPlaylist", function() {
       element,
       factory,
       editorFactory,
+      blueprintFactory,
       sampleAttributeData,
       sampleSelectedTemplates,
       sampleTemplatesFactory;
@@ -105,6 +106,7 @@ describe("directive: templateComponentPlaylist", function() {
     $scope = $rootScope.$new();
     $loading = $injector.get('$loading');
     editorFactory = $injector.get('editorFactory');
+    blueprintFactory = $injector.get('blueprintFactory');
 
     $scope.registerDirective = sinon.stub();
     $scope.setAttributeData = sinon.stub();
@@ -378,15 +380,40 @@ describe("directive: templateComponentPlaylist", function() {
     expect($scope.durationToText(item)).to.equal("12345 seconds");
   });
 
-  it("should edit properties of a playlist item", function() {
+  it("should edit properties of a playlist item", function(done) {
     $scope.selectedTemplates = sampleSelectedTemplates;
 
     $scope.editProperties(0);
 
-    expect($scope.selectedItem["key"]).to.equal(0);
-    expect($scope.selectedItem["play-until-done"]).to.equal("true");
-    expect($scope.selectedItem["duration"]).to.equal(20);
-    expect($scope.selectedItem["transition-type"]).to.equal("fadeIn");
+    setTimeout(function() {
+      expect($scope.selectedItem["key"]).to.equal(0);
+      expect($scope.selectedItem["play-until-done"]).to.equal("true");
+      expect($scope.selectedItem["play-until-done-supported"]).to.equal(true);
+      expect($scope.selectedItem["duration"]).to.equal(20);
+      expect($scope.selectedItem["transition-type"]).to.equal("fadeIn");
+
+      done();
+    }, 10);
+
+  });
+
+  it("should set play-until-done-supported to false", function(done) {
+    $scope.selectedTemplates = sampleSelectedTemplates;
+
+    blueprintFactory.isPlayUntilDone = function() {return Q.resolve(false)};
+
+    $scope.editProperties(0);
+
+    setTimeout(function() {
+      expect($scope.selectedItem["key"]).to.equal(0);
+      expect($scope.selectedItem["play-until-done"]).to.equal("false");
+      expect($scope.selectedItem["play-until-done-supported"]).to.equal(false);
+      expect($scope.selectedItem["duration"]).to.equal(20);
+      expect($scope.selectedItem["transition-type"]).to.equal("fadeIn");
+
+      done();
+    }, 10);
+
   });
 
   it("should save properties of a playlist item", function() {

--- a/web/partials/template-editor/components/component-playlist.html
+++ b/web/partials/template-editor/components/component-playlist.html
@@ -103,17 +103,19 @@ rv-spinner rv-spinner-key="rise-playlist-templates-loader">
 
       <div class="attribute-editor-row">
         <label class="control-label" for="te-playlist-item-duration">Duration:</label>
-        <div class="madero-radio">
-          <input type="radio" ng-model="selectedItem['play-until-done']" value="true" name="pud" id="te-playlist-item-pud-true" ng-change="saveProperties()" aria-required="true" required>
-          <label for="te-playlist-item-pud-true">
-            Play until done (PUD).
-          </label>
-        </div>
-        <div class="madero-radio">
-          <input type="radio" ng-model="selectedItem['play-until-done']" value="false" name="pud" id="te-playlist-item-pud-false" ng-change="saveProperties()" aria-required="true" required>
-          <label for="te-playlist-item-pud-false">
-            A specific time period.
-          </label>
+        <div  ng-show="selectedItem['play-until-done-supported']">
+          <div class="madero-radio">
+            <input type="radio" ng-model="selectedItem['play-until-done']" value="true" name="pud" id="te-playlist-item-pud-true" ng-change="saveProperties()" aria-required="true" required>
+            <label for="te-playlist-item-pud-true">
+              Play until done (PUD).
+            </label>
+          </div>
+          <div class="madero-radio">
+            <input type="radio" ng-model="selectedItem['play-until-done']" value="false" name="pud" id="te-playlist-item-pud-false" ng-change="saveProperties()" aria-required="true" required>
+            <label for="te-playlist-item-pud-false">
+              A specific time period.
+            </label>
+          </div>
         </div>
       </div>
 
@@ -122,7 +124,7 @@ rv-spinner rv-spinner-key="rise-playlist-templates-loader">
         That way the model value is processed immeditly on Form submit and saveProperties() is called only once. -->
         <form>
           <div class="input-group">
-            <input type="number" id="te-playlist-item-duration" class="form-control duration-input-group" ng-model="selectedItem.duration" placeholder="Enter duration" ng-model-options="{ debounce: 1000 }" ng-change="saveProperties()">
+            <input type="number" id="te-playlist-item-duration" class="form-control" ng-class="{duration-input-group : selectedItem['play-until-done-supported']}" ng-model="selectedItem.duration" placeholder="Enter duration" ng-model-options="{ debounce: 1000 }" ng-change="saveProperties()">
             <span class="input-group-addon">seconds</span>
           </div>
         </form>

--- a/web/scripts/template-editor/components/directives/dtv-component-playlist.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-playlist.js
@@ -256,11 +256,20 @@ angular.module('risevision.template-editor.directives')
             //set default values
             $scope.selectedItem.duration = Number.isInteger($scope.selectedItem.duration) ? $scope.selectedItem
               .duration : 10;
-            $scope.selectedItem['play-until-done'] = $scope.selectedItem['play-until-done'] ? 'true' : 'false';
             $scope.selectedItem['transition-type'] = $scope.selectedItem['transition-type'] ? $scope.selectedItem[
               'transition-type'] : 'normal';
 
-            $scope.showProperties();
+            blueprintFactory.isPlayUntilDone($scope.selectedItem.productCode)
+              .then(function (res) {
+                $scope.selectedItem['play-until-done-supported'] = res;
+              })
+              .catch(function () {})
+              .finally(function () {
+                $scope.selectedItem['play-until-done'] = $scope.selectedItem['play-until-done-supported'] &&
+                  $scope.selectedItem['play-until-done'] ? 'true' : 'false';
+
+                $scope.showProperties();
+              });
           };
 
           $scope.saveProperties = function () {


### PR DESCRIPTION
## Description
Do not allow user to set template duration to PUD if it’s not supported by a template.

## Motivation and Context
Epic requirements

## How Has This Been Tested?
Unit test is added.
Validated manually on stage-4. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
