### PR TITLE
Enable weekly-templates for all industries

### DIFF
--- a/test/e2e/common/cases/weekly-templates.js
+++ b/test/e2e/common/cases/weekly-templates.js
@@ -30,9 +30,10 @@ var WeeklyTemplatesScenarios = function() {
     });
 
     // Jenkins account is not an Education company
-    it('should not show Weekly Templates for Non-Education customers',function(){
-      expect(weeklyTemplatesPage.getWeeklyTemplatesMainPanel().isPresent()).to.eventually.be.false;
-      expect(weeklyTemplatesPage.getWeeklyTemplatesExpandedView().isPresent()).to.eventually.be.false;
+    it('should show Weekly Templates for Non-Education customers',function(){
+      helper.wait(weeklyTemplatesPage.getWeeklyTemplatesMainPanel(), 'Notice View');
+      expect(weeklyTemplatesPage.getWeeklyTemplatesMainPanel().isDisplayed()).to.eventually.be.true;
+      expect(weeklyTemplatesPage.getWeeklyTemplatesExpandedView().isDisplayed()).to.eventually.be.true;
       expect(weeklyTemplatesPage.getWeeklyTemplatesNoticeView().isPresent()).to.eventually.be.false;
     });
 

--- a/test/unit/launcher/directives/dtv-weekly-templates.tests.js
+++ b/test/unit/launcher/directives/dtv-weekly-templates.tests.js
@@ -8,19 +8,11 @@ describe('directive: weekly-templates', function() {
       editorFactory;
   beforeEach(module('risevision.apps.launcher.directives'));
   beforeEach(module(function ($provide) {
-    $provide.service('productsFactory', function() {
+    $provide.service('companyAssetsFactory', function() {
       return {
+        weeklyTemplates: 'weeklyTemplates'
       };
-    }); 
-    $provide.service('ScrollingListService', function() {
-      return function() {
-        return {
-          search: {},
-          loadingItems: false,
-          doSearch: sinon.stub()
-        };
-      };
-    });
+    });  
     $provide.service('editorFactory', function() {
       return editorFactory;
     });  
@@ -67,14 +59,7 @@ describe('directive: weekly-templates', function() {
 
     it('should initialize scope', function() {
       expect($scope.fullView).to.be.true;
-      expect($scope.search).to.deep.equal({
-          filter: 'templateOfTheWeek:1',
-          category: 'Templates',
-          count: 4
-        }
-      );
-      expect($scope.factory).to.be.ok;
-      expect($scope.factory.doSearch).to.be.a('function');
+      expect($scope.weeklyTemplates).to.equal('weeklyTemplates');
       expect($scope.toggleView).to.be.a('function');
       expect($scope.select).to.be.a('function');
       expect($scope.alreadyOptedIn).to.be.true;

--- a/test/unit/launcher/directives/dtv-weekly-templates.tests.js
+++ b/test/unit/launcher/directives/dtv-weekly-templates.tests.js
@@ -4,7 +4,6 @@ describe('directive: weekly-templates', function() {
       $rootScope,
       $scope,
       element,
-      isEducationCustomer,
       sessionStorage,
       editorFactory;
   beforeEach(module('risevision.apps.launcher.directives'));
@@ -27,9 +26,6 @@ describe('directive: weekly-templates', function() {
     });  
     $provide.service('userState', function() {
       return {
-        isEducationCustomer: function() {
-          return isEducationCustomer;
-        },
         getCopyOfProfile: function() {
           return {
             mailSyncEnabled: true
@@ -43,7 +39,6 @@ describe('directive: weekly-templates', function() {
     
   }));
   beforeEach(inject(function(_$compile_, _$rootScope_, $templateCache){
-    isEducationCustomer = true;
     sessionStorage = {
         $default: sinon.stub(),
         weeklyTemplatesFullView: true
@@ -78,9 +73,10 @@ describe('directive: weekly-templates', function() {
           count: 4
         }
       );
-      expect($scope.factory).to.be.a.function;
-      expect($scope.toggleView).to.be.a.function;
-      expect($scope.select).to.be.a.function;
+      expect($scope.factory).to.be.ok;
+      expect($scope.factory.doSearch).to.be.a('function');
+      expect($scope.toggleView).to.be.a('function');
+      expect($scope.select).to.be.a('function');
       expect($scope.alreadyOptedIn).to.be.true;
     });
 
@@ -90,19 +86,6 @@ describe('directive: weekly-templates', function() {
       compileDirective();
       expect($scope.fullView).to.be.false;
     })
-
-    it('should load Templates if Education',function() {
-      expect($scope.factory).to.be.a.function;
-      isEducationCustomer = true;
-      compileDirective();
-      expect($scope.factory).to.be.a.function;
-    });
-
-    it('should not load Templates if not Education',function() {
-      isEducationCustomer = false;
-      compileDirective();
-      expect($scope.factory).to.not.be.a.function;
-    });
 
   });
 

--- a/test/unit/launcher/services/svc-company-assets-factory.tests.js
+++ b/test/unit/launcher/services/svc-company-assets-factory.tests.js
@@ -1,4 +1,5 @@
 'use strict';
+
 describe('service: company assets factory:', function() {
   beforeEach(module('risevision.apps.launcher.services'));
 
@@ -30,13 +31,25 @@ describe('service: company assets factory:', function() {
       });
     });
 
+    $provide.service('productsFactory', function() {
+      return {
+        loadProducts: 'loadProducts'
+      };
+    }); 
+    $provide.service('ScrollingListService', function() {
+      return sinon.stub().returns({
+        listService: 'listService'
+      });
+    });
+
   }));
   
-  var companyAssetsFactory, CachedRequest, requestExecute, $rootScope, requestReset;
+  var companyAssetsFactory, CachedRequest, requestExecute, $rootScope, requestReset, ScrollingListService;
   beforeEach(function() {
     inject(function($injector) {
       companyAssetsFactory = $injector.get('companyAssetsFactory');
       CachedRequest = $injector.get('CachedRequest');
+      ScrollingListService = $injector.get('ScrollingListService');
       $rootScope = $injector.get('$rootScope');
     });
   });
@@ -399,6 +412,18 @@ describe('service: company assets factory:', function() {
       $rootScope.$digest();
 
       requestReset.should.have.been.calledThrice;
+    });
+  });
+
+  it('weeklyTemplates:', function() {
+    ScrollingListService.should.have.been.calledWith('loadProducts', {
+      filter: 'templateOfTheWeek:1',
+      category: 'Templates',
+      count: 4
+    });
+
+    expect(companyAssetsFactory.weeklyTemplates).to.deep.equal({
+      listService: 'listService'
     });
   });
 

--- a/web/partials/launcher/weekly-templates.html
+++ b/web/partials/launcher/weekly-templates.html
@@ -1,4 +1,4 @@
-<div id="TemplateList1" class="weekly-templates panel panel-default u_margin-sm-top" ng-if="factory.items.list.length">
+<div id="TemplateList1" class="weekly-templates panel panel-default u_margin-sm-top" ng-if="weeklyTemplates.items.list.length">
   <div class="panel-body">
 
     <div id="weekly-templates-notice" ng-if="!fullView" class="u_clickable" ng-click="toggleView()">
@@ -21,7 +21,7 @@
 
       <div class="row" >
         <div class="u_margin-sm-top">
-          <ng-repeat ng-repeat="product in factory.items.list">
+          <ng-repeat ng-repeat="product in weeklyTemplates.items.list">
             <div id="storeProduct" class="col-sm-6 col-md-4 col-lg-3 col-centered" ng-click="select(product)">
               <div class="product-grid_item panel panel-default">
                 <figure class="product-grid_image u_clickable">

--- a/web/scripts/launcher/directives/dtv-weekly-templates.js
+++ b/web/scripts/launcher/directives/dtv-weekly-templates.js
@@ -1,10 +1,9 @@
 'use strict';
 
 angular.module('risevision.apps.launcher.directives')
-  .directive('weeklyTemplates', ['productsFactory', 'ScrollingListService',
-    'editorFactory', 'userState', '$sessionStorage',
-    function (productsFactory, ScrollingListService, editorFactory,
-      userState, $sessionStorage) {
+  .directive('weeklyTemplates', ['companyAssetsFactory', 'editorFactory', 'userState',
+    '$sessionStorage',
+    function (companyAssetsFactory, editorFactory, userState, $sessionStorage) {
       return {
         restrict: 'E',
         scope: {},
@@ -14,17 +13,9 @@ angular.module('risevision.apps.launcher.directives')
             weeklyTemplatesFullView: true
           });
 
+          $scope.weeklyTemplates = companyAssetsFactory.weeklyTemplates;
+
           $scope.fullView = $sessionStorage.weeklyTemplatesFullView;
-
-          $scope.search = {
-            // sortBy: 'templateReleaseDate DESC',
-            filter: 'templateOfTheWeek:1',
-            category: 'Templates',
-            count: 4
-          };
-
-          $scope.factory = new ScrollingListService(productsFactory.loadProducts,
-            $scope.search);
 
           $scope.toggleView = function () {
             $scope.fullView = !$scope.fullView;

--- a/web/scripts/launcher/directives/dtv-weekly-templates.js
+++ b/web/scripts/launcher/directives/dtv-weekly-templates.js
@@ -23,10 +23,8 @@ angular.module('risevision.apps.launcher.directives')
             count: 4
           };
 
-          if (userState.isEducationCustomer()) {
-            $scope.factory = new ScrollingListService(productsFactory.loadProducts,
-              $scope.search);
-          }
+          $scope.factory = new ScrollingListService(productsFactory.loadProducts,
+            $scope.search);
 
           $scope.toggleView = function () {
             $scope.fullView = !$scope.fullView;

--- a/web/scripts/launcher/services/svc-company-assets-factory.js
+++ b/web/scripts/launcher/services/svc-company-assets-factory.js
@@ -1,9 +1,10 @@
 'use strict';
 
 angular.module('risevision.apps.launcher.services')
-  .factory('companyAssetsFactory', ['$rootScope', '$q', 'CachedRequest',
-    'presentation', 'schedule', 'display',
-    function ($rootScope, $q, CachedRequest, presentation, schedule, display) {
+  .factory('companyAssetsFactory', ['$rootScope', '$q', 'CachedRequest', 'ScrollingListService',
+    'presentation', 'schedule', 'display', 'productsFactory',
+    function ($rootScope, $q, CachedRequest, ScrollingListService, presentation, schedule, display,
+    productsFactory) {
       var factory = {};
 
       var presentationSearch = {
@@ -21,13 +22,22 @@ angular.module('risevision.apps.launcher.services')
         reverse: true,
         count: 20
       };
+      var weeklyTemplatesSearch = {
+        // sortBy: 'templateReleaseDate DESC',
+        filter: 'templateOfTheWeek:1',
+        category: 'Templates',
+        count: 4
+      };
+
       var presentationListRequest = new CachedRequest(presentation.list, presentationSearch);
       var scheduleListRequest = new CachedRequest(schedule.list, scheduleSearch);
       var displayListRequest = new CachedRequest(display.list, displaySearch);
-
+      
       var addScheduleListener, addScheduleCompleted;
       var addDisplayListener, addDisplayCompleted;
       var displaysListListener, activeDisplayCompleted;
+
+      factory.weeklyTemplates = new ScrollingListService(productsFactory.loadProducts, weeklyTemplatesSearch);
 
       var _sendUpdateEvent = function () {
         $rootScope.$broadcast('companyAssetsUpdated');


### PR DESCRIPTION
## Description
Enable weekly-templates for all industries

Use factory for caching

[stage-2]

## Motivation and Context
Show the weekly templates feature for all industries.

## How Has This Been Tested?
Tested in the local environment. Updated unit and e2e tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
