### PR TITLE
Fix parsing error - missing quotation marks around class name

### DIFF
--- a/web/partials/template-editor/components/component-playlist.html
+++ b/web/partials/template-editor/components/component-playlist.html
@@ -124,7 +124,7 @@ rv-spinner rv-spinner-key="rise-playlist-templates-loader">
         That way the model value is processed immeditly on Form submit and saveProperties() is called only once. -->
         <form>
           <div class="input-group">
-            <input type="number" id="te-playlist-item-duration" class="form-control" ng-class="{duration-input-group : selectedItem['play-until-done-supported']}" ng-model="selectedItem.duration" placeholder="Enter duration" ng-model-options="{ debounce: 1000 }" ng-change="saveProperties()">
+            <input type="number" id="te-playlist-item-duration" class="form-control" ng-class="{'duration-input-group' : selectedItem['play-until-done-supported']}" ng-model="selectedItem.duration" placeholder="Enter duration" ng-model-options="{ debounce: 1000 }" ng-change="saveProperties()">
             <span class="input-group-addon">seconds</span>
           </div>
         </form>


### PR DESCRIPTION
## Description
Add quotation marks around class name in order to fix the following error:
> Error: [$parse:syntax] Syntax Error: Token '-' is unexpected, expecting [}] at column 10 of the expression [{duration-input-group : selectedItem['play-until-done-supported']}] starting at [-input-group : selectedItem['play-until-done-supported']}].

## Motivation and Context
Fix parsing error in the console log.

## How Has This Been Tested?
Manually confirmed on stage-4 that error is gone. Also confirmed that CSS is applied correctly.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
