### PR TITLE
Improve E2E - Workaround odd behaviour of select options

### DIFF
--- a/test/e2e/template-editor/cases/components/time-date.js
+++ b/test/e2e/template-editor/cases/components/time-date.js
@@ -41,9 +41,6 @@ var TimeDateComponentScenarios = function () {
       });
 
       it('should select date, time and timezone formatting', function () {
-        helper.wait(timeDateComponentPage.getDateFormat(), 'Date format');
-        timeDateComponentPage.selectOption(timeDateComponentPage.getDateFormatOptions().get(1).getText());
-
         helper.wait(timeDateComponentPage.getHours24Label(), '24 hours');
         timeDateComponentPage.getHours24Label().click();
 
@@ -52,6 +49,11 @@ var TimeDateComponentScenarios = function () {
 
         helper.wait(timeDateComponentPage.getTimeZone(), 'Time Zone');
         timeDateComponentPage.selectOption(timeDateComponentPage.getTimeZoneOptions().get(60).getText());
+
+        templateEditorPage.waitForAutosave();
+
+        helper.wait(timeDateComponentPage.getDateFormat(), 'Date format');
+        timeDateComponentPage.selectOption(timeDateComponentPage.getDateFormatOptions().get(1).getText());
 
         //wait for presentation to be auto-saved
         templateEditorPage.waitForAutosave();

--- a/test/e2e/template-editor/pages/templateEditorPage.js
+++ b/test/e2e/template-editor/pages/templateEditorPage.js
@@ -122,9 +122,6 @@ var TemplateEditorPage = function() {
   };
 
   this.waitForAutosave = function() {
-    //allow time for the dirtyText to appear
-    browser.sleep(100);
-
     savedText.isDisplayed().then(function(isDisplayed) {
       if (!isDisplayed) {
         //wait for presentation to be auto-saved

--- a/test/e2e/template-editor/pages/templateEditorPage.js
+++ b/test/e2e/template-editor/pages/templateEditorPage.js
@@ -122,6 +122,9 @@ var TemplateEditorPage = function() {
   };
 
   this.waitForAutosave = function() {
+    //allow time for the dirtyText to appear
+    browser.sleep(100);
+
     savedText.isDisplayed().then(function(isDisplayed) {
       if (!isDisplayed) {
         //wait for presentation to be auto-saved


### PR DESCRIPTION
## Description
Eventually (due to network latency?) some changes would not be detected and queue an autosave. In this case, the template would be partially saved.
Added an extra `waitForAutosave()` call to prevent that.

## Motivation and Context
E2E tests are failing too often.

## How Has This Been Tested?
E2E tests passed without failures.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
