### PR TITLE
Don't show payment method field for monthlies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11880,7 +11880,7 @@
       }
     },
     "pricing-selector-component": {
-      "version": "github:Rise-Vision/pricing-selector-component#b014a283f617530b7c630342e1ff7635c0aafda0",
+      "version": "github:Rise-Vision/pricing-selector-component#51aa434f791de479ae34c8067faf77580421e106",
       "from": "github:Rise-Vision/pricing-selector-component",
       "requires": {
         "@polymer/polymer": "^3.2.0"

--- a/web/partials/components/purchase-flow/checkout-payment-methods.html
+++ b/web/partials/components/purchase-flow/checkout-payment-methods.html
@@ -5,8 +5,7 @@
   </div>
 
   <form id="form.paymentMethodsForm" role="form" class="u_margin-md-top" name="form.paymentMethodsForm" novalidate>
-    <!-- Alpha Release - Select New Card by default -->
-    <div class="row u_margin-md-top">
+    <div ng-show="!purchase.plan.isMonthly" class="row u_margin-md-top">
       <div class="col-md-8 col-xs-12 form-inline">
         <div class="form-group">
           <label for="payment-method-select" class="u_margin-right">Payment Method</label>
@@ -17,7 +16,7 @@
         </div>
       </div>
     </div>
-    <hr />
+    <hr ng-show="!purchase.plan.isMonthly" />
 
     <div id="credit-card-form" ng-if="paymentMethods.paymentMethod === 'card'">
       <!-- Alpha Release - Select New Card by default -->


### PR DESCRIPTION
## Description
Disables invoice option for monthly subscriptions.

## Motivation and Context
Credit card is the only acceptable option for monthly subscriptions.
Going through a collection process for an outstanding invoice on a
monthly amount is not cost effective. Going forward we'll only accept
invoices for annual subscriptions.

## How Has This Been Tested?
stage-6

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
