### PR TITLE
Always show Schedule Preview button - No longer hides for HTML Templates

### DIFF
--- a/test/unit/schedules/directives/dtv-schedule-fields.tests.js
+++ b/test/unit/schedules/directives/dtv-schedule-fields.tests.js
@@ -50,7 +50,6 @@ describe('directive: scheduleFields', function() {
 
     expect($scope.addUrlItem).to.be.a('function');
     expect($scope.addPresentationItem).to.be.a("function");
-    expect($scope.isPreviewAvailable).to.be.a('function');
 
     expect($scope.previewUrl).to.equal('previewUrl');
   });
@@ -118,24 +117,6 @@ describe('directive: scheduleFields', function() {
         done();
       }, 10);
 
-    });
-  });
-
-  describe('isPreviewAvailable:', function() {
-    it('should have Preview button available', function() {
-      $scope.schedule.content = [];
-      expect($scope.isPreviewAvailable()).to.be.true;
-      $scope.schedule.content = [ classicPres1, classicPres2 ];
-      expect($scope.isPreviewAvailable()).to.be.true;
-    });
-
-    it('should not have Preview button available', function() {
-      $scope.schedule.content = [ htmlPres1 ];
-      expect($scope.isPreviewAvailable()).to.be.false;
-      $scope.schedule.content = [ classicPres1, htmlPres1 ];
-      expect($scope.isPreviewAvailable()).to.be.false;
-      $scope.schedule.content = [ classicPres1, classicPres2, htmlPres1 ];
-      expect($scope.isPreviewAvailable()).to.be.false;
     });
   });
 });

--- a/web/partials/schedules/schedule-fields.html
+++ b/web/partials/schedules/schedule-fields.html
@@ -49,7 +49,7 @@
       </ul>
     </div>
   </div>
-  <a class="btn btn-default" id="previewButton" target="_blank" ng-href="{{previewUrl}}" ng-show="previewUrl && isPreviewAvailable()">
+  <a class="btn btn-default" id="previewButton" target="_blank" ng-href="{{previewUrl}}" ng-show="previewUrl">
     {{'schedules-app.actions.preview' | translate}} <i class="fa fa-play icon-right"></i>
   </a>
 </div>

--- a/web/scripts/schedules/directives/dtv-schedule-fields.js
+++ b/web/scripts/schedules/directives/dtv-schedule-fields.js
@@ -40,14 +40,6 @@ angular.module('risevision.schedules.directives')
               }
             });
           };
-
-          $scope.isPreviewAvailable = function () {
-            var htmlPresentations = _.filter($scope.schedule.content, function (presentation) {
-              return presentationUtils.isHtmlPresentation(presentation);
-            });
-
-            return htmlPresentations.length === 0;
-          };
         } //link()
       };
     }


### PR DESCRIPTION
## Description
Always show Schedule Preview button, no longer hides it when HTML Templates and scheduled to play.

## Motivation and Context
Shared Schedules epic -  HTML Templates now work with Preview.

## How Has This Been Tested?
Locally and on stage-1.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
