### PR TITLE
Dont allow viewer urls in url field

### DIFF
--- a/test/unit/components/url-field/dtv-url-field.tests.js
+++ b/test/unit/components/url-field/dtv-url-field.tests.js
@@ -32,6 +32,7 @@ describe('directive: url field', function() {
     expect($scope.storageType).to.be.ok;
     expect($scope.ngModelCtrl).to.be.ok;
     expect($scope.doValidation).to.be.true;
+    expect($scope.showSkipValidation).to.be.ok;
     expect($scope.forcedValid).to.be.false;
   });
 
@@ -55,6 +56,57 @@ describe('directive: url field', function() {
     $scope.ngModel = 'newValue';
     $scope.$digest();
     expect(element.controller('ngModel').$dirty).to.be.true;
+  });
+
+  describe('showSkipValidation:', function() {
+    it('should not show by default', function() {
+      var controller = element.controller('ngModel');
+
+      expect($scope.showSkipValidation()).to.be.false;
+    });
+
+    it('should show if forcedValid', function() {
+      $scope.forcedValid = true;
+      var controller = element.controller('ngModel');
+
+      expect($scope.showSkipValidation()).to.be.true;
+    });
+
+    it('should show if invalid & dirty', function() {
+      var controller = element.controller('ngModel');
+      controller.$setDirty(true);
+      controller.$setValidity('', false);    
+
+      expect($scope.showSkipValidation()).to.be.true;
+    });
+
+    describe('unskippable errors (hide checkbox):', function() {
+      beforeEach(function() {
+        $scope.forcedValid = true;
+      });
+
+      it('should allow skipping validation for other errors', function(){
+        var controller = element.controller('ngModel');
+        controller.$error = {'myError':true};    
+
+        expect($scope.showSkipValidation()).to.be.true;
+      });
+
+      it('should not allow skipping validation for required errors', function(){
+        var controller = element.controller('ngModel');
+        controller.$error = {'required':true};    
+
+        expect($scope.showSkipValidation()).to.be.false;
+      });
+
+      it('should not allow skipping validation for noPreviewUrl errors', function(){
+        var controller = element.controller('ngModel');
+        controller.$error = {'noPreviewUrl':true};    
+
+        expect($scope.showSkipValidation()).to.be.false;
+      });
+    });
+
   });
 
   it('should toggle forcedValid and clear forms on doValidation change', function(){

--- a/web/partials/components/url-field/url-field.html
+++ b/web/partials/components/url-field/url-field.html
@@ -10,7 +10,7 @@
     <ng-messages-include src="partials/components/url-field/messages.html"></ng-messages-include>
   </ng-messages>
   
-  <div class="checkbox" ng-show="forcedValid || (ngModelCtrl.$invalid && ngModelCtrl.$dirty)">
+  <div class="checkbox" ng-show="showSkipValidation()">
     <label class="input-url-remove-validation">
       <input name="validate-url" ng-click="doValidation = !doValidation" type="checkbox"
              value="validate-url"> {{"url.validate.label" | translate}}

--- a/web/scripts/components/url-field/dtv-url-field.js
+++ b/web/scripts/components/url-field/dtv-url-field.js
@@ -36,6 +36,19 @@
               scope.$emit('urlFieldBlur');
             };
 
+            scope.showSkipValidation = function() {
+              var skipValidation = scope.forcedValid || (scope.ngModelCtrl.$invalid && scope.ngModelCtrl.$dirty);
+              var unskippable = false;
+
+              angular.forEach(scope.ngModelCtrl.$error, function(value, name) {
+                if (name === 'required' || name === 'noPreviewUrl') {
+                  unskippable = true;
+                }
+              });
+
+              return !unskippable && skipValidation;
+            };
+
             scope.$watch('ngModel', function (newValue, oldValue) {
               if (newValue !== oldValue) {
                 scope.ngModelCtrl.$setDirty(true);


### PR DESCRIPTION
## Description
Disable skip validation functionality
for viewer urls and required errors

[stage-2]

## Motivation and Context
Dont allow viewer urls in url field


## How Has This Been Tested?
Tested with local version. Updated tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No