### PR TITLE
Auto select text when showing shared schedule link

### DIFF
--- a/test/unit/schedules/controllers/ctr-shared-schedule-modal.tests.js
+++ b/test/unit/schedules/controllers/ctr-shared-schedule-modal.tests.js
@@ -82,6 +82,20 @@ describe('controller: SharedScheduleModalController', function() {
     });
   });
 
+  describe('onTextFocus', function() {
+    it('should select target element text', function() {
+      var event = {
+        target: {
+          select: sinon.stub()
+        }
+      };
+
+      $scope.onTextFocus(event);
+
+      event.target.select.should.have.been.called;
+    });
+  });
+
   describe('shareOnSocial', function() {
     beforeEach(function() {
       sinon.stub($window, 'open');

--- a/web/partials/schedules/shared-schedule-modal.html
+++ b/web/partials/schedules/shared-schedule-modal.html
@@ -36,7 +36,7 @@
       <div class="col-xs-12">
         <label>Link:</label>
         <div class="input-group">
-          <input class="form-control" type="text" disabled="disabled" value="{{sharedScheduleLink}}" />
+          <input class="form-control" type="text" readonly="readonly" value="{{sharedScheduleLink}}" ng-focus="onTextFocus($event)" focus-me="currentTab === 'link'"/>
           <div class="input-group-btn">
             <button id="copyUrlButton" class="btn btn-primary" ng-click="copyToClipboard(sharedScheduleLink)" aria-label="Copy">Copy</button>
           </div>
@@ -47,7 +47,7 @@
     <div ng-show="currentTab === 'embedCode'" class="row u_margin-sm-top u_margin-sm-bottom">
       <div class="col-xs-12">
         <label>Embed Code:</label>
-        <textarea class="form-control u_margin-sm-bottom resize-vertical" rows="5" disabled="disabled">{{sharedScheduleEmbedCode}}</textarea>
+        <textarea class="form-control u_margin-sm-bottom resize-vertical" rows="5" readonly="readonly" ng-focus="onTextFocus($event)" focus-me="currentTab === 'embedCode'">{{sharedScheduleEmbedCode}}</textarea>
         <button id="copyEmbedCodeButton" class="btn btn-primary" ng-click="copyToClipboard(sharedScheduleEmbedCode)" aria-label="Copy">Copy</button>
       </div>
     </div>

--- a/web/scripts/schedules/controllers/ctr-shared-schedule-modal.js
+++ b/web/scripts/schedules/controllers/ctr-shared-schedule-modal.js
@@ -30,6 +30,10 @@ angular.module('risevision.schedules.controllers')
         }
       };
 
+      $scope.onTextFocus = function (event) {
+        event.target.select();
+      };
+
       $scope.shareOnSocial = function (network) {
         var encodedLink = encodeURIComponent($scope.sharedScheduleLink);
         var url;


### PR DESCRIPTION
## Description
Auto select text when showing shared schedule link and embed code.

I used our `focus-me` directive to check the conditions to trigger text select when switching tabs. 
Also, I had to change `disabled` to `readonly`, as `disabled` does not allow text input to be focused.

## Motivation and Context
Shared Schedules epic.

## How Has This Been Tested?
Locally and on stage-1.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
