### PR TITLE
Add env=embed to Shared Schedules embed code

### DIFF
--- a/test/unit/schedules/controllers/ctr-shared-schedule-modal.tests.js
+++ b/test/unit/schedules/controllers/ctr-shared-schedule-modal.tests.js
@@ -52,7 +52,7 @@ describe('controller: SharedScheduleModalController', function() {
     expect($scope.sharedScheduleEmbedCode).to.be.contain('<div style="position:relative;padding-bottom:56.25%;">\n\
    <iframe style="width:100%;height:100%;position:absolute;left:0px;top:0px;"\n\
       frameborder="0" width="100%" height="100%"\n\
-      src="https://preview.risevision.com/?type=sharedschedule&id=scheduleId">\n\
+      src="https://preview.risevision.com/?type=sharedschedule&id=scheduleId&env=embed">\n\
    </iframe>\n\
 </div>\n\
 <div style="background:#f2f2f2;color:#020620;font-family:Helvetica;font-size:12px;padding:5px;text-align:center;">\n\

--- a/web/scripts/schedules/controllers/ctr-shared-schedule-modal.js
+++ b/web/scripts/schedules/controllers/ctr-shared-schedule-modal.js
@@ -5,7 +5,7 @@ angular.module('risevision.schedules.controllers')
   .value('SHARED_SCHEDULE_EMBED_CODE', '<div style="position:relative;padding-bottom:56.25%;">\n\
    <iframe style="width:100%;height:100%;position:absolute;left:0px;top:0px;"\n\
       frameborder="0" width="100%" height="100%"\n\
-      src="SHARED_SCHEDULE_URL">\n\
+      src="SHARED_SCHEDULE_URL&env=embed">\n\
    </iframe>\n\
 </div>\n\
 <div style="background:#f2f2f2;color:#020620;font-family:Helvetica;font-size:12px;padding:5px;text-align:center;">\n\


### PR DESCRIPTION
## Description
Add env=embed to Shared Schedules embed code, so that we can use it for Viewer analytics.

## Motivation and Context
Shared Schedules, to report what are the sources of Shared Schedules usage.

## How Has This Been Tested?
Tested locally.
[stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
