### PR TITLE
Add master switch check

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "Sortable": "^1.4.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages",
     "xmlToJSON.js": "^1.3.2",
-    "moment": "^2.24.0",
+    "moment": "2.24.0",
     "angularjs-slider": "^7.0.0"
   },
   "devDependencies": {

--- a/test/unit/storage/services/svc-encoding.tests.js
+++ b/test/unit/storage/services/svc-encoding.tests.js
@@ -2,7 +2,7 @@
 describe('service: encoding:', function() {
   beforeEach(module('risevision.storage.services'));
 
-  let encoding;
+  var encoding;
   beforeEach(function(){
     inject(function($injector){
       encoding = $injector.get('encoding');

--- a/web/scripts/storage/services/svc-encoding.js
+++ b/web/scripts/storage/services/svc-encoding.js
@@ -1,9 +1,14 @@
 'use strict';
 
 angular.module('risevision.storage.services')
-  .service('encoding', ['$log', 'storageAPILoader',
-    function ($log, storageAPILoader) {
+  .service('encoding', ['$log', '$http', 'storageAPILoader',
+    function ($log, $http, storageAPILoader) {
       $log.debug('Loading encoding service');
+
+      var switchURL = 'https://storage.googleapis.com/risemedialibrary/encoding-switch';
+      var masterSwitch = false;
+      $http({method: 'HEAD', url: switchURL})
+      .then(function () {masterSwitch = true;}, function () {masterSwitch = false;});
 
       var service = {};
       return service;

--- a/web/scripts/storage/services/svc-file-upload.js
+++ b/web/scripts/storage/services/svc-file-upload.js
@@ -79,7 +79,7 @@ angular.module('risevision.storage.services')
     }
   ])
   .factory('fileUploaderFactory', ['$rootScope', '$q', 'XHRFactory', 'encoding', 'ExifStripper', '$timeout',
-    function ($rootScope, $q, XHRFactory, ExifStripper, $timeout) {
+    function ($rootScope, $q, XHRFactory, encoding, ExifStripper, $timeout) {
       return function () {
         var svc = {};
         var loadBatchTimer = null;

--- a/web/storage-selector.html
+++ b/web/storage-selector.html
@@ -234,6 +234,7 @@
   <script src="scripts/storage/services/svc-upload-uri.js"></script>
   <script src="scripts/storage/services/svc-upload-overwrite-warning.js"></script>
   <script src="scripts/storage/services/svc-pending-operations-factory.js"></script>
+  <script src="scripts/storage/services/svc-encoding.js"></script>
 
   <script src="scripts/storage/filters/ftr-filters.js"></script>
   <script src="scripts/storage/directives/dtv-storage-file-select.js"></script>


### PR DESCRIPTION
## Description
Checks GCS file to confirm master switch is active

## Motivation and Context
The encoding service will delegate back to the existing file upload service if the master switch is off indicating a problem with the third party encoding provider. See Trello [card](https://trello.com/c/FH8D03f7/5912-1-encoding-ui-check-master-switch-on-apps-load).

## How Has This Been Tested?
Confirmed in devtools

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
