### PR TITLE
Debounce twitter user entry by 1 second

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "Sortable": "^1.4.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages",
     "xmlToJSON.js": "^1.3.2",
-    "moment": "^2.24.0",
+    "moment": "2.24.0",
     "angularjs-slider": "^7.0.0"
   },
   "devDependencies": {

--- a/web/partials/template-editor/components/component-twitter.html
+++ b/web/partials/template-editor/components/component-twitter.html
@@ -12,7 +12,7 @@
   <div class="attribute-editor-row" ng-show="connected">
     <div class="form-group has-feedback" ng-class="{ 'has-error': usernameStatus && usernameStatus !== 'VALID', 'has-success': usernameStatus === 'VALID' && username !== '' }">
       <label class="control-label" for="twitterUsername">Enter a username:</label>
-      <input type="text" id="twitterUsername"  class="form-control u_ellipsis" ng-model="username" placeholder="@RiseVision" ng-change="save()">
+      <input type="text" id="twitterUsername"  class="form-control u_ellipsis" ng-model="username" placeholder="@RiseVision" ng-change="save()" ng-model-options="{ debounce: 1000 }" ng-disabled="spinner">
       <streamline-icon class="overlay-icon form-control-feedback" aria-hidden="true" name="{{usernameStatus && usernameStatus !== 'VALID' ? 'exclamation' : 'checkmark'}}" width="14" height="12"></streamline-icon>
       <p class="help-block" ng-switch on="usernameStatus">
         <span ng-switch-when="INVALID_USERNAME">Please provide a valid username.</span>


### PR DESCRIPTION
## Description
Delay `username` changes by 1 second before triggering a save of attribute data

Also temporarily holding version of momentjs to `2.24.0` to unblock unit test failure which are happening when `2.25` is being used. Ezequiels team are aware and will look into this further later.  

## Motivation and Context
When a user types out a username value as opposed to copy/paste, we don't want it triggering a save any quicker than 1 second

## How Has This Been Tested?
Staging with below presentation

https://apps-stage-8.risevision.com/templates/edit/d50d2ddc-f347-48a2-b46d-ad24e3557806/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
