### PR TITLE
Use parent's plan details when available

### DIFF
--- a/test/unit/components/plans/svc-current-plan-factory-spec.js
+++ b/test/unit/components/plans/svc-current-plan-factory-spec.js
@@ -88,7 +88,7 @@ describe("Services: current plan factory", function() {
         expect(currentPlanFactory.currentPlan.playerProAvailableLicenseCount).to.equal(1);
 
         expect(currentPlanFactory.currentPlan.shareCompanyPlan).to.be.true;
-        expect(currentPlanFactory.currentPlan.parentPlan).to.not.be.ok;
+        expect(currentPlanFactory.currentPlan.isParentPlan).to.not.be.ok;
         expect(currentPlanFactory.currentPlan.parentPlanCompanyName).to.equal("parentName");
         expect(currentPlanFactory.currentPlan.parentPlanContactEmail).to.equal("administratorEmail");
 
@@ -121,7 +121,7 @@ describe("Services: current plan factory", function() {
         expect(currentPlanFactory.currentPlan.playerProAvailableLicenseCount).to.equal(1);
 
         expect(currentPlanFactory.currentPlan.shareCompanyPlan).to.be.true;
-        expect(currentPlanFactory.currentPlan.parentPlan).to.be.true;
+        expect(currentPlanFactory.currentPlan.isParentPlan).to.be.true;
         expect(currentPlanFactory.currentPlan.parentPlanCompanyName).to.equal("parentName");
         expect(currentPlanFactory.currentPlan.parentPlanContactEmail).to.equal("administratorEmail");
 
@@ -343,7 +343,7 @@ describe("Services: current plan factory", function() {
 
   describe("Parent plan: ", function() {
     it("should return the plan is inherited from the Parent", function() {
-      currentPlanFactory.currentPlan = { parentPlan: true };
+      currentPlanFactory.currentPlan = { isParentPlan: true };
       expect(currentPlanFactory.isParentPlan()).to.be.true;
     });
 

--- a/test/unit/components/plans/svc-current-plan-factory-spec.js
+++ b/test/unit/components/plans/svc-current-plan-factory-spec.js
@@ -88,8 +88,7 @@ describe("Services: current plan factory", function() {
         expect(currentPlanFactory.currentPlan.playerProAvailableLicenseCount).to.equal(1);
 
         expect(currentPlanFactory.currentPlan.shareCompanyPlan).to.be.true;
-        expect(currentPlanFactory.currentPlan.parentPlan).to.be.ok;
-        expect(currentPlanFactory.currentPlan.parentPlan.type).to.equal("advanced");
+        expect(currentPlanFactory.currentPlan.parentPlan).to.not.be.ok;
         expect(currentPlanFactory.currentPlan.parentPlanCompanyName).to.equal("parentName");
         expect(currentPlanFactory.currentPlan.parentPlanContactEmail).to.equal("administratorEmail");
 
@@ -97,7 +96,7 @@ describe("Services: current plan factory", function() {
       }, 0);
     });
 
-    it("should load Parent Company plan even if no Plan is available for the Company", function(done) {
+    it("should use shared Parent Company plan if no Plan is available for the Company", function(done) {
       sandbox.spy($rootScope, "$emit");
       sandbox.stub(userState, "getSelectedCompanyId").returns("companyId");
       sandbox.stub(userState, "getCopyOfSelectedCompany").returns({
@@ -116,14 +115,13 @@ describe("Services: current plan factory", function() {
       setTimeout(function () {
         expect($rootScope.$emit).to.have.been.called;
         expect(currentPlanFactory.currentPlan).to.be.not.null;
-        expect(currentPlanFactory.currentPlan.type).to.equal("free");
+        expect(currentPlanFactory.currentPlan.type).to.equal("advanced");
         expect(currentPlanFactory.currentPlan.status).to.equal("Active");
         expect(currentPlanFactory.currentPlan.playerProTotalLicenseCount).to.equal(3);
         expect(currentPlanFactory.currentPlan.playerProAvailableLicenseCount).to.equal(1);
 
         expect(currentPlanFactory.currentPlan.shareCompanyPlan).to.be.true;
-        expect(currentPlanFactory.currentPlan.parentPlan).to.be.ok;
-        expect(currentPlanFactory.currentPlan.parentPlan.type).to.equal("advanced");
+        expect(currentPlanFactory.currentPlan.parentPlan).to.be.true;
         expect(currentPlanFactory.currentPlan.parentPlanCompanyName).to.equal("parentName");
         expect(currentPlanFactory.currentPlan.parentPlanContactEmail).to.equal("administratorEmail");
 
@@ -345,7 +343,7 @@ describe("Services: current plan factory", function() {
 
   describe("Parent plan: ", function() {
     it("should return the plan is inherited from the Parent", function() {
-      currentPlanFactory.currentPlan = { parentPlan: {} };
+      currentPlanFactory.currentPlan = { parentPlan: true };
       expect(currentPlanFactory.isParentPlan()).to.be.true;
     });
 

--- a/web/partials/displays/display-details.html
+++ b/web/partials/displays/display-details.html
@@ -50,7 +50,7 @@
     </ul>
 
     <div class="row" ng-show="areAllProLicensesUsed()">
-      <div class="alert alert-danger mt-2 mb-4" ng-show="currentPlanFactory.currentPlan.parentPlan || currentPlanFactory.currentPlan.isPurchasedByParent">
+      <div class="alert alert-danger mt-2 mb-4" ng-show="currentPlanFactory.currentPlan.isParentPlan || currentPlanFactory.currentPlan.isPurchasedByParent">
         <p ng-show="currentPlanFactory.currentPlan.parentPlanContactEmail" translate translate-values="{ administratorEmail: currentPlanFactory.currentPlan.parentPlanContactEmail }">displays-app.details.contact-plan-parent-email</p>
         <p ng-show="!currentPlanFactory.currentPlan.parentPlanContactEmail" translate>displays-app.details.contact-plan-parent-no-email</p>
       </div>

--- a/web/scripts/components/plans/svc-current-plan-factory.js
+++ b/web/scripts/components/plans/svc-current-plan-factory.js
@@ -22,7 +22,7 @@
 
           } else if (company.id && company.parentPlanProductCode) {
             plan = _.cloneDeep(_plansByCode[company.parentPlanProductCode]);
-            plan.parentPlan = true;
+            plan.isParentPlan = true;
             plan.status = 'Active';
 
           } else {
@@ -69,7 +69,7 @@
         };
 
         _factory.isParentPlan = function () {
-          return !!_factory.currentPlan.parentPlan;
+          return !!_factory.currentPlan.isParentPlan;
         };
 
         _factory.isEnterpriseSubCompany = function () {

--- a/web/scripts/components/plans/svc-current-plan-factory.js
+++ b/web/scripts/components/plans/svc-current-plan-factory.js
@@ -20,6 +20,11 @@
             plan.currentPeriodEndDate = new Date(company.planCurrentPeriodEndDate);
             plan.trialExpiryDate = new Date(company.planTrialExpiryDate);
 
+          } else if (company.id && company.parentPlanProductCode) {
+            plan = _.cloneDeep(_plansByCode[company.parentPlanProductCode]);
+            plan.parentPlan = true;
+            plan.status = 'Active';
+
           } else {
             plan = _.cloneDeep(_plansByType.free);
           }
@@ -30,10 +35,6 @@
           plan.playerProAvailableLicenseCount = company.playerProAvailableLicenseCount;
 
           plan.shareCompanyPlan = company.shareCompanyPlan;
-
-          if (company.parentPlanProductCode) {
-            plan.parentPlan = _.cloneDeep(_plansByCode[company.parentPlanProductCode]);
-          }
 
           plan.isPurchasedByParent = !!company.planBillToId && !!company.planShipToId && (company.planBillToId !==
             company.planShipToId) && (_factory.isSubscribed() || _factory.isCancelledActive());


### PR DESCRIPTION
## Description
Use parent's plan details as current Plan status when parent plan is shared with subcompany.

## Motivation and Context
Fix #1665

## How Has This Been Tested?
Locally and on stage-1

Sample company: https://apps-stage-1.risevision.com/schedules/details/01b715b2-3bc6-4234-aabd-4f71b0941552?cid=9bd35f40-c3c6-4ea9-96c8-fdfd895c41e0

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
