### PR TITLE
Use encoding service for upload uri when applicable

### DIFF
--- a/test/unit/storage/services/svc-encoding.tests.js
+++ b/test/unit/storage/services/svc-encoding.tests.js
@@ -1,16 +1,70 @@
 'use strict';
 describe('service: encoding:', function() {
+  var encoding, $httpBackend, authRequestHandler;
+
   beforeEach(module('risevision.storage.services'));
 
-  var encoding;
+  beforeEach(module(function ($provide) {
+    $provide.service('$q', function() {return Q;});
+
+    $provide.service('storageAPILoader', function () {
+      return function() {
+        return Q.resolve({
+          getEncodingUploadURI: function(obj) {return {result: true};}
+        });
+      };
+    });
+
+    $provide.service('userState', function () {
+      return {
+        getSelectedCompanyId: function() {return '12345';},
+        _restoreState: function(){}
+      };
+    });
+  }));
+
   beforeEach(function(){
     inject(function($injector){
+      $httpBackend = $injector.get('$httpBackend');
+
       encoding = $injector.get('encoding');
+      setTimeout(function() {$httpBackend.flush();});
     });
   });
 
-  it('should exist',function(){
-    expect(encoding).to.be.ok;
+  it('should be applicable if file is video', function() {
+    $httpBackend.when('HEAD', /.*encoding-switch/).respond(200, {});
+
+    return encoding.isApplicable('video/subtype')
+    .then(function(resp) {
+      expect(resp).to.be.ok;
+    });
+  });
+
+  it('should not be applicable if file is not video', function() {
+    $httpBackend.when('HEAD', /.*encoding-switch/).respond(200, {});
+
+    return encoding.isApplicable('text/subtype')
+    .then(function(resp) {
+      expect(resp).to.not.be.ok;
+    });
+  });
+
+  it('should not be applicable if master switch is off', function() {
+    $httpBackend.when('HEAD', /.*encoding-switch/).respond(403, {});
+
+    return encoding.isApplicable('video/subtype')
+    .then(function(resp) {
+      expect(resp).to.not.be.ok;
+    });
+  });
+
+  it('should retrieve encoder upload uri from storage server api', function() {
+    $httpBackend.when('HEAD', /.*encoding-switch/).respond(200, {});
+
+    return encoding.getResumableUploadURI('filename')
+    .then(function(resp) {
+      expect(resp).to.be.true;
+    });
   });
 });
-

--- a/test/unit/storage/services/svc-upload-uri.tests.js
+++ b/test/unit/storage/services/svc-upload-uri.tests.js
@@ -19,18 +19,30 @@ describe('service: UploadURIService', function() {
         }
       };
     });
+
+    $provide.service('encoding', function () {
+      return {
+        getResumableUploadURI: function(fileName, fileType) {
+          return Q.resolve(true);
+        },
+        isApplicable: function(fileType) { return Q.resolve(encodingApplicable); }
+      };
+    });
+
     $provide.service('processErrorCode', function() {
       return function(type, item, error) { return type + item + error; };
     });
 
   }));
-  var uploadURIService, storage, returnResult, $rootScope, storageRequestObj;
+  var uploadURIService, storage, encoding, encodingApplicable, returnResult, $rootScope, storageRequestObj;
   beforeEach(function(){
     returnResult = true;
+    encodingApplicable = false;
 
     inject(function($injector){
       $rootScope = $injector.get('$rootScope');
       storage = $injector.get('storage');
+      encoding = $injector.get('encoding');
       uploadURIService = $injector.get('UploadURIService');
     });
   });
@@ -67,6 +79,17 @@ describe('service: UploadURIService', function() {
         done();
       })
       .then(null,done);
+    });
+
+    it("should use encoder service when uploading video and encoder master switch is on",function(done){
+      encodingApplicable = true;
+
+      var file = {name: "fileName", type: "video/mp4"};
+      var spy = sinon.spy(encoding,'getResumableUploadURI');
+      uploadURIService.getURI(file).then(function(result) {
+        spy.should.have.been.calledWith(file.name, file.type);
+        done();
+      });
     });
   });
 });

--- a/web/scripts/storage/services/svc-encoding.js
+++ b/web/scripts/storage/services/svc-encoding.js
@@ -1,16 +1,46 @@
 'use strict';
 
 angular.module('risevision.storage.services')
-  .service('encoding', ['$log', '$http', 'storageAPILoader',
-    function ($log, $http, storageAPILoader) {
+  .service('encoding', ['$q', '$log', '$http', 'storageAPILoader', 'userState',
+    function ($q, $log, $http, storageAPILoader, userState) {
       $log.debug('Loading encoding service');
-
       var switchURL = 'https://storage.googleapis.com/risemedialibrary/encoding-switch';
-      var masterSwitch = false;
-      $http({method: 'HEAD', url: switchURL})
-      .then(function () {masterSwitch = true;}, function () {masterSwitch = false;});
+      var masterSwitchPromise = $http({method: 'HEAD', url: switchURL});
 
       var service = {};
+
+      service.isApplicable = function(fileType) {
+        $log.debug('Checking encoding applicability for ' + fileType);
+
+        if (fileType.indexOf('video/') !== 0) { return $q.resolve(false); }
+
+        return masterSwitchPromise
+        .then(function() {return true;}, function() {return false;});
+      };
+
+      service.getResumableUploadURI = function(fileName) {
+        var deferred = $q.defer();
+        var obj = {
+          companyId: userState.getSelectedCompanyId(),
+          fileName: encodeURIComponent(fileName),
+        };
+
+        $log.debug('Retrieving encoding upload destination', obj);
+
+        storageAPILoader().then(function (storageApi) {
+          return storageApi.getEncodingUploadURI(obj);
+        })
+        .then(function (resp) {
+          deferred.resolve(resp.result);
+        })
+        .then(null, function (e) {
+          $log.error('Error getting resumable upload URI', e);
+          deferred.reject(e);
+        });
+
+        return deferred.promise;
+      };
+
       return service;
     }
   ]);


### PR DESCRIPTION
## Description
Use the encoding service for upload uri when applicable (video file and master switch on).

## Motivation and Context
For videos, we will be initiating a Qencode job, and retrieving the upload URI from that job request.

## How Has This Been Tested?
Unit tests, manual tests locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
