### PR TITLE
Don't allow linting errors during development

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -181,10 +181,20 @@ gulp.task("clean-tmp", function () {
 gulp.task("clean", ["clean-dist", "clean-tmp"]);
 
 gulp.task("lint", function() {
+  let lintError;
+
   return gulp.src(appJSFiles)
     .pipe(jshint())
     .pipe(jshint.reporter("jshint-stylish"))
-    .pipe(jshint.reporter("fail"));
+    .pipe(jshint.reporter("fail"))
+    .on("error", function(e){
+      lintError = true;
+    })
+    .on("end", function(){
+      if(lintError) {
+        process.exit();
+      }
+    });
 });
 
 function buildHtml(path) {
@@ -380,7 +390,7 @@ gulp.task('default', [], function() {
   return true;
 });
 
-gulp.task('dev', ['build-pieces', 'browser-sync', 'watch']);
+gulp.task('dev', ['lint', 'build-pieces', 'browser-sync', 'watch']);
 
 /**
  * Default task, running just `gulp` will compile the sass, launch BrowserSync & watch files.


### PR DESCRIPTION
## Description
Force quit build if there are linting errors.

## Motivation and Context
Catch linting issues earlier in development cycle.

## How Has This Been Tested?
Works as before if there are no linting errors. If there are linting errors, default `gulp` will fail and quit.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
