### PR TITLE
Upload to encoding service for encodable files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist
 tmp
 web/tmp
 web/scripts/config/config.js
+web/vendor/tus
 test/e2e/config/config.json
 .DS_Store
 .project

--- a/.jshintrc
+++ b/.jshintrc
@@ -31,7 +31,8 @@
     "it": false,
     "inject": false,
     "Draggable": false,
-    "moment": false
+    "moment": false,
+    "tus": false
   },
   "predef":["angular","_"]
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -261,6 +261,11 @@ gulp.task('pricing', function() {
   });
 });
 
+gulp.task("tus", function() {
+  return gulp.src("node_modules/tus-js-client/dist/tus.min.js")
+    .pipe(gulp.dest("web/vendor/tus"));
+});
+
 gulp.task("html2js", function() {
   return gulp.src(partialsHTMLFiles)
     .pipe(minifyHtml({
@@ -308,7 +313,7 @@ gulp.task("config", function() {
 });
 
 gulp.task('build-pieces', function (cb) {
-  runSequence(["clean"], ['config', 'i18n-build', 'css-build', 'pricing', 'html2js'], cb);
+  runSequence(["clean"], ['config', 'i18n-build', 'css-build', 'pricing', 'html2js', 'tus'], cb);
 });
 
 gulp.task('build', function (cb) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "pricing-data-component": "github:Rise-Vision/pricing-data-component",
     "pricing-grid-component": "github:Rise-Vision/pricing-grid-component",
     "pricing-selector-component": "github:Rise-Vision/pricing-selector-component",
-    "pricing-summary-component": "github:Rise-Vision/pricing-summary-component"
+    "pricing-summary-component": "github:Rise-Vision/pricing-summary-component",
+    "tus-js-client": "^2.0.0-1"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/web/index.html
+++ b/web/index.html
@@ -552,6 +552,7 @@
   <script src="scripts/storage/services/svc-file-retriever.js"></script>
   <script src="scripts/storage/services/svc-pending-operations-factory.js"></script>
   <script src="scripts/storage/services/svc-encoding.js"></script>
+  <script src="vendor/tus/tus.min.js"></script>
 
   <script src="scripts/storage/filters/ftr-filters.js"></script>
   <script src="scripts/storage/directives/dtv-storage-selector.js"></script>

--- a/web/scripts/storage/directives/dtv-upload.js
+++ b/web/scripts/storage/directives/dtv-upload.js
@@ -114,6 +114,7 @@
 
                   uploadOverwriteWarning.checkOverwrite(resp).then(function () {
                     fileItem.url = resp.message;
+                    fileItem.taskToken = resp.taskToken;
                     fileItem.chunkSize =
                       STORAGE_UPLOAD_CHUNK_SIZE;
                     FileUploader.uploadItem(fileItem);

--- a/web/storage-selector.html
+++ b/web/storage-selector.html
@@ -235,6 +235,7 @@
   <script src="scripts/storage/services/svc-upload-overwrite-warning.js"></script>
   <script src="scripts/storage/services/svc-pending-operations-factory.js"></script>
   <script src="scripts/storage/services/svc-encoding.js"></script>
+  <script src="vendor/tus/tus.min.js"></script>
 
   <script src="scripts/storage/filters/ftr-filters.js"></script>
   <script src="scripts/storage/directives/dtv-storage-file-select.js"></script>


### PR DESCRIPTION
## Description
If the file has an encoding task token, it is encodable. The token will
have come from the resumable upload call. In that case, upload to the encoding service.

## Motivation 
Uploads for encoding go directly to the encoder without using GCS as an intermediary.

## How Has This Been Tested?
Ran locally and confirmed upload proceeds. Should complete in the UI for now. Next PR will start the encoding task instead of showing complete.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
