### PR TITLE
Give priority to Parent Company plan when available

### DIFF
--- a/test/unit/components/plans/svc-current-plan-factory-spec.js
+++ b/test/unit/components/plans/svc-current-plan-factory-spec.js
@@ -67,11 +67,7 @@ describe("Services: current plan factory", function() {
         planCurrentPeriodEndDate: "Jan 1, 2018",
         planTrialExpiryDate: "Jan 14, 2018",
         playerProTotalLicenseCount: 3,
-        playerProAvailableLicenseCount: 1,
-        shareCompanyPlan: true,
-        parentPlanProductCode: ADVANCED_PLAN_CODE,
-        parentPlanCompanyName: "parentName",
-        parentPlanContactEmail: "administratorEmail"
+        playerProAvailableLicenseCount: 1
       });
 
       $rootScope.$emit("risevision.company.selectedCompanyChanged");
@@ -87,10 +83,7 @@ describe("Services: current plan factory", function() {
         expect(currentPlanFactory.currentPlan.playerProTotalLicenseCount).to.equal(3);
         expect(currentPlanFactory.currentPlan.playerProAvailableLicenseCount).to.equal(1);
 
-        expect(currentPlanFactory.currentPlan.shareCompanyPlan).to.be.true;
         expect(currentPlanFactory.currentPlan.isParentPlan).to.not.be.ok;
-        expect(currentPlanFactory.currentPlan.parentPlanCompanyName).to.equal("parentName");
-        expect(currentPlanFactory.currentPlan.parentPlanContactEmail).to.equal("administratorEmail");
 
         done();
       }, 0);
@@ -101,6 +94,43 @@ describe("Services: current plan factory", function() {
       sandbox.stub(userState, "getSelectedCompanyId").returns("companyId");
       sandbox.stub(userState, "getCopyOfSelectedCompany").returns({
         id: "companyId",
+        playerProTotalLicenseCount: 3,
+        playerProAvailableLicenseCount: 1,
+        shareCompanyPlan: true,
+        parentPlanProductCode: ADVANCED_PLAN_CODE,
+        parentPlanCompanyName: "parentName",
+        parentPlanContactEmail: "administratorEmail"
+      });
+
+      $rootScope.$emit("risevision.company.selectedCompanyChanged");
+      $rootScope.$digest();
+
+      setTimeout(function () {
+        expect($rootScope.$emit).to.have.been.called;
+        expect(currentPlanFactory.currentPlan).to.be.not.null;
+        expect(currentPlanFactory.currentPlan.type).to.equal("advanced");
+        expect(currentPlanFactory.currentPlan.status).to.equal("Active");
+        expect(currentPlanFactory.currentPlan.playerProTotalLicenseCount).to.equal(3);
+        expect(currentPlanFactory.currentPlan.playerProAvailableLicenseCount).to.equal(1);
+
+        expect(currentPlanFactory.currentPlan.shareCompanyPlan).to.be.true;
+        expect(currentPlanFactory.currentPlan.isParentPlan).to.be.true;
+        expect(currentPlanFactory.currentPlan.parentPlanCompanyName).to.equal("parentName");
+        expect(currentPlanFactory.currentPlan.parentPlanContactEmail).to.equal("administratorEmail");
+
+        done();
+      }, 0);
+    });
+
+    it("should give priority to Parent Company plan when available", function(done) {
+      sandbox.spy($rootScope, "$emit");
+      sandbox.stub(userState, "getSelectedCompanyId").returns("companyId");
+      sandbox.stub(userState, "getCopyOfSelectedCompany").returns({
+        id: "companyId",
+        planProductCode: BASIC_PLAN_CODE,
+        planSubscriptionStatus: "Subscribed",
+        planCurrentPeriodEndDate: "Jan 1, 2018",
+        planTrialExpiryDate: "Jan 14, 2018",
         playerProTotalLicenseCount: 3,
         playerProAvailableLicenseCount: 1,
         shareCompanyPlan: true,

--- a/web/scripts/components/plans/svc-current-plan-factory.js
+++ b/web/scripts/components/plans/svc-current-plan-factory.js
@@ -12,18 +12,18 @@
           var company = userState.getCopyOfSelectedCompany();
           var plan = null;
 
-          if (company.id && company.planProductCode) {
+          if (company.id && company.parentPlanProductCode) {
+            plan = _.cloneDeep(_plansByCode[company.parentPlanProductCode]);
+            plan.isParentPlan = true;
+            plan.status = 'Active';
+
+          } else if (company.id && company.planProductCode) {
             plan = _.cloneDeep(_plansByCode[company.planProductCode]);
 
             plan.status = company.planSubscriptionStatus;
             plan.trialPeriod = company.planTrialPeriod;
             plan.currentPeriodEndDate = new Date(company.planCurrentPeriodEndDate);
             plan.trialExpiryDate = new Date(company.planTrialExpiryDate);
-
-          } else if (company.id && company.parentPlanProductCode) {
-            plan = _.cloneDeep(_plansByCode[company.parentPlanProductCode]);
-            plan.isParentPlan = true;
-            plan.status = 'Active';
 
           } else {
             plan = _.cloneDeep(_plansByType.free);


### PR DESCRIPTION
## Description
When a parent company plan is present, we give priority to it over subcompany plan information.

## Motivation and Context
A Cancelled plan in a subcompany was being used instead of the shared Parent plan, so the subcompany could not access Shared Schedules.
Variation of https://github.com/Rise-Vision/rise-vision-apps/issues/1665.

## How Has This Been Tested?
Locally, pointing environment to production and validating against impacted company.
Staged on stage-1.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
