### PR TITLE
Start encoding job after upload

### DIFF
--- a/test/unit/storage/services/svc-encoding.tests.js
+++ b/test/unit/storage/services/svc-encoding.tests.js
@@ -33,7 +33,7 @@ describe('service: encoding:', function() {
   });
 
   it('should be applicable if file is video', function() {
-    $httpBackend.when('HEAD', /.*encoding-switch/).respond(200, {});
+    $httpBackend.when('HEAD', /.*encoding-switch-on/).respond(200, {});
 
     return encoding.isApplicable('video/subtype')
     .then(function(resp) {
@@ -42,7 +42,7 @@ describe('service: encoding:', function() {
   });
 
   it('should not be applicable if file is not video', function() {
-    $httpBackend.when('HEAD', /.*encoding-switch/).respond(200, {});
+    $httpBackend.when('HEAD', /.*encoding-switch-on/).respond(200, {});
 
     return encoding.isApplicable('text/subtype')
     .then(function(resp) {
@@ -51,7 +51,7 @@ describe('service: encoding:', function() {
   });
 
   it('should not be applicable if master switch is off', function() {
-    $httpBackend.when('HEAD', /.*encoding-switch/).respond(403, {});
+    $httpBackend.when('HEAD', /.*encoding-switch-on/).respond(403, {});
 
     return encoding.isApplicable('video/subtype')
     .then(function(resp) {
@@ -60,7 +60,7 @@ describe('service: encoding:', function() {
   });
 
   it('should retrieve encoder upload uri from storage server api', function() {
-    $httpBackend.when('HEAD', /.*encoding-switch/).respond(200, {});
+    $httpBackend.when('HEAD', /.*encoding-switch-on/).respond(200, {});
 
     return encoding.getResumableUploadURI('filename')
     .then(function(resp) {

--- a/web/scripts/storage/services/svc-encoding.js
+++ b/web/scripts/storage/services/svc-encoding.js
@@ -4,7 +4,7 @@ angular.module('risevision.storage.services')
   .service('encoding', ['$q', '$log', '$http', 'storageAPILoader', 'userState',
     function ($q, $log, $http, storageAPILoader, userState) {
       $log.debug('Loading encoding service');
-      var switchURL = 'https://storage.googleapis.com/risemedialibrary/encoding-switch';
+      var switchURL = 'https://storage.googleapis.com/risemedialibrary/encoding-switch-on';
       var masterSwitchPromise = $http({method: 'HEAD', url: switchURL});
 
       var service = {};
@@ -39,6 +39,44 @@ angular.module('risevision.storage.services')
         });
 
         return deferred.promise;
+      };
+
+      service.startEncoding = function(item) {
+        var deferred = $q.defer();
+        var obj = {
+          taskToken: item.taskToken,
+          fileUUID: item.tusURL.split('/').pop(),
+          fileName: item.file.name,
+          companyId: userState.getSelectedCompanyId()
+        };
+
+        $log.debug('Requesting encoding start', obj);
+
+        storageAPILoader().then(function (storageApi) {
+          return storageApi.startEncodingTask(obj);
+        })
+        .then(function (resp) {
+          deferred.resolve({
+            statusURL: resp.result.message,
+            fileName: resp.result.fileName
+          });
+        })
+        .then(null, function (e) {
+          $log.error('Error starting encoding task', e);
+          deferred.reject(e);
+        });
+
+        return deferred.promise;
+      };
+
+      service.monitorStatus = function(item, onProgress) {
+        var statusURL = item.encodingStatusURL;
+
+        $log.debug('Checking status at ' + statusURL);
+
+      };
+
+      service.acceptEncodedFile = function() {
       };
 
       return service;

--- a/web/scripts/storage/services/svc-file-upload.js
+++ b/web/scripts/storage/services/svc-file-upload.js
@@ -213,21 +213,24 @@ angular.module('risevision.storage.services')
             },
             onProgress: function(bytesUploaded, bytesTotal) {
               var pct = (bytesUploaded / bytesTotal * 100).toFixed(2);
-              svc.notifyProgressItem(item, pct);
+              svc.notifyProgressItem(item, pct / 2); // Arbitrarily expect encoding to take as long as uploading
             },
             onSuccess: function() {
               item.tusURL = tusUpload.url;
-              svc.startEncoding(item);
+              encoding.startEncoding(item)
+              .then(function(resp) {
+                item.encodingStatusURL = resp.statusURL;
+                item.encodedFileName = resp.fileName;
+              })
+              .then(null, function(e) {
+                svc.notifyErrorItem(item);
+                svc.notifyCompleteItem(item);
+              });
             }
           });
 
           svc.notifyBeforeUploadItem(item);
           tusUpload.start();
-        };
-
-        svc.startEncoding = function (item) {
-          svc.notifySuccessItem(item);
-          svc.notifyCompleteItem(item);
         };
 
         svc.cancelItem = function (value) {


### PR DESCRIPTION
## Description
Requests encoding job start after upload

## Motivation and Context
Storage Server has to trigger the job start. See [doc](https://docs.google.com/document/d/1iDBHE751IN4AndDMsAxuC5BnhN9J_K5giRm1vl4Bm3A/edit#)

## How Has This Been Tested?
Locally ran and confirmed jobs started and completed successfully per Qencode dashboard.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
