### PR TITLE
Revert fixed momentjs version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "Sortable": "^1.4.2",
     "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages",
     "xmlToJSON.js": "^1.3.2",
-    "moment": "2.24.0",
+    "moment": "^2.24.0",
     "angularjs-slider": "^7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
Revert fixed momentjs version.

## Motivation and Context
Fixed version was set earlier this week to overcome a build failure with v2.25.
Looks like it was a temporary problem, as it is now working. It is using v2.25.2.

## How Has This Been Tested?
Build passes without errors.
[stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
