### PR TITLE
Twitter saves 'isStaging' attribute 

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-twitter.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-twitter.tests.js
@@ -13,7 +13,7 @@ describe('directive: templateComponentTwitter', function() {
     factory = { selected: { id: "TEST-ID" }, presentation: {companyId: "abc123"} };
     oauthService = {};
     twitterCredentialsValidation = {};
-    templateEditorUtils = {};
+    templateEditorUtils = {isStaging: sandbox.stub()};
   });
 
   beforeEach(module('risevision.template-editor.directives'));
@@ -279,7 +279,7 @@ describe('directive: templateComponentTwitter', function() {
     describe('isStaging', function () {
       it('should save isStaging to true', function() {
         $scope.setAttributeData = sandbox.stub();
-        templateEditorUtils.isStaging = sandbox.stub().returns(true);
+        $scope.isStaging = true;
         $scope.username = '@twitterHandle';
 
         $scope.save();
@@ -291,7 +291,7 @@ describe('directive: templateComponentTwitter', function() {
 
       it('should save isStaging to false', function() {
         $scope.setAttributeData = sandbox.stub();
-        templateEditorUtils.isStaging = sandbox.stub().returns(false);
+        $scope.isStaging = false;
         $scope.username = '@twitterHandle';
 
         $scope.save();

--- a/test/unit/template-editor/components/directives/dtv-component-twitter.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-twitter.tests.js
@@ -6,12 +6,14 @@ describe('directive: templateComponentTwitter', function() {
     factory,
     oauthService,
     twitterCredentialsValidation,
+    templateEditorUtils,
     sandbox = sinon.sandbox.create();
 
   beforeEach(function() {
     factory = { selected: { id: "TEST-ID" }, presentation: {companyId: "abc123"} };
     oauthService = {};
     twitterCredentialsValidation = {};
+    templateEditorUtils = {};
   });
 
   beforeEach(module('risevision.template-editor.directives'));
@@ -30,6 +32,10 @@ describe('directive: templateComponentTwitter', function() {
 
     $provide.service('twitterCredentialsValidation', function() {
       return twitterCredentialsValidation;
+    });
+
+    $provide.service('templateEditorUtils', function() {
+      return templateEditorUtils;
     });
   }));
 
@@ -220,6 +226,10 @@ describe('directive: templateComponentTwitter', function() {
   });
 
   describe('save', function () {
+    beforeEach(function() {
+      templateEditorUtils.isStaging = sandbox.stub();
+    });
+
     describe('username', function () {
       it('should save data and indicate the username is valid', function() {
         $scope.setAttributeData = sandbox.stub();
@@ -238,7 +248,7 @@ describe('directive: templateComponentTwitter', function() {
 
         $scope.save();
 
-        expect($scope.setAttributeData).to.not.have.been.called;
+        expect($scope.setAttributeData.callCount).to.equal(1);
         expect($scope.usernameStatus).to.equal('INVALID_USERNAME');
       });
     });
@@ -261,8 +271,34 @@ describe('directive: templateComponentTwitter', function() {
 
         $scope.save();
 
-        expect($scope.setAttributeData).to.not.have.been.called;
+        expect($scope.setAttributeData.callCount).to.equal(1);
         expect($scope.maxitemsStatus).to.equal('INVALID_RANGE');
+      });
+    });
+
+    describe('isStaging', function () {
+      it('should save isStaging to true', function() {
+        $scope.setAttributeData = sandbox.stub();
+        templateEditorUtils.isStaging = sandbox.stub().returns(true);
+        $scope.username = '@twitterHandle';
+
+        $scope.save();
+
+        expect($scope.setAttributeData.callCount).to.equal(2);
+        console.log($scope.setAttributeData.firstCall.args);
+        expect($scope.setAttributeData.firstCall.args[2]).to.be.true;
+      });
+
+      it('should save isStaging to false', function() {
+        $scope.setAttributeData = sandbox.stub();
+        templateEditorUtils.isStaging = sandbox.stub().returns(false);
+        $scope.username = '@twitterHandle';
+
+        $scope.save();
+
+        expect($scope.setAttributeData.callCount).to.equal(2);
+        console.log($scope.setAttributeData.firstCall.args);
+        expect($scope.setAttributeData.firstCall.args[2]).to.be.false;
       });
     });
   });

--- a/web/scripts/template-editor/components/directives/dtv-component-twitter.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-twitter.js
@@ -27,6 +27,7 @@ angular.module('risevision.template-editor.directives')
           $scope.connected = false;
           $scope.username = null;
           $scope.usernameStatus = null;
+          $scope.isStaging = templateEditorUtils.isStaging();
 
           $scope.connectToTwitter = function () {
             $scope.spinner = true;
@@ -46,7 +47,7 @@ angular.module('risevision.template-editor.directives')
           };
 
           $scope.save = function () {
-            $scope.setAttributeData($scope.componentId, 'isStaging', templateEditorUtils.isStaging());
+            $scope.setAttributeData($scope.componentId, 'isStaging', $scope.isStaging);
 
             if (_validateUsername($scope.username)) {
               $scope.setAttributeData($scope.componentId, 'username', $scope.username.replace('@', ''));

--- a/web/scripts/template-editor/components/directives/dtv-component-twitter.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-twitter.js
@@ -2,8 +2,8 @@
 
 angular.module('risevision.template-editor.directives')
   .directive('templateComponentTwitter', ['templateEditorFactory', 'TwitterOAuthService', '$loading',
-    'twitterCredentialsValidation',
-    function (templateEditorFactory, TwitterOAuthService, $loading, twitterCredentialsValidation) {
+    'twitterCredentialsValidation', 'templateEditorUtils',
+    function (templateEditorFactory, TwitterOAuthService, $loading, twitterCredentialsValidation, templateEditorUtils) {
       return {
         restrict: 'E',
         scope: true,
@@ -36,6 +36,7 @@ angular.module('risevision.template-editor.directives')
                 $scope.connectionFailure = false;
 
                 $scope.setAttributeData($scope.componentId, 'credentialsUpdated', Date.now());
+                $scope.setAttributeData($scope.componentId, 'isStaging', templateEditorUtils.isStaging());
               }, function () {
                 _handleConnectionFailure();
               })

--- a/web/scripts/template-editor/components/directives/dtv-component-twitter.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-twitter.js
@@ -37,7 +37,6 @@ angular.module('risevision.template-editor.directives')
                 $scope.connectionFailure = false;
 
                 $scope.setAttributeData($scope.componentId, 'credentialsUpdated', Date.now());
-                $scope.setAttributeData($scope.componentId, 'isStaging', templateEditorUtils.isStaging());
               }, function () {
                 _handleConnectionFailure();
               })
@@ -47,6 +46,8 @@ angular.module('risevision.template-editor.directives')
           };
 
           $scope.save = function () {
+            $scope.setAttributeData($scope.componentId, 'isStaging', templateEditorUtils.isStaging());
+
             if (_validateUsername($scope.username)) {
               $scope.setAttributeData($scope.componentId, 'username', $scope.username.replace('@', ''));
             }

--- a/web/scripts/template-editor/components/directives/dtv-component-twitter.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-twitter.js
@@ -3,7 +3,8 @@
 angular.module('risevision.template-editor.directives')
   .directive('templateComponentTwitter', ['templateEditorFactory', 'TwitterOAuthService', '$loading',
     'twitterCredentialsValidation', 'templateEditorUtils',
-    function (templateEditorFactory, TwitterOAuthService, $loading, twitterCredentialsValidation, templateEditorUtils) {
+    function (templateEditorFactory, TwitterOAuthService, $loading, twitterCredentialsValidation,
+      templateEditorUtils) {
       return {
         restrict: 'E',
         scope: true,

--- a/web/scripts/template-editor/services/svc-template-editor-utils.js
+++ b/web/scripts/template-editor/services/svc-template-editor-utils.js
@@ -52,13 +52,13 @@ angular.module('risevision.template-editor.services')
         try {
           var hostname = window.location.hostname;
 
-          return hostname.includes("apps-stage-");
+          return hostname.includes('apps-stage-');
         } catch (err) {
-          console.log("can't access hostname of window.location")
+          console.log('can\'t access hostname of window.location');
         }
 
         return false;
-      }
+      };
 
       svc.fileNameOf = function (path) {
         var parts = path.split('/');

--- a/web/scripts/template-editor/services/svc-template-editor-utils.js
+++ b/web/scripts/template-editor/services/svc-template-editor-utils.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.template-editor.services')
-  .factory('templateEditorUtils', ['messageBox',
-    function (messageBox) {
+  .factory('templateEditorUtils', ['messageBox', '$window',
+    function (messageBox, $window) {
       var svc = {};
 
       svc.intValueFor = function (providedValue, defaultValue) {
@@ -50,7 +50,7 @@ angular.module('risevision.template-editor.services')
 
       svc.isStaging = function () {
         try {
-          var hostname = window.location.hostname;
+          var hostname = $window.location.hostname;
 
           return hostname.includes('apps-stage-');
         } catch (err) {

--- a/web/scripts/template-editor/services/svc-template-editor-utils.js
+++ b/web/scripts/template-editor/services/svc-template-editor-utils.js
@@ -48,6 +48,18 @@ angular.module('risevision.template-editor.services')
         return path[path.length - 1] === '/';
       };
 
+      svc.isStaging = function () {
+        try {
+          var hostname = window.location.hostname;
+
+          return hostname.includes("apps-stage-");
+        } catch (err) {
+          console.log("can't access hostname of window.location")
+        }
+
+        return false;
+      }
+
       svc.fileNameOf = function (path) {
         var parts = path.split('/');
 


### PR DESCRIPTION
## Description
Adding template service util function `isStaging` which checks `window.location.hostname` for _apps-stage-_ is included in the value to determine if this is Apps staging. 

Twitter component uses this function to store its value on initialization and saves to attribute data upon every _username_ and/or _maxitems_ save.   

This is to coincide with changes to Twitter Component on PR - https://github.com/Rise-Vision/rise-data-twitter/pull/33

## Motivation and Context
Twitter web component requires constructing service url to target either staging or production cluster. When component runs on a display, it needs to know if the company is a Test/Staging company so it targets staging service cluster. Further details on Twitter Component PR.

## How Has This Been Tested?
Tested on Apps Stage 8 and on ChrOS display using Charles to map to local version of component. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
