### PR TITLE
Monitor status after job start

### DIFF
--- a/web/scripts/storage/services/svc-file-upload.js
+++ b/web/scripts/storage/services/svc-file-upload.js
@@ -213,7 +213,9 @@ angular.module('risevision.storage.services')
             },
             onProgress: function(bytesUploaded, bytesTotal) {
               var pct = (bytesUploaded / bytesTotal * 100).toFixed(2);
-              svc.notifyProgressItem(item, pct / 2); // Arbitrarily expect encoding to take as long as uploading
+
+              // Arbitrarily expect encoding to take as long as uploading
+              svc.notifyProgressItem(item, pct / 2);
             },
             onSuccess: function() {
               item.tusURL = tusUpload.url;
@@ -221,6 +223,17 @@ angular.module('risevision.storage.services')
               .then(function(resp) {
                 item.encodingStatusURL = resp.statusURL;
                 item.encodedFileName = resp.fileName;
+
+                return encoding.monitorStatus(item, function(pct) {
+                  // Arbitrarily expect upload was first 50% of progress,
+                  // and encoding is remaining 50%
+                  svc.notifyProgressItem(item, 50 + pct / 2);
+                });
+              })
+              .then(encoding.acceptEncodedFile)
+              .then(function() {
+                svc.notifySuccessItem(item);
+                svc.notifyCompleteItem(item);
               })
               .then(null, function(e) {
                 svc.notifyErrorItem(item);


### PR DESCRIPTION
## Description
Polls for progress from the encoder provider status url, assigning the upload to 50% of total time and encoding to the remaining 50% of total time. There is only one progress bar for the entire upload / encode process, and the UI does not indicate that there are multiple steps occurring (per Alan).

## Motivation and Context
During file upload, the user is presented with a progress bar. This encorporates encoding time into that progress bar.

## How Has This Been Tested?
Unit tests + local manual tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
