### PR TITLE
Add template to Core on creation

### DIFF
--- a/test/unit/template-editor/app.tests.js
+++ b/test/unit/template-editor/app.tests.js
@@ -182,7 +182,7 @@ describe('app:', function() {
     });
 
     describe('states: ', function() {
-      it('should retrieve existing presentation', function(done) {
+      it('should retrieve presentation by id', function(done) {
         var $stateParams = {
           presentationId: 'presentationId'
         };
@@ -190,6 +190,38 @@ describe('app:', function() {
         $state.get('apps.editor.templates.edit').resolve.presentationInfo[6]($stateParams, canAccessApps, editorFactory, templateEditorFactory, checkTemplateAccess, financialLicenseFactory)
           .then(function() {
             templateEditorFactory.getPresentation.should.have.been.calledWith('presentationId');
+
+            done();
+          });
+      });
+
+      it('should not retrieve existing presentation', function(done) {
+        var $stateParams = {
+          presentationId: 'presentationId'
+        };
+        templateEditorFactory.presentation = {
+          id: 'presentationId'
+        };
+
+        $state.get('apps.editor.templates.edit').resolve.presentationInfo[6]($stateParams, canAccessApps, editorFactory, templateEditorFactory, checkTemplateAccess, financialLicenseFactory)
+          .then(function() {
+            templateEditorFactory.getPresentation.should.not.have.been.called;
+
+            done();
+          });
+      });
+
+      it('should retrieve a different presentation', function(done) {
+        var $stateParams = {
+          presentationId: 'otherPresentationId'
+        };
+        templateEditorFactory.presentation = {
+          id: 'presentationId'
+        };
+
+        $state.get('apps.editor.templates.edit').resolve.presentationInfo[6]($stateParams, canAccessApps, editorFactory, templateEditorFactory, checkTemplateAccess, financialLicenseFactory)
+          .then(function() {
+            templateEditorFactory.getPresentation.should.have.been.calledWith('otherPresentationId');
 
             done();
           });

--- a/test/unit/template-editor/controllers/ctr-template-editor.tests.js
+++ b/test/unit/template-editor/controllers/ctr-template-editor.tests.js
@@ -30,7 +30,7 @@ describe('controller: TemplateEditor', function() {
     }
   ];
 
-  var $rootScope, $scope, $modal, $timeout, $window, $state, factory, scheduleFactory, blueprintFactory, userState;
+  var $rootScope, $scope, $modal, $timeout, $window, $state, factory, blueprintFactory, userState;
   var sandbox = sinon.sandbox.create();
 
   beforeEach(function() {
@@ -67,11 +67,6 @@ describe('controller: TemplateEditor', function() {
         getBlueprintData: sandbox.stub().returns('blueprintData')
       };
     });
-    $provide.factory('scheduleFactory',function() {
-      return {
-        hasSchedules: function () {}
-      };
-    });
     $provide.factory('userState',function() {
       return {
         _restoreState: sandbox.stub(), 
@@ -106,7 +101,6 @@ describe('controller: TemplateEditor', function() {
       $state = $injector.get('$state');
       factory = $injector.get('templateEditorFactory');
       blueprintFactory = $injector.get('blueprintFactory');
-      scheduleFactory = $injector.get('scheduleFactory');
       userState = $injector.get('userState');
 
       $controller('TemplateEditorController', {

--- a/test/unit/template-editor/services/svc-template-editor-factory.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-factory.tests.js
@@ -53,8 +53,15 @@ describe('service: templateEditorFactory:', function() {
       };
     });
 
+    $provide.factory('scheduleFactory', function() {
+      return {
+        hasSchedules: sandbox.stub().returns(true)
+      };
+    });
+
     $provide.factory('brandingFactory', function() {
       return {
+        isRevised: sandbox.stub().returns(false),
         publishBranding: sandbox.stub(),
         saveBranding: sandbox.stub()
       };
@@ -71,7 +78,7 @@ describe('service: templateEditorFactory:', function() {
   }));
 
   var $state, templateEditorFactory, templateEditorUtils, blueprintFactory, presentation, processErrorCode,
-    HTML_PRESENTATION_TYPE, storeProduct, plansFactory, createFirstSchedule, brandingFactory;
+    HTML_PRESENTATION_TYPE, storeProduct, plansFactory, createFirstSchedule, scheduleFactory, brandingFactory;
 
   beforeEach(function() {
     inject(function($injector) {
@@ -81,6 +88,7 @@ describe('service: templateEditorFactory:', function() {
       presentation = $injector.get('presentation');
       plansFactory = $injector.get('plansFactory');
       createFirstSchedule = $injector.get('createFirstSchedule');
+      scheduleFactory = $injector.get('scheduleFactory');
       brandingFactory = $injector.get('brandingFactory');
       storeProduct = $injector.get('storeProduct');
       templateEditorUtils = $injector.get('templateEditorUtils');
@@ -589,6 +597,56 @@ describe('service: templateEditorFactory:', function() {
     });
   });
 
+  describe('isPublishDisabled: ', function() {
+    beforeEach(function() {
+      templateEditorFactory.presentation.revisionStatusName = 'Published';
+      templateEditorFactory.savingPresentation = false;
+      templateEditorFactory.hasUnsavedChanges = false;
+    });
+
+    it('should return true if neither factory isRevised', function() {
+      expect(templateEditorFactory.isPublishDisabled()).to.be.true;
+    });
+
+    it('should return false if this factory hasUnsavedChanges', function() {
+      templateEditorFactory.presentation.revisionStatusName = 'Revised';
+
+      expect(templateEditorFactory.isPublishDisabled()).to.be.false;
+    });
+
+    it('should return false if branding hasUnsavedChanges', function() {
+      brandingFactory.isRevised.returns(true);
+
+      expect(templateEditorFactory.isPublishDisabled()).to.be.false;
+    });
+
+    it('should return false if both factories have UnsavedChanges', function() {
+      templateEditorFactory.presentation.revisionStatusName = 'Revised';
+      brandingFactory.isRevised.returns(true);
+
+      expect(templateEditorFactory.isPublishDisabled()).to.be.false;
+    });
+
+    it('should return true if factory hasUnsavedChanges', function() {
+      templateEditorFactory.presentation.revisionStatusName = 'Revised';
+      brandingFactory.isRevised.returns(true);
+
+      templateEditorFactory.hasUnsavedChanges = true;
+
+      expect(templateEditorFactory.isPublishDisabled()).to.be.true;
+    });
+
+    it('should return true if factory is saving', function() {
+      templateEditorFactory.presentation.revisionStatus = 'Revised';
+      brandingFactory.isRevised.returns(true);
+
+      templateEditorFactory.savingPresentation = true;
+
+      expect(templateEditorFactory.isPublishDisabled()).to.be.true;
+    });
+
+  });
+
   describe('publish: ', function() {
     beforeEach(function (done) {
       createFirstSchedule.returns(Q.resolve());
@@ -636,8 +694,10 @@ describe('service: templateEditorFactory:', function() {
     });
 
     describe('publishTemplate: ', function() {
+      beforeEach(function() {
+        sandbox.stub(presentation, 'publish').returns(Q.resolve());
+      });
       it('should not publish the presentation if it is not revised', function(done) {
-        sandbox.stub(presentation, 'publish');
         sandbox.stub(templateEditorFactory, 'isRevised').returns(false);
 
         templateEditorFactory.publish()
@@ -653,8 +713,6 @@ describe('service: templateEditorFactory:', function() {
       });
 
       it('should publish the presentation', function(done) {
-        sandbox.stub(presentation, 'publish').returns(Q.resolve());
-
         var timeBeforePublish = new Date();
 
         templateEditorFactory.publish()
@@ -683,7 +741,7 @@ describe('service: templateEditorFactory:', function() {
       });
 
       it('should show an error if fails to publish the presentation', function(done) {
-        sandbox.stub(presentation, 'publish').returns(Q.reject());
+        presentation.publish.returns(Q.reject());
 
         templateEditorFactory.publish()
           .then(null, function(e) {
@@ -700,9 +758,7 @@ describe('service: templateEditorFactory:', function() {
       });
 
       it('should create first Schedule when publishing first presentation and show modal', function(done) {
-        sandbox.stub(presentation, 'publish').returns(Q.resolve());
-
-        templateEditorFactory.publish(templateEditorFactory)
+        templateEditorFactory.publish()
           .then(function() {
             setTimeout(function() {
               createFirstSchedule.should.have.been.calledWith(templateEditorFactory.presentation);
@@ -715,6 +771,24 @@ describe('service: templateEditorFactory:', function() {
           })
           .then(null, done);
       });
+
+      it('should create first Schedule and show modal even if not revised', function(done) {
+        sandbox.stub(templateEditorFactory, 'isRevised').returns(false);
+
+        templateEditorFactory.publish()
+          .then(function() {
+            setTimeout(function() {
+              createFirstSchedule.should.have.been.calledWith(templateEditorFactory.presentation);
+
+              done();
+            });
+          })
+          .then(null, function(err) {
+            done(err);
+          })
+          .then(null, done);
+      });
+
     });
 
     describe('publishBranding: ', function() {

--- a/test/unit/template-editor/services/svc-template-editor-factory.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-factory.tests.js
@@ -11,7 +11,7 @@ describe('service: templateEditorFactory:', function() {
 
     $provide.service('presentation',function () {
       return {
-        add : function() {},
+        add : sinon.stub().returns(Q.resolve()),
         update : function() {},
         get: function() {},
         delete: function () {},
@@ -116,6 +116,8 @@ describe('service: templateEditorFactory:', function() {
       ];
 
       templateEditorFactory.addFromProduct({ productCode: 'test-id', name: 'Test HTML Template' }).then(function () {
+        expect(presentation.add).to.have.been.called;
+
         expect(templateEditorFactory.presentation.id).to.be.undefined;
         expect(templateEditorFactory.presentation.productCode).to.equal('test-id');
         expect(templateEditorFactory.presentation.name).to.equal('Copy of Test HTML Template');
@@ -154,7 +156,7 @@ describe('service: templateEditorFactory:', function() {
 
   describe('save: ', function() {
     beforeEach(function() {
-      sandbox.stub(presentation, 'add').returns(Q.resolve({
+      presentation.add.returns(Q.resolve({
         item: {
           name: 'Test Presentation',
           id: 'presentationId',
@@ -169,10 +171,7 @@ describe('service: templateEditorFactory:', function() {
         }
       }));
 
-      templateEditorFactory.addFromProduct({ productCode: 'test-id', name: 'Test HTML Template' });
-      expect(templateEditorFactory.presentation.id).to.be.undefined;
-      expect(templateEditorFactory.presentation.productCode).to.equal('test-id');
-      expect(templateEditorFactory.presentation.templateAttributeData).to.deep.equal({});
+      templateEditorFactory.presentation.templateAttributeData = {};
     });
 
     it('should wait for both promises to resolve', function(done) {

--- a/web/partials/template-editor/footer.html
+++ b/web/partials/template-editor/footer.html
@@ -16,7 +16,7 @@
     <div class="text-danger">You don’t have permission to edit</div>
   </div>
   <button id="publishButton" require-role="cp" class="btn btn-primary btn-block"
-          ng-disabled="isPublishDisabled()"
+          ng-disabled="factory.isPublishDisabled()"
           ng-click="factory.publish()">
     Publish To Display
   </button>

--- a/web/partials/template-editor/toolbar.html
+++ b/web/partials/template-editor/toolbar.html
@@ -28,7 +28,7 @@
     <div class="text-danger">You don’t have permission to edit</div>
   </div>
   <button id="publishButtonDesktop" require-role="cp" class="btn btn-primary btn-fixed-width"
-          ng-disabled="isPublishDisabled()"
+          ng-disabled="factory.isPublishDisabled()"
           ng-click="factory.publish()">
     Publish To Display
   </button>

--- a/web/scripts/template-editor/app.js
+++ b/web/scripts/template-editor/app.js
@@ -43,13 +43,12 @@ angular.module('risevision.apps')
                       } else {
                         return editorFactory.addFromProductId($stateParams.productId);
                       }
-                    } else {
+                    } else if (!templateEditorFactory.presentation || templateEditorFactory.presentation.id !== $stateParams.presentationId) {
                       return templateEditorFactory.getPresentation($stateParams.presentationId);
                     }
                   })
                   .then(function () {
-                    if ($stateParams.presentationId === 'new' && financialLicenseFactory
-                      .needsFinancialDataLicense()) {
+                    if ($stateParams.presentationId === 'new' && financialLicenseFactory.needsFinancialDataLicense()) {
                       financialLicenseFactory.showFinancialDataLicenseRequiredMessage();
                     } else if (!$stateParams.skipAccessNotice) {
                       checkTemplateAccess(true);

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -2,10 +2,10 @@
 
 angular.module('risevision.template-editor.controllers')
   .controller('TemplateEditorController', ['$scope', '$q', '$filter', '$loading', '$state', '$timeout', '$window',
-    'templateEditorFactory', 'brandingFactory', 'blueprintFactory', 'scheduleFactory', 'AutoSaveService',
+    'templateEditorFactory', 'blueprintFactory', 'AutoSaveService',
     'presentationUtils', 'userState',
-    function ($scope, $q, $filter, $loading, $state, $timeout, $window, templateEditorFactory, brandingFactory,
-      blueprintFactory, scheduleFactory, AutoSaveService, presentationUtils, userState) {
+    function ($scope, $q, $filter, $loading, $state, $timeout, $window, templateEditorFactory,
+      blueprintFactory, AutoSaveService, presentationUtils, userState) {
       var autoSaveService = new AutoSaveService(templateEditorFactory.save);
 
       $scope.factory = templateEditorFactory;
@@ -43,13 +43,6 @@ angular.module('risevision.template-editor.controllers')
         return _.map(filteredComponents, function (component) {
           return component.id;
         });
-      };
-
-      $scope.isPublishDisabled = function () {
-        var isNotRevised = !$scope.factory.isRevised() && !brandingFactory.isRevised() &&
-          scheduleFactory.hasSchedules();
-
-        return $scope.factory.savingPresentation || $scope.factory.isUnsaved() || isNotRevised;
       };
 
       $scope.hasContentEditorRole = function () {

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -4,10 +4,10 @@ angular.module('risevision.template-editor.services')
   .constant('HTML_TEMPLATE_DOMAIN', 'https://widgets.risevision.com')
   .factory('templateEditorFactory', ['$q', '$log', '$state', '$rootScope', 'presentation',
     'processErrorCode', 'userState', 'createFirstSchedule',
-    'templateEditorUtils', 'brandingFactory', 'blueprintFactory', 'presentationTracker',
+    'templateEditorUtils', 'brandingFactory', 'blueprintFactory', 'scheduleFactory', 'presentationTracker',
     'HTML_PRESENTATION_TYPE', 'REVISION_STATUS_REVISED', 'REVISION_STATUS_PUBLISHED',
     function ($q, $log, $state, $rootScope, presentation, processErrorCode, userState,
-      createFirstSchedule, templateEditorUtils, brandingFactory, blueprintFactory,
+      createFirstSchedule, templateEditorUtils, brandingFactory, blueprintFactory, scheduleFactory,
       presentationTracker, HTML_PRESENTATION_TYPE, REVISION_STATUS_REVISED, REVISION_STATUS_PUBLISHED) {
       var factory = {
         hasUnsavedChanges: false
@@ -221,6 +221,13 @@ angular.module('risevision.template-editor.services')
         return factory.presentation.revisionStatusName === REVISION_STATUS_REVISED;
       };
 
+      factory.isPublishDisabled = function () {
+        var isNotRevised = !factory.isRevised() && !brandingFactory.isRevised() &&
+          scheduleFactory.hasSchedules();
+
+        return factory.savingPresentation || factory.isUnsaved() || isNotRevised;
+      };
+
       factory.publish = function () {
         var deferred = $q.defer();
 
@@ -298,7 +305,7 @@ angular.module('risevision.template-editor.services')
       var _publishPresentation = function () {
         if (!factory.isRevised()) {
           // template is already published
-          return $q.resolve();
+          return _createFirstSchedule();
         }
 
         return presentation.publish(factory.presentation.id)

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -61,6 +61,7 @@ angular.module('risevision.template-editor.services')
         presentationTracker('HTML Template Copied', productDetails.productCode, productDetails.name);
 
         return blueprintFactory.getBlueprintCached(factory.presentation.productCode)
+          .then(factory.save)
           .then(null, function (e) {
             _showErrorMessage('add', e);
             return $q.reject(e);
@@ -75,6 +76,8 @@ angular.module('risevision.template-editor.services')
             if (resp && resp.item && resp.item.id) {
               $rootScope.$broadcast('presentationCreated');
 
+              _setPresentation(resp.item);
+
               presentationTracker('Presentation Created', resp.item.id, resp.item.name, {
                 presentationType: 'HTML Template',
                 sharedTemplate: resp.item.productCode
@@ -85,7 +88,6 @@ angular.module('risevision.template-editor.services')
                 productId: undefined,
                 skipAccessNotice: true
               }, {
-                notify: false,
                 location: 'replace'
               });
 


### PR DESCRIPTION
## Description
Add template to Core on creation
Do not wait for controller to autosave; add it on selection.

Create first schedule when publishing
Trigger schedule creation even if not revised
Skip publishing
`_createFirstSchedule` handles case when this is not the first schedule

[stage-2]
## Motivation and Context
Fix for #1672 

Fixes issue where Publish button is enabled but nothing happens when pressed.

## How Has This Been Tested?
Tested Template creation use cases for both Subscribed and Unsubscribed companies. Tested Financial Template creation. Tested Publish. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No