### PR TITLE
Use config for encoding url and add e2e

### DIFF
--- a/test/e2e/storage/cases/upload.js
+++ b/test/e2e/storage/cases/upload.js
@@ -11,6 +11,7 @@ var UploadScenarios = function() {
   describe('Upload', function () {  
     var storageSelectorModalPage = new StorageSelectorModalPage();
     var filesListPage = new FilesListPage();
+    var uploadFilePath;
   
     var describeUpload = function () {
 
@@ -20,7 +21,7 @@ var UploadScenarios = function() {
       });
 
       it('should upload file', function(){
-        var uploadFilePath = process.cwd() + '/package.json';
+        uploadFilePath = uploadFilePath || (process.cwd() + '/package.json');
         storageSelectorModalPage.getUploadInput().sendKeys(uploadFilePath);
 
         expect(storageSelectorModalPage.getUploadPanel().isDisplayed()).to.eventually.be.true;
@@ -61,6 +62,16 @@ var UploadScenarios = function() {
       describe('Upload File:', describeUpload);
     });
     
+    describe('And he is using Storage Home with encoding enabled:',function(){
+      before(function () {
+        StorageHelper.setupStorageHomeWithEncoding();
+        uploadFilePath = process.cwd() + '/web/videos/e2e-upload-video-1.mp4';
+      });
+      after(function () {
+        uploadFilePath = null;
+      });
+      describe('Upload File:', describeUpload);
+    });
   });
 };
 module.exports = UploadScenarios;

--- a/test/e2e/storage/pages/helper.js
+++ b/test/e2e/storage/pages/helper.js
@@ -48,6 +48,11 @@
       helper.waitDisappear(filesListPage.getFilesListLoader(), 'Storage Files Loader');
     },
 
+    setupStorageHomeWithEncoding: function() {
+      browser.driver.executeScript('sessionStorage.setItem("force-upload-encoding", true)');
+      factory.setupStorageHome();
+    },
+
     setupAppsSingleFileSelector: function(){
       homepage.getEditor();
       signInPage.signIn();

--- a/test/unit/storage/services/svc-encoding.tests.js
+++ b/test/unit/storage/services/svc-encoding.tests.js
@@ -3,6 +3,7 @@ describe('service: encoding:', function() {
   var encoding, $httpBackend, authRequestHandler, $timeout;
 
   beforeEach(module('risevision.storage.services'));
+  beforeEach(module('risevision.apps.config'));
 
   beforeEach(module(function ($provide) {
     $provide.service('$q', function() {return Q;});
@@ -35,8 +36,9 @@ describe('service: encoding:', function() {
   });
 
   describe('applicability', function() {
+    console.log('service: encoding: applicability');
     it('should be applicable if file is video', function() {
-      $httpBackend.when('HEAD', /.*encoding-switch-on/).respond(200, {});
+      $httpBackend.when('HEAD', /.*encoding/).respond(200, {});
 
       return encoding.isApplicable('video/subtype')
       .then(function(resp) {
@@ -45,7 +47,7 @@ describe('service: encoding:', function() {
     });
 
     it('should not be applicable if file is not video', function() {
-      $httpBackend.when('HEAD', /.*encoding-switch-on/).respond(200, {});
+      $httpBackend.when('HEAD', /.*encoding/).respond(200, {});
 
       return encoding.isApplicable('text/subtype')
       .then(function(resp) {
@@ -54,7 +56,7 @@ describe('service: encoding:', function() {
     });
 
     it('should not be applicable if master switch is off', function() {
-      $httpBackend.when('HEAD', /.*encoding-switch-on/).respond(403, {});
+      $httpBackend.when('HEAD', /.*encoding/).respond(403, {});
 
       return encoding.isApplicable('video/subtype')
       .then(function(resp) {
@@ -65,8 +67,9 @@ describe('service: encoding:', function() {
   });
 
   describe('upload uri', function() {
+    console.log('service: encoding: upload uri');
     it('should retrieve encoder upload uri from storage server api', function() {
-      $httpBackend.when('HEAD', /.*encoding-switch-on/).respond(200, {});
+      $httpBackend.when('HEAD', /.*encoding/).respond(200, {});
 
       return encoding.getResumableUploadURI('filename')
       .then(function(resp) {
@@ -76,6 +79,7 @@ describe('service: encoding:', function() {
   });
 
   describe('task status checks', function() {
+    console.log('service: encoding: ');
     var taskToken = '12345';
 
     var item = {
@@ -87,7 +91,7 @@ describe('service: encoding:', function() {
       var statusResponse = {statuses: {}};
       statusResponse.statuses[taskToken] = {percent: 50};
 
-      $httpBackend.when('HEAD', /.*encoding-switch-on/).respond(200, {});
+      $httpBackend.when('HEAD', /.*encoding/).respond(200, {});
       $httpBackend.when('POST', /.*status/).respond(200, statusResponse);
 
       var statusPromise = encoding.monitorStatus(item, onProgressSetStatusComplete);
@@ -106,7 +110,7 @@ describe('service: encoding:', function() {
     });
 
     it('retries on monitor check failure', function() {
-      $httpBackend.when('HEAD', /.*encoding-switch-on/).respond(200, {});
+      $httpBackend.when('HEAD', /.*encoding/).respond(200, {});
 
       var statusResponse = {statuses: {}};
       statusResponse.statuses[taskToken] = {percent: 100};
@@ -135,8 +139,9 @@ describe('service: encoding:', function() {
   });
 
   describe('file acceptance', function() {
+    console.log('service: encoding: file acceptance');
     it('should accept the file after encoding', function() {
-      $httpBackend.when('HEAD', /.*encoding-switch-on/).respond(200, {});
+      $httpBackend.when('HEAD', /.*encoding/).respond(200, {});
 
       return encoding.acceptEncodedFile('companyid', 'filename')
       .then(function(resp) {

--- a/test/unit/storage/services/svc-file-upload.tests.js
+++ b/test/unit/storage/services/svc-file-upload.tests.js
@@ -3,6 +3,7 @@
 describe('Services: uploader', function() {
   'use strict';
 
+  beforeEach(module('risevision.apps.config'));
   beforeEach(module('risevision.storage.services'));
 
   beforeEach(module(function ($provide) {

--- a/web/scripts/config/dev.js
+++ b/web/scripts/config/dev.js
@@ -23,6 +23,8 @@
 
   angular.module('risevision.apps.config', [])
     .value('APPS_ENV', 'TEST')
+    .value('ENCODING_MASTER_SWITCH_URL',
+      'https://storage.googleapis.com/risemedialibrary/encoding-switch-on')
     .value('STORAGE_API_ROOT',
       'https://storage-dot-rvacore-test.appspot.com/_ah/api')
     .value('STORE_ENDPOINT_URL',

--- a/web/scripts/config/prod.js
+++ b/web/scripts/config/prod.js
@@ -18,6 +18,8 @@
 
   angular.module('risevision.apps.config', [])
     .value('APPS_ENV', 'PROD')
+    .value('ENCODING_MASTER_SWITCH_URL',
+      'https://storage.googleapis.com/risemedialibrary/encoding-switch-on')
     .value('STORE_ENDPOINT_URL',
       'https://store-dot-rvaserver2.appspot.com/_ah/api')
     .value('RVA_URL', 'http://rva.risevision.com')

--- a/web/scripts/config/stage.js
+++ b/web/scripts/config/stage.js
@@ -22,6 +22,8 @@
 
   angular.module('risevision.apps.config', [])
     .value('APPS_ENV', 'TEST')
+    .value('ENCODING_MASTER_SWITCH_URL',
+      'https://storage.googleapis.com/risemedialibrary/encoding-switch-on')
     .value('STORAGE_API_ROOT',
       'https://storage-dot-rvacore-test.appspot.com/_ah/api')
     .value('STORE_ENDPOINT_URL',

--- a/web/scripts/config/test.js
+++ b/web/scripts/config/test.js
@@ -23,6 +23,8 @@
 
   angular.module('risevision.apps.config', [])
     .value('APPS_ENV', 'TEST')
+    .value('ENCODING_MASTER_SWITCH_URL',
+      'https://storage.googleapis.com/risemedialibrary/no-encoding-for-most-tests')
     .value('STORAGE_API_ROOT',
       'https://storage-dot-rvacore-test.appspot.com/_ah/api')
     .value('STORE_ENDPOINT_URL',

--- a/web/scripts/storage/services/svc-encoding.js
+++ b/web/scripts/storage/services/svc-encoding.js
@@ -1,10 +1,9 @@
 'use strict';
 
 angular.module('risevision.storage.services')
-  .service('encoding', ['$q', '$log', '$http', 'storageAPILoader', 'userState', '$timeout',
-    function ($q, $log, $http, storageAPILoader, userState, $timeout) {
+  .service('encoding', ['ENCODING_MASTER_SWITCH_URL', '$q', '$log', '$http', 'storageAPILoader', 'userState', '$timeout',
+    function (switchURL, $q, $log, $http, storageAPILoader, userState, $timeout) {
       $log.debug('Loading encoding service');
-      var switchURL = 'https://storage.googleapis.com/risemedialibrary/encoding-switch-on';
       var masterSwitchPromise = $http({method: 'HEAD', url: switchURL});
 
       var service = {};
@@ -13,6 +12,8 @@ angular.module('risevision.storage.services')
         $log.debug('Checking encoding applicability for ' + fileType);
 
         if (fileType.indexOf('video/') !== 0) { return $q.resolve(false); }
+
+        if (sessionStorage.getItem('force-upload-encoding') === 'true') {return $q.resolve(true);}
 
         return masterSwitchPromise
         .then(function() {return true;}, function() {return false;});


### PR DESCRIPTION
## Description
Add e2e test for encoding, forcing the master switch url just for the one test.

## Motivation and Context
Reliability

## How Has This Been Tested?
Local e2e run

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
