### PR TITLE
Fix Text component E2E tests

### DIFF
--- a/test/e2e/template-editor/cases/components/text.js
+++ b/test/e2e/template-editor/cases/components/text.js
@@ -35,17 +35,17 @@ var TextComponentScenarios = function () {
       it('should open properties of Text Component', function () {
         templateEditorPage.selectComponent(componentLabel);
 
-        expect(textComponentPage.getTextInput().getAttribute('value')).to.eventually.equal("Financial Literacy");
+        expect(textComponentPage.getTextArea().getAttribute('value')).to.eventually.equal("Financial Literacy");
       });
 
       it('should clear and update the component text', function () {
         // Note: Disconnect from Angular to prevent Autosave timeout from interrupting edits
         browser.waitForAngularEnabled(false);
-        helper.wait(textComponentPage.getTextInput(), 'Text component input');
+        helper.wait(textComponentPage.getTextArea(), 'Text component Text Area');
         browser.sleep(500);
-        textComponentPage.getTextInput().clear();
+        textComponentPage.getTextArea().clear();
         browser.sleep(500);
-        textComponentPage.getTextInput().sendKeys("Changed Text" + protractor.Key.ENTER);
+        textComponentPage.getTextArea().sendKeys("Changed Text");
         browser.waitForAngularEnabled(true);
 
         //wait for presentation to be auto-saved
@@ -56,8 +56,8 @@ var TextComponentScenarios = function () {
         presentationsListPage.loadPresentation(presentationName);
 
         templateEditorPage.selectComponent(componentLabel);
-        expect(textComponentPage.getTextInput().isEnabled()).to.eventually.be.true;
-        expect(textComponentPage.getTextInput().getAttribute('value')).to.eventually.equal("Changed Text");
+        expect(textComponentPage.getTextArea().isEnabled()).to.eventually.be.true;
+        expect(textComponentPage.getTextArea().getAttribute('value')).to.eventually.equal("Changed Text");
       });
 
     });

--- a/test/e2e/template-editor/pages/components/textComponentPage.js
+++ b/test/e2e/template-editor/pages/components/textComponentPage.js
@@ -1,10 +1,10 @@
 'use strict';
 
 var TextComponentPage = function() {
-  var textInput = element(by.id('text-component-input'));
+  var textArea = element(by.id('text-component-input-multiline'));
 
-  this.getTextInput = function () {
-    return textInput;
+  this.getTextArea = function () {
+    return textArea;
   };
 };
 


### PR DESCRIPTION
## Description
Update E2E tests to use text area vs text input, as Template was updated.

## Motivation and Context
The Template used for e2e tests was changed (https://github.com/Rise-Vision/html-template-library/pull/1283) to allow line breaks, so the e2e tests needed to be updated to handle that.

## How Has This Been Tested?
E2E tests pass.
[stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
