### PR TITLE
Feature/encoding both directives

### DIFF
--- a/test/e2e/storage/cases/upload.js
+++ b/test/e2e/storage/cases/upload.js
@@ -37,6 +37,7 @@ var UploadScenarios = function() {
       });
 
       it('should hide Upload panel when finished',function(){
+        this.timeout(25000);
         helper.waitDisappear(storageSelectorModalPage.getUploadPanel(), 'Storage Upload Panel');
         expect(storageSelectorModalPage.getUploadPanel().isDisplayed()).to.eventually.be.false;
       });

--- a/test/e2e/template-editor/cases/components/video.js
+++ b/test/e2e/template-editor/cases/components/video.js
@@ -207,9 +207,9 @@ var VideoComponentScenarios = function () {
     });
 
     describe('file types', function () {
-      it('should use a specific accept attribute value when not on a mobile device', function (done) {
+      it('should accept any video type when not on a mobile device', function (done) {
         videoComponentPage.getUploadInputMain().getAttribute('accept').then(accept => {
-          expect(accept).to.equal('.mp4, .webm');
+          expect(accept).to.equal('*');
           done();
         });
       });

--- a/test/unit/storage/directives/dtv-upload.tests.js
+++ b/test/unit/storage/directives/dtv-upload.tests.js
@@ -178,15 +178,18 @@ describe('directive: upload', function() {
     expect(args[0].name).to.be.equal('test/test1.jpg');
   });
 
-  it('should add warning if the file is not supported', function() {
+  it('should add warning if the file is not supported', function(done) {
     var fileName = 'test1.tif';
     var file1 = { name: fileName, size: 200, slice: function() {}, file: { name: fileName } };
 
     filesFactory.folderPath = 'test/';
     FileUploader.onAfterAddingFile(file1);
 
-    expect($scope.warnings[0].fileName).to.be.equal('test/test1.tif');
-    expect($scope.warnings[0].message).to.be.equal('storage-client.warning.image-not-supported');
+    setTimeout(function(){
+      expect($scope.warnings[0].fileName).to.be.equal('test/test1.tif');
+      expect($scope.warnings[0].message).to.be.equal('storage-client.warning.image-not-supported');
+      done();
+    }, 10);
   });
 
   it('should ask for confirmation before overwriting files', function(done) {

--- a/test/unit/template-editor/directives/dtv-basic-uploader.tests.js
+++ b/test/unit/template-editor/directives/dtv-basic-uploader.tests.js
@@ -334,7 +334,7 @@ describe('directive: basicUploader', function () {
 
       $scope.setAcceptAttribute();
 
-      expect($scope.accept).to.be.equal('video/*');
+      expect($scope.accept).to.be.equal('*');
     });
   });
 });

--- a/test/unit/template-editor/directives/dtv-basic-uploader.tests.js
+++ b/test/unit/template-editor/directives/dtv-basic-uploader.tests.js
@@ -18,8 +18,10 @@ describe('directive: basicUploader', function () {
       return function () {
         return FileUploader = {
           addToQueue: function(files){
-            FileUploader.onAddingFiles({file:files[0]});
-            FileUploader.onAfterAddingFile({file:files[0]});
+            files.forEach(function(file) {
+              FileUploader.onAddingFiles({file:file});
+              FileUploader.onAfterAddingFile({file:file});
+            });
           },
           uploadItem: sinon.stub(),
           queue: [],
@@ -283,12 +285,14 @@ describe('directive: basicUploader', function () {
       var file1 = { name: 'test.jpg' };
       $scope.uploadSelectedFiles([ file1 ])
       .then (function () {
-        expect($scope.uploader.removeExif).to.have.been.called;
-        expect($scope.uploader.addToQueue).to.have.been.calledWith([ file1 ]);
-        expect(templateEditorUtils.fileHasValidExtension).to.have.been.called;
-        expect(templateEditorUtils.showInvalidExtensionsMessage).to.have.not.been.called;
+        setTimeout(function() {
+          expect($scope.uploader.removeExif).to.have.been.called;
+          expect($scope.uploader.addToQueue).to.have.been.calledWith([ file1 ]);
+          expect(templateEditorUtils.fileHasValidExtension).to.have.been.called;
+          expect(templateEditorUtils.showInvalidExtensionsMessage).to.have.not.been.called;
 
-        done();
+          done();
+        }, 50);
       });
     });
 
@@ -297,12 +301,15 @@ describe('directive: basicUploader', function () {
       var file2 = { name: 'test.pdf' };
       $scope.uploadSelectedFiles([ file1, file2 ])
       .then (function () {
-        expect($scope.uploader.removeExif).to.have.been.called;
-        expect($scope.uploader.addToQueue).to.have.been.calledWith([ file1 ]);
-        expect(templateEditorUtils.fileHasValidExtension).to.have.been.called;
-        expect(templateEditorUtils.showInvalidExtensionsMessage).to.have.been.called;
+        setTimeout(function() {
+          expect($scope.uploader.removeExif).to.have.been.called;
+          expect($scope.uploader.uploadItem).to.have.been.calledOnce;
+          expect($scope.uploader.uploadItem.getCall(0).args[0].file.name).to.equal(file1.name);
+          expect(templateEditorUtils.fileHasValidExtension).to.have.been.called;
+          expect(templateEditorUtils.showInvalidExtensionsMessage).to.have.been.called;
 
-        done();
+          done();
+        }, 50);
       });
     });
   });

--- a/test/unit/template-editor/directives/dtv-basic-uploader.tests.js
+++ b/test/unit/template-editor/directives/dtv-basic-uploader.tests.js
@@ -326,7 +326,7 @@ describe('directive: basicUploader', function () {
       expect($scope.accept).to.be.equal('image/*')
     });
 
-    it('should use a specific accept attribute value when not on a mobile device', function () {
+    it('should accept any video type in the file picker pop up if selecting videos when not on a mobile device', function () {
       sinon.stub(presentationUtils, 'isMobileBrowser').callsFake(function() { return false; });
 
       $scope.validExtensions = '.webm, .mp4';
@@ -334,7 +334,7 @@ describe('directive: basicUploader', function () {
 
       $scope.setAcceptAttribute();
 
-      expect($scope.accept).to.be.equal($scope.validExtensions);
+      expect($scope.accept).to.be.equal('video/*');
     });
   });
 });

--- a/web/scripts/storage/directives/dtv-upload.js
+++ b/web/scripts/storage/directives/dtv-upload.js
@@ -66,6 +66,7 @@
               var fileName = fileItem.file.name;
               var extension = fileName && fileName.split('.').pop();
               if (videoTypesNotSupported.indexOf(extension) !== -1) {
+                if (fileItem.encodingFileName) {return;}
                 $scope.warnings.push({
                   fileName: fileName,
                   message: 'storage-client.warning.video-not-supported'
@@ -98,7 +99,6 @@
 
               if (!fileItem.isRetrying) {
                 fileItem.file.name = ($scope.filesFactory.folderPath || '') + fileItem.file.name;
-                chekFileType(fileItem);
               }
 
               $translate('storage-client.uploading', {
@@ -112,12 +112,15 @@
                   $rootScope.$emit('refreshSubscriptionStatus',
                     'trial-available');
 
+                  fileItem.url = resp.message;
+                  fileItem.taskToken = resp.taskToken;
+                  fileItem.encodingFileName = resp.newFileName;
+                  fileItem.chunkSize =
+                    STORAGE_UPLOAD_CHUNK_SIZE;
+
+                  chekFileType(fileItem);
+
                   uploadOverwriteWarning.checkOverwrite(resp).then(function () {
-                    fileItem.url = resp.message;
-                    fileItem.taskToken = resp.taskToken;
-                    fileItem.encodingFileName = resp.newFileName;
-                    fileItem.chunkSize =
-                      STORAGE_UPLOAD_CHUNK_SIZE;
                     FileUploader.uploadItem(fileItem);
                   }).catch(function () {
                     FileUploader.removeFromQueue(fileItem);

--- a/web/scripts/storage/directives/dtv-upload.js
+++ b/web/scripts/storage/directives/dtv-upload.js
@@ -160,7 +160,7 @@
               }
 
               var baseFile = {
-                'name': item.file.name,
+                'name': item.encodingFileName || item.file.name,
                 'updated': {
                   'value': new Date().valueOf().toString()
                 },
@@ -169,7 +169,7 @@
               };
 
               //retrieve to generate thumbnail
-              storage.refreshFileMetadata(item.file.name)
+              storage.refreshFileMetadata(item.encodingFileName || item.file.name)
                 .then(function (file) {
                   console.log('Add file to list of available files', file);
                   $scope.filesFactory.addFile(file);

--- a/web/scripts/template-editor/directives/dtv-basic-uploader.js
+++ b/web/scripts/template-editor/directives/dtv-basic-uploader.js
@@ -130,7 +130,7 @@ angular.module('risevision.template-editor.directives')
             }
 
             var baseFile = {
-              'name': item.file.name,
+              'name': item.encodingFileName || item.file.name,
               'updated': {
                 'value': new Date().valueOf().toString()
               },
@@ -139,7 +139,7 @@ angular.module('risevision.template-editor.directives')
             };
 
             // Retrieve to force thumbnail creation
-            storage.refreshFileMetadata(item.file.name)
+            storage.refreshFileMetadata(item.encodingFileName || item.file.name)
               .then(function (file) {
                 console.log('Add file to list of available files', file);
                 $scope.uploadManager.addFile(file);

--- a/web/scripts/template-editor/directives/dtv-basic-uploader.js
+++ b/web/scripts/template-editor/directives/dtv-basic-uploader.js
@@ -168,7 +168,7 @@ angular.module('risevision.template-editor.directives')
             if (presentationUtils.isMobileBrowser() && _.includes(ALLOWED_VALID_TYPES, $scope.validType)) {
               $scope.accept = $scope.validType + '/*';
             } else {
-              $scope.accept = $scope.validExtensions;
+              $scope.accept = ($scope.validExtensions && $scope.validExtensions.indexOf('mp4') >= 0) ? 'video/*' : $scope.validExtensions;
             }
           };
 

--- a/web/scripts/template-editor/directives/dtv-basic-uploader.js
+++ b/web/scripts/template-editor/directives/dtv-basic-uploader.js
@@ -168,7 +168,7 @@ angular.module('risevision.template-editor.directives')
             if (presentationUtils.isMobileBrowser() && _.includes(ALLOWED_VALID_TYPES, $scope.validType)) {
               $scope.accept = $scope.validType + '/*';
             } else {
-              $scope.accept = ($scope.validExtensions && $scope.validExtensions.indexOf('mp4') >= 0) ? 'video/*' : $scope.validExtensions;
+              $scope.accept = ($scope.validExtensions && $scope.validExtensions.indexOf('mp4') >= 0) ? '*' : $scope.validExtensions;
             }
           };
 


### PR DESCRIPTION
## Description
Don't show warnings for unsupported video extensions when using encoding and use encoding for both the main storage ui as well as the template editor ui

## Motivation and Context
Final significan change for video encoding feature

## How Has This Been Tested?
Unit+manual, main storage UI as well as uploading in a template editor, mov file + mp4 file

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
