### PR TITLE
Check status text when monitoring job completion

### DIFF
--- a/test/unit/storage/services/svc-encoding.tests.js
+++ b/test/unit/storage/services/svc-encoding.tests.js
@@ -104,17 +104,20 @@ describe('service: encoding:', function() {
       $httpBackend.when('POST', /.*status/).respond(200, statusResponse);
 
       var statusPromise = encoding.monitorStatus(item, onProgressSetStatusComplete);
-      $timeout.flush(); // progress through first status check at 50%
 
       function onProgressSetStatusComplete(pct) {
         console.log('Encoding status: ' + pct + '%');
 
         statusResponse.statuses[taskToken].percent = 100;
+        statusResponse.statuses[taskToken].status = 'completed';
 
+        if (pct === 100) { return; }
         setTimeout(function() {$timeout.flush();}, 50); // second check
         setTimeout(function() {$httpBackend.flush();}, 60);
       }
 
+      setTimeout(function() {$timeout.flush();}, 50); // progress through first status check at 50%
+      setTimeout(function() {$httpBackend.flush();}, 60); // progress through first status check at 50%
       return statusPromise;
     });
 
@@ -122,7 +125,7 @@ describe('service: encoding:', function() {
       $httpBackend.when('HEAD', /.*encoding/).respond(200, {});
 
       var statusResponse = {statuses: {}};
-      statusResponse.statuses[taskToken] = {percent: 100};
+      statusResponse.statuses[taskToken] = {percent: 100, status: 'completed'};
 
       var mockResp = $httpBackend.when('POST', /.*status/).respond(500, {});
 

--- a/web/scripts/storage/services/svc-encoding.js
+++ b/web/scripts/storage/services/svc-encoding.js
@@ -104,7 +104,7 @@ angular.module('risevision.storage.services')
             return $q.reject(taskStatus.error_description); // jshint ignore:line
           }
 
-          if (taskStatus.percent !== 100) {
+          if (taskStatus.percent !== 100 || taskStatus.status !== 'completed') {
             onProgress(taskStatus.percent);
 
             return service.monitorStatus(item, onProgress);


### PR DESCRIPTION
## Description
Perform additional check before moving on to next step after encoding job monitoring.

## Motivation and Context
Documentation incorrectly states that **percent** is the "Overall
completion percent for the job." In fact, percent can be 100 while
status is "saving". This ensures status is 'completed' before attempting
to signal Storage Server to copy the file the the company bucket.

## How Has This Been Tested?
Unit test, local manual test, stage manual test, e2e test

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
