### PR TITLE
Show features modal when Display is not licensed

### DIFF
--- a/test/unit/displays/services/svc-screenshot-factory.tests.js
+++ b/test/unit/displays/services/svc-screenshot-factory.tests.js
@@ -20,6 +20,7 @@ describe('service: screenshotFactory:', function() {
     });
     $provide.factory('displayFactory', function() {
       return {
+        showUnlockThisFeatureModal: sinon.stub().returns(false),
         display: {
           id: '123'
         }
@@ -27,7 +28,7 @@ describe('service: screenshotFactory:', function() {
     });
 
   }));
-  var screenshotFactory, display;
+  var screenshotFactory, display, displayFactory;
   var imageBlobLoaderMock, success;
 
   beforeEach(function(){
@@ -35,12 +36,13 @@ describe('service: screenshotFactory:', function() {
       success = true;
 
       display = $injector.get('display');
+      displayFactory = $injector.get('displayFactory');
       screenshotFactory = $injector.get('screenshotFactory');
     });
   });
 
   it('should exist',function(){
-    expect(screenshotFactory).to.be.truely;
+    expect(screenshotFactory).to.be.ok;
     expect(screenshotFactory.requestScreenshot).to.be.a('function');
     expect(screenshotFactory.loadScreenshot).to.be.a('function');
   });
@@ -50,6 +52,15 @@ describe('service: screenshotFactory:', function() {
       sinon.stub(screenshotFactory, 'loadScreenshot', function() {
         return Q.resolve();
       });
+    });
+
+    it('should not proceed if Display is not licensed',function(){
+      displayFactory.showUnlockThisFeatureModal.returns(true);
+
+      screenshotFactory.requestScreenshot();
+
+      display.requestScreenshot.should.not.have.been.called;
+      expect(screenshotFactory.screenshotLoading).to.not.be.ok;
     });
 
     it('should start loading', function() {

--- a/web/partials/displays/unlock-display-feature-modal.html
+++ b/web/partials/displays/unlock-display-feature-modal.html
@@ -1,0 +1,35 @@
+<form id="confirmForm">
+  <div class="modal-header">
+    <button type="button" class="close" ng-click="dismiss()" data-dismiss="modal" aria-hidden="true">
+      <streamline-icon name="close" width="12" height="12"></streamline-icon>
+    </button>
+  </div>
+  <div class="modal-body" stop-event="touchend">
+    <h4>Missing Display License</h4>
+    <div class="plan-features">
+      <p>Unlock this feature by purchasing a license and get access to:</p>
+      <ul>
+        <li><streamline-icon name="checkmark"></streamline-icon>Get a screenshot of your Display.</li>
+        <li><streamline-icon name="checkmark"></streamline-icon>Schedule when your screens turn on and off.</li>
+        <li><streamline-icon name="checkmark"></streamline-icon>Restart and reboot your Display.</li>
+        <li><streamline-icon name="checkmark"></streamline-icon>Receive and show emergency alerts from your CAP provider.</li>
+        <li><streamline-icon name="checkmark"></streamline-icon>Free, world-class email and phone support.</li>
+      </ul>
+      <p><strong>Use the code “SAVE50” at checkout to to get 50% off an annual plan</strong></p>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <div class="row">
+      <div class="col-xs-6">
+        <button class="btn btn-default w-100" ng-click="dismiss()">
+          <span>Cancel</span>
+        </button>
+      </div>
+      <div class="col-xs-6">
+        <button id="confirm-primary" class="btn btn-primary w-100" ng-click="ok()">
+          <span>Buy A License</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</form>

--- a/web/scripts/displays/controllers/ctr-display-controls.js
+++ b/web/scripts/displays/controllers/ctr-display-controls.js
@@ -4,8 +4,9 @@
 angular.module('risevision.displays.controllers')
   .controller('displayControls', ['$scope', 'display',
     '$log', '$modal', '$templateCache', 'processErrorCode', 'displayTracker',
+    'displayFactory',
     function ($scope, display, $log, $modal, $templateCache, processErrorCode,
-      displayTracker) {
+      displayTracker, displayFactory) {
       $scope.displayTracker = displayTracker;
 
       var _restart = function (displayId, displayName) {
@@ -49,6 +50,10 @@ angular.module('risevision.displays.controllers')
       };
 
       $scope.confirm = function (displayId, displayName, mode) {
+        if (displayFactory.showUnlockThisFeatureModal()) {
+          return;
+        }
+
         $scope.modalInstance = $modal.open({
           template: $templateCache.get(
             'partials/components/confirm-modal/confirm-modal.html'),

--- a/web/scripts/displays/services/svc-display-factory.js
+++ b/web/scripts/displays/services/svc-display-factory.js
@@ -3,9 +3,9 @@
 angular.module('risevision.displays.services')
   .factory('displayFactory', ['$rootScope', '$q', '$state', '$modal', '$loading', '$log',
     'display', 'displayTracker', 'playerLicenseFactory', 'processErrorCode', 'storeService',
-    'humanReadableError',
+    'humanReadableError', 'plansFactory',
     function ($rootScope, $q, $state, $modal, $loading, $log, display, displayTracker,
-      playerLicenseFactory, processErrorCode, storeService, humanReadableError) {
+      playerLicenseFactory, processErrorCode, storeService, humanReadableError, plansFactory) {
       var factory = {};
       var _displayId;
 
@@ -200,6 +200,30 @@ angular.module('risevision.displays.services')
         factory.apiError = processErrorCode('Display', action, e);
 
         $log.error(factory.errorMessage, e);
+      };
+
+      factory.showUnlockThisFeatureModal = function () {
+        if (!factory.display || factory.display.playerProAuthorized) {
+          return false;
+
+        } else {
+          $modal.open({
+            templateUrl: 'partials/displays/unlock-display-feature-modal.html',
+            controller: 'confirmModalController',
+            windowClass: 'madero-style centered-modal unlock-this-feature-modal',
+            size: 'sm',
+            resolve: {
+              confirmationTitle: null,
+              confirmationMessage: null,
+              confirmationButton: null,
+              cancelButton: null
+            }
+          }).result.then(function () {
+            plansFactory.showPlansModal();
+          });
+
+          return true;
+        }
       };
 
       return factory;

--- a/web/scripts/displays/services/svc-screenshot-factory.js
+++ b/web/scripts/displays/services/svc-screenshot-factory.js
@@ -6,6 +6,10 @@ angular.module('risevision.displays.services')
       var factory = {};
 
       factory.requestScreenshot = function () {
+        if (displayFactory.showUnlockThisFeatureModal()) {
+          return;
+        }
+
         factory.screenshotLoading = true;
 
         return display.requestScreenshot(displayFactory.display.id)


### PR DESCRIPTION
## Description
Show features modal when Display is not licensed

Check for license on Restart, Reboot and Screenshot actions
Show modal and prompt for purchase

[stage-2]

## Motivation and Context
Encourage users to License their Displays

## How Has This Been Tested?
Tested changes locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No