### PR TITLE
Fall back to storage upload if overwriting non mp4

### DIFF
--- a/test/unit/storage/directives/dtv-upload.tests.js
+++ b/test/unit/storage/directives/dtv-upload.tests.js
@@ -165,6 +165,27 @@ describe('directive: upload', function() {
     expect(args[0].name).to.be.equal('test/test1.jpg');
   });
 
+  it('should fall back to storage encoding if overwriting non mp4', function () {
+    UploadURIService.getURI = sinon.stub()
+      .onCall(0).returns(Q.reject({message: 'Unencodable overwrite'}))
+      .onCall(1).returns(Q.resolve({}));
+
+    var fileName = 'test1.webm';
+    var file1 = { name: fileName, size: 200, slice: function () {}, file: { name: fileName } };
+
+    return FileUploader.onAfterAddingFile(file1)
+    .then(function () {
+      var firstCallArgs = UploadURIService.getURI.getCall(0).args;
+      var secondCallArgs = UploadURIService.getURI.getCall(1).args;
+
+      expect(UploadURIService.getURI.called).to.be.true;
+      expect(firstCallArgs[0].name).to.be.equal('test1.webm');
+      expect(firstCallArgs[1]).to.be.equal(undefined);
+      expect(secondCallArgs[0].name).to.be.equal('test1.webm');
+      expect(secondCallArgs[1]).to.be.equal(true);
+    });
+  });
+
   it('should not modify the name if the file is being retried', function() {
     var fileName = 'test/test1.jpg';
     var file1 = { name: fileName, size: 200, slice: function() {}, isRetrying: true, file: { name: fileName } };

--- a/test/unit/storage/services/svc-storage.tests.js
+++ b/test/unit/storage/services/svc-storage.tests.js
@@ -403,17 +403,14 @@ describe('service: storage:', function() {
   });
 
   describe('getResumableUploadURI:',function(){
-    it('should get Resumable Upload URI',function(done){
-      storage.getResumableUploadURI("fileName","fileType")
+    it('should get Resumable Upload URI',function(){
+      return storage.getResumableUploadURI("fileName","fileType")
         .then(function(result){
           expect(result).to.be.ok;
           expect(storageApiRequestObj.fileName).to.equal('fileName');
           expect(storageApiRequestObj.fileType).to.equal('fileType');
           expect(storageApiRequestObj.companyId).to.equal('TEST_COMP_ID');
-
-          done();
         })
-        .then(null,done);
     });
     
     it('should encode URI',function(done){

--- a/test/unit/template-editor/directives/dtv-basic-uploader.tests.js
+++ b/test/unit/template-editor/directives/dtv-basic-uploader.tests.js
@@ -51,7 +51,7 @@ describe('directive: basicUploader', function () {
 
     $provide.factory('UploadURIService', function () {
       return UploadURIService = {
-         getURI: sinon.stub().returns(Q.resolve({}))
+        getURI: sinon.stub().returns(Q.resolve({}))
       };
     });
   }));
@@ -144,6 +144,27 @@ describe('directive: basicUploader', function () {
 
     expect(UploadURIService.getURI.called).to.be.true;
     expect(args[0].name).to.be.equal('test/test1.jpg');
+  });
+
+  it('should fall back to storage encoding if overwriting non mp4', function () {
+    UploadURIService.getURI = sinon.stub()
+      .onCall(0).returns(Q.reject({message: 'Unencodable overwrite'}))
+      .onCall(1).returns(Q.resolve({}));
+
+    var fileName = 'test1.webm';
+    var file1 = { name: fileName, size: 200, slice: function () {}, file: { name: fileName } };
+
+    return FileUploader.onAfterAddingFile(file1)
+    .then(function () {
+      var firstCallArgs = UploadURIService.getURI.getCall(0).args;
+      var secondCallArgs = UploadURIService.getURI.getCall(1).args;
+
+      expect(UploadURIService.getURI.called).to.be.true;
+      expect(firstCallArgs[0].name).to.be.equal('test1.webm');
+      expect(firstCallArgs[1]).to.be.equal(undefined);
+      expect(secondCallArgs[0].name).to.be.equal('test1.webm');
+      expect(secondCallArgs[1]).to.be.equal(true);
+    });
   });
 
   it('should not modify the name if the file is being retried', function () {

--- a/web/scripts/storage/services/svc-storage.js
+++ b/web/scripts/storage/services/svc-storage.js
@@ -184,8 +184,8 @@ angular.module('risevision.storage.services')
           $log.debug('getting resumable upload URI: ', obj);
 
           storageAPILoader().then(function (storageApi) {
-              return storageApi.getResumableUploadURI(obj);
-            })
+            return storageApi.getResumableUploadURI(obj);
+          })
             .then(function (resp) {
               $log.debug('getting resumable upload URI finished', resp);
 

--- a/web/scripts/storage/services/svc-upload-uri.js
+++ b/web/scripts/storage/services/svc-upload-uri.js
@@ -4,7 +4,7 @@ angular.module('risevision.storage.services')
     function uploadURIService($q, $log, storage, encoding, processErrorCode) {
       var svc = {};
 
-      svc.getURI = function getURI(file) {
+      svc.getURI = function getURI(file, forceStorage) {
         if (!file.name) {
           return $q.reject({
             message: 'Invalid Params'
@@ -14,6 +14,8 @@ angular.module('risevision.storage.services')
         return encoding.isApplicable(file.type)
           .then(function (useEncoding) {
             var applicableService = useEncoding ? encoding : storage;
+
+            if (forceStorage) {applicableService = storage;}
             return applicableService.getResumableUploadURI(file.name, file.type);
           })
           .then(function (resp) {
@@ -21,7 +23,8 @@ angular.module('risevision.storage.services')
           })
           .then(null, function (e) {
             var type = file.type === 'folder' ? 'Folder' : 'File';
-            var message = processErrorCode(type, 'upload', e);
+            var message = e && e.result && e.result.error && e.result.error.message === 'Unencodable overwrite' ?
+              e.result.error.message : processErrorCode(type, 'upload', e);
 
             $log.debug('Failed upload uri request');
             return $q.reject({


### PR DESCRIPTION
## Description
In cases where the filename was already present in storage, and it is
not in the encoding format, allow overwrite of the original file directly
to GCS.

## Context and motivation
Otherwise, we'd encode and save the file as mp4, and the
original would not be overwritten. This would be a problem when users
intend to overwrite content with fresh content using the same file name.

## How Has This Been Tested?
Unit + Staging

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
