### PR TITLE
Check if user has licenses for plans modal

### DIFF
--- a/test/unit/displays/controllers/ctr-display-details.tests.js
+++ b/test/unit/displays/controllers/ctr-display-details.tests.js
@@ -92,7 +92,7 @@ describe('controller: display details', function() {
     });
     $provide.factory('plansFactory', function() {
       return {
-        showPlansModal: function () {}
+        showPlansModal: sinon.spy()
       };
     });
     $provide.factory('currentPlanFactory', function() {
@@ -117,7 +117,7 @@ describe('controller: display details', function() {
   }));
   var $scope, $state, updateCalled, deleteCalled, confirmDelete;
   var resolveLoadScreenshot, resolveRequestScreenshot, enableCompanyProduct, userState,
-  $rootScope, $loading, displayFactory, playerLicenseFactory, playerProFactory, currentPlanFactory;
+  $rootScope, $loading, displayFactory, playerLicenseFactory, playerProFactory, plansFactory, currentPlanFactory;
   var company;
   beforeEach(function(){
     company = {};
@@ -130,6 +130,7 @@ describe('controller: display details', function() {
       displayFactory = $injector.get('displayFactory');
       playerLicenseFactory = $injector.get('playerLicenseFactory');
       playerProFactory = $injector.get('playerProFactory');
+      plansFactory = $injector.get('plansFactory');
       currentPlanFactory = $injector.get('currentPlanFactory');
       enableCompanyProduct = $injector.get('enableCompanyProduct');
       userState = $injector.get('userState');
@@ -222,29 +223,26 @@ describe('controller: display details', function() {
     it('should show the plans modal', function () {
       $scope.display = {};
       sandbox.stub($scope, 'isProAvailable').returns(false);
-      sandbox.stub($scope, 'showPlansModal');
 
       $scope.toggleProAuthorized();
-      expect($scope.showPlansModal).to.have.been.called;
+      expect(plansFactory.showPlansModal).to.have.been.called;
       expect(enableCompanyProduct).to.not.have.been.called;
     });
 
     it('should forward to billing if has a plan but no available licenses', function () {
       $scope.display = {};
       sandbox.stub($scope, 'isProAvailable').returns(false);
-      sandbox.stub($scope, 'showPlansModal');
       sandbox.stub($scope, 'getProLicenseCount').returns(1);
       sandbox.stub($scope, 'areAllProLicensesUsed').returns(true);
 
       $scope.toggleProAuthorized();      
       expect($state.go).to.have.been.calledWith('apps.billing.home');
-      expect($scope.showPlansModal).to.not.have.been.called;
+      expect(plansFactory.showPlansModal).to.not.have.been.called;
       expect(enableCompanyProduct).to.not.have.been.called;
     });
 
     it('should activate Pro status', function (done) {
       sandbox.stub($scope, 'isProAvailable').returns(true);
-      sandbox.stub($scope, 'showPlansModal');
       sandbox.stub(playerLicenseFactory, 'toggleDisplayLicenseLocal');
       enableCompanyProduct.returns(Q.resolve());
 
@@ -266,7 +264,7 @@ describe('controller: display details', function() {
           expect($scope.display.playerProAuthorized).to.be.true;
 
           expect(playerLicenseFactory.toggleDisplayLicenseLocal).to.have.been.calledWith(true);
-          expect($scope.showPlansModal).to.have.not.been.called;
+          expect(plansFactory.showPlansModal).to.have.not.been.called;
           done();        
         }, 0);
       }, 0);
@@ -274,7 +272,6 @@ describe('controller: display details', function() {
 
     it('should not activate Pro status if licenses are not available', function (done) {
       sandbox.stub($scope, 'isProAvailable').returns(true);
-      sandbox.stub($scope, 'showPlansModal');
       sandbox.stub(playerLicenseFactory, 'toggleDisplayLicenseLocal');
       enableCompanyProduct.returns(Q.resolve());
 
@@ -296,7 +293,7 @@ describe('controller: display details', function() {
           expect($scope.display.playerProAuthorized).to.be.false;
 
           expect(playerLicenseFactory.toggleDisplayLicenseLocal).to.have.been.calledWith(true);
-          expect($scope.showPlansModal).to.have.not.been.called;
+          expect(plansFactory.showPlansModal).to.have.not.been.called;
           done();        
         }, 0);
       }, 0);
@@ -304,7 +301,6 @@ describe('controller: display details', function() {
 
     it('should deactivate Pro status', function (done) {
       sandbox.stub($scope, 'isProAvailable').returns(true);
-      sandbox.stub($scope, 'showPlansModal');
       sandbox.stub(playerLicenseFactory, 'toggleDisplayLicenseLocal');
       enableCompanyProduct.returns(Q.resolve());
 
@@ -325,7 +321,7 @@ describe('controller: display details', function() {
           expect($scope.display.playerProAuthorized).to.be.false;
 
           expect(playerLicenseFactory.toggleDisplayLicenseLocal).to.have.been.calledWith(false);
-          expect($scope.showPlansModal).to.have.not.been.called;
+          expect(plansFactory.showPlansModal).to.have.not.been.called;
           done();
         }, 0);
       }, 0);
@@ -333,7 +329,6 @@ describe('controller: display details', function() {
 
     it('should fail to activate Pro status', function (done) {
       sandbox.stub($scope, 'isProAvailable').returns(true);
-      sandbox.stub($scope, 'showPlansModal');
       enableCompanyProduct.returns(Q.reject());
 
       setTimeout(function () {
@@ -353,7 +348,7 @@ describe('controller: display details', function() {
           expect($scope.display.playerProAuthorized).to.be.true;
 
           expect(userState.updateCompanySettings).to.not.have.been.called;
-          expect($scope.showPlansModal).to.have.not.been.called;
+          expect(plansFactory.showPlansModal).to.have.not.been.called;
           done();
         }, 0);
       });

--- a/test/unit/displays/directives/dtv-screenshot.tests.js
+++ b/test/unit/displays/directives/dtv-screenshot.tests.js
@@ -29,7 +29,7 @@ describe('directive: screenshot', function() {
       };
     });
 
-    $provide.service('plansFactory', function() {
+    $provide.service('displayFactory', function() {
       return {};
     });
   }));

--- a/web/locales/en/displays-app.json
+++ b/web/locales/en/displays-app.json
@@ -193,7 +193,6 @@
         "offline-play-desc": "Play your Display content without a network connection",
         "offline-play": "Offline Play",
         "send-email-offline": "Send email notifications when your Display goes offline",
-        "start-trial": "Start a Plan Trial",
         "unlock": "Unlock Licensed Display with any paid plan!"
       },
       "schedule": {

--- a/web/partials/displays/display-fields.html
+++ b/web/partials/displays/display-fields.html
@@ -186,7 +186,7 @@
             <td colspan="2">
               <span translate>displays-app.fields.player.rpp.unlock</span><br/>
               <button type="button" ng-click="showPlansModal()" class="btn btn-xs btn-primary u_margin-sm-top" translate>
-                displays-app.fields.player.rpp.start-trial
+                See Our Plans
               </button>
             </td>
           </tr>

--- a/web/partials/displays/screenshot.html
+++ b/web/partials/displays/screenshot.html
@@ -7,7 +7,7 @@
   </div>
   <div class="panel panel-default u_margin-sm-bottom text-center">
     <div class="panel-body display-screenshot" ng-show="screenshotState(display) === 'no-license'">
-      <p class="text-muted"><a href="#" ng-click="plansFactory.showPlansModal()">Click here to License this Display and enable all functions, including screenshot, restart, reboot and emergency alert broadcasts.</a></p>
+      <p class="text-muted"><a href="#" ng-click="displayFactory.showLicenseUpdate()">Click here to License this Display and enable all functions, including screenshot, restart, reboot and emergency alert broadcasts.</a></p>
       <p class="text-muted"><strong>Use the code “SAVE50” to get 50% off an annual plan.</strong></p>
     </div>
     <div class="panel-body display-screenshot" ng-show="screenshotState(display) === 'no-schedule'">

--- a/web/scripts/displays/controllers/ctr-display-details.js
+++ b/web/scripts/displays/controllers/ctr-display-details.js
@@ -41,7 +41,7 @@ angular.module('risevision.displays.controllers')
           if ($scope.getProLicenseCount() > 0 && $scope.areAllProLicensesUsed()) {
             $state.go('apps.billing.home');
           } else {
-            $scope.showPlansModal();
+            plansFactory.showPlansModal();
           }
         } else {
           var apiParams = {};

--- a/web/scripts/displays/directives/dtv-screenshot.js
+++ b/web/scripts/displays/directives/dtv-screenshot.js
@@ -2,14 +2,14 @@
 
 angular.module('risevision.displays.directives')
   .directive('screenshot', ['$filter', 'display', 'screenshotFactory',
-    'playerProFactory', 'plansFactory',
-    function ($filter, displayService, screenshotFactory, playerProFactory, plansFactory) {
+    'playerProFactory', 'displayFactory',
+    function ($filter, displayService, screenshotFactory, playerProFactory, displayFactory) {
       return {
         restrict: 'E',
         templateUrl: 'partials/displays/screenshot.html',
         link: function ($scope) {
           $scope.screenshotFactory = screenshotFactory;
-          $scope.plansFactory = plansFactory;
+          $scope.displayFactory = displayFactory;
 
           $scope.screenshotState = function (display) {
             var statusFilter = $filter('status');

--- a/web/scripts/displays/services/svc-display-factory.js
+++ b/web/scripts/displays/services/svc-display-factory.js
@@ -202,6 +202,14 @@ angular.module('risevision.displays.services')
         $log.error(factory.errorMessage, e);
       };
 
+      factory.showLicenseUpdate = function() {
+        if (playerLicenseFactory.getProLicenseCount() > 0) {
+          $state.go('apps.billing.home');
+        } else {
+          plansFactory.showPlansModal();
+        }
+      };
+
       factory.showUnlockThisFeatureModal = function () {
         if (!factory.display || factory.display.playerProAuthorized) {
           return false;
@@ -219,7 +227,7 @@ angular.module('risevision.displays.services')
               cancelButton: null
             }
           }).result.then(function () {
-            plansFactory.showPlansModal();
+            factory.showLicenseUpdate();
           });
 
           return true;


### PR DESCRIPTION
## Description
Check if user has licenses for plans modal

Show billing page if they have a plan

Change wording for Start Trial button

[stage-2]

## Motivation and Context
Encourage users to License their Displays

## How Has This Been Tested?
Tested locally, updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No