### PR TITLE
Common-header E2E fix - Handle non empty search input

### DIFF
--- a/test/e2e/common-header/pages/companyUsersModalPage.js
+++ b/test/e2e/common-header/pages/companyUsersModalPage.js
@@ -54,9 +54,14 @@
 
     this.searchUser = function(username) {
       helper.waitDisappear(this.getLoader(), "Company Users Loaded");
-      this.getUsersModalFilter().clear();
+      this.getUsersModalFilter().getAttribute("value").then(function (value) {
+        if (value !== "") {
+          usersModalFilter.clear();
+          helper.wait(loader, "Load Company Users");
+          helper.waitDisappear(loader, "Company Users Loaded");
+        }
+      });
       this.getUsersModalFilter().sendKeys(username);
-      browser.sleep(1000); //wait for search to be triggered
       helper.wait(this.getLoader(), "Load Company Users");
       helper.waitDisappear(this.getLoader(), "Company Users Loaded");
     };

--- a/test/e2e/common-header/pages/companyUsersModalPage.js
+++ b/test/e2e/common-header/pages/companyUsersModalPage.js
@@ -56,6 +56,7 @@
       helper.waitDisappear(this.getLoader(), "Company Users Loaded");
       this.getUsersModalFilter().clear();
       this.getUsersModalFilter().sendKeys(username);
+      browser.sleep(1000); //wait for search to be triggered
       helper.wait(this.getLoader(), "Load Company Users");
       helper.waitDisappear(this.getLoader(), "Company Users Loaded");
     };


### PR DESCRIPTION
## Description
We had two interactions with Search input, and eventually it could trigger two searches, resulting on incorrect user being selected by the e2e test.

## Motivation and Context
Common-header E2E tests are failing often.

## How Has This Been Tested?
E2E tests pass. 
[stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
