### PR TITLE
Do not show for Rise Vision users

### DIFF
--- a/test/unit/displays/controllers/ctr-display-details.tests.js
+++ b/test/unit/displays/controllers/ctr-display-details.tests.js
@@ -541,4 +541,5 @@ describe('controller: display details', function() {
       expect($scope.display.playerProAuthorized).to.be.false;
     });
   });
+
 });

--- a/test/unit/displays/services/svc-display-factory.tests.js
+++ b/test/unit/displays/services/svc-display-factory.tests.js
@@ -77,7 +77,7 @@ describe('service: displayFactory:', function() {
     });
     $provide.factory('userState', function() {
       return {
-        isRiseVisionUser: sandbox.stub().returns(false),
+        isRiseAdmin: sandbox.stub().returns(false),
         _restoreState: function(){}
       }
     });
@@ -545,7 +545,7 @@ describe('service: displayFactory:', function() {
     });
 
     it('should not show for Rise Users', function() {
-      userState.isRiseVisionUser.returns(true);
+      userState.isRiseAdmin.returns(true);
       var display = {
         playerProAuthorized: false
       };

--- a/test/unit/displays/services/svc-display-factory.tests.js
+++ b/test/unit/displays/services/svc-display-factory.tests.js
@@ -75,6 +75,12 @@ describe('service: displayFactory:', function() {
         go : sinon.spy()
       }
     });
+    $provide.factory('userState', function() {
+      return {
+        isRiseVisionUser: sandbox.stub().returns(false),
+        _restoreState: function(){}
+      }
+    });
     $provide.factory('playerLicenseFactory', function() {
       return {
         toggleDisplayLicenseLocal: function () {},
@@ -104,7 +110,7 @@ describe('service: displayFactory:', function() {
       }
     });
   }));
-  var displayFactory, $rootScope, $modal, $state, trackerCalled, updateDisplay, returnList, 
+  var displayFactory, $rootScope, $modal, $state, userState, trackerCalled, updateDisplay, returnList, 
   displayListSpy, displayAddSpy, playerLicenseFactory, plansFactory, display, processErrorCode, validateAddress, storeService;
   beforeEach(function(){
     trackerCalled = undefined;
@@ -121,6 +127,7 @@ describe('service: displayFactory:', function() {
       $modal = $injector.get('$modal');
       $rootScope = $injector.get('$rootScope');
       $state = $injector.get('$state');
+      userState = $injector.get('userState');
       displayListSpy = sinon.spy(display,'list');
       displayAddSpy = sinon.spy(display,'add');
     });
@@ -145,6 +152,7 @@ describe('service: displayFactory:', function() {
     expect(displayFactory.updateDisplay).to.be.a('function');
     expect(displayFactory.deleteDisplay).to.be.a('function'); 
 
+    expect(displayFactory.showLicenseRequired).to.be.a('function');
     expect(displayFactory.showLicenseUpdate).to.be.a('function');
     expect(displayFactory.showUnlockThisFeatureModal).to.be.a('function'); 
   });
@@ -513,6 +521,38 @@ describe('service: displayFactory:', function() {
         done();
       },10);
     });
+  });
+  
+  describe('showLicenseRequired:', function() {
+    it('should not show for null display', function() {
+      expect(displayFactory.showLicenseRequired(null)).to.not.be.true;
+    });
+
+    it('should show for unlicensed display', function() {
+      var display = {
+        playerProAuthorized: false
+      };
+
+      expect(displayFactory.showLicenseRequired(display)).to.be.true;
+    });
+
+    it('should not show for licensed display', function() {
+      var display = {
+        playerProAuthorized: true
+      };
+
+      expect(displayFactory.showLicenseRequired(display)).to.be.false;
+    });
+
+    it('should not show for Rise Users', function() {
+      userState.isRiseVisionUser.returns(true);
+      var display = {
+        playerProAuthorized: false
+      };
+
+      expect(displayFactory.showLicenseRequired(display)).to.be.false;
+    });
+
   });
 
   describe('showLicenseUpdate:', function() {

--- a/web/partials/displays/display-fields.html
+++ b/web/partials/displays/display-fields.html
@@ -83,12 +83,12 @@
               </span>
             </td>
           </tr>
-          <tr class="table-body__row" ng-class="{ 'row--disabled': !display.playerProAuthorized }">
+          <tr class="table-body__row" ng-class="{ 'row--disabled': factory.showLicenseRequired(display) }">
             <td class="table-body__cell" translate><span>displays-app.fields.player.status</span></td>
-            <td class="table-body__cell" ng-if="!display.playerProAuthorized">
+            <td class="table-body__cell" ng-if="factory.showLicenseRequired(display)">
               License Required
             </td>
-            <td class="table-body__cell" ng-if="display.playerProAuthorized">
+            <td class="table-body__cell" ng-if="!factory.showLicenseRequired(display)">
                 <i ng-if="displayService.statusLoading" class="fa fa-spinner fa-spin fa-fw"></i>
                 <span class="text-danger" ng-show="!displayService.statusLoading && (display | status) === 'offline'"> <i class="fa fa-times"></i> Offline</span>
                 <a ng-show="!displayService.statusLoading && (display | status) === 'offline'" href="https://help.risevision.com/hc/en-us/articles/115002694906-Why-is-my-Display-status-offline-" target="_blank">Why is my Display offline?</a>
@@ -98,30 +98,30 @@
                 </a>
             </td>
           </tr>
-          <tr class="table-body__row" ng-class="{ 'row--disabled': !display.playerProAuthorized }">
+          <tr class="table-body__row" ng-class="{ 'row--disabled': factory.showLicenseRequired(display) }">
             <td class="table-body__cell"><span translate>displays-app.fields.player.lastConnection</span></td>
-            <td class="table-body__cell" ng-if="!display.playerProAuthorized">
+            <td class="table-body__cell" ng-if="factory.showLicenseRequired(display)">
               License Required
             </td>
-            <td class="table-body__cell" ng-if="display.playerProAuthorized">
+            <td class="table-body__cell" ng-if="!factory.showLicenseRequired(display)">
               <span>{{display.lastConnectionTime | date:'d-MMM-yyyy h:mm a'}}</span>
             </td>
           </tr>
-          <tr class="table-body__row" ng-class="{ 'row--disabled': !display.playerProAuthorized }">
+          <tr class="table-body__row" ng-class="{ 'row--disabled': factory.showLicenseRequired(display) }">
             <td class="table-body__cell"><span translate>displays-app.fields.player.ipAddress</span></td>
-            <td class="table-body__cell" ng-if="!display.playerProAuthorized">
+            <td class="table-body__cell" ng-if="factory.showLicenseRequired(display)">
               License Required
             </td>
-            <td class="table-body__cell" ng-if="display.playerProAuthorized">
+            <td class="table-body__cell" ng-if="!factory.showLicenseRequired(display)">
               <span>{{display.playerLocalIpAddress}}</span>
             </td>
           </tr>
-          <tr class="table-body__row" ng-show="display.macAddress" ng-class="{ 'row--disabled': !display.playerProAuthorized }">
+          <tr class="table-body__row" ng-show="display.macAddress" ng-class="{ 'row--disabled': factory.showLicenseRequired(display) }">
             <td class="table-body__cell"><span translate>displays-app.fields.player.macAddress</span></td>
-            <td class="table-body__cell" ng-if="!display.playerProAuthorized">
+            <td class="table-body__cell" ng-if="factory.showLicenseRequired(display)">
               License Required
             </td>
-            <td class="table-body__cell" ng-if="display.playerProAuthorized">
+            <td class="table-body__cell" ng-if="!factory.showLicenseRequired(display)">
               <span>{{display.macAddress}}</span></td>
           </tr>
           <tr class="table-body__row">
@@ -283,7 +283,7 @@
 <div class="form-group">
   <div class="checkbox">
     <label class="control-label">
-      <input type="checkbox" ng-model="display.useCompanyAddress" ng-disabled="!display.playerProAuthorized">
+      <input type="checkbox" ng-model="display.useCompanyAddress" ng-disabled="factory.showLicenseRequired(display)">
       <strong translate>displays-app.fields.address.useCompany</strong>
     </label>
   </div>
@@ -358,9 +358,9 @@
 <div class="form-group reboot-time">
   <div class="checkbox">
     <label class="control-label">
-      <input type="checkbox" ng-model="display.restartEnabled" ng-disabled="!display.playerProAuthorized">
+      <input type="checkbox" ng-model="display.restartEnabled" ng-disabled="factory.showLicenseRequired(display)">
       <strong translate>displays-app.fields.reboot</strong>
     </label>
   </div>
-  <time-picker ng-model="display.restartTime" ng-disabled="!display.restartEnabled || !display.playerProAuthorized"></time-picker>
+  <time-picker ng-model="display.restartTime" ng-disabled="!display.restartEnabled || factory.showLicenseRequired(display)"></time-picker>
 </div>

--- a/web/partials/displays/displays-list.html
+++ b/web/partials/displays/displays-list.html
@@ -113,20 +113,20 @@
           </td>
           <td class="table-body__cell display-status">
             <!-- Not Licensed and Installed -->
-            <span class="text-muted" ng-if="!display.playerProAuthorized && !playerNotInstalled(display)">
+            <span class="text-muted" ng-if="displayFactory.showLicenseRequired(display) && !playerNotInstalled(display)">
               License Required
             </span>
             <!-- Licensed and Loading Status -->
-            <i ng-if="displayService.statusLoading && display.playerProAuthorized" class="fa fa-spinner fa-spin fa-fw"></i>
+            <i ng-if="displayService.statusLoading && !displayFactory.showLicenseRequired(display)" class="fa fa-spinner fa-spin fa-fw"></i>
             <!-- Licensed and Offline -->
-            <span class="text-danger" ng-if="!displayService.statusLoading && display.playerProAuthorized && playerOffline(display)">
+            <span class="text-danger" ng-if="!displayService.statusLoading && !displayFactory.showLicenseRequired(display) && playerOffline(display)">
               <i class="fa fa-times"></i> Offline
               <a href="https://help.risevision.com/hc/en-us/articles/115002694906-Why-is-my-Display-status-offline-" target="_blank" translate>
                 displays-app.list.status.whyOffline
               </a>
             </span>
             <!-- Licensed and Online -->
-            <span class="text-success" ng-if="!displayService.statusLoading && display.playerProAuthorized && playerOnline(display)">
+            <span class="text-success" ng-if="!displayService.statusLoading && !displayFactory.showLicenseRequired(display) && playerOnline(display)">
               <i class="fa fa-check"></i> Online
             </span>
             <!-- Not Installed and finished Loading -->
@@ -135,10 +135,10 @@
             </a>
           </td>
           <td class="table-body__cell u_nowrap hidden-xs hidden-sm">
-            <span class="text-muted" ng-if="!display.playerProAuthorized">
+            <span class="text-muted" ng-if="displayFactory.showLicenseRequired(display)">
               License Required
             </span>
-            <span ng-if="display.playerProAuthorized">
+            <span ng-if="!displayFactory.showLicenseRequired(display)">
               {{display.lastConnectionTime | date:'d-MMM-yyyy h:mm a'}}
             </span>
           </td>

--- a/web/scripts/displays/directives/dtv-screenshot.js
+++ b/web/scripts/displays/directives/dtv-screenshot.js
@@ -14,7 +14,7 @@ angular.module('risevision.displays.directives')
           $scope.screenshotState = function (display) {
             var statusFilter = $filter('status');
 
-            if (display && displayFactory.showLicenseRequired(display)) {
+            if (displayFactory.showLicenseRequired(display)) {
               return 'no-license';
             } else if (!display || displayService.statusLoading || screenshotFactory.screenshotLoading) {
               return 'loading';

--- a/web/scripts/displays/directives/dtv-screenshot.js
+++ b/web/scripts/displays/directives/dtv-screenshot.js
@@ -14,7 +14,7 @@ angular.module('risevision.displays.directives')
           $scope.screenshotState = function (display) {
             var statusFilter = $filter('status');
 
-            if (display && !display.playerProAuthorized) {
+            if (display && displayFactory.showLicenseRequired(display)) {
               return 'no-license';
             } else if (!display || displayService.statusLoading || screenshotFactory.screenshotLoading) {
               return 'loading';

--- a/web/scripts/displays/services/svc-display-factory.js
+++ b/web/scripts/displays/services/svc-display-factory.js
@@ -203,7 +203,7 @@ angular.module('risevision.displays.services')
       };
 
       factory.showLicenseRequired = function (display) {
-        return display && !display.playerProAuthorized && !userState.isRiseVisionUser();
+        return display && !display.playerProAuthorized && !userState.isRiseAdmin();
       };
 
       factory.showLicenseUpdate = function() {

--- a/web/scripts/displays/services/svc-display-factory.js
+++ b/web/scripts/displays/services/svc-display-factory.js
@@ -2,9 +2,9 @@
 
 angular.module('risevision.displays.services')
   .factory('displayFactory', ['$rootScope', '$q', '$state', '$modal', '$loading', '$log',
-    'display', 'displayTracker', 'playerLicenseFactory', 'processErrorCode', 'storeService',
+    'userState', 'display', 'displayTracker', 'playerLicenseFactory', 'processErrorCode', 'storeService',
     'humanReadableError', 'plansFactory',
-    function ($rootScope, $q, $state, $modal, $loading, $log, display, displayTracker,
+    function ($rootScope, $q, $state, $modal, $loading, $log, userState, display, displayTracker,
       playerLicenseFactory, processErrorCode, storeService, humanReadableError, plansFactory) {
       var factory = {};
       var _displayId;
@@ -200,6 +200,10 @@ angular.module('risevision.displays.services')
         factory.apiError = processErrorCode('Display', action, e);
 
         $log.error(factory.errorMessage, e);
+      };
+
+      factory.showLicenseRequired = function (display) {
+        return display && !display.playerProAuthorized && !userState.isRiseVisionUser();
       };
 
       factory.showLicenseUpdate = function() {


### PR DESCRIPTION
## Description
Do not show for Rise Vision users
Use utility function for showing License Required

[stage-2]

## Motivation and Context
Allow Rise Vision users to see all fields

## How Has This Been Tested?
Tested changes locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No