### PR TITLE
Allow Restart, Reboot and Update Screenshot for Rise Admins

### DIFF
--- a/test/unit/displays/controllers/ctr-display-controls.tests.js
+++ b/test/unit/displays/controllers/ctr-display-controls.tests.js
@@ -33,7 +33,7 @@ describe('controller: display controls', function() {
     });
     $provide.service('displayFactory', function() { 
       return {
-        showUnlockThisFeatureModal: sinon.stub().returns(false)
+        showUnlockDisplayFeatureModal: sinon.stub().returns(false)
       };
     });
     $provide.service('displayTracker', function() { 
@@ -107,7 +107,7 @@ describe('controller: display controls', function() {
 
   describe('restart: ',function(){
     it('should not proceed if Display is not licensed',function(){
-      displayFactory.showUnlockThisFeatureModal.returns(true);
+      displayFactory.showUnlockDisplayFeatureModal.returns(true);
 
       $scope.confirm('1234', 'restart');
 
@@ -154,7 +154,7 @@ describe('controller: display controls', function() {
   
   describe('reboot: ',function() {
     it('should not proceed if Display is not licensed',function(){
-      displayFactory.showUnlockThisFeatureModal.returns(true);
+      displayFactory.showUnlockDisplayFeatureModal.returns(true);
 
       $scope.confirm('1234', 'reboot');
 

--- a/test/unit/displays/services/svc-display-factory.tests.js
+++ b/test/unit/displays/services/svc-display-factory.tests.js
@@ -154,7 +154,7 @@ describe('service: displayFactory:', function() {
 
     expect(displayFactory.showLicenseRequired).to.be.a('function');
     expect(displayFactory.showLicenseUpdate).to.be.a('function');
-    expect(displayFactory.showUnlockThisFeatureModal).to.be.a('function'); 
+    expect(displayFactory.showUnlockDisplayFeatureModal).to.be.a('function'); 
   });
   
   it('should initialize',function(){
@@ -575,21 +575,22 @@ describe('service: displayFactory:', function() {
     });
   });
 
-  describe('showUnlockThisFeatureModal: ', function() {
+  describe('showUnlockDisplayFeatureModal: ', function() {
     beforeEach(function() {
+      sinon.stub(displayFactory, 'showLicenseRequired').returns(true);
       sinon.stub(displayFactory, 'showLicenseUpdate');
     });
 
-    it('should not open modal and return false if Display is licensed', function() {
-      displayFactory.display.playerProAuthorized = true;
-      
-      expect(displayFactory.showUnlockThisFeatureModal()).to.be.false;
+    it('should not open modal and return false if a license is not required', function() {
+      displayFactory.showLicenseRequired.returns(false);
+
+      expect(displayFactory.showUnlockDisplayFeatureModal()).to.be.false;
       
       $modal.open.should.not.have.been.called;
     });
 
-    it('should open modal on download only mode', function() {
-      expect(displayFactory.showUnlockThisFeatureModal()).to.be.true;
+    it('should open modal if a license is required', function() {
+      expect(displayFactory.showUnlockDisplayFeatureModal()).to.be.true;
 
       $modal.open.should.have.been.calledWithMatch({
     	  controller: "confirmModalController",
@@ -600,7 +601,7 @@ describe('service: displayFactory:', function() {
 
     it('should show license update if user confirms', function(done) {
       playerLicenseFactory.getProLicenseCount.returns(0);
-      displayFactory.showUnlockThisFeatureModal();
+      displayFactory.showUnlockDisplayFeatureModal();
 
       setTimeout(function() {
         displayFactory.showLicenseUpdate.should.have.been.called;

--- a/test/unit/displays/services/svc-screenshot-factory.tests.js
+++ b/test/unit/displays/services/svc-screenshot-factory.tests.js
@@ -20,7 +20,7 @@ describe('service: screenshotFactory:', function() {
     });
     $provide.factory('displayFactory', function() {
       return {
-        showUnlockThisFeatureModal: sinon.stub().returns(false),
+        showUnlockDisplayFeatureModal: sinon.stub().returns(false),
         display: {
           id: '123'
         }
@@ -55,7 +55,7 @@ describe('service: screenshotFactory:', function() {
     });
 
     it('should not proceed if Display is not licensed',function(){
-      displayFactory.showUnlockThisFeatureModal.returns(true);
+      displayFactory.showUnlockDisplayFeatureModal.returns(true);
 
       screenshotFactory.requestScreenshot();
 

--- a/web/scripts/displays/controllers/ctr-display-controls.js
+++ b/web/scripts/displays/controllers/ctr-display-controls.js
@@ -50,7 +50,7 @@ angular.module('risevision.displays.controllers')
       };
 
       $scope.confirm = function (displayId, displayName, mode) {
-        if (displayFactory.showUnlockThisFeatureModal()) {
+        if (displayFactory.showUnlockDisplayFeatureModal()) {
           return;
         }
 

--- a/web/scripts/displays/services/svc-display-factory.js
+++ b/web/scripts/displays/services/svc-display-factory.js
@@ -214,8 +214,8 @@ angular.module('risevision.displays.services')
         }
       };
 
-      factory.showUnlockThisFeatureModal = function () {
-        if (!factory.display || factory.display.playerProAuthorized) {
+      factory.showUnlockDisplayFeatureModal = function () {
+        if (!factory.showLicenseRequired(factory.display)) {
           return false;
 
         } else {

--- a/web/scripts/displays/services/svc-screenshot-factory.js
+++ b/web/scripts/displays/services/svc-screenshot-factory.js
@@ -6,7 +6,7 @@ angular.module('risevision.displays.services')
       var factory = {};
 
       factory.requestScreenshot = function () {
-        if (displayFactory.showUnlockThisFeatureModal()) {
+        if (displayFactory.showUnlockDisplayFeatureModal()) {
           return;
         }
 


### PR DESCRIPTION
## Description
Do not show unlock feature for Rise Admins

Allow Restart, Reboot and Update Screenshot

Rename function to reduce confusion with
plansFactory function

[stage-2]

## Motivation and Context
Allow Rise Admins to perform those actions on Unlicensed Displays

## How Has This Been Tested?
Tested on staging with a non Rise Admin account; and a Rise Admin account. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No