### PR TITLE
Use selected company id to check for Free Displays when adding new Schedule

### DIFF
--- a/test/unit/schedules/services/svc-schedule-factory.tests.js
+++ b/test/unit/schedules/services/svc-schedule-factory.tests.js
@@ -88,6 +88,13 @@ describe('service: scheduleFactory:', function() {
         showLicenseRequiredToUpdateModal: sinon.stub()
       };
     });
+    $provide.service('userState', function() {
+      return {
+        getSelectedCompanyId: sinon.stub().returns('companyId'),
+        getUsername: sinon.stub().returns('username'),
+        _restoreState: sinon.stub()
+      };
+    });
   }));
   var scheduleFactory, trackerCalled, updateSchedule, $state, returnList, scheduleListSpy, scheduleAddSpy, processErrorCode;
   var $rootScope, blueprintFactory, display, plansFactory;
@@ -128,7 +135,7 @@ describe('service: scheduleFactory:', function() {
   });
 
   it('should initialize',function(){
-    expect(scheduleFactory.schedule).to.deep.equal({content: [], distributeToAll: false, distribution: [], timeDefined: false});
+    expect(scheduleFactory.schedule).to.deep.equal({companyId: 'companyId',content: [], distributeToAll: false, distribution: [], timeDefined: false});
   });
 
   describe('newSchedule:', function() {
@@ -139,7 +146,7 @@ describe('service: scheduleFactory:', function() {
 
       expect(trackerCalled).to.equal('Add Schedule');
 
-      expect(scheduleFactory.schedule).to.deep.equal({content: [], distributeToAll: false, distribution: [], timeDefined: false});
+      expect(scheduleFactory.schedule).to.deep.equal({companyId: 'companyId', content: [], distributeToAll: false, distribution: [], timeDefined: false});
     });
 
     it('should not call tracker if param is true',function(){
@@ -250,7 +257,6 @@ describe('service: scheduleFactory:', function() {
 
     it('should check if distrubuted to free displays and show notice if true',function(done){
       updateSchedule = true;
-      scheduleFactory.schedule.companyId = 'companyId';
       scheduleFactory.schedule.distribution = ['display1'];
 
       scheduleFactory.addSchedule();
@@ -320,7 +326,6 @@ describe('service: scheduleFactory:', function() {
 
     it('should check if distrubuted to free displays and show notice if true',function(done){
       updateSchedule = true;
-      scheduleFactory.schedule.companyId = 'companyId';
       scheduleFactory.schedule.distribution = ['display1'];
 
       scheduleFactory.updateSchedule();

--- a/web/scripts/schedules/services/svc-schedule-factory.js
+++ b/web/scripts/schedules/services/svc-schedule-factory.js
@@ -2,9 +2,9 @@
 
 angular.module('risevision.schedules.services')
   .factory('scheduleFactory', ['$q', '$state', '$log', '$rootScope', 'schedule', 'scheduleTracker',
-    'processErrorCode', 'VIEWER_URL', 'HTML_PRESENTATION_TYPE', 'display', 'plansFactory',
+    'processErrorCode', 'VIEWER_URL', 'HTML_PRESENTATION_TYPE', 'display', 'plansFactory', 'userState',
     function ($q, $state, $log, $rootScope, schedule, scheduleTracker, processErrorCode,
-      VIEWER_URL, HTML_PRESENTATION_TYPE, display, plansFactory) {
+      VIEWER_URL, HTML_PRESENTATION_TYPE, display, plansFactory, userState) {
       var factory = {};
       var _hasSchedules;
       var _scheduleId;
@@ -21,6 +21,7 @@ angular.module('risevision.schedules.services')
         _scheduleId = undefined;
 
         factory.schedule = {
+          companyId: userState.getSelectedCompanyId(),
           content: [],
           distributeToAll: false,
           distribution: [],


### PR DESCRIPTION


## Description
Use selected company id to check for Free Displays when adding new Schedule

## Motivation and Context
Fix #1703.
When adding a new Schedule in a subcompany, the company Id was missing, causing the request to check for Free Displays in the parent company. 

## How Has This Been Tested?
Manually tested locally and on stage-1.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
