### PR TITLE
Consider pound sign when checking encoding applicability

### DIFF
--- a/web/scripts/storage/services/svc-upload-uri.js
+++ b/web/scripts/storage/services/svc-upload-uri.js
@@ -11,7 +11,7 @@ angular.module('risevision.storage.services')
           });
         }
 
-        return encoding.isApplicable(file.type)
+        return encoding.isApplicable(file.type, file.name)
           .then(function (useEncoding) {
             var applicableService = useEncoding ? encoding : storage;
 


### PR DESCRIPTION
## Description
Pass file name to isApplicable to check for # sign.

## Motivation and Context
Qencode is working on a fix to allow # signs in output destination.

## How Has This Been Tested?
Locally, staging

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
