### PR TITLE
Simplify non-licensed screenshot message

### DIFF
--- a/web/partials/displays/screenshot.html
+++ b/web/partials/displays/screenshot.html
@@ -7,8 +7,7 @@
   </div>
   <div class="panel panel-default u_margin-sm-bottom text-center">
     <div class="panel-body display-screenshot" ng-show="screenshotState(display) === 'no-license'">
-      <p class="text-muted"><a href="#" ng-click="displayFactory.showLicenseUpdate()">Click here to License this Display and enable all functions, including screenshot, restart, reboot and emergency alert broadcasts.</a></p>
-      <p class="text-muted"><strong>Use the code “SAVE50” to get 50% off an annual plan.</strong></p>
+      <p class="text-muted">License Required</p>
     </div>
     <div class="panel-body display-screenshot" ng-show="screenshotState(display) === 'no-schedule'">
       <p class="text-muted">{{ 'displays-app.fields.screenshot.notAvailable' | translate }}</p>


### PR DESCRIPTION
## Description
Simplify the non-licensed message for screenshots, to make it consistent with other disabled features and to not present users with a confusing flow.

## Motivation and Context
Fix #1709 .

## How Has This Been Tested?
Manually confirmed the message locally and on stage-1.
Sample display: https://apps-stage-1.risevision.com/displays/details/G98VPSFRSGD6?cid=554d3ef9-78b7-4726-8f46-c1ec140c166d

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
