### PR TITLE
Show different file upload message when encoding

### DIFF
--- a/test/unit/storage/services/svc-file-upload.tests.js
+++ b/test/unit/storage/services/svc-file-upload.tests.js
@@ -62,6 +62,12 @@ describe('Services: uploader', function() {
       expect(uploader.queue.length).to.equal(2);
     });
 
+    it('should indicate whether some files are to be encoded', function () {
+      uploader.addToQueue([{ taskToken: 'abc', file: {name: 'test1.txt', size: 200, type: 'text' }}]);
+      expect(uploader.queue.length).to.equal(1);
+      expect(uploader.someEncoding()).to.be.true;
+    });
+
     it('should add one file inside a folder to the queue', function () {
       uploader.addToQueue([{file:{name: 'folder/test1.txt', size: 200, type: 'text' }}]);
       expect(uploader.queue.length).to.equal(1);

--- a/web/locales/en/storage-client.json
+++ b/web/locales/en/storage-client.json
@@ -116,5 +116,6 @@
   "upload-status": "Upload Status",
   "uploading": "Uploading {{filename}}",
   "uploading-count-files": "Uploading {{count}} files",
+  "uploading-count-files-encoding": "Uploading and optimizing files - Depending on the size of your files, this might take a moment",
   "uploading-one-file": "Uploading 1 file"
 }

--- a/web/partials/storage/upload-panel.html
+++ b/web/partials/storage/upload-panel.html
@@ -12,7 +12,8 @@
             <i class="fa" ng-class="{false: 'fa-chevron-up', true:'fa-chevron-down'}[!isCollapsed]"></i>
           </span>
           <p>
-            <strong translate="storage-client.uploading-count-files"></strong>
+            <strong ng-show="someEncoding()" translate="storage-client.uploading-count-files-encoding"></strong>
+            <strong ng-show="!someEncoding()" translate="storage-client.uploading-count-files"></strong>
             <!--
             TODO: To FIX: activeUploadCount does not take into account all files being uploaded but just the queue size of 10
             <strong translate="storage-client.upload-status"></strong>:

--- a/web/scripts/storage/directives/dtv-upload.js
+++ b/web/scripts/storage/directives/dtv-upload.js
@@ -30,6 +30,10 @@
               FileUploader.removeFromQueue(item);
             };
 
+            $scope.someEncoding = function () {
+              return FileUploader.someEncoding();
+            };
+
             $scope.activeUploadCount = function () {
               return FileUploader.queue.filter(function (file) {
                 return !file.isUploaded || file.isError;

--- a/web/scripts/storage/services/svc-file-upload.js
+++ b/web/scripts/storage/services/svc-file-upload.js
@@ -179,6 +179,12 @@ angular.module('risevision.storage.services')
           }
         };
 
+        svc.someEncoding = function() {
+          return svc.queue.some(function (item) {
+            return !!item.taskToken;
+          });
+        };
+
         svc.uploadItem = function (value) {
           var index = svc.getIndexOfItem(value);
           var item = svc.queue[index];


### PR DESCRIPTION
## Description
During upload, if encoding, provide messaging ![messaging](https://user-images.githubusercontent.com/1511535/83691424-1f8f2480-a5c0-11ea-8408-8008289a87a3.png)
 that indicates encoding is active.

## Motivation and Context
This is meant to give more information to the user about what is
happening since we have had at least one user mention confusion about
the size of their uploaded image.

Requested through [Slack](https://rise-vision-inc.slack.com/archives/CD10S3YTT/p1591209667069200?thread_ts=1591208727.069100&cid=CD10S3YTT)

## How Has This Been Tested?
Unit + local + staging

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
