### PR TITLE
Load quill css from node modules

### DIFF
--- a/css-build.js
+++ b/css-build.js
@@ -11,6 +11,7 @@ var paths = {
   sass: ["./web/scss/**/*.scss", "./web/scss/*.scss"],
   appSass: "./web/scss/app.scss",
   alignmentSass: "./web/scss/ui-components/alignment.scss",
+  quillCss: ["./node_modules/quill/dist/quill.core.css", "./node_modules/quill/dist/quill.snow.css"],
   tmpFonts: "./web/tmp/fonts",
   tmpCss: "./web/tmp/css",
   distFonts: "./dist/fonts",
@@ -38,7 +39,13 @@ gulp.task("css-build-alignment", function () {
     .pipe(gulp.dest(paths.distCss));
 });
 
-gulp.task("css-build", ["css-build-alignment", "fonts-copy"], function() {
+gulp.task("css-build-quill", function () {
+  return gulp.src(paths.quillCss)
+    .pipe(gulp.dest(paths.tmpCss))
+    .pipe(gulp.dest(paths.distCss));
+});
+
+gulp.task("css-build", ["css-build-alignment", "css-build-quill", "fonts-copy"], function() {
   console.log("[SASS] recompiling".yellow);
   gulp.src(paths.appSass)
     .pipe(sass({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -283,7 +283,11 @@ gulp.task("ngquill", function() {
 
 gulp.task("quilljs", function() {
   return gulp.src("node_modules/quill/dist/quill.js")
-    .pipe(gulp.dest("web/vendor/quill"));
+    .pipe(gulp.dest("web/vendor/quill"))
+});
+
+gulp.task('quill', function (cb) {
+  runSequence(['ngquill', 'quilljs'], cb);
 });
 
 gulp.task("html2js", function() {
@@ -333,7 +337,7 @@ gulp.task("config", function() {
 });
 
 gulp.task('build-pieces', function (cb) {
-  runSequence(["clean"], ['config', 'i18n-build', 'css-build', 'pricing', 'html2js', 'tus', 'ngquill', 'quilljs'], cb);
+  runSequence(["clean"], ['config', 'i18n-build', 'css-build', 'pricing', 'html2js', 'tus', 'quill'], cb);
 });
 
 gulp.task('build', function (cb) {

--- a/web/index.html
+++ b/web/index.html
@@ -56,8 +56,8 @@
   <link rel="stylesheet" type="text/css" href="bower_components/ng-tags-input/ng-tags-input.bootstrap.min.css">
   <link rel="stylesheet" type="text/css" href="bower_components/angularjs-slider/dist/rzslider.css" />
   <link rel="stylesheet" type="text/css" href="pricing-component.css">
-  <link rel="stylesheet" href="//cdn.quilljs.com/1.3.6/quill.snow.css">
-  <link rel="stylesheet" href="//cdn.quilljs.com/1.3.6/quill.bubble.css">
+  <link rel="stylesheet" type="text/css" href="tmp/css/quill.core.css">
+  <link rel="stylesheet" type="text/css" href="tmp/css/quill.snow.css">
   <!-- endbuild -->
 </head>
 


### PR DESCRIPTION
## Description
- This PR fixes build error
- Load quill css from node modules
- Include quill.core.css
- Remove quill.bubble.css - we are not going to use this this theme https://quilljs.com/docs/themes/#bubble

## Motivation and Context
https://trello.com/c/ianLmiUG/63-do-not-load-quills-css-from-cdn

## How Has This Been Tested?
N/A

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
