### PR TITLE
Feature/backwards compatible

### DIFF
--- a/web/scripts/template-editor/components/directives/dtv-component-text.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-text.js
@@ -20,7 +20,7 @@ angular.module('risevision.template-editor.directives')
             var fontsize = $scope.getAvailableAttributeData($scope.componentId, 'fontsize');
             var minfontsize = $scope.getAvailableAttributeData($scope.componentId, 'minfontsize');
             var maxfontsize = $scope.getAvailableAttributeData($scope.componentId, 'maxfontsize');
-            var richText = $scope.getAvailableAttributeData($scope.componentId, 'richText');
+            var richText = $scope.getAvailableAttributeData($scope.componentId, 'richText') ? $scope.getAvailableAttributeData($scope.componentId, 'richText') : value;
 
 
             var fontsizeInt = templateEditorUtils.intValueFor(fontsize, null);


### PR DESCRIPTION
## Description
Setting the value of existing presentations into quill if they have not been edited/created by quill editor.

## Motivation and Context
https://trello.com/c/Zm14HfRA/28-attribute-editor-implementation-3

## How Has This Been Tested?
I was not been able to test it because of this blocked card https://trello.com/c/ianLmiUG/63-do-not-load-quills-css-from-cdn .

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
