### PR TITLE
Always stage Apps despite build failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,6 +219,9 @@ workflows:
       - test_build:
           requires:
             - dependencies
+          filters:
+            branches:
+              ignore: /(stage).*/
       - test_unit:
           requires:
             - test_build
@@ -309,7 +312,7 @@ workflows:
               only: master
       - deploy_staging:
           requires:
-            - test_build
+            - dependencies
           filters:
             branches:
               only: /(feature|fix|chore|stage).*/


### PR DESCRIPTION
## Description
Always stage Apps despite build failure

For other branches `stage` independently of `build`
For stage branches skip `build`

[stage-19]

## Motivation and Context
Faster staging of branches

## How Has This Been Tested
Staging build passes; no other code changes.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No