### PR TITLE
Fix #1730 - Properly handle 'Enter' on Schedule Details

### DIFF
--- a/test/e2e/schedules/cases/scheduleadd.js
+++ b/test/e2e/schedules/cases/scheduleadd.js
@@ -63,6 +63,12 @@ var ScheduleAddScenarios = function() {
       expect(scheduleAddPage.getShareScheduleButton().isDisplayed()).to.eventually.be.true;
     });
 
+    it('should save the Schedule on Enter pressed', function() {
+      scheduleAddPage.getScheduleNameField().sendKeys(protractor.Key.ENTER);
+      helper.waitForElementTextToChange(scheduleAddPage.getSaveButton(),'Save', 'Schedules Suve Button');
+      expect(scheduleAddPage.getSaveButton().getText()).to.eventually.equal('Save');
+    });
+
     describe('Share Schedule cases:', function() {
       it('should open Share Schedule modal', function() {
         scheduleAddPage.getShareScheduleButton().click();

--- a/web/partials/schedules/playlist.html
+++ b/web/partials/schedules/playlist.html
@@ -7,13 +7,13 @@
 
         <div class="pull-right">
           <span class="btn-group btn-group-sm">
-            <button class="btn btn-default" id="moveUpButton" ng-click="factory.movePlaylistItemUp(playlistItem)" ng-disabled="!factory.canPlaylistItemMoveUp(playlistItem)"><i class="fa fa-arrow-up"></i></button>
-            <button class="btn btn-default" id="moveDownButton" ng-click="factory.movePlaylistItemDown(playlistItem)" ng-disabled="!factory.canPlaylistItemMoveDown(playlistItem)"><i class="fa fa-arrow-down"></i></button>
+            <button type="button" class="btn btn-default" id="moveUpButton" ng-click="factory.movePlaylistItemUp(playlistItem)" ng-disabled="!factory.canPlaylistItemMoveUp(playlistItem)"><i class="fa fa-arrow-up"></i></button>
+            <button type="button" class="btn btn-default" id="moveDownButton" ng-click="factory.movePlaylistItemDown(playlistItem)" ng-disabled="!factory.canPlaylistItemMoveDown(playlistItem)"><i class="fa fa-arrow-down"></i></button>
           </span>
-          <button class="btn btn-sm btn-default" id="duplicateButton" ng-click="factory.duplicatePlaylistItem(playlistItem)">
+          <button type="button" class="btn btn-sm btn-default" id="duplicateButton" ng-click="factory.duplicatePlaylistItem(playlistItem)">
             <i class="fa fa-copy"></i>
           </button>
-          <button class="btn btn-sm btn-default" id="removeButton" ng-click="remove(playlistItem)">
+          <button type="button" class="btn btn-sm btn-default" id="removeButton" ng-click="remove(playlistItem)">
             <i class="fa fa-trash-o"></i>
           </button>
         </div>

--- a/web/partials/schedules/schedule-add.html
+++ b/web/partials/schedules/schedule-add.html
@@ -8,7 +8,7 @@
 <div rv-spinner rv-spinner-key="schedule-loader" rv-spinner-start-active="0"></div>
 
 <div>
-  <form id="scheduleAdd" role="form" name="scheduleDetails" novalidate>
+  <form id="scheduleAdd" role="form" name="scheduleDetails" ng-submit="save()" novalidate>
     
     <schedule-fields></schedule-fields>
     
@@ -18,12 +18,12 @@
 
       <div class="button-row text-right">
         <!-- Indicates a successful or positive action -->
-        <button id="saveButton" type="submit" class="btn btn-primary" ng-click="save()" ng-disabled="scheduleDetails.$invalid || factory.savingSchedule" require-role="cp">
+        <button id="saveButton" type="submit" class="btn btn-primary" ng-disabled="scheduleDetails.$invalid || factory.savingSchedule" require-role="cp">
           {{ factory.savingSchedule ? ('common.saving' | translate) : ('common.save' | translate)}} 
           <i class="fa fa-check icon-right"></i>
         </button>
         <!-- Indicates cancel or non-destructive action -->
-        <button id="cancelButton"  ui-sref="apps.schedules.list" class="btn btn-default">
+        <button id="cancelButton" type="button" ui-sref="apps.schedules.list" class="btn btn-default">
           {{'common.cancel' | translate}}
           <i class="fa fa-times icon-right"></i>
         </button>

--- a/web/partials/schedules/schedule-details.html
+++ b/web/partials/schedules/schedule-details.html
@@ -13,7 +13,7 @@
 <div rv-spinner rv-spinner-key="schedule-loader" rv-spinner-start-active="0"></div>
 
 <div>
-  <form role="form" name="scheduleDetails" novalidate>
+  <form role="form" name="scheduleDetails" ng-submit="save()" novalidate>
     
     <schedule-fields></schedule-fields>
 
@@ -30,12 +30,12 @@
       <div>
       <span class="hidden-xs u_margin-right"><last-modified change-date="schedule.changeDate" changed-by="schedule.changedBy"></last-modified></span>
         <!-- Indicates a successful or positive action -->
-        <button type="submit" class="btn btn-primary" ng-click="save()" ng-disabled="scheduleDetails.$invalid || factory.savingSchedule" require-role="cp">
+        <button id="saveButton" type="submit" class="btn btn-primary" ng-disabled="scheduleDetails.$invalid || factory.savingSchedule" require-role="cp">
           {{ factory.savingSchedule ? ('common.saving' | translate) : ('common.save' | translate)}} 
           <i class="fa fa-check icon-right"></i>
         </button>
         <!-- Indicates cancel or non-destructive action -->
-        <button ui-sref="apps.schedules.list" class="btn btn-default">
+        <button type="button" ui-sref="apps.schedules.list" class="btn btn-default">
           {{'common.cancel' | translate}}
           <i class="fa fa-times icon-right"></i>
         </button>

--- a/web/partials/schedules/schedule-fields.html
+++ b/web/partials/schedules/schedule-fields.html
@@ -32,11 +32,11 @@
   <div class="pull-left">
     <h3 class="u_remove-top" style="line-height:33px;" translate>schedules-app.playlist.title</h3>
   </div>
-  <button class="btn btn-default" id="shareScheduleButton" ng-click="openSharedScheduleModal()" ng-show="schedule.id">
+  <button type="button" class="btn btn-default" id="shareScheduleButton" ng-click="openSharedScheduleModal()" ng-show="schedule.id">
     Share Schedule
   </button>
   <div class="btn-group" dropdown>
-    <button id="addPlaylistItemButton" dropdown-toggle class="dropdown-toggle btn btn-primary">{{'schedules-app.playlist.add-playlist-item' | translate}} <i class="fa fa-plus icon-right"></i></button>
+    <button id="addPlaylistItemButton" type="button" dropdown-toggle class="dropdown-toggle btn btn-primary">{{'schedules-app.playlist.add-playlist-item' | translate}} <i class="fa fa-plus icon-right"></i></button>
     <div class="dropdown-menu playlist-menu" role="menu">
       <ul>
       <li>


### PR DESCRIPTION
## Description
Default type for buttons is "submit", which was causing 'Share Schedule' button to be triggered instead of Save button.

Similar to https://github.com/Rise-Vision/rise-vision-apps/pull/889.

## Motivation and Context
Fix #1730.

## How Has This Been Tested?
Manually and automated tests: [stage-1].

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
