### PR TITLE
Do not show Weekly Templates on smaller resolutions

### DIFF
--- a/web/partials/launcher/app-home.html
+++ b/web/partials/launcher/app-home.html
@@ -4,7 +4,7 @@
 	<div class="row">
 		<div class="col-xs-12">
 			<in-app-messages></in-app-messages>
-			<weekly-templates></weekly-templates>
+			<weekly-templates class="hidden-xs"></weekly-templates>
 		</div>
 	</div>
 


### PR DESCRIPTION
## Description
Do not show Weekly Templates on smaller resolutions (i.e. mobile).

## Motivation and Context
It was taking the entire screen and removing focus from the Embedded Schedule.

## How Has This Been Tested?
Visually confirmed. [stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why