### PR TITLE
Add tooltip and overlay for the Share button

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,6 +29,7 @@
     "checklist-model": "~1.0.0",
     "font-awesome": "~4.7.0",
     "lodash": "~4.17.4",
+    "hone": "^1.1.0",
     "jquery": "~3.3.1",
     "jszip": "~2.5.0",
     "ngstorage": "~0.3.0",

--- a/web/index.html
+++ b/web/index.html
@@ -93,6 +93,7 @@
   <script src="vendor/@shopify/draggable/draggable.bundle.js"></script>
   <script src="bower_components/stretchy/stretchy.js"></script>
   <script src="bower_components/xmlToJSON.js/lib/xmlToJSON.js"></script>
+  <script src="bower_components/hone/hone.js"></script>
 
   <!-- Background image settings widget component -->
   <script src="bower_components/angular-bootstrap-colorpicker/js/bootstrap-colorpicker-module.js"></script>

--- a/web/partials/launcher/app-home.html
+++ b/web/partials/launcher/app-home.html
@@ -12,9 +12,35 @@
 		<div class="form-inline schedules-toolbar">
 			<span class="hidden-xs pull-right action-buttons">
 				<button type="button" class="btn btn-default">Edit Schedule</button>
-				<button type="button" class="btn btn-primary">Share</button>
-			</span>
 
+				<script>
+					var lookAtMe = document.getElementById('shareButton'),
+    				hone = new Hone({
+							classPrefix: 'madero-style tooltip-backdrop',
+							borderRadius: 4,
+							padding: '10px'
+						});
+				</script>
+
+				<script type="text/ng-template" id="myTooltipTemplate.html">
+					<span>
+						<strong>Communicate Everywhere</strong><br>
+						<span class="u_margin-md-top">
+							Keep your community connected anywhere they are. Share your message to digital signage, websites, personal computers, and more.
+						</span>
+						<span class="u_margin-md-top">
+							<a href="">Got it.</a>
+						</span>
+					</span>
+				</script>
+				<button id="shareButton" type="button" class="btn btn-primary"
+				onclick="hone.position(lookAtMe);hone.show()"
+				tooltip-template="'myTooltipTemplate.html'"
+				tooltip-placement="bottom" 
+				tooltip-class="madero-style"
+				tooltip-trigger="click"
+				>Share</button>
+			</span>
 		  	<div class="form-group">
 			    <label for="schedule-selector">Preview A Schedule:</label>
 			    <select id="schedule-selector" class="form-control">

--- a/web/scss/bootstrap-variables.scss
+++ b/web/scss/bootstrap-variables.scss
@@ -514,13 +514,13 @@ $state-danger-border:            darken(adjust-hue($state-danger-bg, -10), 5%);
 //** Tooltip max width
 $tooltip-max-width:           200px;
 //** Tooltip text color
-$tooltip-color:               #fff;
+$tooltip-color:               $text-color;
 //** Tooltip background color
-$tooltip-bg:                  #000;
+$tooltip-bg:                  #fff;
 $tooltip-opacity:             .9;
 
 //** Tooltip arrow width
-$tooltip-arrow-width:         5px;
+$tooltip-arrow-width:         8px;
 //** Tooltip arrow color
 $tooltip-arrow-color:         $tooltip-bg;
 

--- a/web/scss/sections/template-editor-layout.scss
+++ b/web/scss/sections/template-editor-layout.scss
@@ -1463,6 +1463,50 @@ $short-phone-height: 570px;
   .display-id {
     font-size: 18px;
   }
+  
+  &.tooltip-backdrop {
+    background: rgba(2, 6, 32, 0.5);
+    z-index: 1001;
+    fill: rgb(2, 6, 32);
+    fill-opacity: 0.5;
+  }
+
+  &.tooltip {
+    opacity: 1;
+    margin-left: -50px;
+    margin-top: 8px;
+
+    .tooltip-inner {
+      text-align: left;
+      padding: 9px;
+      border: 1px solid rgb(153, 153, 153);
+      box-shadow: 0px 0px 15px 0px rgba(0, 0, 0, 0.5);
+      opacity: 1;
+    }
+
+    &.bottom .tooltip-arrow {
+      margin-top: 1px;
+      margin-left: 50px;
+    }
+
+    /* styles for arrow border */
+    .tooltip-arrow:after {
+      content: '';
+      position: absolute;
+      width: 0;
+      height: 0;
+      border-color: transparent;
+      border-style: solid;
+      z-index: -1;
+    }
+
+    &.bottom .tooltip-arrow:after {
+      margin-top: -2px;
+      margin-left: calc(-#{$tooltip-arrow-width} - 1px);
+      border-width: 0 calc(#{$tooltip-arrow-width} + 1px) calc(#{$tooltip-arrow-width} + 1px);
+      border-bottom-color: rgb(153, 153, 153);
+    }
+  }
 }
 
 .madero-radio, .madero-checkbox {


### PR DESCRIPTION
## Description
Add tooltip and overlay for the Share button

[stage-2]

## Motivation and Context
Overlay highlights the Share button and shows a tooltip for the user.

## How Has This Been Tested?
Tested changes locally

TODOs:
- Styling for the tooltip html
- Tooltip and overlay open/close logic
- General refactoring
- Mobile view
- Tests

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
See todos above
