### PR TITLE
Show warning message if Company does not have Schedules yet

### DIFF
--- a/test/unit/launcher/controllers/ctr-app-home.tests.js
+++ b/test/unit/launcher/controllers/ctr-app-home.tests.js
@@ -65,6 +65,11 @@ describe('controller: AppHomeCtrl', function() {
       expect($scope.getEmbedUrl('ID')).to.equal('http://trustedUrl');
       $sce.trustAsResourceUrl.should.have.been.calledWith('https://preview.risevision.com/?type=sharedschedule&id=ID&env=embed');
     });
+
+    it('should return null, to not render iframe, when scheduleId is not provided', function() {
+      expect($scope.getEmbedUrl(null)).to.equal(null);
+      $sce.trustAsResourceUrl.should.not.have.been.called;
+    });
   });
 
   describe('load:', function() {

--- a/web/partials/launcher/app-home.html
+++ b/web/partials/launcher/app-home.html
@@ -11,11 +11,17 @@
 	<div class="row">
 		<div class="col-xs-12">
 			<div id="errorBox" ng-show="apiError" class="alert alert-danger" role="alert">
-		      <strong>{{errorMessage}}</strong> {{apiError}}
-		    </div>
+				<strong>{{errorMessage}}</strong> {{apiError}}
+			</div>
+
+			<div ng-show="schedules.length === 0 && !loadingItems && !apiError" class="alert alert-warning" role="alert">
+				<strong>You haven't created any Schedules yet.</strong>
+				Keep your community connected anywhere they are. Share your message to digital signage, websites, personal computers, and more.
+				<a ui-sref="apps.schedules.add">Add a new Schedule.</a>
+			</div>
 		</div>
 
-		<div class="form-inline schedules-toolbar" ng-hide="apiError">
+		<div class="form-inline schedules-toolbar" ng-show="selectedScheduleId">
 			<span class="hidden-xs pull-right action-buttons">
 				<button type="button" class="btn btn-default">Edit Schedule</button>
 
@@ -56,7 +62,7 @@
 		</div>
 	</div>
 
-	<div class="container" ng-hide="apiError">
+	<div class="container" ng-show="selectedScheduleId">
 		<div class="schedule-embed">
 		   <iframe frameborder="0" ng-src="{{getEmbedUrl(selectedScheduleId)}}">
 		   </iframe>
@@ -64,7 +70,7 @@
 	</div>
 </div>
 
-<div class="mobile-footer visible-xs" ng-hide="apiError">
+<div class="mobile-footer visible-xs" ng-show="selectedScheduleId" >
 	<div class="container">
 	    <button type="button" class="btn btn-default btn-block">Edit Schedule</button> 
 		<button type="button" class="btn btn-primary btn-block">Share</button>	

--- a/web/scripts/launcher/controllers/ctr-app-home.js
+++ b/web/scripts/launcher/controllers/ctr-app-home.js
@@ -20,6 +20,9 @@ angular.module('risevision.apps.launcher.controllers')
       });
 
       $scope.getEmbedUrl = function (scheduleId) {
+      	if (!scheduleId) {
+      		return null;
+      	}
         var url = SHARED_SCHEDULE_URL.replace('SCHEDULE_ID', scheduleId) + '&env=embed';
         return $sce.trustAsResourceUrl(url);
       };


### PR DESCRIPTION
## Description
Show warning message if Company does not have Schedules yet
Do not render iframe if Schedule ID has not been provided

## Motivation and Context
Why is this change required? What problem does it solve?

## How Has This Been Tested?
Visually confirmed the tested cases. 
Sample: https://apps-stage-1.risevision.com/apphome?cid=edc26bd2-4b4a-49cc-b2b1-840e6ba9bd51

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
