### PR TITLE
Refresh tooltip calculations on resize

### DIFF
--- a/web/scripts/common/directives/dtv-tooltip-overlay.js
+++ b/web/scripts/common/directives/dtv-tooltip-overlay.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.apps.directives')
-  .directive('tooltipOverlay', ['$compile', '$timeout', 'honeBackdropFactory',
-    function ($compile, $timeout, honeBackdropFactory) {
+  .directive('tooltipOverlay', ['$window', '$compile', '$timeout', 'honeBackdropFactory',
+    function ($window, $compile, $timeout, honeBackdropFactory) {
       return {
         restrict: 'A',
         scope: {
@@ -21,16 +21,30 @@ angular.module('risevision.apps.directives')
             post: function postLink($scope, iElement, iAttrs, controller) {  
               $compile(iElement)($scope);
 
+              var digestWrapper = function() {
+                $scope.$digest();
+              };
+
+              var show = function() {
+                if (element.is(':hidden')) { return; }
+
+                honeBackdropFactory.createForElement(element, {});
+                element.trigger('show');                
+                angular.element($window).bind('resize', digestWrapper);
+              };
+
+              var hide = function() {
+                honeBackdropFactory.hide();
+                element.trigger('hide');
+                angular.element($window).unbind('resize', digestWrapper);
+              };
+
               $scope.$watch('isShowing', function() {
                 $timeout(function() {
                   if ($scope.isShowing) {
-                    if (element.is(':hidden')) { return; }
-
-                    honeBackdropFactory.createForElement(element, {});
-                    element.trigger('show');
+                    show();
                   } else {
-                    honeBackdropFactory.hide();
-                    element.trigger('hide');
+                    hide();
                   }                  
                 });
               });


### PR DESCRIPTION
## Description
Refresh tooltip calculations on resize

Add and remove resize handler
Trigger  which repositions the tooltip

[stage-18]

## Motivation and Context
Tooltip does not reposition when window is resized and the button moves.

## How Has This Been Tested?
Tested changes locally

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
