### PR TITLE
Hide weekly templates if tooltip is active

### DIFF
--- a/web/partials/launcher/app-home.html
+++ b/web/partials/launcher/app-home.html
@@ -4,7 +4,7 @@
 	<div class="row">
 		<div class="col-xs-12">
 			<in-app-messages></in-app-messages>
-			<weekly-templates class="hidden-xs"></weekly-templates>
+			<weekly-templates class="hidden-xs" ng-if="showWeeklyTemplates"></weekly-templates>
 		</div>
 	</div>
 

--- a/web/scripts/common/directives/dtv-tooltip-overlay.js
+++ b/web/scripts/common/directives/dtv-tooltip-overlay.js
@@ -22,6 +22,7 @@ angular.module('risevision.apps.directives')
               $compile(iElement)($scope);
 
               var digestWrapper = function() {
+                // trigger $digest cycle to reposition tooltip
                 $scope.$digest();
               };
 

--- a/web/scripts/launcher/controllers/ctr-app-home.js
+++ b/web/scripts/launcher/controllers/ctr-app-home.js
@@ -16,7 +16,8 @@ angular.module('risevision.apps.launcher.controllers')
       $scope.showWeeklyTemplates = false;
 
       var triggerOverlay = function () {
-        $scope.showTooltipOverlay = localStorageService.get(tooltipDismissedKey) !== true
+        $scope.showTooltipOverlay = localStorageService.get(tooltipDismissedKey) !== true;
+
         if ($scope.showTooltipOverlay) {
           var handler = $scope.$on('tooltipOverlay.dismissed', function() {
             localStorageService.set(tooltipDismissedKey, true);

--- a/web/scripts/launcher/controllers/ctr-app-home.js
+++ b/web/scripts/launcher/controllers/ctr-app-home.js
@@ -12,14 +12,18 @@ angular.module('risevision.apps.launcher.controllers')
         reverse: true,
       };
 
-      $scope.showTooltipOverlay = localStorageService.get(tooltipDismissedKey) !== true;
+      $scope.showTooltipOverlay = false;
+      $scope.showWeeklyTemplates = false;
 
-      if ($scope.showTooltipOverlay) {
-        var handler = $scope.$on('tooltipOverlay.dismissed', function() {
-          localStorageService.set(tooltipDismissedKey, true);
-          handler();
-        });        
-      }
+      var triggerOverlay = function () {
+        $scope.showTooltipOverlay = localStorageService.get(tooltipDismissedKey) !== true
+        if ($scope.showTooltipOverlay) {
+          var handler = $scope.$on('tooltipOverlay.dismissed', function() {
+            localStorageService.set(tooltipDismissedKey, true);
+            handler();
+          });        
+        }
+      };
 
       $scope.$watch('loadingItems', function (loading) {
         if (loading) {
@@ -47,6 +51,8 @@ angular.module('risevision.apps.launcher.controllers')
             $scope.schedules = result.items || [];
             if ($scope.schedules.length > 0) {
               $scope.selectedScheduleId = $scope.schedules[0].id;
+
+              triggerOverlay();
             }
           })
           .catch(function (e) {
@@ -56,6 +62,8 @@ angular.module('risevision.apps.launcher.controllers')
           })
           .finally(function () {
             $scope.loadingItems = false;
+
+            $scope.showWeeklyTemplates = !$scope.showTooltipOverlay;
           });
       };
 


### PR DESCRIPTION
## Description
Hide weekly templates if tooltip is active

Do not hide if they have no Schedules
Wait for Schedules to load

[stage-2]

## Motivation and Context
The button and overlay could be shifted down too much when Weekly Templates show.

Also fixes an issue where the overlay was trying to show before the list was loaded and failing.

## How Has This Been Tested?
Tested changes locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
