### PR TITLE
Copy tinyMCE resource files to vendors folder

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -276,6 +276,15 @@ gulp.task("tus", function() {
     .pipe(gulp.dest("web/vendor/tus"));
 });
 
+gulp.task("tinymce", function() {
+  var files = [
+    "web/bower_components/tinymce/themes/modern/theme.min.js",
+    "web/bower_components/tinymce/skins/**/*"
+  ];
+  return gulp.src(files, {base: "web/bower_components/"})
+    .pipe(gulp.dest("web/vendor"));
+});
+
 gulp.task("html2js", function() {
   return gulp.src(partialsHTMLFiles)
     .pipe(minifyHtml({
@@ -323,7 +332,7 @@ gulp.task("config", function() {
 });
 
 gulp.task('build-pieces', function (cb) {
-  runSequence(["clean"], ['config', 'i18n-build', 'css-build', 'pricing', 'html2js', 'tus'], cb);
+  runSequence(["clean"], ['config', 'i18n-build', 'css-build', 'pricing', 'html2js', 'tus', 'tinymce'], cb);
 });
 
 gulp.task('build', function (cb) {

--- a/web/scripts/template-editor/components/directives/dtv-component-text.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-text.js
@@ -1,6 +1,9 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
+  .value('uiTinymceConfig', {
+    baseUrl: '/vendor/tinymce/'
+  })
   .directive('templateComponentText', ['$timeout', '$window', 'templateEditorFactory', 'templateEditorUtils',
     function ($timeout, $window, templateEditorFactory, templateEditorUtils) {
       return {


### PR DESCRIPTION
## Description
This PR fixes the problem with component not loading on stage-3 introduced in https://github.com/Rise-Vision/rise-vision-apps/pull/1765. 

## Motivation and Context
Basically the problem was that tinyMCE tried to load `/themes/modern/theme.min.js` file from the wrong folder and server was returning some random response instead of throwing 404 error, so it was hard to notice in the console.

## How Has This Been Tested?
Tested visually.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
