### PR TITLE
Fix toolbar

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -276,6 +276,15 @@ gulp.task("tus", function() {
     .pipe(gulp.dest("web/vendor/tus"));
 });
 
+gulp.task("tinymce", function() {
+  var files = [
+    "web/bower_components/tinymce/themes/modern/theme.min.js",
+    "web/bower_components/tinymce/skins/**/*"
+  ];
+  return gulp.src(files, {base: "web/bower_components/"})
+    .pipe(gulp.dest("web/vendor"));
+});
+
 gulp.task("html2js", function() {
   return gulp.src(partialsHTMLFiles)
     .pipe(minifyHtml({
@@ -323,7 +332,7 @@ gulp.task("config", function() {
 });
 
 gulp.task('build-pieces', function (cb) {
-  runSequence(["clean"], ['config', 'i18n-build', 'css-build', 'pricing', 'html2js', 'tus'], cb);
+  runSequence(["clean"], ['config', 'i18n-build', 'css-build', 'pricing', 'html2js', 'tus', 'tinymce'], cb);
 });
 
 gulp.task('build', function (cb) {

--- a/web/partials/template-editor/components/component-text.html
+++ b/web/partials/template-editor/components/component-text.html
@@ -1,5 +1,5 @@
 <div class="attribute-editor-component">
-  <div class="attribute-editor-row">
+  <div class="attribute-editor-row" ng-if="tinymceOptions">
     <textarea ui-tinymce="tinymceOptions" ng-model="richText" ng-change="save()"></textarea>
   </div>
 </div>

--- a/web/scripts/template-editor/components/directives/dtv-component-text.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-text.js
@@ -1,6 +1,9 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
+  .value('uiTinymceConfig', {
+    baseUrl: '/vendor/tinymce/'
+  })
   .directive('templateComponentText', ['$timeout', '$window', 'templateEditorFactory', 'templateEditorUtils',
     function ($timeout, $window, templateEditorFactory, templateEditorUtils) {
       return {


### PR DESCRIPTION
## Description
This PR fixes the problem with tinyMCE ignoring `tinymceOptions`. It seems that the problem was caused by directive being initialized before `tinymceOptions` object is created.

## Motivation and Context
https://trello.com/c/g69ElxpW/64-rich-text-configure-tinymce-toolbar-5

## How Has This Been Tested?
Tested visually

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
