### PR TITLE
Reposition tooltip on resize

### DIFF
--- a/test/unit/common/directives/dtv-tooltip-digest-on-resize.tests.js
+++ b/test/unit/common/directives/dtv-tooltip-digest-on-resize.tests.js
@@ -1,0 +1,74 @@
+'use strict';
+describe('directive: tooltip-digest-on-resize', function() {
+  var $scope,
+    element,
+    $window,
+    sandbox = sinon.sandbox.create();
+
+  beforeEach(module('risevision.apps.directives'));
+
+  beforeEach(inject(function($compile, $rootScope, $injector){
+    $scope = $rootScope.$new();
+
+    $window = $injector.get('$window');
+    var $document = $injector.get('$document');
+    var $body = angular.element($document[0].body);
+
+    element = $compile('<div tooltip-digest-on-resize></div>')($scope);
+
+    $body.append(element);
+
+    $scope = element.scope();
+    $scope.$digest();
+
+    sinon.spy($scope, '$digest');
+  }));
+
+  afterEach(function () {
+    element.remove();
+
+    sandbox.restore();
+  });
+
+  it('should initialize', function() {
+    expect($scope).to.be.ok;
+  });
+
+  it('should compile', function() {
+    expect(element[0].outerHTML).to.equal('<div tooltip-digest-on-resize="" class="ng-scope"></div>');
+  });
+
+  describe('window resize:', function() {
+    it('should bind to window resize event on show', function() {
+      var windowStub = {
+        bind: sandbox.stub()
+      };
+      sandbox.stub(angular,'element').returns(windowStub);
+
+      element.trigger('show');
+
+      windowStub.bind.should.have.been.calledWith('resize');
+    });
+
+    it('should unbind from window resize on hide', function() {
+      var windowStub = {
+        unbind: sandbox.stub()
+      };
+      sandbox.stub(angular,'element').returns(windowStub);
+
+      element.trigger('hide');
+
+      windowStub.unbind.should.have.been.calledWith('resize');
+    });
+
+    it('should trigger digest cycle on resize', function() {
+      element.trigger('show');
+
+      angular.element($window).trigger('resize');
+
+      $scope.$digest.should.have.been.called;
+    });
+  });
+
+
+});

--- a/test/unit/common/directives/dtv-tooltip-overlay.tests.js
+++ b/test/unit/common/directives/dtv-tooltip-overlay.tests.js
@@ -88,19 +88,6 @@ describe('directive: tooltip-overlay', function() {
 
       $timeout.flush();
     });
-
-    it('should trigger digest cycle on resize', function() {
-      $scope.isShowing = true;
-      $scope.$digest();
-
-      $timeout.flush();
-
-      $scope.$digest.reset();
-
-      angular.element($window).trigger('resize');
-
-      $scope.$digest.should.have.been.called;
-    });
   });
 
   describe('hide', function() {
@@ -142,19 +129,6 @@ describe('directive: tooltip-overlay', function() {
       $scope.$digest();
 
       $timeout.flush();
-    });
-
-    it('should remove resize handler', function() {
-      $scope.isShowing = false;
-      $scope.$digest();
-
-      $timeout.flush();
-
-      $scope.$digest.reset();
-
-      angular.element($window).trigger('resize');
-
-      $scope.$digest.should.not.have.been.called;
     });
   });
 

--- a/web/index.html
+++ b/web/index.html
@@ -338,6 +338,7 @@
   <script src="scripts/common/directives/dtv-guid-validator.js"></script>
   <script src="scripts/common/directives/dtv-in-app-messages.js"></script>
   <script src="scripts/common/directives/dtv-confirm-email.js"></script>
+  <script src="scripts/common/directives/dtv-tooltip-digest-on-resize.js"></script>
   <script src="scripts/common/directives/dtv-tooltip-overlay.js"></script>
 
   <script src="scripts/common/services/svc-cached-request.js"></script>

--- a/web/partials/launcher/app-home.html
+++ b/web/partials/launcher/app-home.html
@@ -25,7 +25,7 @@
         <span class="hidden-xs pull-right action-buttons">
         <button type="button" class="btn btn-default" ng-click="showTooltipOverlay=true;">Edit Schedule</button>
         <ng-show ng-show="showTooltipOverlay">
-          <button id="shareButton" type="button" class="btn btn-primary" tooltip-overlay="showTooltipOverlay" tooltip-placement="bottom" tooltip-class="madero-style tooltip-pull-left">Share</button>
+          <button id="shareButton" type="button" class="btn btn-primary" tooltip-overlay="showTooltipOverlay" tooltip-placement="bottom" tooltip-class="madero-style tooltip-pull-left" tooltip-digest-on-resize>Share</button>
         </ng-show>
         <share-schedule-button schedule-id="selectedScheduleId" ng-hide="showTooltipOverlay"></share-schedule-button>
       </span>

--- a/web/partials/schedules/share-schedule-button.html
+++ b/web/partials/schedules/share-schedule-button.html
@@ -4,6 +4,7 @@
   tooltip-trigger="show"
   tooltip-animation="false"
   tooltip-template="'partials/schedules/share-schedule-popover.html'" 
+  tooltip-digest-on-resize
   ng-click="toggleTooltip()">
   Share
 </button>

--- a/web/scripts/common/directives/dtv-tooltip-digest-on-resize.js
+++ b/web/scripts/common/directives/dtv-tooltip-digest-on-resize.js
@@ -1,0 +1,25 @@
+'use strict';
+
+angular.module('risevision.apps.directives')
+  .directive('tooltipDigestOnResize', ['$window',
+    function ($window) {
+      return {
+        restrict: 'A',
+        link: function ($scope, element) {
+
+          var digestWrapper = function () {
+            // trigger $digest cycle to reposition tooltip
+            $scope.$digest();
+          };
+
+          element.bind('show', function () {
+            angular.element($window).bind('resize', digestWrapper);
+          });
+
+          element.bind('hide', function () {
+            angular.element($window).unbind('resize', digestWrapper);
+          });
+        }
+      };
+    }
+  ]);

--- a/web/scripts/common/directives/dtv-tooltip-overlay.js
+++ b/web/scripts/common/directives/dtv-tooltip-overlay.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.apps.directives')
-  .directive('tooltipOverlay', ['$window', '$compile', '$timeout', 'honeBackdropFactory',
-    function ($window, $compile, $timeout, honeBackdropFactory) {
+  .directive('tooltipOverlay', ['$compile', '$timeout', 'honeBackdropFactory',
+    function ($compile, $timeout, honeBackdropFactory) {
       return {
         restrict: 'A',
         scope: {
@@ -21,11 +21,6 @@ angular.module('risevision.apps.directives')
             post: function postLink($scope, iElement, iAttrs, controller) {
               $compile(iElement)($scope);
 
-              var digestWrapper = function () {
-                // trigger $digest cycle to reposition tooltip
-                $scope.$digest();
-              };
-
               var show = function () {
                 if (element.is(':hidden')) {
                   return;
@@ -33,13 +28,11 @@ angular.module('risevision.apps.directives')
 
                 honeBackdropFactory.createForElement(element, {});
                 element.trigger('show');
-                angular.element($window).bind('resize', digestWrapper);
               };
 
               var hide = function () {
                 honeBackdropFactory.hide();
                 element.trigger('hide');
-                angular.element($window).unbind('resize', digestWrapper);
               };
 
               $scope.$watch('isShowing', function () {


### PR DESCRIPTION
## Description
Adds `tooltip-digest-on-resize` directive, that performs a `$scope.$digest()` on window resize when the tooltip is open to reposition the tooltip on the screen.

## Motivation and Context
Apps Home Changes

## How Has This Been Tested?
Locally and on [stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
