### PR TITLE
Move baseURL to tinymceOptions

### DIFF
--- a/web/scripts/template-editor/components/directives/dtv-component-text.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-text.js
@@ -1,9 +1,6 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
-  .value('uiTinymceConfig', {
-    baseUrl: '/vendor/tinymce/'
-  })
   .directive('templateComponentText', ['$timeout', '$window', 'templateEditorFactory', 'templateEditorUtils',
     function ($timeout, $window, templateEditorFactory, templateEditorUtils) {
       return {
@@ -18,6 +15,7 @@ angular.module('risevision.template-editor.directives')
           };
 
           $scope.tinymceOptions = {
+            baseURL: '/vendor/tinymce/',
             plugins: 'colorpicker textcolor',
             menubar: false,
             toolbar1: 'fontselect fontsizeselect | ' +


### PR DESCRIPTION
## Description
Now that `tinymceOptions` are working, we can move `baseURL` there instead of defining in the `uiTinymceConfig`.

## Motivation and Context
Refactoring

## How Has This Been Tested?
Visually

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
