### PR TITLE
Save rich text

### DIFF
--- a/web/partials/template-editor/components/component-text.html
+++ b/web/partials/template-editor/components/component-text.html
@@ -1,5 +1,5 @@
 <div class="attribute-editor-component">
   <div class="attribute-editor-row" ng-if="tinymceOptions">
-    <textarea ui-tinymce="tinymceOptions" ng-model="richText" ng-change="save()"></textarea>
+    <textarea ui-tinymce="tinymceOptions" ng-model="data.richText" ng-change="save()"></textarea>
   </div>
 </div>

--- a/web/scripts/template-editor/components/directives/dtv-component-text.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-text.js
@@ -26,7 +26,9 @@ angular.module('risevision.template-editor.directives')
               'removeformat code'
           };
 
-          $scope.richText = '';
+          $scope.data = {
+            richText: ''
+          };
 
           function _load() {
             $scope.isMultiline = $scope.getBlueprintData($scope.componentId, 'multiline');
@@ -46,7 +48,7 @@ angular.module('risevision.template-editor.directives')
             $scope.sliderOptions.onEnd = $scope.save;
 
             $scope.value = value;
-            $scope.richText = richText;
+            $scope.data.richText = richText;
             $scope.fontsize = fontsizeInt;
             $scope.showFontSize = !!fontsizeInt;
 
@@ -56,7 +58,7 @@ angular.module('risevision.template-editor.directives')
           }
 
           $scope.save = function () {
-            $scope.setAttributeData($scope.componentId, 'richText', $scope.richText);
+            $scope.setAttributeData($scope.componentId, 'richText', $scope.data.richText);
             $scope.setAttributeData($scope.componentId, 'value', undefined);
 
             if ($scope.showFontSize) {


### PR DESCRIPTION
## Description
Save rich text. This [article](https://github.com/angular/angular.js/wiki/Understanding-Scopes) explains why it was not working before. In short, the tinyMCE directive was creating the `richText` variable in it's own scope, so the value defined in the controller was not updating. When we move `richText` inside the object, then we pass reference to the object and  tinyMCE directive uses that reference.

## Motivation and Context
https://trello.com/c/4yWu2Ycr/24-rich-text-editor-epic-specs

## How Has This Been Tested?
Tested visually

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
