### PR TITLE
jshint - ignore `camelcase` only, not everything

### DIFF
--- a/web/scripts/template-editor/components/directives/dtv-component-text.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-text.js
@@ -14,7 +14,7 @@ angular.module('risevision.template-editor.directives')
             hidePointerLabels: true
           };
 
-          /* jshint ignore:start */
+          /*jshint camelcase: false */
           $scope.tinymceOptions = {
             baseURL: '/vendor/tinymce/', //set path to load theme and skin files
             plugins: 'colorpicker textcolor lists link',
@@ -37,7 +37,7 @@ angular.module('risevision.template-editor.directives')
               });
             }
           };
-          /* jshint ignore:end */
+          /*jshint camelcase: true */
 
           $scope.data = {
             richText: ''

--- a/web/scripts/template-editor/components/directives/dtv-component-text.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-text.js
@@ -16,7 +16,7 @@ angular.module('risevision.template-editor.directives')
 
           /* jshint ignore:start */
           $scope.tinymceOptions = {
-            baseURL: '/vendor/tinymce/',
+            baseURL: '/vendor/tinymce/', //set path to load theme and skin files
             plugins: 'colorpicker textcolor lists link',
             menubar: false,
             toolbar1: 'fontselect fontsizeselect | ' +
@@ -25,7 +25,17 @@ angular.module('risevision.template-editor.directives')
               'alignleft aligncenter alignright alignjustify | ' +
               'bullist numlist | ' + 'link | ' +
               'removeformat code',
-            fontsize_formats: '8px 10px 12px 14px 18px 24px 36px'
+            fontsize_formats: '8px 10px 12px 14px 18px 24px 36px',
+            setup: function(editor) {
+              editor.on('paste', function(e) {
+                //paste does not trigger change event
+                //editor.getContent() needs timeout in order to include the change
+                setTimeout(function() {
+                  $scope.data.richText = editor.getContent();
+                  $scope.save();
+                }, 100);
+              });
+            }
           };
           /* jshint ignore:end */
 


### PR DESCRIPTION
## Description
 Change jshint directive to ignore `camelcase` only, not everything.

## Motivation and Context
There might be js syntax errors that we want to catch, so disabling jshint completely is not a good idea.

## How Has This Been Tested?
Ran `gulp lint` task locally

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
