### PR TITLE
Prompt to subscribe when clicking Share and is not subscribed to a plan.

### DIFF
--- a/test/unit/components/plans/svc-current-plan-factory-spec.js
+++ b/test/unit/components/plans/svc-current-plan-factory-spec.js
@@ -353,6 +353,11 @@ describe("Services: current plan factory", function() {
       expect(currentPlanFactory.isPlanActive()).to.be.true;
     });
 
+    it("should return the plan is active when canceled but still active", function() {
+      sandbox.stub(currentPlanFactory, "isCancelledActive").returns(true);
+      expect(currentPlanFactory.isPlanActive()).to.be.true;
+    });
+
     it("should return the plan is not active otherwise", function() {
       sandbox.stub(currentPlanFactory, "isTrialExpired").returns(true);
       expect(currentPlanFactory.isPlanActive()).to.be.false;

--- a/test/unit/components/plans/svc-plans-factory-spec.js
+++ b/test/unit/components/plans/svc-plans-factory-spec.js
@@ -29,8 +29,7 @@ describe("Services: plans factory", function() {
     });
     $provide.service("currentPlanFactory", function() {
       return {
-        isPlanActive: sinon.stub().returns(true),
-        isCancelledActive: sinon.stub().returns(false)
+        isPlanActive: sinon.stub().returns(true)
       };
     });
     $provide.service("$state", function() {

--- a/test/unit/components/subscription-status/svc-subscription-status.tests.js
+++ b/test/unit/components/subscription-status/svc-subscription-status.tests.js
@@ -13,8 +13,7 @@ describe("Services: subscriptionStatusService", function() {
         currentPlan: {
           trialExpiryDate: new Date()
         },
-        isPlanActive: sinon.stub().returns(false),
-        isCancelledActive: sinon.stub().returns(false)
+        isPlanActive: sinon.stub().returns(false)
       };
     });
 
@@ -66,15 +65,7 @@ describe("Services: subscriptionStatusService", function() {
         subscriptionStatusService.get("1");
 
         storeProduct.status.should.not.have.been.called;
-      });
-
-      it("should use cancelled but active plan", function() {
-        currentPlanFactory.isCancelledActive.returns(true);
-
-        subscriptionStatusService.get("1");
-
-        storeProduct.status.should.not.have.been.called;
-      });      
+      });  
     });
 
     describe("should map Plan to Subscription Status", function() {

--- a/test/unit/schedules/directives/dtv-schedule-fields.tests.js
+++ b/test/unit/schedules/directives/dtv-schedule-fields.tests.js
@@ -32,8 +32,7 @@ describe('directive: scheduleFields', function() {
     });
     $provide.service('currentPlanFactory', function() {
       return {
-        isPlanActive: sinon.stub().returns(false),
-        isCancelledActive: sinon.stub().returns(false)
+        isPlanActive: sinon.stub().returns(false)
       };
     });
     $provide.service('plansFactory', function() {
@@ -159,18 +158,6 @@ describe('directive: scheduleFields', function() {
       $scope.openSharedScheduleModal();
 
       $modal.open.should.have.been.calledOnce;
-      $modal.open.should.have.been.calledWith({
-        templateUrl: 'partials/schedules/shared-schedule-modal.html',
-        controller: 'SharedScheduleModalController',
-        size: 'md'
-      });
-    });
-
-    it('should open Shared Schedule modal if has a still active cancelled plan', function() {
-      currentPlanFactory.isCancelledActive.returns(true);
-      
-      $scope.openSharedScheduleModal();
-
       $modal.open.should.have.been.calledWith({
         templateUrl: 'partials/schedules/shared-schedule-modal.html',
         controller: 'SharedScheduleModalController',

--- a/test/unit/schedules/directives/dtv-share-schedule-button.tests.js
+++ b/test/unit/schedules/directives/dtv-share-schedule-button.tests.js
@@ -1,13 +1,29 @@
 'use strict';
 describe('directive: share-schedule-button', function() {
-  var $scope, $rootScope, element, $timeout, innerElementStub, sandbox = sinon.sandbox.create();
+  var $scope, $rootScope, element, $timeout, innerElementStub, currentPlanFactory, plansFactory,
+    sandbox = sinon.sandbox.create();
+
 
   beforeEach(module('risevision.schedules.directives'));
+  beforeEach(module(function ($provide) {
+    $provide.service('currentPlanFactory', function() {
+      return {
+        isPlanActive: sinon.stub().returns(true)
+      };
+    });
+    $provide.service('plansFactory', function() {
+      return {
+        showUnlockThisFeatureModal: sinon.stub()
+      };
+    });
+  }));
 
   beforeEach(inject(function($compile, $templateCache, $injector){
     $templateCache.put('partials/schedules/share-schedule-button.html', '<div id="tooltipButton"></div><div id="actionSheetButton"></div>');
     $rootScope = $injector.get('$rootScope');
     $timeout = $injector.get('$timeout');
+    currentPlanFactory = $injector.get('currentPlanFactory');
+    plansFactory = $injector.get('plansFactory');
 
     innerElementStub = {
       trigger: sandbox.stub()
@@ -59,6 +75,13 @@ describe('directive: share-schedule-button', function() {
 
       innerElementStub.trigger.should.have.been.calledWith('hide');
     });
+
+    it('should show Unlock This Feature modal if user is not subscribed to a plan', function() {
+      currentPlanFactory.isPlanActive.returns(false);
+      $scope.toggleTooltip();
+
+      plansFactory.showUnlockThisFeatureModal.should.have.been.called;
+    });
   });
 
   describe('toggleActionSheet:', function() {
@@ -68,7 +91,7 @@ describe('directive: share-schedule-button', function() {
       innerElementStub.trigger.should.have.been.calledWith('toggle');
     });
 
-    it('should close close if open', function() {
+    it('should close action sheet if open', function() {
       //open
       $scope.toggleActionSheet();
       innerElementStub.trigger.resetHistory();
@@ -77,6 +100,13 @@ describe('directive: share-schedule-button', function() {
       $scope.toggleActionSheet();
 
       innerElementStub.trigger.should.have.been.calledWith('toggle');
+    });
+
+    it('should show Unlock This Feature modal if user is not subscribed to a plan', function() {
+      currentPlanFactory.isPlanActive.returns(false);
+      $scope.toggleActionSheet();
+      
+      plansFactory.showUnlockThisFeatureModal.should.have.been.called;
     });
   });
 

--- a/web/scripts/components/plans/svc-current-plan-factory.js
+++ b/web/scripts/components/plans/svc-current-plan-factory.js
@@ -61,7 +61,7 @@
         };
 
         _factory.isPlanActive = function () {
-          return _factory.isSubscribed() || _factory.isOnTrial();
+          return _factory.isSubscribed() || _factory.isOnTrial() || _factory.isCancelledActive();
         };
 
         _factory.isFree = function () {

--- a/web/scripts/components/plans/svc-plans-factory.js
+++ b/web/scripts/components/plans/svc-plans-factory.js
@@ -220,7 +220,7 @@
               }
             }
           }).result.then(function () {
-            if (currentPlanFactory.isPlanActive() || currentPlanFactory.isCancelledActive()) {
+            if (currentPlanFactory.isPlanActive()) {
               $state.go('apps.billing.home');
             } else {
               _factory.showPlansModal();

--- a/web/scripts/components/subscription-status/svc-subscription-status.js
+++ b/web/scripts/components/subscription-status/svc-subscription-status.js
@@ -106,7 +106,7 @@
         };
 
         var checkSubscriptionStatus = function (productCodes) {
-          if (currentPlanFactory.isPlanActive() || currentPlanFactory.isCancelledActive()) {
+          if (currentPlanFactory.isPlanActive()) {
             return $q.resolve(mapCurrentPlan(productCodes));
           } else {
             return storeProduct.status(productCodes)

--- a/web/scripts/schedules/directives/dtv-schedule-fields.js
+++ b/web/scripts/schedules/directives/dtv-schedule-fields.js
@@ -44,7 +44,7 @@ angular.module('risevision.schedules.directives')
           };
 
           $scope.openSharedScheduleModal = function () {
-            if (currentPlanFactory.isPlanActive() || currentPlanFactory.isCancelledActive()) {
+            if (currentPlanFactory.isPlanActive()) {
               $modal.open({
                 templateUrl: 'partials/schedules/shared-schedule-modal.html',
                 controller: 'SharedScheduleModalController',

--- a/web/scripts/schedules/directives/dtv-share-schedule-button.js
+++ b/web/scripts/schedules/directives/dtv-share-schedule-button.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.schedules.directives')
-  .directive('shareScheduleButton', ['$timeout',
-    function ($timeout) {
+  .directive('shareScheduleButton', ['$timeout', 'currentPlanFactory', 'plansFactory',
+    function ($timeout, currentPlanFactory, plansFactory) {
       return {
         restrict: 'E',
         templateUrl: 'partials/schedules/share-schedule-button.html',
@@ -31,6 +31,9 @@ angular.module('risevision.schedules.directives')
           };
 
           $scope.toggleTooltip = function () {
+            if (!currentPlanFactory.isPlanActive()) {
+              return plansFactory.showUnlockThisFeatureModal();
+            }
             $timeout(function () {
               if (isTooltipOpen) {
                 isTooltipOpen = false;
@@ -43,6 +46,9 @@ angular.module('risevision.schedules.directives')
           };
 
           $scope.toggleActionSheet = function () {
+            if (!currentPlanFactory.isPlanActive()) {
+              return plansFactory.showUnlockThisFeatureModal();
+            }
             if (isActionSheetOpen) {
               isActionSheetOpen = false;
               actionSheetButton.trigger('toggle');

--- a/web/scss/bootstrap-variables.scss
+++ b/web/scss/bootstrap-variables.scss
@@ -602,9 +602,9 @@ $modal-content-border-color:                   rgba(0,0,0,.2);
 $modal-content-fallback-border-color:          #999;
 
 //** Modal backdrop background color
-$modal-backdrop-bg:           #fff;
+$modal-backdrop-bg:           $madero-black;
 //** Modal backdrop opacity
-$modal-backdrop-opacity:      .7;
+$modal-backdrop-opacity:      .5;
 //** Modal header border color
 $modal-header-border-color:   #e5e5e5;
 //** Modal footer border color


### PR DESCRIPTION
## Description
Prompt users to subscribe when they click Share and are not subscribed to a plan.
Refactor `currentPlanFactory.isPlanActive()` to also account for cancelled but still active plans.
Update Modal Backdrop color to match the mockups & style guide.

## Motivation and Context
Apps Home Changes.

## How Has This Been Tested?
Manually tested locally and on [stage-1].
Sample: https://apps-stage-1.risevision.com/apphome?cid=edc26bd2-4b4a-49cc-b2b1-840e6ba9bd51

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
