### PR TITLE
Backwards compatibility - text and font size are converted to rich text

### DIFF
--- a/web/scripts/template-editor/components/directives/dtv-component-text.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-text.js
@@ -9,10 +9,7 @@ angular.module('risevision.template-editor.directives')
         templateUrl: 'partials/template-editor/components/component-text.html',
         link: function ($scope, element) {
           $scope.factory = templateEditorFactory;
-          $scope.sliderOptions = {
-            hideLimitLabels: true,
-            hidePointerLabels: true
-          };
+          $scope.data = {};
 
           /*jshint camelcase: false */
           $scope.tinymceOptions = {
@@ -26,6 +23,8 @@ angular.module('risevision.template-editor.directives')
               'bullist numlist | ' + 'link | ' +
               'removeformat code',
             fontsize_formats: '8px 10px 12px 14px 18px 24px 36px',
+            force_p_newlines : false,
+            forced_root_block : '',
             setup: function(editor) {
               editor.on('paste', function(e) {
                 //paste does not trigger change event
@@ -39,15 +38,10 @@ angular.module('risevision.template-editor.directives')
           };
           /*jshint camelcase: true */
 
-          $scope.data = {
-            richText: ''
-          };
-
           function _load() {
             $scope.isMultiline = $scope.getBlueprintData($scope.componentId, 'multiline');
             var value = $scope.getAvailableAttributeData($scope.componentId, 'value');
-            var richText = $scope.getAvailableAttributeData($scope.componentId, 'richText') ? $scope
-              .getAvailableAttributeData($scope.componentId, 'richText') : value;
+            var richText = $scope.getAvailableAttributeData($scope.componentId, 'richText');
             var fontsize = $scope.getAvailableAttributeData($scope.componentId, 'fontsize');
             var minfontsize = $scope.getAvailableAttributeData($scope.componentId, 'minfontsize');
             var maxfontsize = $scope.getAvailableAttributeData($scope.componentId, 'maxfontsize');
@@ -56,14 +50,13 @@ angular.module('risevision.template-editor.directives')
             var minFontSize = templateEditorUtils.intValueFor(minfontsize, 1);
             var maxFontSize = templateEditorUtils.intValueFor(maxfontsize, 200);
 
-            $scope.sliderOptions.floor = minFontSize;
-            $scope.sliderOptions.ceil = maxFontSize;
-            $scope.sliderOptions.onEnd = $scope.save;
-
-            $scope.value = value;
-            $scope.data.richText = richText;
-            $scope.fontsize = fontsizeInt;
-            $scope.showFontSize = !!fontsizeInt;
+            if (richText !== null && typeof richText !== 'undefined') {
+              $scope.data.richText = richText;
+            } else if (!!fontsizeInt) {
+              $scope.data.richText = '<span style="font-size: ' + fontsizeInt + 'px;">' + value + '</span>';
+            } else {
+              $scope.data.richText = value;
+            }
 
             $timeout(function () {
               $window.dispatchEvent(new Event('resize'));
@@ -73,10 +66,6 @@ angular.module('risevision.template-editor.directives')
           $scope.save = function () {
             $scope.setAttributeData($scope.componentId, 'richText', $scope.data.richText);
             $scope.setAttributeData($scope.componentId, 'value', undefined);
-
-            if ($scope.showFontSize) {
-              $scope.setAttributeData($scope.componentId, 'fontsize', $scope.fontsize);
-            }
           };
 
           $scope.registerDirective({


### PR DESCRIPTION
## Description
 Backwards compatibility - text and font size are converted to rich text

## Motivation and Context
https://trello.com/c/1CLmF6mV/67-rich-text-backwards-compatibility-text-and-font-size-are-converted-to-rich-text-3

## How Has This Been Tested?
Tested visually on local machine

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
