### PR TITLE
Click the retry button if failure during upload

### DIFF
--- a/test/e2e/storage/cases/upload.js
+++ b/test/e2e/storage/cases/upload.js
@@ -63,14 +63,20 @@ var UploadScenarios = function() {
       describe('Upload File:', describeUpload);
     });
     
-    xdescribe('And he is using Storage Home with encoding enabled:',function(){
+    describe('And he is using Storage Home with encoding enabled:',function(){
+      var intervalHandle;
+
       before(function () {
+        intervalHandle = storageSelectorModalPage.clickRetryOnFailure();
         StorageHelper.setupStorageHomeWithEncoding();
         uploadFilePath = process.cwd() + '/web/videos/e2e-upload-video-1.mp4';
       });
+
       after(function () {
         uploadFilePath = null;
+        clearInterval(intervalHandle);
       });
+
       describe('Upload File:', describeUpload);
     });
   });

--- a/test/e2e/storage/pages/storageSelectorModalPage.js
+++ b/test/e2e/storage/pages/storageSelectorModalPage.js
@@ -14,6 +14,7 @@ var StorageSelectorModalPage = function() {
   var startTrialButton = element(by.id('startTrialButton'));
   var activeTrialBanner = element(by.css('.subscription-status.trial'));
   var overwriteConfirmationModal = element(by.css('.confirm-overwrite-modal'));
+  var retryAllButton = element(by.css('button#retryAll'));
   var overwriteFilesButton = element(by.css('.confirm-overwrite-modal')).element(by.buttonText('Yes, overwrite files'));
   
 
@@ -71,6 +72,18 @@ var StorageSelectorModalPage = function() {
 
   this.getOverwriteFilesButton = function() {
      return overwriteFilesButton;
+  }
+
+  this.clickRetryOnFailure = function() {
+    return setInterval(function() {
+      retryAllButton.isPresent().then(function(present) {
+        return present && retryAllButton.isDisplayed();
+      })
+      .then(function(readyToClick) {
+        if (readyToClick) { retryAllButton.click(); }
+      })
+      .catch(console.error);
+    }, 3000);
   }
 
 };

--- a/web/partials/storage/upload-panel.html
+++ b/web/partials/storage/upload-panel.html
@@ -26,7 +26,7 @@
             <button class="btn btn-default btn-sm" type="button" ng-click="cancelAllUploads()" title="{{'storage-client.cancel-uploads' | translate}}">
               <span translate="storage-client.cancel-uploads"></span>
             </button>
-            <button class="btn btn-default btn-sm" type="button" ng-click="retryFailedUploads()" ng-show="getErrorCount() > 0 && getNotErrorCount() === 0" title="{{'storage-client.retry-failed-uploads' | translate}}">
+            <button id="retryAll" class="btn btn-default btn-sm" type="button" ng-click="retryFailedUploads()" ng-show="getErrorCount() > 0 && getNotErrorCount() === 0" title="{{'storage-client.retry-failed-uploads' | translate}}">
             <span translate="storage-client.retry-failed-uploads"></span>
             </button>
           </div>


### PR DESCRIPTION
## Description
During upload encoding, check to see if it fails and the `retry` button is visible in the UI. If so, click it. On retry, the upload will process via GCS directly.

## Motivation and Context
Encoding upload E2E test was failing if the encoding service was down or really slow. See https://github.com/Rise-Vision/rise-vision-apps/pull/1773#event-3474740258

## How Has This Been Tested?
Locally disabled the service upload endpoint by addinga host file entry to localhost. Confirmed the encoding upload failed, and retry succeeded.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
