### PR TITLE
Reposition hone on $digest cycles

### DIFF
--- a/test/unit/common/services/svc-hone-backdrop-factory.tests.js
+++ b/test/unit/common/services/svc-hone-backdrop-factory.tests.js
@@ -3,11 +3,12 @@
 describe('service: honeBackdropFactory:', function() {
   beforeEach(module('risevision.apps.services'));
 
-  var $window, $body, honeBackdropFactory, hone;
+  var $rootScope, $window, $body, honeBackdropFactory, hone;
   var originalHone;
 
   beforeEach(function(){
     inject(function($injector){
+      $rootScope = $injector.get('$rootScope');
       $window = $injector.get('$window');
       var $document = $injector.get('$document');
 
@@ -166,6 +167,33 @@ describe('service: honeBackdropFactory:', function() {
       honeBackdropFactory.reposition();
 
       hone.position.should.not.have.been.called;
+    });
+
+    describe('reposition on digest', function() {
+      beforeEach(function() {
+        sinon.stub(honeBackdropFactory, 'reposition');
+      })
+
+      afterEach(function() {
+        honeBackdropFactory.reposition.restore();
+      })
+
+      it('should reposition on $digest cycles', function() {
+        honeBackdropFactory.createForElement(['element'], 'options');
+
+        $rootScope.$digest();
+
+        honeBackdropFactory.reposition.should.have.been.called;
+      });
+
+      it('should not reposition on $digest cycles if hidden', function() {
+        honeBackdropFactory.createForElement(['element'], 'options');
+        honeBackdropFactory.hide();
+
+        $rootScope.$digest();
+
+        honeBackdropFactory.reposition.should.not.have.been.called;
+      });
     });
   });
 

--- a/web/scripts/common/services/svc-hone-backdrop-factory.js
+++ b/web/scripts/common/services/svc-hone-backdrop-factory.js
@@ -1,14 +1,15 @@
 'use strict';
 
 angular.module('risevision.apps.services')
-  .factory('honeBackdropFactory', ['$window', '$document',
-    function ($window, $document) {
+  .factory('honeBackdropFactory', ['$rootScope', '$window', '$document',
+    function ($rootScope, $window, $document) {
       var service = {};
       var $body = angular.element($document[0].body);
       var preventDefault = function (e) {
         e.preventDefault();
       };
       var hone;
+      var digestWatch;
 
       function getHone() {
         if (!hone) {
@@ -42,11 +43,18 @@ angular.module('risevision.apps.services')
         } else {
           service.shouldPreventScrolling(false);
         }
+
+        digestWatch = $rootScope.$watch(service.reposition);
       };
 
       service.hide = function () {
         getHone().hide();
         service.shouldPreventScrolling(false);
+
+        if (digestWatch) {
+          digestWatch();
+          digestWatch = null;
+        }
       };
 
       service.shouldPreventScrolling = function (shouldPreventScrolling) {


### PR DESCRIPTION
## Description
Reposition hone on $digest cycles

[stage-2]

## Motivation and Context
UI can change on $digest and the overlay does not update. Use the same logic as tooltip inner works.

## How Has This Been Tested?
Tested by adding a disappearance timeout for the inApp messages to ensure the overlay repositions.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No