### PR TITLE
Show transparent scroll overlay for share options

### DIFF
--- a/web/partials/schedules/share-schedule-popover.html
+++ b/web/partials/schedules/share-schedule-popover.html
@@ -16,7 +16,7 @@
   <div ng-show="currentTab === 'link'" class="row u_margin-sm-top">
     <div class="col-xs-12">
 
-      <div class="u_scroll-x text-center sideways-panels pb-4">
+      <div class="u_scroll-x text-center sideways-panels scrollbox pb-4">
         <div id="extensionButton" class="panel panel-default u_remove-bottom u_clickable" ng-click="currentTab = 'chromeExtension'">
           <div class="panel-body">
             <div class="row pt-2">

--- a/web/scss/sections/apps-home.scss
+++ b/web/scss/sections/apps-home.scss
@@ -237,6 +237,10 @@
       
     	/* Opera doesn't support this in the shorthand */
     	background-attachment: local, local, scroll, scroll;
+
+      @media (max-width: $screen-sm) {
+        background-size: 20px 112px, 20px 112px, 20px 112px, 20px 112px;
+      }
     }
 
     // Using white/transparencies requires a ::before element

--- a/web/scss/sections/apps-home.scss
+++ b/web/scss/sections/apps-home.scss
@@ -198,6 +198,8 @@
     .sideways-panels {
       .panel {
         border-color: rgb(153, 153, 153);
+        background-color: transparent;
+
         @extend .mr-2;
 
         &:last-child{
@@ -217,5 +219,49 @@
       font-size: 12px;
       padding: 15px;
     }
+
+    // from https://codepen.io/vakhula/pen/OJVqBOK
+    .scrollbox {
+      background-image: 
+        /* Shadows */ 
+        linear-gradient(to right, white, white),
+        linear-gradient(to right, white, white),
+      
+        /* Shadow covers */ 
+        linear-gradient(to right, rgba(0,0,0,.25), rgba(255,255,255,0)),
+        linear-gradient(to left, rgba(0,0,0,.25), rgba(255,255,255,0));   
+      
+      background-position: left top, right top, left top, right top;
+    	background-repeat: no-repeat;
+    	background-size: 20px 106px, 20px 106px, 20px 106px, 20px 106px;
+      
+    	/* Opera doesn't support this in the shorthand */
+    	background-attachment: local, local, scroll, scroll;
+    }
+
+    // Using white/transparencies requires a ::before element
+    // however since it's a separate element the `background-attachment: scroll`
+    // doesn't work so the background is static 
+    // .scrollbox::before {
+    //   position: absolute;
+    //   content: '';
+    //   z-index: 2;
+    //   width: 352px;
+    //   height: 100%;
+    //   pointer-events: none;
+    // 
+    //   background-image: 
+    //     /* Shadows */ 
+    //     linear-gradient(to right, rgb(255, 255, 255) 0%, rgba(255, 255, 255, 0) 100%),
+    //     linear-gradient(to left, rgb(255, 255, 255) 0%, rgba(255, 255, 255, 0) 100%);
+    // 
+    //   background-position: left top, right top;
+    // 	 background-repeat: no-repeat;
+    //   background-size: 20px 106px, 20px 106px;
+    // 
+    // 	 /* Opera doesn't support this in the shorthand */
+    //   background-attachment: scroll, scroll;
+    // }
+
   }
 }


### PR DESCRIPTION
## Description
Show transparent scroll overlay for share options

Use black overlay due to technical difficulties in
implementing a white/transparent version

See commented out code for reasons

[stage-2]

## Motivation and Context
Partial implementation of the UI prototype for the epic. Could not do full implementation due to time/technical constraints.

## How Has This Been Tested?
Tested changes locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No