### PR TITLE
Feature/jpg compress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tmp
 web/tmp
 web/scripts/config/config.js
 web/vendor/tus
+web/vendor/compressor
 test/e2e/config/config.json
 .DS_Store
 .project

--- a/.jshintrc
+++ b/.jshintrc
@@ -32,7 +32,8 @@
     "inject": false,
     "Draggable": false,
     "moment": false,
-    "tus": false
+    "tus": false,
+    "Compressor": false
   },
   "predef":["angular","_"]
 }

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Because of the way git works (mainly, references to remote repositories), it's i
 gulp test:unit
 ```
 
+If gulp fails with something like `..contextify.cc:628:static void node::contextify::ContextifyScript:` try switching to nodejs 9 and rebuilding node_modules.
+
 ### Protractor End-to-End Testing
 
 E2E tests require some environment variables to be defined for the accounts used for testing. The variables are `E2E_USER` / `E2E_PASS` for Google Authentication and `E2E_USER1` / `E2E_PASS1` for Custom Authentication. The command would be as follows:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -272,6 +272,11 @@ gulp.task('pricing', function() {
   });
 });
 
+gulp.task("jpgcompressor", function() {
+  return gulp.src("node_modules/compressorjs/dist/compressor.min.js")
+    .pipe(gulp.dest("web/vendor/compressor"));
+});
+
 gulp.task("tus", function() {
   return gulp.src("node_modules/tus-js-client/dist/tus.min.js")
     .pipe(gulp.dest("web/vendor/tus"));
@@ -324,7 +329,7 @@ gulp.task("config", function() {
 });
 
 gulp.task('build-pieces', function (cb) {
-  runSequence(["clean"], ['config', 'i18n-build', 'css-build', 'pricing', 'html2js', 'tus'], cb);
+  runSequence(["clean"], ['config', 'i18n-build', 'css-build', 'pricing', 'html2js', 'tus', 'jpgcompressor'], cb);
 });
 
 gulp.task('build', function (cb) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -347,6 +347,10 @@ gulp.task("config-e2e", function() {
     .pipe(gulp.dest("test/e2e/config"));
 });
 
+gulp.task("test:unit:nocoverage", factory.testUnitAngular({
+    testFiles: unitTestFiles
+}));
+
 gulp.task("test:unit", factory.testUnitAngular({
     coverageFiles: "../../web/scripts/**/*.js",
     testFiles: unitTestFiles

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@polymer/polymer": "^3.2.0",
     "@shopify/draggable": "1.0.0-beta.8",
     "bower": "^1.5.3",
+    "compressorjs": "^1.0.6",
     "pricing-data-component": "github:Rise-Vision/pricing-data-component",
     "pricing-grid-component": "github:Rise-Vision/pricing-grid-component",
     "pricing-selector-component": "github:Rise-Vision/pricing-selector-component",

--- a/test/unit/storage/services/svc-file-upload.tests.js
+++ b/test/unit/storage/services/svc-file-upload.tests.js
@@ -11,6 +11,18 @@ describe('Services: uploader', function() {
       return Q;
     });
 
+    $provide.service('$log', function() {
+      return { debug: sinon.stub() };
+    });
+
+    $provide.service('bigQueryLogging', function() {
+      return { logEvent: sinon.stub() };
+    });
+
+    $provide.service('FilesFactory', function() {
+      return { folderPath: '' };
+    });
+
     $provide.service('XHRFactory', function() {
       return {
         get: function() {
@@ -44,6 +56,7 @@ describe('Services: uploader', function() {
       uploader.onBeforeUploadItem = function() {};
       uploader.onCancelItem = function() {};
       uploader.onCompleteItem = function() {};
+      uploader.currentFilePath = function() {};
 
       JPGCompressor = $injector.get('JPGCompressor');
       $timeout = $injector.get('$timeout');
@@ -353,7 +366,7 @@ describe('Services: uploader', function() {
     beforeEach(function () {
       window.Compressor = function (file, opts) {
         file.processed = true;
-        opts.success();
+        opts.success({});
       };
     });
 

--- a/test/unit/storage/services/svc-file-upload.tests.js
+++ b/test/unit/storage/services/svc-file-upload.tests.js
@@ -1,6 +1,6 @@
 /*jshint expr:true */
 
-describe('Services: uploader', function() {
+describe.only('Services: uploader', function() {
   'use strict';
 
   beforeEach(module('risevision.apps.config'));
@@ -29,10 +29,10 @@ describe('Services: uploader', function() {
     })
   }));
 
-  var uploader, lastAddedFileItem, $timeout, XHRFactory, ExifStripper;
+  var uploader, lastAddedFileItem, $timeout, XHRFactory, ExifStripper, Compressor;
 
   beforeEach(function() {
-  	inject(function($injector) {
+    inject(function($injector) {
       lastAddedFileItem = null;
 
       uploader = $injector.get('FileUploader');
@@ -45,8 +45,9 @@ describe('Services: uploader', function() {
       uploader.onCancelItem = function() {};
       uploader.onCompleteItem = function() {};
 
+      Compressor = $injector.get('JPGCompressor');
       $timeout = $injector.get('$timeout');
-  	});
+    });
   });
 
   it('should exist', function () {
@@ -346,6 +347,20 @@ describe('Services: uploader', function() {
       });
     });
 
+  });
+
+  describe('jpg compression:', function () {
+    beforeEach(function () {
+      window.Compressor = function () {
+        return {
+          compress: sinon.stub()
+        };
+      };
+    });
+
+    it('has the compressor', function () {
+      Compressor.compress({domfileItem: {}});
+    });
   });
 
 });

--- a/test/unit/storage/services/svc-file-upload.tests.js
+++ b/test/unit/storage/services/svc-file-upload.tests.js
@@ -1,6 +1,6 @@
 /*jshint expr:true */
 
-describe.only('Services: uploader', function() {
+describe('Services: uploader', function() {
   'use strict';
 
   beforeEach(module('risevision.apps.config'));
@@ -29,7 +29,7 @@ describe.only('Services: uploader', function() {
     })
   }));
 
-  var uploader, lastAddedFileItem, $timeout, XHRFactory, ExifStripper, Compressor;
+  var uploader, lastAddedFileItem, $timeout, XHRFactory, ExifStripper, JPGCompressor;
 
   beforeEach(function() {
     inject(function($injector) {
@@ -45,7 +45,7 @@ describe.only('Services: uploader', function() {
       uploader.onCancelItem = function() {};
       uploader.onCompleteItem = function() {};
 
-      Compressor = $injector.get('JPGCompressor');
+      JPGCompressor = $injector.get('JPGCompressor');
       $timeout = $injector.get('$timeout');
     });
   });
@@ -351,15 +351,25 @@ describe.only('Services: uploader', function() {
 
   describe('jpg compression:', function () {
     beforeEach(function () {
-      window.Compressor = function () {
-        return {
-          compress: sinon.stub()
-        };
+      window.Compressor = function (file, opts) {
+        file.processed = true;
+        opts.success();
       };
     });
 
     it('has the compressor', function () {
-      Compressor.compress({domfileItem: {}});
+      JPGCompressor.compress({file: {type: 'image/jpeg'}, domFileItem: {}});
+    });
+
+    it('processes an array of fileItems and returns a promise', function () {
+      var domFileItem = {};
+
+      return uploader.compress([{
+        file: {type: 'image/jpeg'},
+        domFileItem: domFileItem
+      }]).then(function () {
+        assert(domFileItem.processed);
+      });
     });
   });
 

--- a/web/index.html
+++ b/web/index.html
@@ -554,6 +554,7 @@
   <script src="scripts/storage/services/svc-pending-operations-factory.js"></script>
   <script src="scripts/storage/services/svc-encoding.js"></script>
   <script src="vendor/tus/tus.min.js"></script>
+  <script src="vendor/compressor/compressor.min.js"></script>
 
   <script src="scripts/storage/filters/ftr-filters.js"></script>
   <script src="scripts/storage/directives/dtv-storage-selector.js"></script>

--- a/web/scripts/storage/directives/dtv-storage-file-select.js
+++ b/web/scripts/storage/directives/dtv-storage-file-select.js
@@ -11,6 +11,7 @@
         link: function ($scope, element) {
           element.bind('change', function () {
             $scope.uploader.removeExif(this.files)
+              .then($scope.uploader.compress)
               .then(function (fileItems) {
                 return $scope.uploader.addToQueue(fileItems);
               })

--- a/web/scripts/storage/directives/dtv-upload.js
+++ b/web/scripts/storage/directives/dtv-upload.js
@@ -100,6 +100,10 @@
               uploadOverwriteWarning.resetConfirmation();
             };
 
+            FileUploader.currentFilePath = function () {
+              return $scope.filesFactory.folderPath;
+            };
+
             FileUploader.onAfterAddingFile = function (fileItem) {
               console.info('onAfterAddingFile', fileItem.file.name);
 

--- a/web/scripts/storage/services/svc-file-upload.js
+++ b/web/scripts/storage/services/svc-file-upload.js
@@ -66,6 +66,13 @@ angular.module('risevision.storage.services')
       }
     };
   }])
+  .factory('JPGCompressor', [function () {
+    return {
+      compress: function (fileItem) {
+        new Compressor(fileItem.domFileItem, {});
+      }
+    };
+  }])
   .factory('XHRFactory', [function () {
     return {
       get: function () {

--- a/web/scripts/storage/services/svc-file-upload.js
+++ b/web/scripts/storage/services/svc-file-upload.js
@@ -67,11 +67,13 @@ angular.module('risevision.storage.services')
     };
   }])
   .factory('JPGCompressor', ['$q', 'bigQueryLogging', '$log', function ($q, bigQueryLogging, $log) {
+    var disabled = false;
+
     return {
       compress: function (fileItem, folderPath) {
         var deferred = $q.defer();
 
-        if (fileItem.file.type !== 'image/jpeg') { return deferred.resolve(); }
+        if (disabled || fileItem.file.type !== 'image/jpeg') { return deferred.resolve(); }
 
         new Compressor(fileItem.domFileItem, {
           quality: 0.7,
@@ -86,6 +88,7 @@ angular.module('risevision.storage.services')
           error: function (err) {
             $log.debug(err);
             bigQueryLogging.logEvent('image compress error', folderPath + fileItem.file.name + ' | ' + err.message);
+            disabled = true;
             return deferred.resolve();
           }
         });

--- a/web/scripts/template-editor/directives/dtv-basic-uploader.js
+++ b/web/scripts/template-editor/directives/dtv-basic-uploader.js
@@ -55,6 +55,7 @@ angular.module('risevision.template-editor.directives')
 
           $scope.uploadSelectedFiles = function (selectedFiles) {
             return $scope.uploader.removeExif(selectedFiles)
+              .then($scope.uploader.compress)
               .then(function (fileItems) {
                 return $scope.uploader.addToQueue(fileItems);
               });

--- a/web/scripts/template-editor/directives/dtv-basic-uploader.js
+++ b/web/scripts/template-editor/directives/dtv-basic-uploader.js
@@ -139,6 +139,10 @@ angular.module('risevision.template-editor.directives')
             }
           };
 
+          FileUploader.currentFilePath = function () {
+            return $scope.uploadManager.folderPath;
+          };
+
           FileUploader.onBeforeUploadItem = function (item) {
             console.log('Attempting to upload', item.file.name);
           };

--- a/web/storage-selector.html
+++ b/web/storage-selector.html
@@ -233,6 +233,7 @@
   <script src="scripts/storage/services/svc-pending-operations-factory.js"></script>
   <script src="scripts/storage/services/svc-encoding.js"></script>
   <script src="vendor/tus/tus.min.js"></script>
+  <script src="vendor/compressor/compressor.min.js"></script>
 
   <script src="scripts/storage/filters/ftr-filters.js"></script>
   <script src="scripts/storage/directives/dtv-storage-file-select.js"></script>


### PR DESCRIPTION
## Description
Compress jpg files on upload. JPG represents ~70% of image uploads. PNG will be handled separately via backend. Together they represent over 95% of uploads.

## Motivation and Context
Network traffic reduction and local cache size reduction.

## How Has This Been Tested?

 - Uploaded JPG via storage selector as well as template editor. Confirmed BQ logs and correct file size in Storage.

 - Forced failure in library, confired bq log, file upload continues without interrupting user, and does not attempt compression on subsequent upload.

