### PR TITLE
Use new viewer env for Apps Home

### DIFF
--- a/test/unit/launcher/controllers/ctr-apps-home.tests.js
+++ b/test/unit/launcher/controllers/ctr-apps-home.tests.js
@@ -73,7 +73,7 @@ describe('controller: AppsHomeCtrl', function() {
   describe('getEmbedUrl:', function() {
     it('should return a trusted embed URL', function() {     
       expect($scope.getEmbedUrl('ID')).to.equal('http://trustedUrl');
-      $sce.trustAsResourceUrl.should.have.been.calledWith('https://preview.risevision.com/?type=sharedschedule&id=ID&env=embed');
+      $sce.trustAsResourceUrl.should.have.been.calledWith('https://preview.risevision.com/?type=sharedschedule&id=ID&env=apps_home');
     });
 
     it('should return null, to not render iframe, when scheduleId is not provided', function() {

--- a/web/scripts/launcher/controllers/ctr-apps-home.js
+++ b/web/scripts/launcher/controllers/ctr-apps-home.js
@@ -38,7 +38,7 @@ angular.module('risevision.apps.launcher.controllers')
         if (!scheduleId) {
           return null;
         }
-        var url = SHARED_SCHEDULE_URL.replace('SCHEDULE_ID', scheduleId) + '&env=embed';
+        var url = SHARED_SCHEDULE_URL.replace('SCHEDULE_ID', scheduleId) + '&env=apps_home';
         return $sce.trustAsResourceUrl(url);
       };
 


### PR DESCRIPTION
## Description
Use new viewer env for Apps Home

[stage-2]

## Motivation and Context
Provide more minute tracking of bandwidth and usage for Shared Schedule previews in Apps.

Fix issue where navigation UI is not showing in Apps embeds.

## How Has This Been Tested?
Tested changes locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
