### PR TITLE
Fix  #1805 - Hide Share action-sheet when resizing screen

### DIFF
--- a/test/unit/schedules/directives/dtv-share-schedule-button.tests.js
+++ b/test/unit/schedules/directives/dtv-share-schedule-button.tests.js
@@ -26,7 +26,9 @@ describe('directive: share-schedule-button', function() {
     plansFactory = $injector.get('plansFactory');
 
     innerElementStub = {
-      trigger: sandbox.stub()
+      trigger: sandbox.stub(),
+      bind: sandbox.stub(),
+      unbind: sandbox.stub()
     };
     sandbox.stub(angular,'element').returns(innerElementStub);
 
@@ -111,6 +113,20 @@ describe('directive: share-schedule-button', function() {
       
       plansFactory.showUnlockThisFeatureModal.should.have.been.called;
     });
+
+    it('should bind to window resize on open', function() {
+      $scope.toggleActionSheet();
+
+      innerElementStub.bind.should.have.been.calledWith('resize',$scope.toggleActionSheet);
+    });
+
+    it('should unbind from window resize when closing', function() {
+      $scope.toggleActionSheet();
+      innerElementStub.trigger.resetHistory();
+      $scope.toggleActionSheet();
+
+      innerElementStub.unbind.should.have.been.calledWith('resize',$scope.toggleActionSheet);
+    });
   });
 
   describe('dismiss:', function() {
@@ -125,7 +141,7 @@ describe('directive: share-schedule-button', function() {
       innerElementStub.trigger.should.have.been.calledWith('hide');
     });
 
-    it('should close action sheet if open', function() {
+    it('should close action sheet if open and unbind from window resize', function() {
       $scope.toggleActionSheet();
       $timeout.flush();
       innerElementStub.trigger.resetHistory();
@@ -134,6 +150,7 @@ describe('directive: share-schedule-button', function() {
       $timeout.flush();
 
       innerElementStub.trigger.should.have.been.calledWith('toggle');
+      innerElementStub.unbind.should.have.been.calledWith('resize',$scope.toggleActionSheet);
     });
   });
 });

--- a/web/scripts/components/action-sheet.js
+++ b/web/scripts/components/action-sheet.js
@@ -90,6 +90,10 @@ angular.module('risevision.common.components.action-sheet', [])
           } else {
             iElement.bind('toggle', toggle);
           }
+
+          scope.$on('$destroy', function() {
+            actionSheetDomEl.remove();
+          });
         }
       };
     }

--- a/web/scripts/schedules/directives/dtv-share-schedule-button.js
+++ b/web/scripts/schedules/directives/dtv-share-schedule-button.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.schedules.directives')
-  .directive('shareScheduleButton', ['$timeout', 'currentPlanFactory', 'plansFactory',
-    function ($timeout, currentPlanFactory, plansFactory) {
+  .directive('shareScheduleButton', ['$timeout', 'currentPlanFactory', 'plansFactory', '$window',
+    function ($timeout, currentPlanFactory, plansFactory, $window) {
       return {
         restrict: 'E',
         templateUrl: 'partials/schedules/share-schedule-button.html',
@@ -24,8 +24,7 @@ angular.module('risevision.schedules.directives')
               }
 
               if (isActionSheetOpen) {
-                isActionSheetOpen = false;
-                actionSheetButton.trigger('toggle');
+                _closeActionSheet();
               }
             });
           };
@@ -50,13 +49,23 @@ angular.module('risevision.schedules.directives')
               return plansFactory.showUnlockThisFeatureModal();
             }
             if (isActionSheetOpen) {
-              isActionSheetOpen = false;
-              actionSheetButton.trigger('toggle');
+              _closeActionSheet();
             } else {
               isActionSheetOpen = true;
+              angular.element($window).bind('resize',$scope.toggleActionSheet);
               actionSheetButton.trigger('toggle');
             }
           };
+
+          var _closeActionSheet = function() {
+            isActionSheetOpen = false;
+            angular.element($window).unbind('resize',$scope.toggleActionSheet);
+            actionSheetButton.trigger('toggle');
+          };
+
+          $scope.$on('$destroy', function() {
+            angular.element($window).unbind('resize',$scope.toggleActionSheet);
+          });
         }
       };
     }


### PR DESCRIPTION
## Description
Hides Share Schedule action-sheet when resizing screen to prevent it from showing on larger resolutions along with the tooltip.
Also, cleans up action-sheet from body on $destroy, to prevent adding multiple instances.

## Motivation and Context
Fix  #1805.

## How Has This Been Tested?
Manually tested locally and on [stage-20].

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
