### PR TITLE
Send user company role on identify, logged in and user updated events

### DIFF
--- a/test/unit/common-header/controllers/ctr-user-settings-spec.js
+++ b/test/unit/common-header/controllers/ctr-user-settings-spec.js
@@ -84,7 +84,8 @@ describe("controller: user settings", function() {
       firstName : "first",
       lastName : "last",
       telephone : "telephone",
-      email : "e@mail.com"
+      email : "e@mail.com",
+      companyRole : "companyRole"
     };
     savedUser = userProfile;
     userState = function(){
@@ -227,7 +228,7 @@ describe("controller: user settings", function() {
         expect($scope.loading).to.be.false;
         userProfileSpy.should.have.been.once;
 
-        userTracker.should.have.been.calledWith("User Updated", "user@example.io", true, {updatedUserId: "user@example.io"});
+        userTracker.should.have.been.calledWith("User Updated", "user@example.io", true, {updatedUserId: "user@example.io", updatedUserCompanyRole: "companyRole"});
         $modalInstance.close.should.have.been.calledWith("success");
         
         done();

--- a/test/unit/common-header/controllers/ctr-user-settings-spec.js
+++ b/test/unit/common-header/controllers/ctr-user-settings-spec.js
@@ -211,7 +211,6 @@ describe("controller: user settings", function() {
       $scope.save();
       expect($scope.loading).to.be.false;
 
-      userTracker.should.not.have.been.called;
       $modalInstance.close.should.not.have.been.called;
     });
 
@@ -228,7 +227,6 @@ describe("controller: user settings", function() {
         expect($scope.loading).to.be.false;
         userProfileSpy.should.have.been.once;
 
-        userTracker.should.have.been.calledWith("User Updated", "user@example.io", true, {updatedUserId: "user@example.io", updatedUserCompanyRole: "companyRole"});
         $modalInstance.close.should.have.been.calledWith("success");
         
         done();

--- a/test/unit/components/core-api-client/svc-user.tests.js
+++ b/test/unit/components/core-api-client/svc-user.tests.js
@@ -32,13 +32,31 @@ describe("User Profile: getUserProfile", function() {
                 }, 0);
               }
             };
-          }
+          },
+          patch: function() {
+            return {
+              execute: function (callback) {
+                setTimeout(function () {
+                  callback({result: true});
+                }, 0);
+              }
+            };
+          } 
         }
       };
       deffered.resolve(gapi);
       return deffered.promise;
     });
     $provide.value("CORE_URL", "");
+    $provide.service("userTracker", function() { 
+      return sinon.spy();
+    });
+    $provide.service("userState", function() { 
+      return {
+        getUsername: sinon.stub().returns("username"),
+        checkUsername: sinon.stub().returns(true)
+      }
+    });
 
   }));
 
@@ -91,6 +109,26 @@ describe("User Profile: getUserProfile", function() {
           done();
         });
       });      
+    });
+  });
+
+  describe("updateUser", function() {
+    beforeEach(module(function ($provide) {
+      $provide.value("getUserProfile", function(username,clear) {
+        return Q.resolve();
+      });
+    }));
+
+    it("should update user and track event", function(done) {
+      inject(function (updateUser, userTracker) {
+        var profile = {
+          companyRole: "other"
+        };
+        updateUser("username", profile).then(function(){
+          userTracker.should.have.been.calledWith("User Updated", "username", true, {updatedUserId: "username", updatedUserCompanyRole: "other"});
+          done();
+        });
+      });
     });
   });
 

--- a/test/unit/components/logging/svc-analytics-factory.tests.js
+++ b/test/unit/components/logging/svc-analytics-factory.tests.js
@@ -84,6 +84,52 @@ describe("Services: analyticsFactory", function() {
         email: undefined,
         firstName: "",
         lastName: "",
+        companyRole: "",
+        registeredDate: "2020-01-01",
+        subscriptionRenewalDate: undefined,
+        subscriptionStatus: "Free",
+        subscriptionTrialExpiryDate: undefined
+      };
+      identifySpy.should.have.been.calledWith("username",expectProperties);
+
+      expect($window.dataLayer[$window.dataLayer.length-2].event).to.equal("analytics.identify");
+      expect($window.dataLayer[$window.dataLayer.length-2].userId).to.equal("username");
+      expect($window.dataLayer[$window.dataLayer.length-2].analytics.user.properties).to.deep.equal(expectProperties);
+
+      trackSpy.should.have.been.calledWithMatch("logged in",expectProperties);
+      expect($window.dataLayer[$window.dataLayer.length-1].event).to.equal("analytics.track");
+      var actualProperties = $window.dataLayer[$window.dataLayer.length-1].analytics.event.properties;
+      Object.keys(expectProperties).forEach(function(key) {
+        expect(actualProperties[key]).to.deep.equal(expectProperties[key]);
+      });
+      expect(actualProperties.loginDate).to.be.a("date");
+
+      done();
+    }, 10);
+  });
+
+  it("should identify user and track logged in event with correct profile data", function(done) {
+    var identifySpy = sinon.spy(analyticsFactory, "identify");
+    var trackSpy = sinon.spy(analyticsFactory, "track");
+    profile.firstName = "firstName";
+    profile.lastName = "lastName";
+    profile.companyRole = "companyRole";
+    profile.email = "user@email.com";
+
+    analyticsEvents.identify();
+    
+    setTimeout(function() {
+      var expectProperties = {
+        company: { id: "companyId", name: "companyName", companyIndustry: "K-12 Education", parentId: "parent123" },
+        companyId: "companyId",
+        companyName: "companyName",
+        companyIndustry: "K-12 Education",
+        parentId: "parent123",
+        userId: "username",
+        email: "user@email.com",
+        firstName: "firstName",
+        lastName: "lastName",
+        companyRole: "companyRole",
         registeredDate: "2020-01-01",
         subscriptionRenewalDate: undefined,
         subscriptionStatus: "Free",
@@ -126,6 +172,7 @@ describe("Services: analyticsFactory", function() {
         email: undefined,
         firstName: "",
         lastName: "",
+        companyRole: "",
         registeredDate: undefined,
         subscriptionRenewalDate: undefined,
         subscriptionStatus: "Free",
@@ -157,6 +204,7 @@ describe("Services: analyticsFactory", function() {
         email: undefined,
         firstName: "",
         lastName: "",
+        companyRole: "",
         registeredDate: "2020-01-01",
         subscriptionRenewalDate: undefined,
         subscriptionStatus: "Free",
@@ -185,6 +233,7 @@ describe("Services: analyticsFactory", function() {
         email: undefined,
         firstName: "",
         lastName: "",
+        companyRole: "",
         registeredDate: "2020-01-01"
       });
       done();

--- a/web/scripts/common-header/controllers/ctr-user-settings-modal.js
+++ b/web/scripts/common-header/controllers/ctr-user-settings-modal.js
@@ -137,12 +137,7 @@ angular.module('risevision.common.header')
               if (userState.checkUsername(username)) {
                 userState.updateUserProfile(resp.item);
               }
-
-              userTracker('User Updated', userState.getUsername(), userState.checkUsername(username), {
-                updatedUserId: username,
-                updatedUserCompanyRole: $scope.user.companyRole ? $scope.user.companyRole : ''
-              });
-
+              
               $modalInstance.close('success');
             })
             .catch(function (error) {

--- a/web/scripts/common-header/controllers/ctr-user-settings-modal.js
+++ b/web/scripts/common-header/controllers/ctr-user-settings-modal.js
@@ -137,7 +137,7 @@ angular.module('risevision.common.header')
               if (userState.checkUsername(username)) {
                 userState.updateUserProfile(resp.item);
               }
-              
+
               $modalInstance.close('success');
             })
             .catch(function (error) {

--- a/web/scripts/common-header/controllers/ctr-user-settings-modal.js
+++ b/web/scripts/common-header/controllers/ctr-user-settings-modal.js
@@ -139,7 +139,8 @@ angular.module('risevision.common.header')
               }
 
               userTracker('User Updated', userState.getUsername(), userState.checkUsername(username), {
-                updatedUserId: username
+                updatedUserId: username,
+                updatedUserCompanyRole: $scope.user.companyRole ? $scope.user.companyRole : ''
               });
 
               $modalInstance.close('success');

--- a/web/scripts/components/action-sheet.js
+++ b/web/scripts/components/action-sheet.js
@@ -91,7 +91,7 @@ angular.module('risevision.common.components.action-sheet', [])
             iElement.bind('toggle', toggle);
           }
 
-          scope.$on('$destroy', function() {
+          scope.$on('$destroy', function () {
             actionSheetDomEl.remove();
           });
         }

--- a/web/scripts/components/core-api-client/svc-user.js
+++ b/web/scripts/components/core-api-client/svc-user.js
@@ -68,9 +68,9 @@
     ])
 
     .factory('updateUser', ['$q', 'coreAPILoader', '$log',
-      'getUserProfile', 'pick', 'USER_WRITABLE_FIELDS',
+      'getUserProfile', 'pick', 'USER_WRITABLE_FIELDS', 'userTracker', 'userState',
       function ($q, coreAPILoader, $log, getUserProfile, pick,
-        USER_WRITABLE_FIELDS) {
+        USER_WRITABLE_FIELDS, userTracker, userState) {
         return function (username, profile) {
           var deferred = $q.defer();
           profile = pick(profile, USER_WRITABLE_FIELDS);
@@ -86,6 +86,10 @@
                 deferred.reject(resp);
               } else if (resp.result) {
                 getUserProfile(username, true).then(function () {
+                  userTracker('User Updated', userState.getUsername(), userState.checkUsername(username), {
+                    updatedUserId: username,
+                    updatedUserCompanyRole: profile.companyRole ? profile.companyRole : ''
+                  });
                   deferred.resolve(resp);
                 });
               } else {

--- a/web/scripts/components/core-api-client/svc-user.js
+++ b/web/scripts/components/core-api-client/svc-user.js
@@ -86,7 +86,8 @@
                 deferred.reject(resp);
               } else if (resp.result) {
                 getUserProfile(username, true).then(function () {
-                  userTracker('User Updated', userState.getUsername(), userState.checkUsername(username), {
+                  userTracker('User Updated', userState.getUsername(), userState.checkUsername(
+                    username), {
                     updatedUserId: username,
                     updatedUserCompanyRole: profile.companyRole ? profile.companyRole : ''
                   });

--- a/web/scripts/components/logging/svc-analytics-factory.js
+++ b/web/scripts/components/logging/svc-analytics-factory.js
@@ -110,6 +110,7 @@
               email: profile.email,
               firstName: profile.firstName ? profile.firstName : '',
               lastName: profile.lastName ? profile.lastName : '',
+              companyRole: profile.companyRole ? profile.companyRole : '',
               registeredDate: profile.termsAcceptanceDate
             };
             if (userState.getUserCompanyId()) {

--- a/web/scripts/components/purchase-flow/services/svc-address-factory.js
+++ b/web/scripts/components/purchase-flow/services/svc-address-factory.js
@@ -3,7 +3,8 @@
 angular.module('risevision.common.components.purchase-flow')
   .service('addressFactory', ['$q', '$log', 'userState', 'storeService', 'updateCompany', 'updateUser',
     'addressService', 'contactService', 'confirmModal',
-    function ($q, $log, userState, storeService, updateCompany, updateUser, addressService, contactService, confirmModal) {
+    function ($q, $log, userState, storeService, updateCompany, updateUser, addressService, contactService,
+      confirmModal) {
       var factory = {};
 
       var _addressesAreIdentical = function (src, result) {
@@ -153,15 +154,16 @@ angular.module('risevision.common.components.purchase-flow')
         return deferred.promise;
       };
 
-      factory.confirmAndSetGeneralDelivery = function(addressObject) {
-        return confirmModal('Address Information', 
-          'The address you provided couldn\'t be validated. This can happen if the address does not exist in the USPS records. If you\'re sure the address is correct you can specify this address as General Delivery and we\'ll only validate the City, State and Zip Code.<br/>Would you like to specify this address as General Delivery?',
-          'Yes',
-          'Cancel',
-          'general-delivery-modal')
-        .then(function() {
-          addressObject.unit = addressObject.unit? addressObject.unit + ' - General Delivery' : 'General Delivery';  
-        });
+      factory.confirmAndSetGeneralDelivery = function (addressObject) {
+        return confirmModal('Address Information',
+            'The address you provided couldn\'t be validated. This can happen if the address does not exist in the USPS records. If you\'re sure the address is correct you can specify this address as General Delivery and we\'ll only validate the City, State and Zip Code.<br/>Would you like to specify this address as General Delivery?',
+            'Yes',
+            'Cancel',
+            'general-delivery-modal')
+          .then(function () {
+            addressObject.unit = addressObject.unit ? addressObject.unit + ' - General Delivery' :
+              'General Delivery';
+          });
       };
 
       return factory;

--- a/web/scripts/schedules/controllers/ctr-shared-schedule-popover.js
+++ b/web/scripts/schedules/controllers/ctr-shared-schedule-popover.js
@@ -27,23 +27,23 @@ USER_FIRST_NAME')
       SHARED_SCHEDULE_URL, SHARED_SCHEDULE_EMBED_CODE, SHARED_SCHEDULE_INVITE_MESSAGE) {
       $scope.currentTab = 'link';
 
-      $scope.getLink = function() {
+      $scope.getLink = function () {
         return $scope.schedule ? SHARED_SCHEDULE_URL.replace('SCHEDULE_ID', $scope.schedule.id) : '';
       };
 
-      $scope.getEmbedCode = function() {
+      $scope.getEmbedCode = function () {
         return $scope.schedule ? SHARED_SCHEDULE_EMBED_CODE.replace('SHARED_SCHEDULE_URL', $scope.getLink()) : '';
       };
 
-      $scope.getInviteMessage = function() {
+      $scope.getInviteMessage = function () {
         if (!$scope.schedule) {
           return '';
         }
         var profile = userState.getCopyOfProfile();
-        var firstName =  profile.firstName ? profile.firstName : '';
+        var firstName = profile.firstName ? profile.firstName : '';
         return SHARED_SCHEDULE_INVITE_MESSAGE
           .replace('SHARED_SCHEDULE_URL', $scope.getLink())
-          .replace('USER_FIRST_NAME',firstName);
+          .replace('USER_FIRST_NAME', firstName);
       };
 
       $scope.copyToClipboard = function (text) {

--- a/web/scripts/schedules/directives/dtv-share-schedule-button.js
+++ b/web/scripts/schedules/directives/dtv-share-schedule-button.js
@@ -52,19 +52,19 @@ angular.module('risevision.schedules.directives')
               _closeActionSheet();
             } else {
               isActionSheetOpen = true;
-              angular.element($window).bind('resize',$scope.toggleActionSheet);
+              angular.element($window).bind('resize', $scope.toggleActionSheet);
               actionSheetButton.trigger('toggle');
             }
           };
 
-          var _closeActionSheet = function() {
+          var _closeActionSheet = function () {
             isActionSheetOpen = false;
-            angular.element($window).unbind('resize',$scope.toggleActionSheet);
+            angular.element($window).unbind('resize', $scope.toggleActionSheet);
             actionSheetButton.trigger('toggle');
           };
 
-          $scope.$on('$destroy', function() {
-            angular.element($window).unbind('resize',$scope.toggleActionSheet);
+          $scope.$on('$destroy', function () {
+            angular.element($window).unbind('resize', $scope.toggleActionSheet);
           });
         }
       };

--- a/web/scripts/storage/services/svc-file-upload.js
+++ b/web/scripts/storage/services/svc-file-upload.js
@@ -73,13 +73,16 @@ angular.module('risevision.storage.services')
       compress: function (fileItem, folderPath) {
         var deferred = $q.defer();
 
-        if (disabled || fileItem.file.type !== 'image/jpeg') { return deferred.resolve(); }
+        if (disabled || fileItem.file.type !== 'image/jpeg') {
+          return deferred.resolve();
+        }
 
         new Compressor(fileItem.domFileItem, {
           quality: 0.7,
           checkOrientation: false,
-          success: function(result) {
-            bigQueryLogging.logEvent('image compressed', folderPath + fileItem.file.name, result.size / fileItem.file.size);
+          success: function (result) {
+            bigQueryLogging.logEvent('image compressed', folderPath + fileItem.file.name, result.size /
+              fileItem.file.size);
 
             fileItem.domFileItem = result;
             fileItem.file.size = result.size;
@@ -87,7 +90,8 @@ angular.module('risevision.storage.services')
           },
           error: function (err) {
             $log.debug(err);
-            bigQueryLogging.logEvent('image compress error', folderPath + fileItem.file.name + ' | ' + err.message);
+            bigQueryLogging.logEvent('image compress error', folderPath + fileItem.file.name + ' | ' + err
+              .message);
             disabled = true;
             return deferred.resolve();
           }
@@ -109,7 +113,8 @@ angular.module('risevision.storage.services')
       return fileUploaderFactory();
     }
   ])
-  .factory('fileUploaderFactory', ['$rootScope', '$q', 'XHRFactory', 'encoding', 'ExifStripper', '$timeout', 'JPGCompressor',
+  .factory('fileUploaderFactory', ['$rootScope', '$q', 'XHRFactory', 'encoding', 'ExifStripper', '$timeout',
+    'JPGCompressor',
     function ($rootScope, $q, XHRFactory, encoding, ExifStripper, $timeout, JPGCompressor) {
       return function () {
         var svc = {};
@@ -131,11 +136,13 @@ angular.module('risevision.storage.services')
 
         svc.compress = function (fileItems) {
           return fileItems.reduce(function (pChain, fileItem) {
-            return pChain.then(function () {
-              return JPGCompressor.compress(fileItem, svc.currentFilePath());
+              return pChain.then(function () {
+                return JPGCompressor.compress(fileItem, svc.currentFilePath());
+              });
+            }, $q.resolve())
+            .then(function () {
+              return fileItems;
             });
-          }, $q.resolve())
-          .then(function () { return fileItems; });
         };
 
         svc.removeExif = function (files) {


### PR DESCRIPTION
## Description
Send user company role on `identify()`, `logged in` and `User Updated` events.

## Motivation and Context
https://trello.com/c/RlfB1tKI/6373-add-user-role-to-identify-and-log-in-event-1

## How Has This Been Tested?
Locally and on [stage-19].

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
