### PR TITLE
Require CP role to access Selected Schedules

### DIFF
--- a/web/partials/template-editor/attribute-list.html
+++ b/web/partials/template-editor/attribute-list.html
@@ -21,7 +21,7 @@
   <label class="u_margin-md-top">Settings for this Presentation:</label>
 </div>
 
-<div class="attribute-row attribute-row-hover schedules-attribute-row mt-2">
+<div class="attribute-row attribute-row-hover schedules-attribute-row mt-2" require-role="cp">
   <div class="col-xs-10 pl-0 attribute-desc" ng-class="{'danger' : !schedulesComponent.hasSelectedSchedules }">
     <span>
       Schedules

--- a/web/scripts/template-editor/directives/dtv-attribute-list.js
+++ b/web/scripts/template-editor/directives/dtv-attribute-list.js
@@ -1,9 +1,9 @@
 'use strict';
 
 angular.module('risevision.template-editor.directives')
-  .directive('templateAttributeList', ['templateEditorFactory', 'brandingFactory',
+  .directive('templateAttributeList', ['userState', 'templateEditorFactory', 'brandingFactory',
     'blueprintFactory', 'scheduleSelectorFactory',
-    function (templateEditorFactory, brandingFactory, blueprintFactory, scheduleSelectorFactory) {
+    function (userState, templateEditorFactory, brandingFactory, blueprintFactory, scheduleSelectorFactory) {
       return {
         restrict: 'E',
         scope: true,
@@ -12,7 +12,10 @@ angular.module('risevision.template-editor.directives')
           $scope.factory = templateEditorFactory;
 
           $scope.brandingComponent = brandingFactory.getBrandingComponent();
-          $scope.schedulesComponent = scheduleSelectorFactory.getSchedulesComponent();
+
+          if (userState.hasRole('cp')) {
+            $scope.schedulesComponent = scheduleSelectorFactory.getSchedulesComponent();            
+          }
 
           $scope.components = blueprintFactory.blueprintData.components
             .filter(function (c) {


### PR DESCRIPTION
## Description
Require CP role to access Selected Schedules

[stage-2]

## Motivation and Context
Non CP users cannot access the functionality.

## How Has This Been Tested?
Tested changes with and without the CP role.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No