### PR TITLE
Refresh unselected schedules list on tooltip open

### DIFF
--- a/web/partials/schedules/schedule-selector-tooltip.html
+++ b/web/partials/schedules/schedule-selector-tooltip.html
@@ -1,7 +1,7 @@
 <span class="schedule-selector-tooltip">
   <div class="row">
     <div class="col-xs-12">
-      <search-filter filter-config="filterConfig" search="factory.unselectedSchedules.search" do-search="factory.unselectedSchedules.doSearch" icon-set="madero"></search-filter>
+      <search-filter filter-config="filterConfig" search="factory.search" do-search="factory.unselectedSchedules.doSearch" icon-set="madero"></search-filter>
     </div> 
   </div>
 
@@ -11,7 +11,7 @@
     rv-spinner-key="selected-schedules-spinner"
     rv-spinner-start-active="0"
   >
-    <div class="flex-row" ng-repeat="schedule in factory.selectedSchedules track by $index">
+    <div class="flex-row" ng-repeat="schedule in factory.selectedSchedules | filter:factory.search.query track by $index">
       <div class="row-entry">
         <div class="madero-checkbox u_clickable" ng-click="factory.selectItem(schedule, false)">
           <input type="checkbox" ng-checked="factory.isSelected(schedule, true)" tabindex="1">
@@ -59,7 +59,7 @@
 
   <div class="row">
     <div class="col-xs-6">
-      <button type="button" class="btn btn-default btn-block" ng-click="closeTooltip()">Cancel</button>
+      <button type="button" class="btn btn-default btn-block" ng-click="toggleTooltip()">Cancel</button>
     </div>
     <div class="col-xs-6">
       <button type="button" class="btn btn-primary btn-block" ng-click="select()">Select</button>

--- a/web/partials/schedules/schedule-selector.html
+++ b/web/partials/schedules/schedule-selector.html
@@ -1,7 +1,7 @@
 <button id="schedule-selector" class="form-control btn-select btn-block"
   tooltip-template="'partials/schedules/schedule-selector-tooltip.html'"
   tooltip-trigger="show"
-  ng-click="showTooltip($event)" 
+  ng-click="toggleTooltip($event)" 
   tooltip-animation="false"
   tooltip-placement="bottom" 
   tooltip-class="madero-style tooltip-schedule-selector ml-0"

--- a/web/scripts/schedules/directives/dtv-schedule-selector.js
+++ b/web/scripts/schedules/directives/dtv-schedule-selector.js
@@ -9,6 +9,7 @@ angular.module('risevision.schedules.directives')
         scope: true,
         link: function ($scope, element) {
           var tooltipElement = angular.element(element[0].querySelector('#schedule-selector'));
+          $scope.showTooltip = false;
           $scope.factory = scheduleSelectorFactory;
           $scope.filterConfig = {
             placeholder: 'Search schedules'
@@ -25,21 +26,27 @@ angular.module('risevision.schedules.directives')
             }
           });
 
-          $scope.showTooltip = function ($event) {
-            $timeout(function () {
-              tooltipElement.trigger('show');
-            });
-          };
+          $scope.toggleTooltip = function ($event) {
+            if (!$scope.showTooltip) {
+              $timeout(function () {
+                tooltipElement.trigger('show');
 
-          $scope.closeTooltip = function () {
-            $timeout(function () {
-              tooltipElement.trigger('hide');
-            });
+                $scope.factory.load();
+
+                $scope.showTooltip = true;
+              });
+            } else {
+              $timeout(function () {
+                tooltipElement.trigger('hide');
+                
+                $scope.showTooltip = false;
+              });
+            }
           };
 
           $scope.select = function () {
             $scope.factory.select();
-            $scope.closeTooltip();
+            $scope.toggleTooltip();
           };
         }
       };

--- a/web/scripts/template-editor/components/directives/dtv-component-schedules.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-schedules.js
@@ -10,21 +10,11 @@ angular.module('risevision.template-editor.directives')
         link: function ($scope, element) {
           $scope.factory = scheduleSelectorFactory;
 
-          function _load() {
-            $scope.factory.loadUnselectedSchedules();
-          }
-
-          $scope.save = function () {
-            $scope.factory.save();
-          };
-
           $scope.registerDirective({
             type: 'rise-schedules',
             element: element,
             show: function () {
               $scope.setPanelTitle('Schedules');
-
-              _load();
             },
             onBackHandler: function () {
               // TODO: close tooltip if open


### PR DESCRIPTION
## Description
Refresh unselected schedules list on tooltip open

Toggle tooltip open and close
Load unselected schedules on open only

Fix search to apply to both lists
Use client side search for selected schedules

Refactor code and cleanup

[stage-2]

## Motivation and Context
Fixes and improvements for the epic

## How Has This Been Tested?
Tested changes in the local environment.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No