### PR TITLE
Hide element path [stage-4]

### DIFF
--- a/web/scripts/template-editor/components/directives/dtv-component-rich-text.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-rich-text.js
@@ -27,6 +27,7 @@ angular.module('risevision.template-editor.directives')
             fontsize_formats: '24px 36px 48px 60px 72px 84px 96px 108px 120px 150px 200px 300px',
             force_p_newlines: false,
             forced_root_block: '',
+            elementpath: false,
             content_style: '@import url("' + getGoogleFontsUrl() + '");',
             font_formats: getSortedFontFormats(),
             setup: function (editor) {

--- a/web/scss/ui-components/tinymce.scss
+++ b/web/scss/ui-components/tinymce.scss
@@ -114,3 +114,7 @@
     }
   }
 }
+
+.mce-path {
+  display: none !important;
+}


### PR DESCRIPTION
## Description
- Hide label that displays element path 
- Remove empty space occupied by element path

<img width="384" alt="Screen Shot 2020-07-07 at 2 03 57 PM" src="https://user-images.githubusercontent.com/6841220/86823882-6955a980-c05b-11ea-9ead-33e6f31b679a.png">

## Motivation and Context
UI cleanup

## How Has This Been Tested?
N/A

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
