### PR TITLE
Lazy load google fonts

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -13,7 +13,6 @@
   <link rel="shortcut icon" href="https://s3.amazonaws.com/Rise-Images/favicons/rv_favicon.ico" type="image/x-icon">
   <meta name="google-site-verification" content="TO2kG46s9wDLSVLPOZE0SUjLJoOzU4OxroBYzaNZLeA" />
   <link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/mfpgpdablffhbfofnhlpgmokokbahooi">
-  <link href="https://fonts.googleapis.com/css?family=Roboto|Open Sans|Lato|Noto Sans JP|Montserrat|Roboto Condensed|Source Sans Pro|Oswald|Raleway|Roboto Mono|Poppins|Noto Sans|Roboto Slab|Merriweather|PT Sans|Ubuntu|Playfair Display|Muli|Open Sans Condensed|PT Serif|Mukta|Nunito|Lora|Work Sans|Fira Sans|Rubik|Noto Sans KR|Noto Serif|Titillium Web|Nanum Gothic|Noto Sans TC|Quicksand|Nunito Sans|PT Sans Narrow|Heebo|Inconsolata|Barlow|Hind Siliguri|Oxygen|Arimo|Dosis|Libre Baskerville|Crimson Text|Karla|Slabo 27px|Josefin Sans|Bitter|Anton|Libre Franklin|Cabin" rel="stylesheet">
 
   <!-- Schema.org markup for Google+ -->
   <meta itemprop="name" content="Rise Vision | Apps">

--- a/web/scripts/template-editor/components/directives/dtv-component-rich-text.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-rich-text.js
@@ -53,6 +53,17 @@ angular.module('risevision.template-editor.directives')
               .data.richText)));
           };
 
+          $scope.registerDirective({
+            type: 'rise-rich-text',
+            iconType: 'streamline',
+            icon: 'text',
+            element: element,
+            show: function () {
+              $scope.componentId = $scope.factory.selected.id;
+              _load();
+            }
+          });
+
           function getAllFontsUsed(richText) {
             var wrapper = document.createElement('div'),
               families = '',
@@ -89,17 +100,6 @@ angular.module('risevision.template-editor.directives')
 
             return googleFontsUsed;
           }
-
-          $scope.registerDirective({
-            type: 'rise-rich-text',
-            iconType: 'streamline',
-            icon: 'text',
-            element: element,
-            show: function () {
-              $scope.componentId = $scope.factory.selected.id;
-              _load();
-            }
-          });
 
           function getSortedFontFormats() {
             var allFonts = COMMON_FONT_FAMILIES.concat(getGoogleFontsFamilies());

--- a/web/scripts/template-editor/components/directives/dtv-component-rich-text.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-rich-text.js
@@ -13,35 +13,8 @@ angular.module('risevision.template-editor.directives')
           $scope.factory = templateEditorFactory;
           $scope.data = {};
 
-          /*jshint camelcase: false */
-          $scope.tinymceOptions = {
-            baseURL: '/vendor/tinymce/', //set path to load theme and skin files
-            plugins: 'colorpicker textcolor lists',
-            menubar: false,
-            toolbar1: 'fontselect fontsizeselect | ' +
-              'bold italic underline | ' +
-              'forecolor backcolor | ' +
-              'numlist bullist | ' +
-              'alignleft aligncenter alignright | ' +
-              'removeformat',
-            fontsize_formats: '24px 36px 48px 60px 72px 84px 96px 108px 120px 150px 200px 300px',
-            force_p_newlines: false,
-            forced_root_block: '',
-            elementpath: false,
-            content_style: '@import url("' + getGoogleFontsUrl() + '");',
-            font_formats: getSortedFontFormats(),
-            setup: function (editor) {
-              editor.on('paste', function (e) {
-                //paste does not trigger change event
-                //editor.getContent() needs timeout in order to include the change
-                setTimeout(function () {
-                  $scope.data.richText = editor.getContent();
-                  $scope.save();
-                }, 100);
-              });
-            }
-          };
-          /*jshint camelcase: true */
+          loadGoogleFonts();
+          initTinyMce();
 
           function _load() {
             $scope.data.richText = $scope.getAvailableAttributeData($scope.componentId, 'richtext');
@@ -63,6 +36,38 @@ angular.module('risevision.template-editor.directives')
               _load();
             }
           });
+
+          function initTinyMce() {
+            /*jshint camelcase: false */
+            $scope.tinymceOptions = {
+              baseURL: '/vendor/tinymce/', //set path to load theme and skin files
+              plugins: 'colorpicker textcolor lists',
+              menubar: false,
+              toolbar1: 'fontselect fontsizeselect | ' +
+                'bold italic underline | ' +
+                'forecolor backcolor | ' +
+                'numlist bullist | ' +
+                'alignleft aligncenter alignright | ' +
+                'removeformat',
+              fontsize_formats: '24px 36px 48px 60px 72px 84px 96px 108px 120px 150px 200px 300px',
+              force_p_newlines: false,
+              forced_root_block: '',
+              elementpath: false,
+              content_style: '@import url("' + getGoogleFontsUrl() + '");',
+              font_formats: getSortedFontFormats(),
+              setup: function (editor) {
+                editor.on('paste', function (e) {
+                  //paste does not trigger change event
+                  //editor.getContent() needs timeout in order to include the change
+                  setTimeout(function () {
+                    $scope.data.richText = editor.getContent();
+                    $scope.save();
+                  }, 100);
+                });
+              }
+            };
+            /*jshint camelcase: true */
+          }
 
           function getAllFontsUsed(richText) {
             var wrapper = document.createElement('div'),
@@ -120,6 +125,19 @@ angular.module('risevision.template-editor.directives')
             });
 
             return result;
+          }
+
+          //lazy load Google fonts
+          function loadGoogleFonts() {
+            var linkId = 'mostPopularGoogleFonts';
+            if (!document.getElementById(linkId)) {
+              var link = document.createElement('link');
+              link.rel = 'stylesheet';
+              link.type = 'text/css';
+              link.id = linkId;
+              link.href = getGoogleFontsUrl();
+              document.head.appendChild(link);
+            }
           }
 
         }


### PR DESCRIPTION
## Description
- Load Google fonts when rich-text directive is used instead of loading every time. Fonts are loaded to the page only once, however tinyMCE still loads it every time when it creates editor iFrame.
- Moved tinyMCE configuration into a function for better readability

**Note:** To eliminate fonts loading by tinyMCE iFrame every time directive is created, we can load CSS from the code via XHR, then append CSS content as a "<style>" to the page's header and as well as pass it to the tinyMCE `content_style` property. That way fonts will be loaded only once. I didn't implement this optimization because I don't think it worth the complexity. The fonts file is only ~100KB.

## Motivation and Context
Optimization

## How Has This Been Tested?
Visually

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
