### PR TITLE
Set default font size

### DIFF
--- a/web/scripts/template-editor/components/directives/dtv-component-rich-text.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-rich-text.js
@@ -143,7 +143,9 @@ angular.module('risevision.template-editor.directives')
           function getContentStyle() {
             var googleFontsCss = '@import url("' + getGoogleFontsUrl() + '");';
             //zoom calculation: 400px (attribute editor width) / 1920px (temaplte width) = ~20%
-            var scaleEditorCss = 'body {transform-origin: top left; transform: scale(0.2); width: 500%;}';
+            var scaleEditorCss = 'body {transform-origin: top left; transform: scale(0.2); width: 500%;' +
+              //set default font size
+              'font-size: 96px !important;}';
             return googleFontsCss + scaleEditorCss;
           }
 


### PR DESCRIPTION
## Description
Set default font size

## Motivation and Context
The current default font size is 14px which is too small and not even an option in the font size dropdown.

## How Has This Been Tested?
Tested visually by running Apps locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
