### PR TITLE
Persist values to user settings

### DIFF
--- a/web/scripts/common/directives/dtv-tooltip-overlay.js
+++ b/web/scripts/common/directives/dtv-tooltip-overlay.js
@@ -38,7 +38,9 @@ angular.module('risevision.apps.directives')
               };
 
               $scope.$watch('tooltipKey', function () {
-                if (!$scope.tooltipKey) { return; }
+                if (!$scope.tooltipKey) {
+                  return;
+                }
 
                 if (tourFactory.isShowing($scope.tooltipKey)) {
                   show();


### PR DESCRIPTION
## Description
Persist values to user settings

[stage-19]

## Motivation and Context
User settings are more reliable than local storage.

Applies to both Apps Home Share and Schedule Selector tooltips.

## How Has This Been Tested?
Tested both tooltips locally, updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No