### PR TITLE
Wait for Schedules to load before closing overlay

### DIFF
--- a/test/e2e/common/pages/homepage.js
+++ b/test/e2e/common/pages/homepage.js
@@ -43,6 +43,8 @@ var HomePage = function() {
   var signInLink = element(by.id('sign-in-link'));
 
   this.dismissFeatureTour = function() {
+    helper.waitDisappear(appsHomeLoader, 'Apps Home Loader');
+
     return shareTooltipDismiss.isPresent().then(function(isTooltipPresent) {
       if (isTooltipPresent) {
         helper.clickOverIFrame(shareTooltipDismiss, 'Tooltip Dismiss Button');


### PR DESCRIPTION
## Description
Wait for Schedules to load before closing overlay

[stage-15]

## Motivation and Context
Fixes tests that sometimes fail to close the overlay.

## How Has This Been Tested?
Build passes.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No