### PR TITLE
Populate font sizes with increment of 6px 

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-rich-text.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-rich-text.tests.js
@@ -92,4 +92,8 @@ describe('directive: templateComponentRichText', function() {
     )).to.be.true;
   });
 
+  it('should configure font sizes', function() {
+    expect($scope.tinymceOptions.fontsize_formats).to.include(" 96px");
+    expect($scope.tinymceOptions.fontsize_formats).to.include(" 300px");
+  });
 });

--- a/web/scripts/template-editor/components/directives/dtv-component-rich-text.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-rich-text.js
@@ -49,7 +49,7 @@ angular.module('risevision.template-editor.directives')
                 'numlist bullist | ' +
                 'alignleft aligncenter alignright | ' +
                 'removeformat',
-              fontsize_formats: '24px 36px 48px 60px 72px 84px 96px 108px 120px 150px 200px 300px',
+              fontsize_formats: getFontSizes(),
               force_p_newlines: false,
               forced_root_block: '',
               elementpath: false,
@@ -147,6 +147,16 @@ angular.module('risevision.template-editor.directives')
               //set default font size
               'font-size: 96px !important;}';
             return googleFontsCss + scaleEditorCss;
+          }
+
+          function getFontSizes() {
+            var result = '';
+
+            for (var i = 24; i <= 300; i += 6) {
+              result += (result ? ' ' : '') + i + 'px';
+            }
+
+            return result;
           }
 
         }


### PR DESCRIPTION
## Description
Populate font sizes with increment of 6px 

## Motivation and Context
TinyMCE plugins API does not allow us to implement custom font size picker the way we want. The main limitation is that the API only allows buttons in the toolbar.

## How Has This Been Tested?
Visually on local machine and with unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
