### PR TITLE
Update Share feature tour to promote Chrome Enterprise

### DIFF
--- a/test/unit/launcher/controllers/ctr-apps-home.tests.js
+++ b/test/unit/launcher/controllers/ctr-apps-home.tests.js
@@ -128,7 +128,7 @@ describe('controller: AppsHomeCtrl', function() {
       $scope.load();
 
       setTimeout(function() {
-        expect($scope.tooltipKey).to.equal('ShareTooltip');
+        expect($scope.tooltipKey).to.equal('ShareEnterpriseTooltip');
 
         done();
       },10);

--- a/web/partials/launcher/apps-home.html
+++ b/web/partials/launcher/apps-home.html
@@ -52,7 +52,7 @@
     <div class="container">
       <a type="button" class="btn btn-default btn-block" ui-sref="apps.schedules.details({scheduleId: selectedSchedule.id})">Edit Schedule</a>
       <ng-show ng-show="tooltipKey">
-        <button type="button" class="btn btn-primary btn-block" tooltip-overlay tooltip-placement="top" tooltip-class="madero-style tooltip-share-guide">Share</button>
+        <button type="button" class="btn btn-primary btn-block" tooltip-overlay tooltip-template="'partials/launcher/share-tooltip.html'" tooltip-placement="top" tooltip-class="madero-style tooltip-share-guide">Share</button>
       </ng-show>
       <share-schedule-button schedule="selectedSchedule" ng-hide="tooltipKey"></share-schedule-button>
     </div>

--- a/web/partials/launcher/share-tooltip.html
+++ b/web/partials/launcher/share-tooltip.html
@@ -1,7 +1,7 @@
 <span>
-  <h4 class="u_remove-top">Communicate Everywhere</h4>
+  <h4 class="u_remove-top">New! Deploy schedules to managed devices.</h4>
   <p class="text-lg">
-    Keep your community connected anywhere they are. Share your message to digital signage, websites, personal computers, and more.
+    Google Chrome Enterprise users can now deploy a schedule to managed devices.
   </p>
   <p class="text-lg u_remove-bottom">
     <a id="share-tooltip-dismiss" href="#" ng-click="dismiss()">Got it.</a>

--- a/web/scripts/launcher/controllers/ctr-apps-home.js
+++ b/web/scripts/launcher/controllers/ctr-apps-home.js
@@ -12,7 +12,7 @@ angular.module('risevision.apps.launcher.controllers')
       };
 
       var triggerOverlay = function () {
-        $scope.tooltipKey = 'ShareTooltip';
+        $scope.tooltipKey = 'ShareEnterpriseTooltip';
       };
 
       $scope.$watch('loadingItems', function (loading) {


### PR DESCRIPTION
## Description
Updates Feature Tour to promote Chrome Enterprise.
Renames tooltipKey to make sure this will be visible to users that dismissed previous message.
Fixes missing popup on mobile.

## Motivation and Context
No Touch Deployment epic.

## How Has This Been Tested?
Manually tested locally.
[stage-13]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
