### PR TITLE
Add tracking env parameter for Chrome Enterprise link

### DIFF
--- a/test/unit/schedules/controllers/ctr-shared-schedule-popover.tests.js
+++ b/test/unit/schedules/controllers/ctr-shared-schedule-popover.tests.js
@@ -58,6 +58,17 @@ describe('controller: SharedSchedulePopoverController', function() {
     expect($scope.getLink()).to.equal('https://preview.risevision.com/?type=sharedschedule&id=scheduleId');
   });
 
+  describe('getEnterpriseLink', function() {
+    it('should get schedule link with enterprise env', function() {
+      expect($scope.getEnterpriseLink()).to.equal('https://preview.risevision.com/?type=sharedschedule&id=scheduleId&env=enterprise'); 
+    });
+
+    it('should return blank if no schedule defined', function() {
+      $scope.schedule = null;
+      expect($scope.getEnterpriseLink()).to.equal(''); 
+    });
+  });
+
   it('getEmbedCode', function() {
     expect($scope.getEmbedCode()).to.be.contain('<div style="position:relative;padding-bottom:56.25%;">\n\
    <iframe style="width:100%;height:100%;position:absolute;left:0px;top:0px;"\n\

--- a/web/partials/schedules/share-schedule-popover.html
+++ b/web/partials/schedules/share-schedule-popover.html
@@ -151,8 +151,8 @@
     <div class="col-xs-12">
       <span class="text-sm font-weight-bold">Share URL:</span>
       <div class="aligner mt-1">
-        <input class="form-control copy-text-box w-100" type="text" readonly="readonly" value="{{getLink()}}" ng-focus="onTextFocus($event)" focus-me="currentTab === 'chromeEnterprise'"/>
-        <button id="copyUrlButton" class="btn btn-default ml-2" ng-click="copyToClipboard(getLink())" aria-label="Copy">Copy</button>
+        <input class="form-control copy-text-box w-100" type="text" readonly="readonly" value="{{getEnterpriseLink()}}" ng-focus="onTextFocus($event)" focus-me="currentTab === 'chromeEnterprise'"/>
+        <button id="copyUrlButton" class="btn btn-default ml-2" ng-click="copyToClipboard(getEnterpriseLink())" aria-label="Copy">Copy</button>
       </div>
       <p class="text-sm mt-4 mb-0"><a id="chromeEnterpriseHelpLink" href="https://help.risevision.com/hc/en-us" target="_blank">Click here</a> for instructions on how you can deploy this schedule to your managed devices.</p>
     </div>

--- a/web/scripts/schedules/controllers/ctr-shared-schedule-popover.js
+++ b/web/scripts/schedules/controllers/ctr-shared-schedule-popover.js
@@ -31,6 +31,10 @@ USER_FIRST_NAME')
         return $scope.schedule ? SHARED_SCHEDULE_URL.replace('SCHEDULE_ID', $scope.schedule.id) : '';
       };
 
+      $scope.getEnterpriseLink = function () {
+        return $scope.schedule ? $scope.getLink() + '&env=enterprise' : '';
+      };
+
       $scope.getEmbedCode = function () {
         return $scope.schedule ? SHARED_SCHEDULE_EMBED_CODE.replace('SHARED_SCHEDULE_URL', $scope.getLink()) : '';
       };


### PR DESCRIPTION
## Description
Add tracking env parameter for Chrome Enterprise link.
Updated taxonomy to include the new value.

## Motivation and Context
No Touch Deployment epic.

## How Has This Been Tested?
Confirmed that Viewer works as expected and sets `enterprise` as platform.
Confirmed that URL input text and clipboard link are correct.
[stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
