### PR TITLE
Fix checkbox and row for long Schedule names

### DIFF
--- a/web/partials/schedules/preview-selector-tooltip.html
+++ b/web/partials/schedules/preview-selector-tooltip.html
@@ -19,7 +19,7 @@
             <streamline-icon name="checkmark" width="14" height="12"></streamline-icon>
           </label>
         </div>
-        <div class="mr-auto u_clickable" ng-click="selectSchedule(schedule)">
+        <div class="mr-auto u_clickable u_text-ellipsis" ng-click="selectSchedule(schedule)">
           {{schedule.name}}
         </div>
         <div class="u_float-left mr-3">

--- a/web/partials/schedules/schedule-selector-tooltip.html
+++ b/web/partials/schedules/schedule-selector-tooltip.html
@@ -19,7 +19,7 @@
             <streamline-icon name="checkmark" width="14" height="12"></streamline-icon>
           </label>
         </div>
-        <div class="mr-auto u_clickable" ng-click="factory.selectItem(schedule, true)">
+        <div class="mr-auto u_clickable u_text-ellipsis" ng-click="factory.selectItem(schedule, true)">
           {{schedule.name}}
         </div>
         <div class="u_float-left mr-3">
@@ -38,7 +38,7 @@
             <streamline-icon name="checkmark" width="14" height="12"></streamline-icon>
           </label>
         </div>
-        <div class="mr-auto u_clickable" ng-click="factory.selectItem(schedule, false)">
+        <div class="mr-auto u_clickable u_text-ellipsis" ng-click="factory.selectItem(schedule, false)">
           {{schedule.name}}
         </div>
         <div class="u_float-left mr-3">

--- a/web/scss/sections/apps-home.scss
+++ b/web/scss/sections/apps-home.scss
@@ -86,6 +86,11 @@
   &.tooltip {
     opacity: 1;
 
+    .scrollable-list {
+      min-height: 150px;
+      max-height: 150px;
+    }    
+
     &.tooltip-guide {
       .tooltip-inner {
         text-align: left;

--- a/web/scss/sections/schedules.scss
+++ b/web/scss/sections/schedules.scss
@@ -28,10 +28,3 @@
     }
   }
 }
-
-.schedule-selector-tooltip {
-  .scrollable-list {
-    min-height: 150px;
-    max-height: 150px;
-  }
-}

--- a/web/scss/sections/template-editor-layout.scss
+++ b/web/scss/sections/template-editor-layout.scss
@@ -1475,6 +1475,7 @@ $short-phone-height: 570px;
   margin-top: 0px;
   margin-bottom: 0px;
   min-height: 25px;
+  min-width: 31px;
 
   & label, & label {
     padding-left: 0px;


### PR DESCRIPTION
## Description
Fix checkbox and row for long Schedule names

Fix applies to other instances of the checkbox
where the checkmark is not visible

[stage-19]

## Motivation and Context
Fix styling issue when text is too long

## How Has This Been Tested?
Tested changes locally for both lists.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
