### PR TITLE
Use more generic selector for list height

### DIFF
--- a/web/scss/sections/apps-home.scss
+++ b/web/scss/sections/apps-home.scss
@@ -86,6 +86,11 @@
   &.tooltip {
     opacity: 1;
 
+    .scrollable-list {
+      min-height: 150px;
+      max-height: 150px;
+    }    
+
     &.tooltip-guide {
       .tooltip-inner {
         text-align: left;

--- a/web/scss/sections/schedules.scss
+++ b/web/scss/sections/schedules.scss
@@ -27,11 +27,11 @@
       color: $madero-gray;
     }
   }
-}
 
-.schedule-selector-tooltip {
-  .scrollable-list {
-    min-height: 150px;
-    max-height: 150px;
+  &.tooltip {
+    .scrollable-list {
+      min-height: 150px;
+      max-height: 150px;
+    }    
   }
 }

--- a/web/scss/sections/schedules.scss
+++ b/web/scss/sections/schedules.scss
@@ -27,11 +27,4 @@
       color: $madero-gray;
     }
   }
-
-  &.tooltip {
-    .scrollable-list {
-      min-height: 150px;
-      max-height: 150px;
-    }    
-  }
 }


### PR DESCRIPTION
## Description
Use more generic selector for list height

[stage-18]

## Motivation and Context
Fixes list height for Preview Schedule Selector in Apps Home.

## How Has This Been Tested?
Tested list height in both Preview Selector and Schedule Selector in Editor.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No