### PR TITLE
Add an encoding bypass session storage item

### DIFF
--- a/test/e2e/storage/pages/helper.js
+++ b/test/e2e/storage/pages/helper.js
@@ -46,11 +46,12 @@
       signInPage.signIn();
       helper.wait(storageHomePage.getStorageAppContainer(), 'Storage Apps Container');
       helper.waitDisappear(filesListPage.getFilesListLoader(), 'Storage Files Loader');
+      browser.driver.executeScript('sessionStorage.setItem("bypass-upload-encoding", true)');
     },
 
     setupStorageHomeWithEncoding: function() {
-      browser.driver.executeScript('sessionStorage.setItem("force-upload-encoding", true)');
       factory.setupStorageHome();
+      browser.driver.executeScript('sessionStorage.setItem("bypass-upload-encoding", false)');
     },
 
     setupAppsSingleFileSelector: function(){

--- a/web/scripts/config/test.js
+++ b/web/scripts/config/test.js
@@ -24,7 +24,7 @@
   angular.module('risevision.apps.config', [])
     .value('APPS_ENV', 'TEST')
     .value('ENCODING_MASTER_SWITCH_URL',
-      'https://storage.googleapis.com/risemedialibrary/no-encoding-for-most-tests')
+      'https://storage.googleapis.com/risemedialibrary/encoding-switch-on')
     .value('STORAGE_API_ROOT',
       'https://storage-dot-rvacore-test.appspot.com/_ah/api')
     .value('STORE_ENDPOINT_URL',

--- a/web/scripts/storage/services/svc-encoding.js
+++ b/web/scripts/storage/services/svc-encoding.js
@@ -33,6 +33,10 @@ angular.module('risevision.storage.services')
           return $q.resolve(true);
         }
 
+        if (sessionStorage.getItem('bypass-upload-encoding') === 'true') {
+          return $q.resolve(false);
+        }
+
         return masterSwitchPromise
           .then(function () {
             return true;


### PR DESCRIPTION
## Description

Previously e2e tests were not checking the live master switch. They were
checking a fake, so that it would always return false unless the
force-encoding session storage flag was set. Which is was, for one test.
So that test would always use the encoding service. This would cause the
test to fail during encoding provider downtime.

With this change, the e2e tests will use the live master switch, but in
most cases they will ignore the master switch setting because they've
set the bypass session flag. One e2e test will run without bypass so
that it uses the encoding if the master switch is on.

The advantage is that if the live master switch is off because the
encoding service is down, the e2e test will respect the switch setting
and upload directly to GCS rather than failing. In most cases, when the
live master switch is on, the E2E test will use the encoding service and
confirm functionality.

[stage-6]

## Motivation and Context
Reduce e2e test failures.
See also: [Enable / Disable Rise Storage Video Upload Optimization](https://docs.google.com/document/d/1zeqJ2KRJg2-nTT3wS7W24MsHDoIg2piEVTK0CrImHSM/edit#heading=h.1euqbk7vm41c)

## How Has This Been Tested?
Unit tested. Tested on staging to confirm master switch functionality and new bypass functionality.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
