### PR TITLE
Add preview holder for Schedule manage

### DIFF
--- a/test/e2e/schedules/cases/scheduleadd.js
+++ b/test/e2e/schedules/cases/scheduleadd.js
@@ -5,6 +5,7 @@ var SignInPage = require('./../../common/pages/signInPage.js');
 var CommonHeaderPage = require('./../../common-header/pages/commonHeaderPage.js');
 var SchedulesListPage = require('./../pages/schedulesListPage.js');
 var ScheduleAddPage = require('./../pages/scheduleAddPage.js');
+var PlaylistItemModalPage = require('./../pages/playlistItemModalPage.js');
 var ShareSchedulePopoverPage = require('./../pages/shareSchedulePopoverPage.js');
 var helper = require('rv-common-e2e').helper;
 
@@ -19,6 +20,7 @@ var ScheduleAddScenarios = function() {
     var schedulesListPage;
     var scheduleAddPage;
     var shareSchedulePopoverPage;
+    var playlistItemModalPage;
 
     before(function () {
       homepage = new HomePage();
@@ -27,6 +29,7 @@ var ScheduleAddScenarios = function() {
       scheduleAddPage = new ScheduleAddPage();
       commonHeaderPage = new CommonHeaderPage();
       shareSchedulePopoverPage = new ShareSchedulePopoverPage();
+      playlistItemModalPage = new PlaylistItemModalPage();
 
       homepage.getSchedules();
       signInPage.signIn();
@@ -38,9 +41,8 @@ var ScheduleAddScenarios = function() {
       expect(scheduleAddPage.getScheduleNameField().isPresent()).to.eventually.be.true;
     });
 
-    it('should not show Preview and Share Schedule buttons', function () {
-      expect(scheduleAddPage.getPreviewButton().isDisplayed()).to.eventually.be.false;
-      expect(scheduleAddPage.getShareScheduleButton().isDisplayed()).to.eventually.be.false;
+    it('should not show Share Schedule buttons', function () {
+      expect(scheduleAddPage.getShareScheduleButton().isPresent()).to.eventually.be.false;
     });
 
     it('should show Save Button', function () {
@@ -51,13 +53,26 @@ var ScheduleAddScenarios = function() {
       expect(scheduleAddPage.getCancelButton().isPresent()).to.eventually.be.true;
     });
 
+    // Share button won't show without a Playlist Item
+    it('should add a playlist item', function() {
+      // wait for transitions
+      browser.sleep(500);
+
+      scheduleAddPage.getAddPlaylistItemButton().click();
+      scheduleAddPage.getAddUrlItemButton().click();
+
+      playlistItemModalPage.getUrlInput().sendKeys('http://risevision.com/content2.html');
+      playlistItemModalPage.getSaveButton().click();
+
+      expect(scheduleAddPage.getPlaylistItems().count()).to.eventually.equal(1);
+    });
+
     it('should add schedule', function () {
       scheduleAddPage.getSaveButton().click();
       helper.wait(scheduleAddPage.getDeleteButton(), 'Delete Button');
       helper.wait(scheduleAddPage.getShareScheduleButton(), 'Share Schedule Button');
       
       expect(scheduleAddPage.getDeleteButton().isDisplayed()).to.eventually.be.true;
-      expect(scheduleAddPage.getPreviewButton().isDisplayed()).to.eventually.be.true;
       expect(scheduleAddPage.getShareScheduleButton().isDisplayed()).to.eventually.be.true;
     });
 

--- a/test/e2e/schedules/pages/scheduleAddPage.js
+++ b/test/e2e/schedules/pages/scheduleAddPage.js
@@ -19,7 +19,6 @@ var ScheduleAddPage = function() {
 
   var playlistItems = element.all(by.repeater('playlistItem in playlistItems'));
 
-  var previewButton = element(by.id('previewButton'));
   var shareScheduleButton = element(by.id('tooltipButton'));
 
   var saveButton = element(by.id('saveButton'));
@@ -42,10 +41,6 @@ var ScheduleAddPage = function() {
 
   this.getScheduleNameField = function() {
     return displayNameField;
-  };
-
-  this.getPreviewButton = function() {
-    return previewButton;
   };
 
   this.getShareScheduleButton = function() {

--- a/test/unit/schedules/directives/dtv-schedule-fields.tests.js
+++ b/test/unit/schedules/directives/dtv-schedule-fields.tests.js
@@ -1,6 +1,6 @@
 'use strict';
 describe('directive: scheduleFields', function() {
-  var $scope, $rootScope, playlistFactory, $modal;
+  var $scope, $rootScope, playlistFactory, $modal, $sce;
   var classicPres1 = { name: 'classic1' };
   var classicPres2 = { name: 'classic2' };
   var htmlPres1 = { name: 'html1', presentationType: 'HTML Template' };
@@ -23,18 +23,14 @@ describe('directive: scheduleFields', function() {
         addPresentationItems: sinon.spy()
       };
     });
-    $provide.service('scheduleFactory', function() {
-      return {
-        getPreviewUrl: function () {
-          return 'previewUrl';
-        }
-      };
-    });
+
+    $provide.value('SHARED_SCHEDULE_URL','https://preview.risevision.com/?type=sharedschedule&id=SCHEDULE_ID');
   }));
 
   beforeEach(inject(function($compile, _$rootScope_, $templateCache, $injector){
     $modal = $injector.get('$modal');
     playlistFactory = $injector.get('playlistFactory');
+    $sce = $injector.get('$sce');
 
     $templateCache.put('partials/schedules/schedule-fields.html', '<p>mock</p>');
     $rootScope = _$rootScope_;
@@ -50,9 +46,7 @@ describe('directive: scheduleFields', function() {
 
     expect($scope.addUrlItem).to.be.a('function');
     expect($scope.addPresentationItem).to.be.a("function");
-    expect($scope.isPreviewAvailable).to.be.a('function');
-
-    expect($scope.previewUrl).to.equal('previewUrl');
+    expect($scope.getEmbedUrl).to.be.a('function');
   });
 
   it('addUrlItem:', function() {
@@ -121,21 +115,29 @@ describe('directive: scheduleFields', function() {
     });
   });
 
-  describe('isPreviewAvailable:', function() {
-    it('should have Preview button available', function() {
-      $scope.schedule.content = [];
-      expect($scope.isPreviewAvailable()).to.be.true;
-      $scope.schedule.content = [ classicPres1, classicPres2 ];
-      expect($scope.isPreviewAvailable()).to.be.true;
+  describe('getEmbedUrl:', function() {
+    beforeEach(function() {
+      sinon.stub($sce, 'trustAsResourceUrl').returns('http://trustedUrl');
     });
 
-    it('should not have Preview button available', function() {
-      $scope.schedule.content = [ htmlPres1 ];
-      expect($scope.isPreviewAvailable()).to.be.false;
-      $scope.schedule.content = [ classicPres1, htmlPres1 ];
-      expect($scope.isPreviewAvailable()).to.be.false;
-      $scope.schedule.content = [ classicPres1, classicPres2, htmlPres1 ];
-      expect($scope.isPreviewAvailable()).to.be.false;
+    afterEach(function() {
+      $sce.trustAsResourceUrl.restore();
     });
+
+    it('should return a trusted embed URL', function() {
+      $scope.schedule.id = 'ID';
+
+      expect($scope.getEmbedUrl()).to.equal('http://trustedUrl');
+      $sce.trustAsResourceUrl.should.have.been.calledWith('https://preview.risevision.com/?type=sharedschedule&id=ID&env=apps_schedule');
+    });
+
+    it('should return null, to not render iframe, when schedule id is not provided', function() {
+      $scope.schedule = null;
+
+      expect($scope.getEmbedUrl()).to.equal(null);
+      $sce.trustAsResourceUrl.should.not.have.been.called;
+    });
+
   });
+
 });

--- a/test/unit/schedules/services/svc-schedule-factory.tests.js
+++ b/test/unit/schedules/services/svc-schedule-factory.tests.js
@@ -77,7 +77,6 @@ describe('service: scheduleFactory:', function() {
     $provide.service('processErrorCode', function() {
       return processErrorCode = sinon.spy(function() { return 'error'; });
     });
-    $provide.value('VIEWER_URL', 'http://rvaviewer-test.appspot.com');
     $provide.service('display', function() {
       return {
         hasFreeDisplays: sinon.stub().returns(Q.resolve(true))
@@ -131,7 +130,6 @@ describe('service: scheduleFactory:', function() {
     expect(scheduleFactory.addSchedule).to.be.a('function');
     expect(scheduleFactory.updateSchedule).to.be.a('function');
     expect(scheduleFactory.deleteSchedule).to.be.a('function');
-    expect(scheduleFactory.getPreviewUrl).to.be.a('function');
   });
 
   it('should initialize',function(){
@@ -390,22 +388,6 @@ describe('service: scheduleFactory:', function() {
         done();
       },10);
     });
-  });
-
-  it('getPreviewUrl: ', function(done) {
-    expect(scheduleFactory.getPreviewUrl()).to.not.be.ok;
-
-    scheduleFactory.getSchedule('scheduleId')
-      .then(function() {
-        expect(scheduleFactory.getPreviewUrl()).to.be.ok;
-        expect(scheduleFactory.getPreviewUrl()).to.equal('http://rvaviewer-test.appspot.com/?type=schedule&id=scheduleId');
-
-        done();
-      })
-      .then(null, function(e) {
-        done(e);
-      })
-      .then(null,done);
   });
 
   describe('checkFirstSchedule:', function(){

--- a/web/partials/launcher/apps-home.html
+++ b/web/partials/launcher/apps-home.html
@@ -56,7 +56,7 @@
     </div>
 
     <div class="container" ng-show="selectedSchedule">
-      <div class="schedule-embed">
+      <div class="preview-embed">
         <iframe frameborder="0" ng-src="{{getEmbedUrl(selectedSchedule.id)}}">
         </iframe>
       </div>

--- a/web/partials/schedules/playlist.html
+++ b/web/partials/schedules/playlist.html
@@ -1,4 +1,4 @@
-<div rv-sortable on-sort="sortItem(evt)" class="scrollable-list sortable-list border-container u_margin-sm-top">
+<div rv-sortable on-sort="sortItem(evt)" class="scrollable-list sortable-list border-container">
   <div class="list-group-item border-bottom rv-sortable-item flex-row" ng-repeat="playlistItem in playlistItems track by $index">
     <div class="row-entry">
       <div class="pr-4 rv-sortable-handle u_clickable">

--- a/web/partials/schedules/schedule-fields.html
+++ b/web/partials/schedules/schedule-fields.html
@@ -53,7 +53,7 @@
     <playlist playlist-items="schedule.content"></playlist>
   </div>
   <!-- presentationIds field is only updated when the Schedule is saved -->
-  <div class="preview-container" ng-if="schedule.id && schedule.presentationIds.length">
+  <div class="preview-container" ng-if="schedule.id && schedule.content.length">
     <div class="text-right border-bottom py-4 mb-4">
       <label class="pull-left mt-3 mb-0">Schedule Preview</label>
 

--- a/web/partials/schedules/schedule-fields.html
+++ b/web/partials/schedules/schedule-fields.html
@@ -26,8 +26,8 @@
 
 <distribution-selector distribution="schedule.distribution" distribute-to-all="schedule.distributeToAll" hide-cta="true"></distribution-selector>
 
-<div class="template-editor-body">
-  <div class="attribute-editor">
+<div class="schedule-fields-body">
+  <div class="playlist-container">
     <div class="text-right py-4">
       <label class="pull-left mt-3 mb-0" translate>schedules-app.playlist.title</label>
 
@@ -53,14 +53,14 @@
     <playlist playlist-items="schedule.content"></playlist>
   </div>
   <!-- presentationIds field is only updated when the Schedule is saved -->
-  <div class="preview-holder" ng-if="schedule.id && schedule.presentationIds.length">
+  <div class="preview-container" ng-if="schedule.id && schedule.presentationIds.length">
     <div class="text-right border-bottom py-4 mb-4">
       <label class="pull-left mt-3 mb-0">Schedule Preview</label>
 
       <share-schedule-button schedule="schedule" button-class="btn-default btn-toolbar"></share-schedule-button>
     </div>
 
-    <div class="schedule-embed">
+    <div class="preview-embed">
       <iframe frameborder="0" ng-src="{{getEmbedUrl()}}">
       </iframe>
     </div>

--- a/web/partials/schedules/schedule-fields.html
+++ b/web/partials/schedules/schedule-fields.html
@@ -26,31 +26,43 @@
 
 <distribution-selector distribution="schedule.distribution" distribute-to-all="schedule.distributeToAll" hide-cta="true"></distribution-selector>
 
-<div class="u_margin-md-top text-right">
-  <label class="pull-left mt-3 mb-0" translate>schedules-app.playlist.title</label>
+<div class="template-editor-body">
+  <div class="attribute-editor">
+    <div class="text-right py-4">
+      <label class="pull-left mt-3 mb-0" translate>schedules-app.playlist.title</label>
 
-  <div class="btn-group" dropdown>
-    <button id="addPlaylistItemButton" type="button" dropdown-toggle class="dropdown-toggle btn btn-default btn-toolbar">{{'schedules-app.playlist.add-playlist-item' | translate}}</button>
-    <div class="dropdown-menu playlist-menu" role="menu">
-      <ul>
-      <li>
-        <a class="u_clickable" id="addPresentationItemButton" ng-click="addPresentationItem()">
-          <span translate>schedules-app.playlist.item.presentation</span>
-        </a>
-      </li>
-      <li>
-        <a class="u_clickable" id="addUrlItemButton" ng-click="addUrlItem()">
-          <span translate>schedules-app.playlist.item.url</span>
-        </a>
-      </li>
-      </ul>
+      <div class="btn-group" dropdown>
+        <button id="addPlaylistItemButton" type="button" dropdown-toggle class="dropdown-toggle btn btn-default btn-toolbar">{{'schedules-app.playlist.add-playlist-item' | translate}}</button>
+        <div class="dropdown-menu playlist-menu" role="menu">
+          <ul>
+          <li>
+            <a class="u_clickable" id="addPresentationItemButton" ng-click="addPresentationItem()">
+              <span translate>schedules-app.playlist.item.presentation</span>
+            </a>
+          </li>
+          <li>
+            <a class="u_clickable" id="addUrlItemButton" ng-click="addUrlItem()">
+              <span translate>schedules-app.playlist.item.url</span>
+            </a>
+          </li>
+          </ul>
+        </div>
+      </div>  
     </div>
-  </div>  
-  <a class="btn btn-default btn-toolbar" id="previewButton" target="_blank" ng-href="{{previewUrl}}" ng-show="previewUrl && isPreviewAvailable()">
-    {{'schedules-app.actions.preview' | translate}}
-  </a>
-  <share-schedule-button schedule="schedule" button-class="btn-default btn-toolbar" ng-show="schedule.id"></share-schedule-button>
 
+    <playlist playlist-items="schedule.content"></playlist>
+  </div>
+  <!-- presentationIds field is only updated when the Schedule is saved -->
+  <div class="preview-holder" ng-if="schedule.id && schedule.presentationIds.length">
+    <div class="text-right border-bottom py-4 mb-4">
+      <label class="pull-left mt-3 mb-0">Schedule Preview</label>
+
+      <share-schedule-button schedule="schedule" button-class="btn-default btn-toolbar"></share-schedule-button>
+    </div>
+
+    <div class="schedule-embed">
+      <iframe frameborder="0" ng-src="{{getEmbedUrl()}}">
+      </iframe>
+    </div>
+  </div>
 </div>
-
-<playlist playlist-items="schedule.content"></playlist>

--- a/web/scripts/schedules/directives/dtv-schedule-fields.js
+++ b/web/scripts/schedules/directives/dtv-schedule-fields.js
@@ -1,16 +1,12 @@
 'use strict';
 
 angular.module('risevision.schedules.directives')
-  .directive('scheduleFields', ['$modal', 'scheduleFactory', 'playlistFactory',
-    '$sce', 'SHARED_SCHEDULE_URL',
-    function ($modal, scheduleFactory, playlistFactory, $sce,
-    SHARED_SCHEDULE_URL) {
+  .directive('scheduleFields', ['$modal', 'playlistFactory', '$sce', 'SHARED_SCHEDULE_URL',
+    function ($modal, playlistFactory, $sce, SHARED_SCHEDULE_URL) {
       return {
         restrict: 'E',
         templateUrl: 'partials/schedules/schedule-fields.html',
         link: function ($scope) {
-          $scope.previewUrl = scheduleFactory.getPreviewUrl();
-
           var openPlaylistModal = function (playlistItem) {
             $modal.open({
               templateUrl: 'partials/schedules/playlist-item.html',

--- a/web/scripts/schedules/directives/dtv-schedule-fields.js
+++ b/web/scripts/schedules/directives/dtv-schedule-fields.js
@@ -1,8 +1,10 @@
 'use strict';
 
 angular.module('risevision.schedules.directives')
-  .directive('scheduleFields', ['$modal', 'scheduleFactory', 'playlistFactory', 'presentationUtils',
-    function ($modal, scheduleFactory, playlistFactory, presentationUtils) {
+  .directive('scheduleFields', ['$modal', 'scheduleFactory', 'playlistFactory',
+    '$sce', 'SHARED_SCHEDULE_URL',
+    function ($modal, scheduleFactory, playlistFactory, $sce,
+    SHARED_SCHEDULE_URL) {
       return {
         restrict: 'E',
         templateUrl: 'partials/schedules/schedule-fields.html',
@@ -41,12 +43,12 @@ angular.module('risevision.schedules.directives')
             });
           };
 
-          $scope.isPreviewAvailable = function () {
-            var htmlPresentations = _.filter($scope.schedule.content, function (presentation) {
-              return presentationUtils.isHtmlPresentation(presentation);
-            });
-
-            return htmlPresentations.length === 0;
+          $scope.getEmbedUrl = function () {
+            if (!$scope.schedule) {
+              return null;
+            }
+            var url = SHARED_SCHEDULE_URL.replace('SCHEDULE_ID', $scope.schedule.id) + '&env=apps_schedule';
+            return $sce.trustAsResourceUrl(url);
           };
         } //link()
       };

--- a/web/scripts/schedules/services/svc-schedule-factory.js
+++ b/web/scripts/schedules/services/svc-schedule-factory.js
@@ -2,9 +2,9 @@
 
 angular.module('risevision.schedules.services')
   .factory('scheduleFactory', ['$q', '$state', '$log', '$rootScope', 'schedule', 'scheduleTracker',
-    'processErrorCode', 'VIEWER_URL', 'HTML_PRESENTATION_TYPE', 'display', 'plansFactory', 'userState',
+    'processErrorCode', 'HTML_PRESENTATION_TYPE', 'display', 'plansFactory', 'userState',
     function ($q, $state, $log, $rootScope, schedule, scheduleTracker, processErrorCode,
-      VIEWER_URL, HTML_PRESENTATION_TYPE, display, plansFactory, userState) {
+      HTML_PRESENTATION_TYPE, display, plansFactory, userState) {
       var factory = {};
       var _hasSchedules;
       var _scheduleId;
@@ -215,13 +215,6 @@ angular.module('risevision.schedules.services')
           .finally(function () {
             factory.loadingSchedule = false;
           });
-      };
-
-      factory.getPreviewUrl = function () {
-        if (_scheduleId) {
-          return VIEWER_URL + '/?type=schedule&id=' + _scheduleId;
-        }
-        return null;
       };
 
       factory.scheduleHasTransitions = function (schedule) {

--- a/web/scss/sections/apps-home.scss
+++ b/web/scss/sections/apps-home.scss
@@ -44,19 +44,6 @@
 				margin-left: 8px;
 			}	
 		}
-
-		.schedule-embed {
-			position: relative;
-			padding-bottom: 56.25%;
-
-			iframe {
-				position: absolute;
-				width: 100%;
-				height: 100%;
-				left: 0px;
-				top: 0px;
-			}
-		}
 	}
 
 	.mobile-footer {

--- a/web/scss/sections/schedules.scss
+++ b/web/scss/sections/schedules.scss
@@ -15,27 +15,68 @@
   }
 }
 
-@media (min-width: 768px) {
-  .attribute-editor {
-    --sidebar-width: 450px;
+.schedule-fields-body {
+  margin-left: 0px;
+  margin-right: 0px;
+  display: flex;
+  flex-flow: column;
 
-    .scrollable-list {
-      max-height: calc(100vh - 387px);
-      min-height: 387px;
+  @media (min-width: $screen-sm) {
+    display: flex;
+    flex-flow: row;
+    height: calc(100vh - var(--body-height));
+  }
 
-      .draggable-mirror {
-        border-top: 1px solid $madero-gray;
-        background: rgba(242, 242, 242, 0.85);
-      }
+  .preview-container {
+    background-image: linear-gradient(white, #f2f2f2);
+    width: 100%;
+    overflow: auto;
+
+    @media (min-width: $screen-sm) {
+      @extend .ml-md-5;
+
+      width: 100%;
+      height: 100%;
     }
   }
 
-  .preview-holder {
-    @extend .ml-md-5;
+  .playlist-container {
+    --sidebar-width: 450px;
+
+    height: 100%;
+    overflow: hidden;
+
+    @media (min-width: $screen-sm) {
+      flex-grow: 1;
+      flex-shrink: 0;
+      flex-basis: var(--sidebar-width);
+      width: var(--sidebar-width);
+
+      .scrollable-list {
+        max-height: calc(100vh - 387px);
+        min-height: 387px;
+
+        .draggable-mirror {
+          border-top: 1px solid $madero-gray;
+          background: rgba(242, 242, 242, 0.85);
+        }
+
+        .list-group-item {
+          height: 62px;
+          padding-top: 0px;
+          padding-bottom: 0px;
+        }
+
+        .name-container {
+          margin-top: 0px;
+          height: auto;
+        }
+      }
+    }
   }
 }
 
-.schedule-embed {
+.preview-embed {
   position: relative;
   padding-bottom: 56.25%;
 

--- a/web/scss/sections/schedules.scss
+++ b/web/scss/sections/schedules.scss
@@ -14,3 +14,36 @@
     }
   }
 }
+
+@media (min-width: 768px) {
+  .attribute-editor {
+    --sidebar-width: 450px;
+
+    .scrollable-list {
+      max-height: calc(100vh - 387px);
+      min-height: 387px;
+
+      .draggable-mirror {
+        border-top: 1px solid $madero-gray;
+        background: rgba(242, 242, 242, 0.85);
+      }
+    }
+  }
+
+  .preview-holder {
+    @extend .ml-md-5;
+  }
+}
+
+.schedule-embed {
+  position: relative;
+  padding-bottom: 56.25%;
+
+  iframe {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    left: 0px;
+    top: 0px;
+  }
+}

--- a/web/scss/sections/schedules.scss
+++ b/web/scss/sections/schedules.scss
@@ -28,7 +28,6 @@
   }
 
   .preview-container {
-    background-image: linear-gradient(white, #f2f2f2);
     width: 100%;
     overflow: auto;
 

--- a/web/scss/sections/template-editor-layout.scss
+++ b/web/scss/sections/template-editor-layout.scss
@@ -991,6 +991,12 @@ $short-phone-height: 570px;
     }
   }
 
+  .open > .btn-default.dropdown-toggle {
+    background: $white;
+    color: $madero-green;
+    border-color: $madero-green;
+  }
+
   .btn-primary {
     &, &:hover, &:active, &:focus {
       color: $white;


### PR DESCRIPTION
## Description
Add preview holder for Schedule manage

Side by side on larger resolutions
One below the other on smaller screens

Fix issue with drag items color
Fix dropdown button styling issue

Various spacing and styling fixes

[stage-2]

## Motivation and Context
Integrate schedule preview on the schedule page

## How Has This Been Tested?
Tested changes locally at various resolutions. Will refactor CSS and fix tests in a subsequent PR.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No