### PR TITLE
Add Colors component to attribute list [stage-8]

### DIFF
--- a/web/partials/template-editor/attribute-list.html
+++ b/web/partials/template-editor/attribute-list.html
@@ -40,6 +40,26 @@
     </a>
   </div>
 </div>
+
+<div id="overrideColors">
+  <div class="attribute-row">
+    <div class="col-xs-10 pl-0 attribute-desc">
+      <component-icon icon="{{ getComponentIcon(colorsComponent) }}" type="{{ getComponentIconType(colorsComponent) }}"></component-icon>
+      <span>
+        Override Brand Colors
+      </span>
+    </div>
+    <div class="col-xs-2 pr-0 align-right">
+      <a id="override-colors-edit" ng-click="editComponent(colorsComponent);">
+        <span class="attribute-edit text-nowrap">
+          <span translate>template.attribute-editor.edit-component</span>
+          <i class="fa fa-lg fa-angle-right arrow-icon"></i>
+        </span>
+      </a>
+    </div>
+  </div>
+</div>
+
 <div ng-mouseleave="highlightComponent(null)">
   <div class="attribute-row attribute-row-hover" ng-repeat="comp in components track by $index">
     <div class="col-xs-10 pl-0 attribute-desc" ng-mouseover="highlightComponent(comp.id)">

--- a/web/scripts/template-editor/components/directives/dtv-component-colors.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-colors.js
@@ -22,6 +22,7 @@ angular.module('risevision.template-editor.directives')
             icon: 'palette',
             element: element,
             show: function () {
+              $scope.setPanelTitle('Override Brand Colors');
               element.show();
               $scope.componentId = $scope.factory.selected.id;
               $scope.load();

--- a/web/scripts/template-editor/directives/dtv-attribute-list.js
+++ b/web/scripts/template-editor/directives/dtv-attribute-list.js
@@ -21,7 +21,7 @@ angular.module('risevision.template-editor.directives')
 
           $scope.colorsComponent = {
             type: 'rise-data-colors'
-          }
+          };
 
           $scope.components = blueprintFactory.blueprintData.components
             .filter(function (c) {

--- a/web/scripts/template-editor/directives/dtv-attribute-list.js
+++ b/web/scripts/template-editor/directives/dtv-attribute-list.js
@@ -19,6 +19,10 @@ angular.module('risevision.template-editor.directives')
               .presentation);
           }
 
+          $scope.colorsComponent = {
+            type: 'rise-data-colors'
+          }
+
           $scope.components = blueprintFactory.blueprintData.components
             .filter(function (c) {
               return !c.nonEditable;


### PR DESCRIPTION
## Description
Force adding Colors component to attribute list and position under Schedules component

**Note**
A follow up PR will be done to address the name of the component _rise-data-colors_ and update it to _override-brand-colors_ throughout the code base. 

## Motivation and Context
Development of Override Brand Settings feature

## How Has This Been Tested?
Tested on Apps with this template presentation - 

**Note**
The settings of Colors component is out of scope of this PR and will be refactored in future PRs. It does not need testing.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
