### PR TITLE
Rename colors component type value [stage-8]

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-colors.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-colors.tests.js
@@ -40,7 +40,7 @@ describe('directive: templateComponentColors', function() {
 
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
-    expect(directive.type).to.equal('rise-data-colors');
+    expect(directive.type).to.equal('rise-override-brand-colors');
     expect(directive.iconType).to.equal('streamline');
     expect(directive.icon).to.exist;
     expect(directive.show).to.be.a('function');

--- a/web/locales/en/template.json
+++ b/web/locales/en/template.json
@@ -68,7 +68,6 @@
   "rise-image": "Image",
   "rise-data-financial": "Financial",
   "rise-data-rss": "RSS",
-  "rise-data-colors": "Colors",
   "rise-data-counter-down": "Count Down",
   "rise-data-counter-up": "Count Up",
   "rise-data-twitter": "Twitter",

--- a/web/scripts/template-editor/components/directives/dtv-component-colors.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-colors.js
@@ -17,7 +17,7 @@ angular.module('risevision.template-editor.directives')
           };
 
           $scope.registerDirective({
-            type: 'rise-data-colors',
+            type: 'rise-override-branding-colors',
             iconType: 'streamline',
             icon: 'palette',
             element: element,

--- a/web/scripts/template-editor/components/directives/dtv-component-colors.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-colors.js
@@ -17,7 +17,7 @@ angular.module('risevision.template-editor.directives')
           };
 
           $scope.registerDirective({
-            type: 'rise-override-branding-colors',
+            type: 'rise-override-brand-colors',
             iconType: 'streamline',
             icon: 'palette',
             element: element,

--- a/web/scripts/template-editor/directives/dtv-attribute-list.js
+++ b/web/scripts/template-editor/directives/dtv-attribute-list.js
@@ -20,7 +20,7 @@ angular.module('risevision.template-editor.directives')
           }
 
           $scope.colorsComponent = {
-            type: 'rise-data-colors'
+            type: 'rise-override-branding-colors'
           };
 
           $scope.components = blueprintFactory.blueprintData.components

--- a/web/scripts/template-editor/directives/dtv-attribute-list.js
+++ b/web/scripts/template-editor/directives/dtv-attribute-list.js
@@ -20,7 +20,7 @@ angular.module('risevision.template-editor.directives')
           }
 
           $scope.colorsComponent = {
-            type: 'rise-override-branding-colors'
+            type: 'rise-override-brand-colors'
           };
 
           $scope.components = blueprintFactory.blueprintData.components


### PR DESCRIPTION
## Description
Rename colors component type value to be accurate to its purpose - "rise-override-brand-colors"

**Note**
We may want to rename the file names also in a future PR for better clarity, will leave this decision until the end of tasks

## Motivation and Context
Development of override brand settings epic

## How Has This Been Tested?
Tested on Apps stage-8 and locally with this template presentation - https://apps-stage-8.risevision.com/templates/edit/9553695c-7446-46b2-957f-6de7eb42f403/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
