### PR TITLE
Conditionally add Colors component based on "branding" in blueprint [stage-8]

### DIFF
--- a/test/unit/template-editor/directives/dtv-attribute-list.tests.js
+++ b/test/unit/template-editor/directives/dtv-attribute-list.tests.js
@@ -7,6 +7,7 @@ describe('directive: attribute-list', function() {
     {id: 'cp2', nonEditable: false},
     {id: 'cp3'}
   ];
+  var hasBranding = true;
 
   beforeEach(module('risevision.template-editor.directives'));
   beforeEach(module(mockTranslate()));
@@ -15,6 +16,9 @@ describe('directive: attribute-list', function() {
       return {
         blueprintData: {
           components: components
+        },
+        hasBranding: function() {
+          return hasBranding;
         }
       };
     });
@@ -64,6 +68,20 @@ describe('directive: attribute-list', function() {
 
   it('should retrieve branding component', function() {
     expect($scope.brandingComponent).to.equal('brandingComponent');
+  });
+
+  it('should set colors component if blueprint specifies branding', function() {
+    expect($scope.colorsComponent).to.deep.equal({type: 'rise-override-brand-colors'});
+  });
+
+  it('should not set colors component if blueprint does not specify branding', function() {
+    hasBranding = false;
+
+    compileDirective();
+
+    expect($scope.colorsComponent).to.be.null;
+
+    hasBranding = true;
   });
 
   describe('schedulesComponent', function() {

--- a/web/partials/template-editor/attribute-list.html
+++ b/web/partials/template-editor/attribute-list.html
@@ -41,7 +41,7 @@
   </div>
 </div>
 
-<div id="overrideColors">
+<div id="overrideColors" ng-show="colorsComponent">
   <div class="attribute-row">
     <div class="col-xs-10 pl-0 attribute-desc">
       <component-icon icon="{{ getComponentIcon(colorsComponent) }}" type="{{ getComponentIconType(colorsComponent) }}"></component-icon>

--- a/web/scripts/template-editor/directives/dtv-attribute-list.js
+++ b/web/scripts/template-editor/directives/dtv-attribute-list.js
@@ -19,9 +19,9 @@ angular.module('risevision.template-editor.directives')
               .presentation);
           }
 
-          $scope.colorsComponent = {
+          $scope.colorsComponent = blueprintFactory.hasBranding() ? {
             type: 'rise-override-brand-colors'
-          };
+          } : null;
 
           $scope.components = blueprintFactory.blueprintData.components
             .filter(function (c) {


### PR DESCRIPTION
## Description
Add Colors component conditionally based on `branding` flag of template blueprint. So if the Template was not configured to enable editing Branding, then Colors component will not be shown. 

## Motivation and Context
Development of override brand settings

## How Has This Been Tested?
Colors component is shown in this presentation - https://apps-stage-8.risevision.com/templates/edit/9553695c-7446-46b2-957f-6de7eb42f403/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

Colors component is not shown in this presentation as it is not _Branding_ enabled - https://apps-stage-8.risevision.com/templates/edit/5948cda4-91ec-4c26-a13b-8c18b701bc09/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
