### PR TITLE
Save/load branding override settings

### DIFF
--- a/test/unit/template-editor/components/directives/dtv-component-colors.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-colors.tests.js
@@ -6,7 +6,7 @@ describe('directive: templateComponentColors', function() {
     factory;
 
   beforeEach(function() {
-    factory = { selected: { id: "TEST-ID" } };
+    factory = { selected: { id: 'TEST-ID' } };
   });
 
   beforeEach(module('risevision.template-editor.directives'));
@@ -25,9 +25,10 @@ describe('directive: templateComponentColors', function() {
     $scope = $rootScope.$new();
 
     $scope.registerDirective = sinon.stub();
-    $scope.setAttributeData = sinon.stub();
+    $scope.setAttributeDataGlobal = sinon.stub();
+    $scope.getAttributeDataGlobal = sinon.stub();
 
-    element = $compile("<template-component-colors></template-component-colors>")($scope);
+    element = $compile('<template-component-colors></template-component-colors>')($scope);
     $scope = element.scope();
     $scope.$digest();
   }));
@@ -35,7 +36,7 @@ describe('directive: templateComponentColors', function() {
   it('should exist', function() {
     expect($scope).to.be.ok;
     expect($scope.factory).to.be.ok;
-    expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" } });
+    expect($scope.factory).to.deep.equal({ selected: { id: 'TEST-ID' } });
     expect($scope.registerDirective).to.have.been.called;
 
     var directive = $scope.registerDirective.getCall(0).args[0];
@@ -44,6 +45,62 @@ describe('directive: templateComponentColors', function() {
     expect(directive.iconType).to.equal('streamline');
     expect(directive.icon).to.exist;
     expect(directive.show).to.be.a('function');
+  });
+
+  it('should save colors if override is true', function() {
+    $scope.override = true;
+    $scope.baseColor = 'red';
+    $scope.accentColor = 'green';
+    $scope.save();
+    expect($scope.setAttributeDataGlobal.calledWith('brandingOverride', {baseColor: 'red', accentColor: 'green'})).to.be.true;
+  });
+
+  it('should not save colors if override is false', function() {
+    $scope.override = false;
+    $scope.baseColor = 'red';
+    $scope.accentColor = 'green';
+    $scope.save();
+    expect($scope.setAttributeDataGlobal.calledWith('brandingOverride', null)).to.be.true;
+  });
+
+  it('should load colors and set override to true', function() {
+    $scope.getAttributeDataGlobal.returns({baseColor: 'red', accentColor: 'green'});
+    $scope.load();
+    expect($scope.override).to.be.true;
+    expect($scope.baseColor).to.equal('red');
+    expect($scope.accentColor).to.equal('green');
+  });
+
+  it('should set override to false', function() {
+    $scope.getAttributeDataGlobal.returns(null);
+    $scope.load();
+    expect($scope.override).to.be.false;
+  });
+
+  it('should save baseColor on change', function() {
+    $scope.getAttributeDataGlobal.returns({baseColor: 'red', accentColor: 'green'});
+    $scope.load(); //register $watch for baseColor
+    $scope.$digest();
+
+    $scope.save = sinon.stub();
+
+    $scope.baseColor = 'blue';
+    $scope.$digest();
+
+    expect($scope.save).to.be.calledOnce;
+  });
+
+  it('should save accentColor on change', function() {
+    $scope.getAttributeDataGlobal.returns({baseColor: 'red', accentColor: 'green'});
+    $scope.load(); //register $watch for accentColor
+    $scope.$digest();
+
+    $scope.save = sinon.stub();
+
+    $scope.accentColor = 'blue';
+    $scope.$digest();
+
+    expect($scope.save).to.be.calledOnce;
   });
 
 });

--- a/test/unit/template-editor/services/svc-template-editor-factory.tests.js
+++ b/test/unit/template-editor/services/svc-template-editor-factory.tests.js
@@ -898,4 +898,28 @@ describe('service: templateEditorFactory:', function() {
 
   });
   
+  describe('getAttributeDataGlobal / setAttributeDataGlobal', function () {
+
+    beforeEach(function(){
+      templateEditorFactory.presentation = { templateAttributeData: {} };
+    });
+
+    it('should set an attribute data value',function() {
+      templateEditorFactory.setAttributeDataGlobal('brandingOverride', {baseColor: 'red', accentColor: 'green'});
+
+      expect(templateEditorFactory.presentation.templateAttributeData).to.deep.equal({
+        brandingOverride: {baseColor: 'red', accentColor: 'green'}
+      });
+    });
+
+    it('should get an attribute data value',function() {
+      templateEditorFactory.setAttributeDataGlobal('brandingOverride', {baseColor: 'red', accentColor: 'green'});
+
+      var data = templateEditorFactory.getAttributeDataGlobal('brandingOverride');
+
+      expect(data).to.deep.equal({baseColor: 'red', accentColor: 'green'});
+    });
+
+  });
+
 });

--- a/web/partials/template-editor/components/component-colors.html
+++ b/web/partials/template-editor/components/component-colors.html
@@ -1,7 +1,7 @@
 <div class="attribute-editor-component colors-container" >
   <div class="attribute-editor-row">
     <span class="colors-checkbox">
-      <input id="overrideBranding" type="checkbox" ng-change="saveOverride()" ng-model="override">
+      <input id="overrideBranding" type="checkbox" ng-change="save()" ng-model="override">
       <label class="control-label" for="overrideBranding">Override Branding</label>
     </span>
   </div>

--- a/web/scripts/template-editor/components/directives/dtv-component-colors.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-colors.js
@@ -12,8 +12,17 @@ angular.module('risevision.template-editor.directives')
 
           // TODO: refactor logic for Override Brand Settings epic
 
-          $scope.saveOverride = function () {
-            $scope.setAttributeData($scope.componentId, 'override', $scope.override);
+          $scope.save = function () {
+            var brandingOverride = null;
+
+            if ($scope.override) {
+              brandingOverride = {
+                'baseColor': $scope.baseColor,
+                'accentColor': $scope.accentColor
+              };
+            }
+
+            $scope.setAttributeDataGlobal('brandingOverride', brandingOverride);
           };
 
           $scope.registerDirective({
@@ -30,19 +39,22 @@ angular.module('risevision.template-editor.directives')
           });
 
           $scope.load = function () {
-            $scope.baseColor = $scope.getAvailableAttributeData($scope.componentId, 'base');
-            $scope.accentColor = $scope.getAvailableAttributeData($scope.componentId, 'accent');
-            $scope.override = $scope.getAvailableAttributeData($scope.componentId, 'override');
+
+            var brandingOverride = $scope.getAttributeDataGlobal('brandingOverride');
+
+            $scope.override = !!brandingOverride;
+            $scope.baseColor = $scope.override ? brandingOverride.baseColor : null;
+            $scope.accentColor = $scope.override ? brandingOverride.accentColor : null;
 
             $scope.$watch('baseColor', function (newVal, oldVal) {
               if (newVal && newVal !== oldVal) {
-                $scope.setAttributeData($scope.componentId, 'base', $scope.baseColor);
+                $scope.save();
               }
             });
 
             $scope.$watch('accentColor', function (newVal, oldVal) {
               if (newVal && newVal !== oldVal) {
-                $scope.setAttributeData($scope.componentId, 'accent', $scope.accentColor);
+                $scope.save();
               }
             });
           };

--- a/web/scripts/template-editor/controllers/ctr-template-editor.js
+++ b/web/scripts/template-editor/controllers/ctr-template-editor.js
@@ -25,6 +25,14 @@ angular.module('risevision.template-editor.controllers')
         templateEditorFactory.setAttributeData(componentId, attributeKey, value);
       };
 
+      $scope.getAttributeDataGlobal = function (attributeKey) {
+        return templateEditorFactory.getAttributeDataGlobal(attributeKey);
+      };
+
+      $scope.setAttributeDataGlobal = function (attributeKey, value) {
+        templateEditorFactory.setAttributeDataGlobal(attributeKey, value);
+      };
+
       $scope.getAvailableAttributeData = function (componentId, attributeName) {
         var result = $scope.getAttributeData(componentId, attributeName);
 

--- a/web/scripts/template-editor/services/svc-template-editor-factory.js
+++ b/web/scripts/template-editor/services/svc-template-editor-factory.js
@@ -280,6 +280,14 @@ angular.module('risevision.template-editor.services')
         component[attributeKey] = value;
       };
 
+      factory.getAttributeDataGlobal = function (attributeKey) {
+        return factory.presentation.templateAttributeData[attributeKey];
+      };
+
+      factory.setAttributeDataGlobal = function (attributeKey, value) {
+        factory.presentation.templateAttributeData[attributeKey] = value;
+      };
+
       // updateAttributeData: do not update the object on getAttributeData
       // or it will unnecessarily trigger hasUnsavedChanges = true
       var _componentFor = function (componentId, updateAttributeData) {


### PR DESCRIPTION
## Description
- Add new methods for saving data to the rood of the attribute data json i.e. globally.
- Updated logic for saving and loading override settings inside directive.

## Motivation and Context
Development of override brand settings epic

## How Has This Been Tested?
Tested manually. Automated tests added.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
