### PR TITLE
Fix chrome version based on the one installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,8 @@ commands:
           command: |
             export STAGE_ENV=$(cat stage.txt)
             echo "Running tests on $STAGE_ENV";
+            export CHROME_VERSION=$(google-chrome --version | grep -iE "[0-9.]{10,20}")
+            echo "Chrome version $CHROME_VERSION";
             TEST_FILES=$(circleci tests glob "<< parameters.casesfile >>" | circleci tests split)
             NODE_ENV=test XUNIT_FILE=~/rise-vision-apps/reports/angular-xunit.xml PROSHOT_DIR=~/rise-vision-apps/reports/screenshots DBUS_SESSION_BUS_ADDRESS=/dev/null xvfb-run -a --server-args="-screen 0 1280x800x24" node run-test.js $TEST_FILES
       - store_test_results:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -364,7 +364,8 @@ gulp.task("server", factory.testServer({
 }));
 gulp.task("server-close", factory.testServerClose());
 gulp.task("test:webdriver_update", factory.webdriverUpdateSpecific({
-    browsers: ["gecko=false"]
+    browsers: ["gecko=false"],
+    webdriverManagerArgs: ["--versions.chrome=" + (process.env.CHROME_VERSION || "latest")]
   }
 ));
 gulp.task("test:e2e:core", ["test:webdriver_update"],factory.testE2EAngular({


### PR DESCRIPTION
## Description
Fix chrome version based on the one installed

[stage-16]

## Motivation and Context
Fixes issue where Chromedriver and Chrome versions don't match.

## How Has This Been Tested?
Reviewed logging to confirm that the Chrome version is detected and downloaded. e2e tests pass.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No