### PR TITLE
Hide color pickers when override is unchecked

### DIFF
--- a/web/partials/template-editor/components/component-colors.html
+++ b/web/partials/template-editor/components/component-colors.html
@@ -7,7 +7,7 @@
   </div>
 </div>
 
-<div class="attribute-list-container">
+<div class="attribute-list-container" ng-show="override">
 
   <label class="control-label" for="base-color">Base Color:</label>
   <p>Pick a dark color.</p>


### PR DESCRIPTION
## Description
Hide color pickers when override is unchecked

## Motivation and Context
Development of override brand settings

## How Has This Been Tested?
Visually on local machine

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
