### PR TITLE
Show free display count for distribution

### DIFF
--- a/test/unit/displays/services/svc-display.tests.js
+++ b/test/unit/displays/services/svc-display.tests.js
@@ -226,7 +226,7 @@ describe('service: display:', function() {
               if (obj.companyId) {
                 def.resolve({
                   result: {
-                    item: "true"
+                    items: [freeDisplay]
                   }
                 });
               } else {
@@ -629,7 +629,7 @@ describe('service: display:', function() {
 
     it('should check if has free displays', function(done) {
       display.hasFreeDisplays('companyId', ['displayId']).then(function(result) {
-        expect(result).to.equal(true);
+        expect(result).to.deep.equal(['freeDisplay']);
         done();
       });
     });

--- a/test/unit/displays/services/svc-display.tests.js
+++ b/test/unit/displays/services/svc-display.tests.js
@@ -226,7 +226,7 @@ describe('service: display:', function() {
               if (obj.companyId) {
                 def.resolve({
                   result: {
-                    items: [freeDisplay]
+                    items: ['freeDisplay']
                   }
                 });
               } else {

--- a/test/unit/schedules/directives/dtv-schedule-fields.tests.js
+++ b/test/unit/schedules/directives/dtv-schedule-fields.tests.js
@@ -64,6 +64,7 @@ describe('directive: scheduleFields', function() {
 
     expect($scope.applyTimeline).to.be.false;
     expect($scope.tooltipKey).to.equal('ShareEnterpriseTooltip');
+    expect($scope.freeDisplays).to.deep.equal([]);
 
     expect($scope.factory).to.equal(scheduleFactory);
     expect($scope.plansFactory).to.equal(plansFactory);
@@ -71,7 +72,7 @@ describe('directive: scheduleFields', function() {
 
   describe('hasFreeDisplays:', function() {
     beforeEach(function() {
-      sinon.stub(scheduleFactory, 'hasFreeDisplays').returns(Q.resolve('hasFreeDisplays'));
+      sinon.stub(scheduleFactory, 'hasFreeDisplays').returns(Q.resolve(['display1']));
     });
 
     it('should watch distribution field', function() {
@@ -96,7 +97,7 @@ describe('directive: scheduleFields', function() {
       $scope.$digest();
 
       setTimeout(function() {
-        expect($scope.hasFreeDisplays).to.equal('hasFreeDisplays');        
+        expect($scope.freeDisplays).to.deep.equal(['display1']);        
 
         done();
       }, 10);

--- a/test/unit/schedules/services/svc-schedule-factory.tests.js
+++ b/test/unit/schedules/services/svc-schedule-factory.tests.js
@@ -81,7 +81,7 @@ describe('service: scheduleFactory:', function() {
     });
     $provide.service('display', function() {
       return {
-        hasFreeDisplays: sinon.stub().returns(Q.resolve(true))
+        hasFreeDisplays: sinon.stub().returns(Q.resolve(['freeDisplay']))
       };
     });
     $provide.service('userState', function() {
@@ -204,7 +204,7 @@ describe('service: scheduleFactory:', function() {
 
       scheduleFactory.hasFreeDisplays()
         .then(function(result) {
-          expect(result).to.be.true;
+          expect(result).to.deep.equal(['freeDisplay']);
 
           done();
         });
@@ -215,11 +215,11 @@ describe('service: scheduleFactory:', function() {
     it('should return false if distributed to licensed displays',function(done){
       scheduleFactory.schedule.distribution = ['display1'];
 
-      display.hasFreeDisplays.returns(Q.resolve(false));
+      display.hasFreeDisplays.returns(Q.resolve([]));
 
       scheduleFactory.hasFreeDisplays()
         .then(function(result) {
-          expect(result).to.be.false;
+          expect(result).to.deep.equal([]);
 
           done();
         });
@@ -241,7 +241,7 @@ describe('service: scheduleFactory:', function() {
 
       scheduleFactory.hasFreeDisplays()
         .then(function(result) {
-          expect(result).to.be.false;
+          expect(result).to.deep.equal([]);
 
           done();
         });

--- a/web/partials/schedules/schedule-fields.html
+++ b/web/partials/schedules/schedule-fields.html
@@ -23,8 +23,8 @@ recurrence-days-of-week = "factory.schedule.recurrenceDaysOfWeek"
 ></timeline-textbox>
 
 <distribution-selector distribution="factory.schedule.distribution" distribute-to-all="factory.schedule.distributeToAll" distribution-style="madero"></distribution-selector>
-<div class="danger mt-2" ng-show="hasFreeDisplays">
-  You selected unlicensed displays that won’t show your content. <a href="#" class="madero-link" ng-click="plansFactory.showPurchaseOptions()">License them?</a>
+<div class="danger mt-2" ng-show="freeDisplays.length">
+  You selected {{freeDisplays.length}} unlicensed display{{freeDisplays.length > 1 ? 's' : ''}} that won’t show your content. <a href="#" class="madero-link" ng-click="plansFactory.showPurchaseOptions()">License {{freeDisplays.length > 1 ? 'them' : 'it'}}?</a>
 </div>
 
 <div class="schedule-fields-body mt-4">

--- a/web/scripts/components/plans/svc-plans-factory.js
+++ b/web/scripts/components/plans/svc-plans-factory.js
@@ -180,7 +180,7 @@
           }
         };
 
-        _factory.showPurchaseOptions = function() {
+        _factory.showPurchaseOptions = function () {
           if (currentPlanFactory.isPlanActive()) {
             $state.go('apps.billing.home');
           } else {

--- a/web/scripts/displays/services/svc-display.js
+++ b/web/scripts/displays/services/svc-display.js
@@ -347,7 +347,7 @@
               })
               .then(function (resp) {
                 $log.debug('hasFreeDisplays resp', resp);
-                deferred.resolve(resp.result && resp.result.item && resp.result.item === 'true');
+                deferred.resolve(resp.result && resp.result.items);
               })
               .then(null, function (e) {
                 console.error('Failed to retrieve hasFreeDisplays.', e);

--- a/web/scripts/schedules/directives/dtv-schedule-fields.js
+++ b/web/scripts/schedules/directives/dtv-schedule-fields.js
@@ -11,13 +11,14 @@ angular.module('risevision.schedules.directives')
           var originalChangeDate = scheduleFactory.schedule.changeDate;
           $scope.applyTimeline = false;
           $scope.tooltipKey = 'ShareEnterpriseTooltip';
+          $scope.freeDisplays = [];
           $scope.factory = scheduleFactory;
           $scope.plansFactory = plansFactory;
 
           $scope.$watchGroup(['factory.schedule.distribution', 'factory.schedule.distributeToAll'], function () {
             scheduleFactory.hasFreeDisplays()
               .then(function(result) {
-                $scope.hasFreeDisplays = result;
+                $scope.freeDisplays = result;
               });
           });
 

--- a/web/scripts/schedules/directives/dtv-schedule-fields.js
+++ b/web/scripts/schedules/directives/dtv-schedule-fields.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('risevision.schedules.directives')
-  .directive('scheduleFields', ['$modal', 'scheduleFactory', 'playlistFactory', 'plansFactory', '$sce', 
+  .directive('scheduleFields', ['$modal', 'scheduleFactory', 'playlistFactory', 'plansFactory', '$sce',
     'SHARED_SCHEDULE_URL',
     function ($modal, scheduleFactory, playlistFactory, plansFactory, $sce, SHARED_SCHEDULE_URL) {
       return {
@@ -17,7 +17,7 @@ angular.module('risevision.schedules.directives')
 
           $scope.$watchGroup(['factory.schedule.distribution', 'factory.schedule.distributeToAll'], function () {
             scheduleFactory.hasFreeDisplays()
-              .then(function(result) {
+              .then(function (result) {
                 $scope.freeDisplays = result;
               });
           });
@@ -58,7 +58,8 @@ angular.module('risevision.schedules.directives')
             if (!scheduleFactory.schedule) {
               return null;
             }
-            var url = SHARED_SCHEDULE_URL.replace('SCHEDULE_ID', scheduleFactory.schedule.id) + '&env=apps_schedule';
+            var url = SHARED_SCHEDULE_URL.replace('SCHEDULE_ID', scheduleFactory.schedule.id) +
+              '&env=apps_schedule';
 
             if (!$scope.applyTimeline) {
               url += '&applyTimeline=false';

--- a/web/scripts/schedules/services/svc-schedule-factory.js
+++ b/web/scripts/schedules/services/svc-schedule-factory.js
@@ -120,7 +120,7 @@ angular.module('risevision.schedules.services')
         var distribution = factory.schedule.distribution ? factory.schedule.distribution : [];
 
         if (!distribution.length && !factory.schedule.distributeToAll) {
-          return $q.resolve(false);
+          return $q.resolve([]);
         }
 
         return display.hasFreeDisplays(factory.schedule.companyId,


### PR DESCRIPTION
## Description
Show free display count for distribution

[stage-2]

## Motivation and Context
Indicate how many free Displays are assigned to a Schedule.

## How Has This Been Tested?
Tested changes locally; updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No