### PR TITLE
Remove 50% discount wording from pricing component

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "compressorjs": "^1.0.6",
     "pricing-data-component": "github:Rise-Vision/pricing-data-component",
     "pricing-grid-component": "github:Rise-Vision/pricing-grid-component",
-    "pricing-selector-component": "github:Rise-Vision/pricing-selector-component",
+    "pricing-selector-component": "github:Rise-Vision/pricing-selector-component#staging/remove-discount",
     "pricing-summary-component": "github:Rise-Vision/pricing-summary-component",
     "tus-js-client": "^2.0.0-1"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "compressorjs": "^1.0.6",
     "pricing-data-component": "github:Rise-Vision/pricing-data-component",
     "pricing-grid-component": "github:Rise-Vision/pricing-grid-component",
-    "pricing-selector-component": "github:Rise-Vision/pricing-selector-component#staging/remove-discount",
+    "pricing-selector-component": "github:Rise-Vision/pricing-selector-component",
     "pricing-summary-component": "github:Rise-Vision/pricing-summary-component",
     "tus-js-client": "^2.0.0-1"
   },

--- a/web/pricing-component.mjs
+++ b/web/pricing-component.mjs
@@ -66,28 +66,9 @@ class PricingComponent extends PolymerElement {
           color: #999999;
           margin: 1em 0 0.5em 0;
         }
-
-        p.promo {
-          text-align: center
-        }
-
-        span.promo {
-          background-color: #FFE8AE;
-        }
-
-        h3.coupon {
-          text-align: center;
-          font-size: 24px;
-          margin-top: 15px;
-          margin-bottom: 15px;
-        }
       </style>
 
       <section hidden$=[[!dataLoaded]]>
-        <p class="promo"><strong>Special offer</strong>: digital signage can help keep people safe. To help make it accessible to everyone, <span class="promo">we're offering 50% off your first year</span> if you purchase an annual plan.</p>
-
-        <h3 class="coupon"><span class="promo">Use the code SAVE50 at checkout</span>.</h3>
-
         <pricing-data-component prod-env=[[prodEnv]] pricing-data={{pricingData}}></pricing-data-component>
 
         <pricing-selector-component class="component"


### PR DESCRIPTION
## Description
Remove 50% discount wording from pricing component

[stage-19]

## Motivation and Context
Discount will no longer be offered.

## How Has This Been Tested?
Tested changes locally and on staging. No relevant tests to update.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No