### PR TITLE
Save attribute data when color is deleted

### DIFF
--- a/web/scripts/template-editor/components/directives/dtv-component-colors.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-colors.js
@@ -47,13 +47,13 @@ angular.module('risevision.template-editor.directives')
             $scope.accentColor = $scope.override ? brandingOverride.accentColor : null;
 
             $scope.$watch('baseColor', function (newVal, oldVal) {
-              if (newVal && newVal !== oldVal) {
+              if (newVal !== oldVal) {
                 $scope.save();
               }
             });
 
             $scope.$watch('accentColor', function (newVal, oldVal) {
-              if (newVal && newVal !== oldVal) {
+              if (newVal !== oldVal) {
                 $scope.save();
               }
             });


### PR DESCRIPTION
## Description
Save attribute data when color is deleted i.e. when the value in the textbox is cleared.

## Motivation and Context
User cannot remove selected color.

## How Has This Been Tested?
Visually on local machine.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
