### PR TITLE
Fix scrolling on home page for mobile

### DIFF
--- a/web/partials/launcher/apps-home.html
+++ b/web/partials/launcher/apps-home.html
@@ -1,4 +1,4 @@
-<div id="apps-home-container" class="full-page-flex-container madero-style" common-header-height>
+<div id="apps-home-container" class="madero-style">
 
   <div class="scrollable-content" rv-spinner rv-spinner-key="apps-home-loader" rv-spinner-start-active="1">
     <div class="row">
@@ -30,7 +30,7 @@
               Share
             </button>
           </ng-show>
-          <share-schedule-button schedule="selectedSchedule" button-class="btn-primary" ng-hide="tooltipKey"></share-schedule-button>
+          <share-schedule-button schedule="selectedSchedule" button-class="btn-primary schedules-toolbar-btn" ng-hide="tooltipKey"></share-schedule-button>
         </span>
 
         <div class="form-group" preview-selector>

--- a/web/partials/launcher/apps-home.html
+++ b/web/partials/launcher/apps-home.html
@@ -67,7 +67,7 @@
     <div class="container">
       <a type="button" class="btn btn-default btn-block" ui-sref="apps.schedules.details({scheduleId: selectedSchedule.id})">Edit Schedule</a>
       <ng-show ng-show="tooltipKey">
-        <button type="button" class="btn btn-primary btn-block" tooltip-overlay tooltip-template="'partials/schedules/share-schedule-tooltip.html'" tooltip-placement="top" tooltip-class="madero-style tooltip-guide tooltip-share-guide">Share</button>
+        <button type="button" class="btn btn-primary btn-block" tooltip-overlay tooltip-template="'partials/schedules/share-schedule-tooltip.html'" tooltip-placement="top" tooltip-append-to-body="true" tooltip-class="madero-style tooltip-guide tooltip-share-guide">Share</button>
       </ng-show>
       <share-schedule-button schedule="selectedSchedule" button-class="btn-primary btn-block" ng-hide="tooltipKey"></share-schedule-button>
     </div>

--- a/web/partials/schedules/schedule-fields.html
+++ b/web/partials/schedules/schedule-fields.html
@@ -57,7 +57,7 @@ recurrence-days-of-week = "factory.schedule.recurrenceDaysOfWeek"
         <div class="form-group my-4">
           <label translate>schedules-app.playlist.empty</label>
         </div>
-        <div class="btn-group pb-2" dropdown>
+        <div class="btn-group mb-2" dropdown>
           <button id="addPlaylistItemButton" type="button" dropdown-toggle class="dropdown-toggle btn btn-default btn-toolbar">{{'schedules-app.playlist.add-playlist-item' | translate}}</button>
           <div class="dropdown-menu playlist-menu" role="menu">
             <ul>

--- a/web/scss/sections/apps-home.scss
+++ b/web/scss/sections/apps-home.scss
@@ -1,22 +1,3 @@
-.full-page-flex-container {
-	position: absolute;
-	top: var(--common-header-height);
-	bottom: 0;
-	left: 0;
-	right: 0;
-	display: flex;
-	flex-direction: column;
-	/* for Firefox */
-	min-height: 0;
-
-	.scrollable-content {
-		flex-grow: 1; 
-		overflow: auto;  
-		/* for Firefox */
-		min-height: 0;
-	}
-}
-
 #apps-home-container {
 	.scrollable-content {
 		padding-top: 10px;
@@ -24,10 +5,14 @@
 		padding-right: 20px;
 		padding-bottom: 20px;
 
+		@media (max-width: $screen-sm) {
+			padding-bottom: 155px;
+		}
+
 		.schedules-toolbar {
 			padding-bottom: 20px;
 			margin-left: 10px;
-    		margin-right: 10px;
+			margin-right: 10px;
 			margin-bottom: 20px;
 			border-bottom: 1px solid $madero-gray;
 
@@ -39,7 +24,7 @@
 				margin-right: 10px;
 			}
 
-			.schedules-toolbar-btn, share-schedule-button > button {
+			.schedules-toolbar-btn {
 				min-width: 160px;
 				margin-left: 8px;
 			}	
@@ -47,10 +32,13 @@
 	}
 
 	.mobile-footer {
-		padding-left: 20px;
-		padding-right: 20px;
+		position: fixed;
+		width: 100%;
+		bottom: 0px;
+		background: white;
+
 		.container {
-			padding: 20px 0px;
+			padding: 20px;
 			border-top: 1px solid $madero-gray;
 
 			.btn-default {

--- a/web/scss/sections/schedules.scss
+++ b/web/scss/sections/schedules.scss
@@ -71,6 +71,10 @@
       }
     }
 
+    .playlist-menu {
+      margin-top: -9px;
+    }
+
     @media (min-width: $screen-lg) {
       .scrollable-list {
         height: 387px;


### PR DESCRIPTION
## Description
Fix scrolling on home page for mobile

Make footer fixed
Small css refactor

Fix add playlist item dropdown location

[stage-2]

## Motivation and Context
Fix for #1896 

Fixes issue by resolving the problem where the page content was scrolling incorrectly in relation to the tooltip.

## How Has This Been Tested?
Tested changes locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No