### PR TITLE
Override Brand Colors e2e tests [stage-8]

### DIFF
--- a/test/e2e/template-editor/cases/components/branding-colors-override.js
+++ b/test/e2e/template-editor/cases/components/branding-colors-override.js
@@ -1,0 +1,67 @@
+'use strict';
+
+var expect = require('rv-common-e2e').expect;
+var PresentationListPage = require('./../../pages/presentationListPage.js');
+var TemplateEditorPage = require('./../../pages/templateEditorPage.js');
+var BrandingColorsOverrideComponentPage = require('./../../pages/components/brandingColorsOverrideComponentPage.js');
+var helper = require('rv-common-e2e').helper;
+
+var BrandingColorsOverrideComponentScenarios = function () {
+  describe('Branding Colors Override Component', function () {
+    var presentationsListPage;
+    var templateEditorPage;
+    var brandingColorsOverrideComponentPage;
+
+    before(function () {
+      presentationsListPage = new PresentationListPage();
+      templateEditorPage = new TemplateEditorPage();
+      brandingColorsOverrideComponentPage = new BrandingColorsOverrideComponentPage();
+
+      presentationsListPage.loadCurrentCompanyPresentationList();
+
+      presentationsListPage.createNewPresentationFromTemplate('Example Branding Template', 'example-branding-template');
+    });
+
+    describe('Branding Colors Override list', function () {
+
+      it('should list Branding Colors Override Settings link', function () {
+        expect(templateEditorPage.getBrandingColorsOverrideContainer().isDisplayed()).to.eventually.be.true;
+        expect(templateEditorPage.getBrandingColorsOverrideEditLink().isDisplayed()).to.eventually.be.true;
+      });
+
+      it('should open Branding Colors Override Settings', function () {
+        helper.clickWhenClickable(templateEditorPage.getBrandingColorsOverrideEditLink(),'Edit Branding Colors Override Link');
+        browser.sleep(1000);
+
+        expect(brandingColorsOverrideComponentPage.getCheckboxInput().isDisplayed()).to.eventually.be.true;
+        expect(brandingColorsOverrideComponentPage.getCheckboxInput().isSelected()).to.eventually.be.false;
+
+        expect(brandingColorsOverrideComponentPage.getColorsContainer().isDisplayed()).to.eventually.be.false;
+      });
+
+      it('should show color settings when override checkbox selected', function () {
+        helper.clickWhenClickable(brandingColorsOverrideComponentPage.getCheckboxInput(),'Select override checkbox');
+        browser.sleep(3000);
+
+        expect(brandingColorsOverrideComponentPage.getColorsContainer().isDisplayed()).to.eventually.be.true;
+        expect(brandingColorsOverrideComponentPage.getBaseColorInput().isDisplayed()).to.eventually.be.true;
+        expect(brandingColorsOverrideComponentPage.getAccentColorInput().isDisplayed()).to.eventually.be.true;
+
+        expect(brandingColorsOverrideComponentPage.getBaseColorInput().isEnabled()).to.eventually.be.true;
+        expect(brandingColorsOverrideComponentPage.getAccentColorInput().isEnabled()).to.eventually.be.true;
+      });
+
+      it('should set colors', function() {
+        brandingColorsOverrideComponentPage.getBaseColorInput().sendKeys("red");
+        brandingColorsOverrideComponentPage.getAccentColorInput().sendKeys("yellow");
+
+        expect(brandingColorsOverrideComponentPage.getBaseColorInput().getAttribute('value')).to.eventually.equal("red");
+        expect(brandingColorsOverrideComponentPage.getAccentColorInput().getAttribute('value')).to.eventually.equal("yellow");
+      });
+
+    });
+
+  });
+};
+
+module.exports = BrandingColorsOverrideComponentScenarios;

--- a/test/e2e/template-editor/pages/components/brandingColorsOverrideComponentPage.js
+++ b/test/e2e/template-editor/pages/components/brandingColorsOverrideComponentPage.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var BrandingColorsOverrideComponentPage = function() {
+  var checkboxInput = element(by.css('.colors-checkbox'));
+  var colorsContainer = element(by.id('branding-colors-override-container'));
+  var baseColorInput = element(by.id('branding-colors-override-base'));
+  var accentColorInput = element(by.id('branding-colors-override-accent'));
+
+  this.getCheckboxInput = function () {
+    return checkboxInput;
+  };
+
+  this.getColorsContainer = function () {
+    return colorsContainer;
+  };
+
+  this.getBaseColorInput = function () {
+    return baseColorInput;
+  };
+
+  this.getAccentColorInput = function () {
+    return accentColorInput;
+  };
+};
+
+module.exports = BrandingColorsOverrideComponentPage;

--- a/test/e2e/template-editor/pages/templateEditorPage.js
+++ b/test/e2e/template-editor/pages/templateEditorPage.js
@@ -22,7 +22,9 @@ var TemplateEditorPage = function() {
   var financialDataLicenseCloseButton = element(by.css('#confirmForm .close'));
   var licenseRequiredMessage = element(by.css('.display-license-required-message'));
   var brandingContainer = element(by.id('branding'));
+  var brandingColorsOverrideContainer = element(by.id('branding-colors-override'));
   var brandingEditLink = element(by.id('branding-edit'));
+  var brandingColorsOverrideEditLink = element(by.id('branding-colors-override-edit'));
 
   var schedulesTooltipDismiss = element(by.id('schedules-tooltip-dismiss'));
 
@@ -121,6 +123,14 @@ var TemplateEditorPage = function() {
 
   this.getBrandingEditLink = function () {
     return brandingEditLink;
+  };
+
+  this.getBrandingColorsOverrideContainer = function () {
+    return brandingColorsOverrideContainer;
+  };
+
+  this.getBrandingColorsOverrideEditLink = function () {
+    return brandingColorsOverrideEditLink;
   };
 
   this.waitForAutosave = function() {

--- a/test/e2e/template-editor/template-editor3.cases.js
+++ b/test/e2e/template-editor/template-editor3.cases.js
@@ -6,6 +6,7 @@
 
   var PlaylistComponentScenarios = require('./cases/components/playlist.js');
   var TwitterComponentScenarios = require('./cases/components/twitter.js');
+  var BrandingColorsOverrideComponentScenarios = require('./cases/components/branding-colors-override.js');
 
   describe('Template Editor 3', function() {
 
@@ -30,6 +31,7 @@
 
     var playlistComponentScenarios = new PlaylistComponentScenarios();
     var twitterComponentScenarios = new TwitterComponentScenarios(subCompanyName);
+    var brandingColorsOverrideComponentScenarios = new BrandingColorsOverrideComponentScenarios();
 
     after(function() {
       // Loading the Presentation List is a workaround to a Chrome Driver issue that has it fail to click on elements over the Preview iframe

--- a/web/partials/template-editor/attribute-list.html
+++ b/web/partials/template-editor/attribute-list.html
@@ -41,7 +41,7 @@
   </div>
 </div>
 
-<div id="overrideColors" ng-show="colorsComponent">
+<div id="branding-colors-override" ng-show="colorsComponent">
   <div class="attribute-row">
     <div class="col-xs-10 pl-0 attribute-desc">
       <component-icon icon="{{ getComponentIcon(colorsComponent) }}" type="{{ getComponentIconType(colorsComponent) }}"></component-icon>
@@ -50,7 +50,7 @@
       </span>
     </div>
     <div class="col-xs-2 pr-0 align-right">
-      <a id="override-colors-edit" ng-click="editComponent(colorsComponent);">
+      <a id="branding-colors-override-edit" ng-click="editComponent(colorsComponent);">
         <span class="attribute-edit text-nowrap">
           <span translate>template.attribute-editor.edit-component</span>
           <i class="fa fa-lg fa-angle-right arrow-icon"></i>

--- a/web/partials/template-editor/components/component-colors.html
+++ b/web/partials/template-editor/components/component-colors.html
@@ -7,19 +7,19 @@
   </div>
 </div>
 
-<div class="attribute-list-container" ng-show="override">
+<div id="branding-colors-override-container" class="attribute-list-container" ng-show="override">
 
-  <label class="control-label" for="base-color">Base Color:</label>
+  <label class="control-label" for="branding-colors-override-base">Base Color:</label>
   <p>Pick a dark color.</p>
   <div class="input-group" colorpicker="rgba" colorpicker-position="bottom" ng-model="baseColor">
-    <input id="base-color" type="text" class="form-control" ng-model="baseColor" placeholder="Enter a hex value, eg. #00FF00">
+    <input id="branding-colors-override-base" type="text" class="form-control" ng-model="baseColor" placeholder="Enter a hex value, eg. #00FF00">
     <span class="input-group-addon color-wheel"></span>
   </div>
 
-  <label class="control-label u_margin-md-top" for="accent-color">Accent Color:</label>
+  <label class="control-label u_margin-md-top" for="branding-colors-override-accent">Accent Color:</label>
   <p>Pick a light color.</p>
   <div class="input-group" colorpicker="rgba" colorpicker-position="bottom" ng-model="accentColor">
-    <input id="accent-color" type="text" class="form-control" ng-model="accentColor" placeholder="Enter a hex value, eg. #00FF00">
+    <input id="branding-colors-override-accent" type="text" class="form-control" ng-model="accentColor" placeholder="Enter a hex value, eg. #00FF00">
     <span class="input-group-addon color-wheel"></span>
   </div>
 


### PR DESCRIPTION
## Description
Adding e2e tests for override brand colors component

## Motivation and Context
Development of Override Brand Settings feature

## How Has This Been Tested?
Running e2e tests locally and on CCI - https://circleci.com/gh/Rise-Vision/rise-vision-apps/66783

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
