### PR TITLE
Don't catch error when encoding has definitely failed

### DIFF
--- a/test/unit/storage/services/svc-encoding.tests.js
+++ b/test/unit/storage/services/svc-encoding.tests.js
@@ -162,6 +162,27 @@ describe('service: encoding:', function() {
         assert('Two status calls', statusChecks === 2);
       });
     });
+
+    it('shows error on encoding error', function() {
+      $httpBackend.when('HEAD', /.*encoding/).respond(200, {});
+
+      var statusResponse = {statuses: {}};
+      statusResponse.statuses[taskToken] = {status: 'completed', error: 1, error_description: 'test_error_desc'};
+
+      var mockResp = $httpBackend.when('POST', /.*status/).respond(200, statusResponse);
+
+      var statusPromise = encoding.monitorStatus(item, function() {});
+      $timeout.flush();
+
+      setTimeout(function() {
+        setTimeout(function() {try{$httpBackend.flush();}catch(e){}}, 5);
+        setTimeout(function() {try{$timeout.flush();}catch(e){}}, 10);
+      }, 50);
+
+      return statusPromise.then(function() {
+        assert('should not pass', false);
+      }).then(null, function() {});
+    });
   });
 
   describe('file acceptance', function() {

--- a/web/scripts/storage/services/svc-encoding.js
+++ b/web/scripts/storage/services/svc-encoding.js
@@ -136,6 +136,7 @@ angular.module('risevision.storage.services')
             }
 
             if (taskStatus.error) {
+              retry = Infinity;
               return $q.reject(taskStatus.error_description); // jshint ignore:line
             }
 


### PR DESCRIPTION
## Description
See commit subject

## Motivation and Context
When there is a successful response from Qencode, but the response includes an error, the status request was being retried until the retry limit was reached. This sets the retry count to infinity when we know there is an error and there is no point in retrying the status check any further.

## How Has This Been Tested?
Unit test + staging (to be confirmed by Robb)
