### PR TITLE
Use processErrorCode for address error failure

### DIFF
--- a/test/unit/components/gapi-loader/svc-util.tests.js
+++ b/test/unit/components/gapi-loader/svc-util.tests.js
@@ -4,26 +4,30 @@
 describe("Services: util", function() {
 
   beforeEach(module("risevision.common.components.util"));
-  
-  it("humanReadableError: ",function(done){
-    var message1 = {"message": "error 1"};
-    var message2 = {"error": {"message": "error 2"}};
-    var message3 = {"error": "error 3"};
-    var message4 = {"random": "error 4"};
-    
-    inject(function(humanReadableError) {
-      expect(humanReadableError).to.be.ok;
-      expect(humanReadableError).to.be.a("function");
+  beforeEach(module("risevision.common.components.scrolling-list"));
 
-      expect(humanReadableError()).to.equal("Unknown Error");
-      expect(humanReadableError("string")).to.equal("string");
-      expect(humanReadableError(message1)).to.equal(JSON.stringify(message1.message));
-      expect(humanReadableError(message2)).to.equal(JSON.stringify(message2.error.message));
-      expect(humanReadableError(message3)).to.equal(JSON.stringify(message3.error));
-      expect(humanReadableError(message4)).to.equal(JSON.stringify(message4));
+  describe("humanReadableError: ",function(){
+    it("original",function(done){
+      var message1 = {"message": "error 1"};
+      var message2 = {"error": {"message": "error 2"}};
+      var message3 = {"error": "error 3"};
+      var message4 = {"random": "error 4"};
       
-      done();
+      inject(function(humanReadableError) {
+        expect(humanReadableError).to.be.ok;
+        expect(humanReadableError).to.be.a("function");
+
+        expect(humanReadableError()).to.equal("Unknown Error");
+        expect(humanReadableError("string")).to.equal("string");
+        expect(humanReadableError(message1)).to.equal(message1.message);
+        expect(humanReadableError(message2)).to.equal(message2.error.message);
+        expect(humanReadableError(message3)).to.equal(message3.error);
+        expect(humanReadableError(message4)).to.equal(JSON.stringify(message4));
+        
+        done();
+      });
     });
+
   });
   
   it("dateIsInRange: ",function(done){

--- a/test/unit/components/scrolling-list/svc-process-error-code.tests.js
+++ b/test/unit/components/scrolling-list/svc-process-error-code.tests.js
@@ -25,6 +25,24 @@ describe("service: process error code:", function() {
     expect(processErrorCode).to.be.a('function');
   });
 
+  it('should show default message if error is undefined', function() {
+    expect(processErrorCode(itemName, action, null)).to.equal("An Error has Occurred");
+  });
+
+  it('should skip prefix if itemName or action are missing', function() {
+    expect(processErrorCode(null, action, {
+      status: 400
+    })).to.equal("An Error has Occurred");
+
+    expect(processErrorCode(itemName, null, {
+      status: 400
+    })).to.equal("An Error has Occurred");
+
+    expect(processErrorCode(null, null, {
+      status: 400
+    })).to.equal("An Error has Occurred");
+  });
+
   it("should attempt to internationalize Storage errors", function() {
     expect(processErrorCode(itemName, action, {
       result: { error: { message: "i18n-fail" } }

--- a/web/scripts/components/gapi-loader/svc-util.js
+++ b/web/scripts/components/gapi-loader/svc-util.js
@@ -2,26 +2,23 @@
   'use strict';
   angular.module('risevision.common.components.util', [])
 
-    .value('humanReadableError', function (resp) {
-      var message;
-
-      if (!resp) {
-        return 'Unknown Error';
-      } else if (typeof resp === 'string') {
-        return resp;
-      } else if (resp.message) {
-        message = resp.message;
-      } else if (resp.error) {
-        if (resp.error.message) {
-          message = resp.error.message;
-        } else {
-          message = resp.error;
-        }
-      } else {
-        message = resp;
-      }
-      return JSON.stringify(message);
-    })
+    .factory('humanReadableError', ['getError',
+      function (getError) {
+        return function (resp) {
+          if (!resp) {
+            return 'Unknown Error';
+          }
+          
+          var error = getError(resp);
+          var message = error.message || error;
+          
+          if (typeof message === 'string') {
+            return message;
+          } else {
+            return JSON.stringify(message);
+          }
+        };
+      }])
 
     .factory('dateIsInRange', [
 

--- a/web/scripts/components/scrolling-list/svc-process-error-code.js
+++ b/web/scripts/components/scrolling-list/svc-process-error-code.js
@@ -23,10 +23,14 @@ angular.module('risevision.common.components.scrolling-list')
         var actionName = actionsMap[action];
         var error = getError(e);
         var errorString = error.message ? error.message : 'An Error has Occurred';
-        var messagePrefix = $filter('translate')('apps-common.errors.actionFailed', {
-          itemName: itemName,
-          actionName: actionName
-        });
+        var messagePrefix = '';
+        
+        if (itemName && actionName) {
+          messagePrefix = $filter('translate')('apps-common.errors.actionFailed', {
+            itemName: itemName,
+            actionName: actionName
+          }) + ' ';
+        }
 
         // Attempt to internationalize Storage error
         var key = 'storage-client.error.' + (action ? action + '.' : '') + error.message;
@@ -39,11 +43,11 @@ angular.module('risevision.common.components.scrolling-list')
           return errorString;
         } else if (e.status === 400) {
           if (errorString.indexOf('is not editable') >= 0) {
-            return messagePrefix + ' ' + errorString;
+            return messagePrefix + errorString;
           } else if (errorString.indexOf('is required') >= 0) {
-            return messagePrefix + ' ' + errorString;
+            return messagePrefix + errorString;
           } else {
-            return messagePrefix + ' ' + errorString;
+            return messagePrefix + errorString;
           }
         } else if (e.status === 401) {
           return $filter('translate')('apps-common.errors.notAuthenticated', {
@@ -52,22 +56,22 @@ angular.module('risevision.common.components.scrolling-list')
           });
         } else if (e.status === 403) {
           if (errorString.indexOf('User is not allowed access') >= 0) {
-            return messagePrefix + ' ' + $filter('translate')('apps-common.errors.parentCompanyAction');
+            return messagePrefix + $filter('translate')('apps-common.errors.parentCompanyAction');
           } else if (errorString.indexOf('User does not have the necessary rights') >= 0) {
-            return messagePrefix + ' ' + $filter('translate')('apps-common.errors.permissionRequired');
+            return messagePrefix + $filter('translate')('apps-common.errors.permissionRequired');
           } else if (errorString.indexOf('Premium Template requires Purchase') >= 0) {
-            return messagePrefix + ' ' + $filter('translate')('apps-common.errors.premiumTemplate');
+            return messagePrefix + $filter('translate')('apps-common.errors.premiumTemplate');
           } else if (errorString.indexOf('Storage requires active subscription') >= 0) {
-            return messagePrefix + ' ' + $filter('translate')('apps-common.errors.storageSubscription');
+            return messagePrefix + $filter('translate')('apps-common.errors.storageSubscription');
           } else {
-            return messagePrefix + ' ' + errorString;
+            return messagePrefix + errorString;
           }
         } else if (e.status === 404) {
           return $filter('translate')('apps-common.errors.notFound', {
             itemName: itemName
           });
         } else if (e.status === 409) {
-          return messagePrefix + ' ' + errorString;
+          return messagePrefix + errorString;
         } else if (e.status === 500 || e.status === 503) {
           return $filter('translate')('apps-common.errors.serverError', {
             itemName: itemName,

--- a/web/scripts/displays/services/svc-display-factory.js
+++ b/web/scripts/displays/services/svc-display-factory.js
@@ -3,9 +3,9 @@
 angular.module('risevision.displays.services')
   .factory('displayFactory', ['$rootScope', '$q', '$state', '$modal', '$loading', '$log',
     'userState', 'display', 'displayTracker', 'playerLicenseFactory', 'processErrorCode', 'storeService',
-    'humanReadableError', 'plansFactory',
+    'plansFactory',
     function ($rootScope, $q, $state, $modal, $loading, $log, userState, display, displayTracker,
-      playerLicenseFactory, processErrorCode, storeService, humanReadableError, plansFactory) {
+      playerLicenseFactory, processErrorCode, storeService, plansFactory) {
       var factory = {};
       var _displayId;
 
@@ -159,7 +159,7 @@ angular.module('risevision.displays.services')
           })
           .catch(function (e) {
             factory.errorMessage = 'We couldn\'t update your address.';
-            factory.apiError = humanReadableError(e);
+            factory.apiError = processErrorCode(null, null, e);
             factory.isAddressError = true;
             $log.error(factory.errorMessage, e);
           })


### PR DESCRIPTION
## Description
Use processErrorCode for address error failure

Improve humanReadableError handler to use
getError and no longer have quotes

[stage-15]

## Motivation and Context
Fixes issue where network errors are not handled properly when validating address
Requires an updated store-server version that returns proper error codes

## How Has This Been Tested?
Tested changes locally with the new version. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No