### PR TITLE
Fix Player Actions alignment & Share Schedule modal being cropped

### DIFF
--- a/test/e2e/schedules/cases/scheduleadd.js
+++ b/test/e2e/schedules/cases/scheduleadd.js
@@ -133,7 +133,7 @@ var ScheduleAddScenarios = function() {
       it('should close Share Schedule modal', function() {
         shareSchedulePopoverPage.getCloseButton().click();
 
-        expect(shareSchedulePopoverPage.getShareSchedulePopover().isDisplayed()).to.eventually.be.false; 
+        expect(shareSchedulePopoverPage.getShareSchedulePopover().isPresent()).to.eventually.be.false; 
       });
     });
 

--- a/test/e2e/schedules/pages/shareSchedulePopoverPage.js
+++ b/test/e2e/schedules/pages/shareSchedulePopoverPage.js
@@ -1,19 +1,19 @@
 'use strict';
 var ShareSchedulePopoverPage = function() {
-  var shareSchedulePopover = element(by.id('shareSchedulePopover'));
+  var shareSchedulePopover = element(by.css('.tooltip.tooltip-share-options'));
 
-  var closeButton = element(by.css("#shareSchedulePopover .close"));
-  var goBackButton = element(by.id("shareSchedulePopoverGoBack"));
+  var closeButton = element(by.css(".tooltip.tooltip-share-options .close"));
+  var goBackButton = element(by.css(".tooltip.tooltip-share-options #shareSchedulePopoverGoBack"));
 
-  var embedCodeTabLink = element(by.id('embedButton'));
-  var chromeExtensionTabLink = element(by.id('extensionButton')); 
+  var embedCodeTabLink = element(by.css('.tooltip.tooltip-share-options #embedButton'));
+  var chromeExtensionTabLink = element(by.css('.tooltip.tooltip-share-options #extensionButton')); 
 
-  var copyLinkButton = element(by.id('copyUrlButton'));
-  var copyEmbedCodeButton = element(by.id('copyEmbedCodeButton'));
+  var copyLinkButton = element(by.css('.tooltip.tooltip-share-options #copyUrlButton'));
+  var copyEmbedCodeButton = element(by.css('.tooltip.tooltip-share-options #copyEmbedCodeButton'));
 
-  var twitterShareButton = element(by.id('twitterShareButton'));
+  var twitterShareButton = element(by.css('.tooltip.tooltip-share-options #twitterShareButton'));
 
-  var chromeExtensionLink = element(by.id('chromeExtensionLink'));
+  var chromeExtensionLink = element(by.css('.tooltip.tooltip-share-options #chromeExtensionLink'));
 
 
   this.getShareSchedulePopover = function() {

--- a/web/partials/displays/display-fields.html
+++ b/web/partials/displays/display-fields.html
@@ -1,11 +1,11 @@
 <div class="madero-style fields-container">
   <div class="row">
 
-    <div class="col-sm-12 col-md-8 pb-2 pb-lg-0">
+    <div class="col-sm-12 col-md-7 pb-2 pb-lg-0">
       <stretchy-input class="mb-0 mr-auto" ng-model="display.name"></stretchy-input> 
     </div>
 
-    <div class="col-sm-12 col-md-4 pl-lg-0">
+    <div class="col-sm-12 col-md-5 pl-lg-0">
       <div class="pull-right">
         <label class="mr-2">Media Player Actions:</label>
         <div class="btn-group" dropdown>
@@ -454,14 +454,13 @@
     </div>
   </div>
 
-  <!-- TODO: Remove madero-style once it's global for the page -->
   <div class="preview-container" ng-show="selectedSchedule">
     <div class="row border-bottom u_padding-20-vertical mx-0 mb-4">
       <div class="col-sm-12 px-0 form-inline">
         <preview-selector ng-model="selectedSchedule" additional-class="mr-auto mb-0"></preview-selector>
 
         <span class="pull-right button-toolbar">
-          <a id="viewSchedule" type="button" class="btn btn-default btn-toolbar" ui-sref="apps.schedules.details({ scheduleId: selectedSchedule.id, cid: selectedSchedule.companyId })">Edit Schedule</a>
+          <a id="viewSchedule" type="button" class="btn btn-default btn-toolbar hidden-md" ui-sref="apps.schedules.details({ scheduleId: selectedSchedule.id, cid: selectedSchedule.companyId })">Edit Schedule</a>
           <ng-show ng-show="tooltipKey">
             <button id="shareButton" type="button" class="btn btn-default btn-toolbar" 
             tooltip-overlay tooltip-template="'partials/schedules/share-schedule-tooltip.html'" tooltip-placement="bottom" tooltip-class="madero-style tooltip-guide tooltip-share-guide">

--- a/web/partials/schedules/share-schedule-button.html
+++ b/web/partials/schedules/share-schedule-button.html
@@ -5,6 +5,7 @@
   tooltip-animation="false"
   tooltip-template="'partials/schedules/share-schedule-popover.html'" 
   tooltip-digest-on-resize
+  tooltip-append-to-body="true"
   ng-click="toggleTooltip()">
   Share
 </button>


### PR DESCRIPTION
## Description

- Append to body to not crop Share Schedule modal
- Fix Player Actions alignment
- Hide Edit Schedule button on md size due to lack of space (to be reverted later, once padding are corrected)

## Motivation and Context
Display Improvements

## How Has This Been Tested?
Visually confirmed locally and on [stage-1].

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
