### PR TITLE
Revert restart time field

### DIFF
--- a/web/partials/displays/display-fields.html
+++ b/web/partials/displays/display-fields.html
@@ -217,7 +217,9 @@
           </div>
         </div>
 
-        <div ng-show="!factory.showLicenseRequired(display) && display.restartEnabled" class="input-group rise-date-picker radio-nested-input-group mt-3">
+        <time-picker ng-model="display.restartTime" ng-show="!factory.showLicenseRequired(display) && display.restartEnabled"></time-picker>
+
+        <!-- <div ng-show="!factory.showLicenseRequired(display) && display.restartEnabled" class="input-group rise-date-picker radio-nested-input-group mt-3">
           <input type="text"
                  class="form-control"
                  readonly="true"
@@ -233,7 +235,7 @@
               <streamline-icon name="clock"></streamline-icon>
             </button>
           </span>
-        </div>
+        </div> -->
       </div>
 
       <div class="list-group-item" ng-if="!playerProFactory.isCROSLegacy(display) && !playerProFactory.isChromeOSPlayer(display)">


### PR DESCRIPTION
## Description
Revert restart time field

[stage-2]

## Motivation and Context
Revert to using the old Time picker.
Temporarily fix the issue with Restart time not being configurable correctly. Will work on a long term fix in a different PR.

## How Has This Been Tested?
Tested changes in the local environment.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No