### PR TITLE
New flow for Licensing and Plan Upgrade

### DIFF
--- a/test/unit/billing/app.tests.js
+++ b/test/unit/billing/app.tests.js
@@ -1,0 +1,84 @@
+'use strict';
+
+describe('app:', function() {
+  var sandbox = sinon.sandbox.create();
+  var $state, canAccessApps, $stateParams, ChargebeeFactory, userState, chargebeeFactoryStub;
+
+  beforeEach(function () {
+    angular.module('risevision.apps.partials',[]);
+
+    module('risevision.apps');
+
+    module(function ($provide) {
+      $provide.service('canAccessApps',function(){
+        return sandbox.stub().returns(Q.resolve());
+      });
+      $provide.service('ChargebeeFactory', function () {
+        return function() {
+          return chargebeeFactoryStub = {
+            openEditSubscription: sandbox.stub()
+          };
+        };
+      });
+      
+      $provide.service('currentPlanFactory', function () {
+        return {
+        };
+      });
+
+      $provide.service('userState', function () {
+        return {
+          _restoreState: sandbox.stub(),
+          getSelectedCompanyId: sandbox.stub().returns('cid')
+        };
+      });
+    });
+
+    inject(function ($injector) {
+      $state = $injector.get('$state');
+      canAccessApps = $injector.get('canAccessApps');
+      $stateParams = $injector.get('$stateParams');
+      ChargebeeFactory = $injector.get('ChargebeeFactory');
+      userState = $injector.get('userState');
+    });
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  describe('state apps.billing.home:',function(){
+
+    it('should register state',function(){
+      var state = $state.get('apps.billing.home');
+      expect(state).to.be.ok;
+      expect(state.url).to.equal('/billing?edit');
+      expect(state.controller).to.be.ok;
+    });
+
+    it('should open Edit Subscription if edit param is provided', function(done) {
+      $stateParams.edit = 'subscriptionId';
+      $state.get('apps.billing.home').resolve.canAccessApps[4](canAccessApps, $stateParams, ChargebeeFactory, userState);
+      setTimeout(function() {
+        canAccessApps.should.have.been.called.once;
+        chargebeeFactoryStub.openEditSubscription.should.have.been.calledWith('cid','subscriptionId');
+
+        done();
+      }, 10);
+    });
+
+    it('should not open Edit Subscription if edit is not present', function(done) {
+      chargebeeFactoryStub.openEditSubscription.resetHistory();
+
+      $state.get('apps.billing.home').resolve.canAccessApps[4](canAccessApps, $stateParams, ChargebeeFactory, userState);
+      setTimeout(function() {
+        canAccessApps.should.have.been.called.once;
+        chargebeeFactoryStub.openEditSubscription.should.not.have.been.called;
+
+        done();
+      }, 10);
+    });
+
+  });
+
+});

--- a/test/unit/common-header/services/svc-chargebee-factory-spec.js
+++ b/test/unit/common-header/services/svc-chargebee-factory-spec.js
@@ -77,7 +77,8 @@ describe("Services: ChargebeeFactory", function() {
             ADDRESS: "ADDRESS",
             BILLING_HISTORY: "BILLING_HISTORY",
             PAYMENT_SOURCES: "PAYMENT_SOURCES",
-            SUBSCRIPTION_DETAILS: "SUBSCRIPTION_DETAILS"
+            SUBSCRIPTION_DETAILS: "SUBSCRIPTION_DETAILS",
+            EDIT_SUBSCRIPTION: "EDIT_SUBSCRIPTION"
           };
         }
       };
@@ -298,6 +299,18 @@ describe("Services: ChargebeeFactory", function() {
       });
     });
 
+    it("should open Edit Subscription section", function(done) {
+      chargebeeFactoryInstance.openEditSubscription("companyId1", "subs1");
+
+      setTimeout(function () {
+        expect(chargebeePortal.open).to.have.been.calledOnce;
+        expect(chargebeePortal.open.getCall(0).args[1].sectionType).to.equal(chargebeeSections.EDIT_SUBSCRIPTION);
+        expect(chargebeePortal.open.getCall(0).args[1].params.subscriptionId).to.equal("subs1");
+        expect(plansFactory.apiError).to.not.be.ok;
+        done();
+      });
+    });
+
     describe("companies with origin=chargebee without Chargebee account", function () {
       beforeEach(function() {
         storeService.createSession.restore(); // Method was already mocked
@@ -362,6 +375,16 @@ describe("Services: ChargebeeFactory", function() {
 
       it("should open Store Account instead of Customer Portal Subscription Details", function(done) {
         chargebeeFactoryInstance.openSubscriptionDetails("companyId1");
+
+        setTimeout(function () {
+          expect(chargebeePortal.open).to.not.have.been.called;
+          expect(plansFactory.showPlansModal).to.have.been.calledOnce;
+          done();
+        });
+      });
+
+      it("should open Store Account instead of Customer Portal Edit Subscription", function(done) {
+        chargebeeFactoryInstance.openEditSubscription("companyId1");
 
         setTimeout(function () {
           expect(chargebeePortal.open).to.not.have.been.called;

--- a/test/unit/components/plans/svc-current-plan-factory-spec.js
+++ b/test/unit/components/plans/svc-current-plan-factory-spec.js
@@ -63,6 +63,7 @@ describe("Services: current plan factory", function() {
       sandbox.stub(userState, "getCopyOfSelectedCompany").returns({
         id: "companyId",
         planProductCode: BASIC_PLAN_CODE,
+        planSubscriptionId: "subscriptionId",
         planSubscriptionStatus: "Subscribed",
         planCurrentPeriodEndDate: "Jan 1, 2018",
         planTrialExpiryDate: "Jan 14, 2018",
@@ -77,6 +78,7 @@ describe("Services: current plan factory", function() {
         expect($rootScope.$emit).to.have.been.called;
         expect(currentPlanFactory.currentPlan).to.be.not.null;
         expect(currentPlanFactory.currentPlan.type).to.equal("basic");
+        expect(currentPlanFactory.currentPlan.subscriptionId).to.equal("subscriptionId");
         expect(currentPlanFactory.currentPlan.status).to.equal("Subscribed");
         expect(currentPlanFactory.currentPlan.currentPeriodEndDate.getTime()).to.equal(new Date("Jan 1, 2018").getTime());
         expect(currentPlanFactory.currentPlan.trialExpiryDate.getTime()).to.equal(new Date("Jan 14, 2018").getTime());
@@ -98,6 +100,7 @@ describe("Services: current plan factory", function() {
         playerProAvailableLicenseCount: 1,
         shareCompanyPlan: true,
         parentPlanProductCode: ADVANCED_PLAN_CODE,
+        planSubscriptionId: "subscriptionId",
         parentPlanCompanyName: "parentName",
         parentPlanContactEmail: "administratorEmail"
       });
@@ -109,6 +112,7 @@ describe("Services: current plan factory", function() {
         expect($rootScope.$emit).to.have.been.called;
         expect(currentPlanFactory.currentPlan).to.be.not.null;
         expect(currentPlanFactory.currentPlan.type).to.equal("advanced");
+        expect(currentPlanFactory.currentPlan.subscriptionId).to.equal("subscriptionId");
         expect(currentPlanFactory.currentPlan.status).to.equal("Active");
         expect(currentPlanFactory.currentPlan.playerProTotalLicenseCount).to.equal(3);
         expect(currentPlanFactory.currentPlan.playerProAvailableLicenseCount).to.equal(1);

--- a/test/unit/components/plans/svc-plans-factory-spec.js
+++ b/test/unit/components/plans/svc-plans-factory-spec.js
@@ -29,6 +29,9 @@ describe("Services: plans factory", function() {
     });
     $provide.service("currentPlanFactory", function() {
       return {
+        currentPlan: {
+          subscriptionId: 'subscriptionId'
+        },
         isPlanActive: sinon.stub().returns(true)
       };
     });
@@ -37,10 +40,16 @@ describe("Services: plans factory", function() {
         go: sinon.stub()
       };
     });
+    $provide.factory('confirmModal', function() {
+       return confirmModalStub = sinon.stub().returns(Q.resolve());
+    });
+    $provide.factory('messageBox', function() {
+       return messageBoxStub = sinon.stub();
+    });
   }));
 
-  var sandbox, $modal, userState, plansFactory, analyticsFactory, currentPlanFactory, $state;
-  var VOLUME_PLAN;
+  var sandbox, $modal, userState, plansFactory, analyticsFactory, currentPlanFactory, $state,
+    confirmModalStub, messageBoxStub, VOLUME_PLAN;
 
   beforeEach(function() {
     sandbox = sinon.sandbox.create();
@@ -101,18 +110,34 @@ describe("Services: plans factory", function() {
   });
   
   describe("showPurchaseOptions: ", function() {
-    it('should go to billing page on confimation if company has a plan', function(done) {
+    it('should go to billing page/edit subscription if company has a plan and manages it', function(done) {
       plansFactory.showPurchaseOptions();
 
       setTimeout(function(){
-        expect($modal.open).to.not.have.been.called;
+        expect($state.go).to.have.been.calledWith('apps.billing.home', {edit: 'subscriptionId'});
 
-        expect($state.go).to.have.been.calledWith('apps.billing.home');
+        expect(messageBoxStub).to.not.have.been.called;
         done();
       },10);
     });
 
-    it('should open Plans Modal on confimation', function(done) {
+    it('should show a message if company has a plan but it is managed by a parent company', function(done) {
+      currentPlanFactory.currentPlan.isPurchasedByParent = true
+      plansFactory.showPurchaseOptions();
+
+      setTimeout(function(){
+        expect(messageBoxStub).to.have.been.calledWith(
+          'You can\'t edit your current plan.',
+          'Your plan is managed by your parent company. Please contact your account administrator for additional licenses.',
+          'Ok', 'madero-style centered-modal', 'partials/template-editor/message-box.html', 'sm'
+        );
+
+        expect($state.go).to.not.have.been.called;
+        done();
+      },10);
+    });
+
+    it('should open Plans Modal if company does not have a plan', function(done) {
       currentPlanFactory.isPlanActive.returns(false);
 
       plansFactory.showPurchaseOptions();
@@ -120,6 +145,40 @@ describe("Services: plans factory", function() {
       setTimeout(function(){
         expect($modal.open).to.have.been.called;
         expect($modal.open).to.have.been.calledWithMatch({controller: 'PlansModalCtrl'});
+
+        done();
+      },10);
+    });
+  });
+
+  describe("confirmAndPurchase:", function(){
+    it("should show confirmation message and proceed to purchase on confirmation", function(done) {
+      sinon.spy(plansFactory, "showPurchaseOptions");
+
+      plansFactory.confirmAndPurchase();
+
+      setTimeout(function() {        
+        expect(confirmModalStub).to.have.been.calledWith(
+          'Almost there!',
+          'There aren\'t any available licenses to assign. Subscribe to additional licenses?',
+          'Yes', 'No', 'madero-style centered-modal',
+          'partials/components/confirm-modal/madero-confirm-modal.html', 'sm'
+        );
+        expect(plansFactory.showPurchaseOptions).to.have.been.called;
+
+        done();
+      },10);
+    });
+
+    it("should not proceed to purchase if dismissed", function(done) {
+      confirmModalStub.returns(Q.reject());
+      sinon.spy(plansFactory, "showPurchaseOptions");
+
+      plansFactory.confirmAndPurchase();
+
+      setTimeout(function() {        
+        expect(confirmModalStub).to.have.been.called;
+        expect(plansFactory.showPurchaseOptions).to.not.have.been.called;
 
         done();
       },10);

--- a/test/unit/components/plans/svc-plans-factory-spec.js
+++ b/test/unit/components/plans/svc-plans-factory-spec.js
@@ -200,47 +200,4 @@ describe("Services: plans factory", function() {
     });
   });
 
-  describe("showLicenseRequiredToUpdateModal:", function() {
-    beforeEach(function() {
-      sinon.stub(plansFactory, 'showPurchaseOptions');
-    });
-
-    it('should open License Required To Update Modal', function(){
-      plansFactory.showLicenseRequiredToUpdateModal();
-
-      expect($modal.open).to.have.been.calledOnce;
-      expect($modal.open).to.have.been.calledWithMatch({
-        templateUrl: 'partials/components/confirm-modal/madero-confirm-modal.html',
-        controller: "confirmModalController",
-        windowClass: 'madero-style centered-modal'
-      });
-      expect($modal.open.getCall(0).args[0].resolve.confirmationTitle()).to.equal('Missing Display License');
-      expect($modal.open.getCall(0).args[0].resolve.confirmationMessage()).to.equal('A Display License is required to automatically update your Display. Please restart it to apply the latest changes.');
-    });
-
-    it('should show purchase options on confimation', function(done) {
-      $modal.open.returns({result: Q.resolve()});
-
-      plansFactory.showLicenseRequiredToUpdateModal();
-
-      setTimeout(function() {
-        plansFactory.showPurchaseOptions.should.have.been.called;
-
-        done();
-      }, 10);
-    });
-
-    it('should not show purchase options if dismissed', function(done) {
-      $modal.open.returns({result: Q.reject()});
-
-      plansFactory.showLicenseRequiredToUpdateModal();
-
-      setTimeout(function() {
-        plansFactory.showPurchaseOptions.should.not.have.been.called;
-
-        done();
-      }, 10);
-    });
-  });
-
 });

--- a/test/unit/displays/controllers/ctr-display-details.tests.js
+++ b/test/unit/displays/controllers/ctr-display-details.tests.js
@@ -99,7 +99,7 @@ describe('controller: display details', function() {
     });
     $provide.factory('plansFactory', function() {
       return {
-        showPlansModal: sinon.spy()
+        confirmAndPurchase: sinon.spy()
       };
     });
     $provide.factory('currentPlanFactory', function() {
@@ -329,24 +329,12 @@ describe('controller: display details', function() {
   });
 
   describe('toggleProAuthorized', function () {
-    it('should show the plans modal', function () {
+    it('should prompt to subscribe if no licenses are available', function () {
       $scope.display = {};
       sandbox.stub($scope, 'isProAvailable').returns(false);
 
       $scope.toggleProAuthorized();
-      expect(plansFactory.showPlansModal).to.have.been.called;
-      expect(enableCompanyProduct).to.not.have.been.called;
-    });
-
-    it('should forward to billing if has a plan but no available licenses', function () {
-      $scope.display = {};
-      sandbox.stub($scope, 'isProAvailable').returns(false);
-      sandbox.stub($scope, 'getProLicenseCount').returns(1);
-      sandbox.stub($scope, 'areAllProLicensesUsed').returns(true);
-
-      $scope.toggleProAuthorized();      
-      expect($state.go).to.have.been.calledWith('apps.billing.home');
-      expect(plansFactory.showPlansModal).to.not.have.been.called;
+      expect(plansFactory.confirmAndPurchase).to.have.been.called;
       expect(enableCompanyProduct).to.not.have.been.called;
     });
 
@@ -373,7 +361,7 @@ describe('controller: display details', function() {
           expect($scope.display.playerProAuthorized).to.be.true;
 
           expect(playerLicenseFactory.toggleDisplayLicenseLocal).to.have.been.calledWith(true);
-          expect(plansFactory.showPlansModal).to.have.not.been.called;
+          expect(plansFactory.confirmAndPurchase).to.have.not.been.called;
           done();        
         }, 0);
       }, 0);
@@ -402,7 +390,7 @@ describe('controller: display details', function() {
           expect($scope.display.playerProAuthorized).to.be.false;
 
           expect(playerLicenseFactory.toggleDisplayLicenseLocal).to.have.been.calledWith(true);
-          expect(plansFactory.showPlansModal).to.have.not.been.called;
+          expect(plansFactory.confirmAndPurchase).to.have.not.been.called;
           done();        
         }, 0);
       }, 0);
@@ -434,7 +422,7 @@ describe('controller: display details', function() {
           expect($scope.display.playerProAuthorized).to.be.false;
 
           expect(playerLicenseFactory.toggleDisplayLicenseLocal).to.have.been.calledWith(false);
-          expect(plansFactory.showPlansModal).to.have.not.been.called;
+          expect(plansFactory.confirmAndPurchase).to.have.not.been.called;
           done();
         }, 0);
       }, 0);
@@ -462,7 +450,7 @@ describe('controller: display details', function() {
           expect($scope.display.playerProAuthorized).to.be.true;
 
           expect(userState.updateCompanySettings).to.not.have.been.called;
-          expect(plansFactory.showPlansModal).to.have.not.been.called;
+          expect(plansFactory.confirmAndPurchase).to.have.not.been.called;
           done();
         }, 0);
       });

--- a/web/partials/schedules/schedule-fields.html
+++ b/web/partials/schedules/schedule-fields.html
@@ -24,7 +24,7 @@ recurrence-days-of-week = "factory.schedule.recurrenceDaysOfWeek"
 
 <distribution-selector distribution="factory.schedule.distribution" distribute-to-all="factory.schedule.distributeToAll" distribution-style="madero"></distribution-selector>
 <div class="danger mt-2" ng-show="freeDisplays.length">
-  You selected {{freeDisplays.length}} unlicensed display{{freeDisplays.length > 1 ? 's' : ''}} that won’t show your content. <a href="#" class="madero-link" ng-click="plansFactory.showPurchaseOptions()">License {{freeDisplays.length > 1 ? 'them' : 'it'}}?</a>
+  You selected {{freeDisplays.length}} unlicensed display{{freeDisplays.length > 1 ? 's' : ''}} that won’t show your content. <a href="#" class="madero-link" ng-click="plansFactory.confirmAndPurchase()">License {{freeDisplays.length > 1 ? 'them' : 'it'}}?</a>
 </div>
 
 <div class="schedule-fields-body fields-preview-panels mt-4">

--- a/web/partials/template-editor/message-box.html
+++ b/web/partials/template-editor/message-box.html
@@ -6,7 +6,7 @@
   </div>
   <div class="modal-body" stop-event="touchend">
     <h4 translate>{{title}}</h4>
-    <p translate>{{message}}</p>
+    <p class="text-left" translate>{{message}}</p>
   </div>
   <div class="modal-footer">
     <div class="row">

--- a/web/scripts/billing/app.js
+++ b/web/scripts/billing/app.js
@@ -25,7 +25,7 @@ angular.module('risevision.apps')
               function (canAccessApps, $stateParams, ChargebeeFactory, userState) {
                 return canAccessApps().then(function () {
                   if ($stateParams.edit) {
-                    new ChargebeeFactory().openSubscriptionEdit(userState.getSelectedCompanyId(), $stateParams.edit);
+                    new ChargebeeFactory().openEditSubscription(userState.getSelectedCompanyId(), $stateParams.edit);
                   }
                 });
               }

--- a/web/scripts/billing/app.js
+++ b/web/scripts/billing/app.js
@@ -14,16 +14,20 @@ angular.module('risevision.apps')
         })
 
         .state('apps.billing.home', {
-          url: '/billing',
+          url: '/billing?edit',
           templateProvider: ['$templateCache', function ($templateCache) {
             return $templateCache.get(
               'partials/billing/app-billing.html');
           }],
           controller: 'BillingCtrl',
           resolve: {
-            canAccessApps: ['canAccessApps',
-              function (canAccessApps) {
-                return canAccessApps();
+            canAccessApps: ['canAccessApps', '$stateParams', 'ChargebeeFactory', 'userState',
+              function (canAccessApps, $stateParams, ChargebeeFactory, userState) {
+                return canAccessApps().then(function () {
+                  if ($stateParams.edit) {
+                    new ChargebeeFactory().openSubscriptionEdit(userState.getSelectedCompanyId(), $stateParams.edit);
+                  }
+                });
               }
             ]
           }

--- a/web/scripts/common-header/services/svc-chargebee-factory.js
+++ b/web/scripts/common-header/services/svc-chargebee-factory.js
@@ -185,11 +185,19 @@ angular.module('risevision.store.services')
             });
         };
 
+        factory.openSubscriptionEdit = function (companyId, subscriptionId) {
+          _openSubscriptionSection(companyId, subscriptionId, 'EDIT_SUBSCRIPTION');
+        };
+
         factory.openSubscriptionDetails = function (companyId, subscriptionId) {
+          _openSubscriptionSection(companyId, subscriptionId, 'SUBSCRIPTION_DETAILS');
+        };
+
+        var _openSubscriptionSection = function (companyId, subscriptionId, section) {
           _getChargebeePortal(companyId)
             .then(function (portal) {
               portal.open(_chargebeeCallbacks, {
-                sectionType: $window.Chargebee.getPortalSections().SUBSCRIPTION_DETAILS,
+                sectionType: $window.Chargebee.getPortalSections()[section],
                 params: {
                   subscriptionId: subscriptionId
                 }

--- a/web/scripts/common-header/services/svc-chargebee-factory.js
+++ b/web/scripts/common-header/services/svc-chargebee-factory.js
@@ -185,7 +185,7 @@ angular.module('risevision.store.services')
             });
         };
 
-        factory.openSubscriptionEdit = function (companyId, subscriptionId) {
+        factory.openEditSubscription = function (companyId, subscriptionId) {
           _openSubscriptionSection(companyId, subscriptionId, 'EDIT_SUBSCRIPTION');
         };
 

--- a/web/scripts/components/plans/app.js
+++ b/web/scripts/components/plans/app.js
@@ -15,6 +15,8 @@
 
   angular.module('risevision.common.components.plans', [
     'risevision.common.config',
+    'risevision.common.components.confirm-modal',
+    'risevision.common.components.message-box',
     'risevision.common.components.plans.services',
     'risevision.common.components.purchase-flow',
     'risevision.common.components.scrolling-list',

--- a/web/scripts/components/plans/svc-current-plan-factory.js
+++ b/web/scripts/components/plans/svc-current-plan-factory.js
@@ -31,6 +31,7 @@
 
           _factory.currentPlan = plan;
 
+          plan.subscriptionId = company.planSubscriptionId;
           plan.playerProTotalLicenseCount = company.playerProTotalLicenseCount;
           plan.playerProAvailableLicenseCount = company.playerProAvailableLicenseCount;
 

--- a/web/scripts/components/plans/svc-plans-factory.js
+++ b/web/scripts/components/plans/svc-plans-factory.js
@@ -160,8 +160,8 @@
       proLicenseCount: 0
     }])
     .factory('plansFactory', ['$modal', '$templateCache', 'userState', 'PLANS_LIST', 'analyticsFactory',
-      'currentPlanFactory', '$state',
-      function ($modal, $templateCache, userState, PLANS_LIST, analyticsFactory, currentPlanFactory, $state) {
+      'currentPlanFactory', '$state', 'confirmModal', 'messageBox',
+      function ($modal, $templateCache, userState, PLANS_LIST, analyticsFactory, currentPlanFactory, $state, confirmModal, messageBox) {
         var _factory = {};
 
         _factory.showPlansModal = function () {
@@ -180,9 +180,27 @@
           }
         };
 
+        _factory.confirmAndPurchase = function() {
+          confirmModal( 'Almost there!',
+            'There aren\'t any available licenses to assign. Subscribe to additional licenses?',
+            'Yes', 'No', 'madero-style centered-modal',
+            'partials/components/confirm-modal/madero-confirm-modal.html', 'sm')
+          .then(function() {
+            _factory.showPurchaseOptions();
+          });
+        }
+
         _factory.showPurchaseOptions = function () {
           if (currentPlanFactory.isPlanActive()) {
-            $state.go('apps.billing.home');
+            if (currentPlanFactory.currentPlan.isPurchasedByParent) {
+              messageBox(
+                'You can\'t edit your current plan.',
+                'Your plan is managed by your parent company. Please contact your account administrator for additional licenses.',
+                'Ok', 'madero-style centered-modal', 'partials/template-editor/message-box.html', 'sm'
+              );
+            } else {
+              $state.go('apps.billing.home',{edit: currentPlanFactory.currentPlan.subscriptionId});
+            }
           } else {
             _factory.showPlansModal();
           }

--- a/web/scripts/components/plans/svc-plans-factory.js
+++ b/web/scripts/components/plans/svc-plans-factory.js
@@ -226,30 +226,6 @@
           });
         };
 
-        _factory.showLicenseRequiredToUpdateModal = function () {
-          $modal.open({
-            templateUrl: 'partials/components/confirm-modal/madero-confirm-modal.html',
-            controller: 'confirmModalController',
-            windowClass: 'madero-style centered-modal',
-            resolve: {
-              confirmationTitle: function () {
-                return 'Missing Display License';
-              },
-              confirmationMessage: function () {
-                return 'A Display License is required to automatically update your Display. Please restart it to apply the latest changes.';
-              },
-              confirmationButton: function () {
-                return 'Buy a License';
-              },
-              cancelButton: function () {
-                return 'Okay';
-              }
-            }
-          }).result.then(function () {
-            _factory.showPurchaseOptions();
-          });
-        };
-
         _factory.initVolumePlanTrial = function () {
           var plan = _.find(PLANS_LIST, {
             type: 'volume'

--- a/web/scripts/components/plans/svc-plans-factory.js
+++ b/web/scripts/components/plans/svc-plans-factory.js
@@ -188,7 +188,7 @@
           .then(function() {
             _factory.showPurchaseOptions();
           });
-        }
+        };
 
         _factory.showPurchaseOptions = function () {
           if (currentPlanFactory.isPlanActive()) {

--- a/web/scripts/displays/controllers/ctr-display-details.js
+++ b/web/scripts/displays/controllers/ctr-display-details.js
@@ -76,11 +76,7 @@ angular.module('risevision.displays.controllers')
 
         if (!$scope.isProAvailable()) {
           $scope.display.playerProAuthorized = false;
-          if ($scope.getProLicenseCount() > 0 && $scope.areAllProLicensesUsed()) {
-            $state.go('apps.billing.home');
-          } else {
-            plansFactory.showPlansModal();
-          }
+          plansFactory.confirmAndPurchase();
         } else {
           var apiParams = {};
           var playerProAuthorized = !$scope.display.playerProAuthorized;

--- a/web/scripts/displays/controllers/ctr-display-details.js
+++ b/web/scripts/displays/controllers/ctr-display-details.js
@@ -18,7 +18,6 @@ angular.module('risevision.displays.controllers')
       $scope.playerActionsFactory = playerActionsFactory;
       $scope.updatingRPP = false;
       $scope.monitoringSchedule = {};
-      $scope.showPlansModal = plansFactory.showPlansModal;
       $scope.selectedSchedule = null;
       $scope.scheduleFactory = scheduleFactory;
 


### PR DESCRIPTION
## Description
New flow for Licensing and Plan Upgrade:
- If it has enough licenses -> use it
- If it doesn't have enough licenses: 
  - If it doesn't have a plan -> open Plans Modal
  - If has a plan & owns it -> open Edit Subscription section in Customer Portal
  - If has a plan but plan is managed by parent company -> show contact Parent modal

## Motivation and Context
Display Improvements epic.

## How Has This Been Tested?
Locally and on stage-1.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
