### PR TITLE
Remove scope inheritance for display object

### DIFF
--- a/test/unit/displays/directives/dtv-display-email.tests.js
+++ b/test/unit/displays/directives/dtv-display-email.tests.js
@@ -23,6 +23,14 @@ describe('directive: display email', function() {
       }
     });
 
+    $provide.service('displayFactory', function() {
+      return {
+        display: {
+          id: 'ID'
+        }
+      };
+    });
+
     $provide.service('processErrorCode', function() {
       return function(error) {
         return 'processed ' + error;
@@ -44,7 +52,6 @@ describe('directive: display email', function() {
     
     $scope = elm.scope();
 
-    $scope.display = {};
     $scope.emailForm = {
       $setPristine: sinon.spy()
     };
@@ -52,7 +59,6 @@ describe('directive: display email', function() {
 
   it('should compile html', function() {
     expect(elm.html()).to.equal('<p></p>');
-    expect($scope.display).to.be.ok;
     expect($scope.sendEmail).to.be.a('function');
   });
 
@@ -103,7 +109,6 @@ describe('directive: display email', function() {
     });
 
     it('should send instructions to another email address',function(done){
-      $scope.display.id = 'ID';
       $scope.email = 'another@email.com';
       $scope.emailInvalid = false;
 

--- a/web/index.html
+++ b/web/index.html
@@ -340,6 +340,7 @@
   <script src="scripts/common/directives/dtv-tooltip-digest-on-resize.js"></script>
   <script src="scripts/common/directives/dtv-tooltip-overlay.js"></script>
   <script src="scripts/common/directives/dtv-stretchy-input.js"></script>
+  <script src="scripts/common/directives/dtv-yes-no-toggle.js"></script>
 
   <script src="scripts/common/services/svc-cached-request.js"></script>
   <script src="scripts/common/services/svc-gadgets-api.js"></script>
@@ -411,6 +412,7 @@
   <script src="scripts/displays/directives/dtv-name-your-display.js"></script>
   <script src="scripts/displays/directives/dtv-display-email.js"></script>
   <script src="scripts/displays/directives/dtv-display-fields.js"></script>
+  <script src="scripts/displays/directives/dtv-display-address.js"></script>
   <script src="scripts/displays/directives/dtv-select-on-focus.js"></script>
   <script src="scripts/displays/directives/dtv-screenshot.js"></script>
   <script src="scripts/displays/directives/dtv-time-picker.js"></script>

--- a/web/partials/common/yes-no-toggle.html
+++ b/web/partials/common/yes-no-toggle.html
@@ -1,5 +1,5 @@
 <div class="btn-group-checkbox">
-  <input type="checkbox" id="{{buttonId}}" name="{{buttonId}}" ng-model="ngModel" ng-click="ngClick()" ng-disabled="ngDisabled">
+  <input type="checkbox" id="{{buttonId}}" name="{{buttonId}}" ng-model="ngModel" ng-change="onChange()" ng-disabled="ngDisabled">
 
   <div class="btn-group btn-group-justified">
     <button type="button" class="btn" ng-disabled="ngDisabled"

--- a/web/partials/common/yes-no-toggle.html
+++ b/web/partials/common/yes-no-toggle.html
@@ -1,0 +1,16 @@
+<div class="btn-group-checkbox">
+  <input type="checkbox" id="{{buttonId}}" name="{{buttonId}}" ng-model="ngModel" ng-click="ngClick()" ng-disabled="ngDisabled">
+
+  <div class="btn-group btn-group-justified">
+    <button type="button" class="btn" ng-disabled="ngDisabled"
+      ng-class="{'btn-toggle-blue-off' : !ngModel, 'btn-toggle-blue-on' : ngModel}">
+      Yes
+      <streamline-icon name="checkmark" ng-show="ngModel"></streamline-icon>
+    </button>
+    <button type="button" class="btn" ng-disabled="ngDisabled"
+      ng-class="{'btn-toggle-blue-off' : ngModel, 'btn-toggle-blue-on' : !ngModel}">
+      No
+      <streamline-icon name="checkmark" ng-show="!ngModel"></streamline-icon>
+    </button>
+  </div>
+</div>

--- a/web/partials/displays/display-address.html
+++ b/web/partials/displays/display-address.html
@@ -1,0 +1,67 @@
+<div ng-hide="factory.display.useCompanyAddress" class="list-group-item address-fields">
+  <div class="form-group">
+    <label class="control-label" translate>displays-app.fields.address.description</label>
+    <input type="text" class="form-control" ng-model="factory.display.addressDescription">
+  </div>
+
+  <div class="row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <label class="control-label" translate>displays-app.fields.address.street</label>
+        <input type="text" class="form-control" ng-model="factory.display.street" name="street">
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="form-group">
+        <label class="control-label" translate>displays-app.fields.address.unit</label>
+        <input type="text" class="form-control" ng-model="factory.display.unit" name="unit">
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <label class="control-label" translate>displays-app.fields.address.city</label>
+        <input type="text" class="form-control" ng-model="factory.display.city" name="city">
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="form-group">
+        <label class="control-label" translate>displays-app.fields.address.country.name</label>
+        <select class="form-control" ng-model="factory.display.country" name="country" ng-options="c.code as c.name for c in countries" empty-select-parser>
+          <option value="" ng-show="false" translate>displays-app.fields.address.country.placeholder</option>
+        </select>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <label class="control-label" translate>displays-app.fields.address.province.name</label>
+        <input type="text" class="form-control" ng-model="factory.display.province" name="province" ng-if="factory.display.country != 'US' && factory.display.country != 'CA'" />
+        <select class="form-control selectpicker" ng-model="factory.display.province" name="province" ng-options="c[1] as c[0] for c in regionsCA" ng-if="factory.display.country == 'CA'" empty-select-parser>
+          <option value="" ng-show="false" translate>displays-app.fields.address.province.provincePlaceholder</option>
+        </select>
+        <select class="form-control selectpicker" ng-model="factory.display.province" name="province" ng-options="c[1] as c[0] for c in regionsUS" ng-if="factory.display.country == 'US'" empty-select-parser>
+          <option value="" ng-show="false" translate>displays-app.fields.address.province.statePlaceholder</option>
+        </select>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="form-group">
+        <label class="control-label" translate>displays-app.fields.address.postalCode</label>
+        <input type="text" class="form-control" ng-model="factory.display.postalCode" name="postalCode">
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group mb-0">
+    <label class="control-label" translate>displays-app.fields.address.timezone.name</label>
+    <select class="form-control" ng-model="factory.display.timeZoneOffset" integer-parser>
+      <option value="" ng-show="false" translate>displays-app.fields.address.timezone.placeholder</option>
+      <option value="{{c[1]}}" ng-repeat="c in timezones">{{c[0]}}</option>
+    </select>
+  </div>
+
+</div><!--display address-->

--- a/web/partials/displays/display-details-license-required.html
+++ b/web/partials/displays/display-details-license-required.html
@@ -1,4 +1,4 @@
-<span class="mr-auto" ng-if="factory.showLicenseRequired(display)">
+<span class="mr-auto" ng-if="factory.showLicenseRequired()">
 	<a href="" ng-click="confirmLicensing()" ng-show="userState.hasRole('da')">License Required</a>
 	<span ng-show="!userState.hasRole('da')">License Required</span>
 </span>

--- a/web/partials/displays/display-details.html
+++ b/web/partials/displays/display-details.html
@@ -30,12 +30,12 @@
       </div>
 
       <div class="button-row text-right mt-5">
-        <p class="visible-sm visible-xs text-right"><last-modified change-date="display.changeDate" changed-by="display.changedBy"></last-modified></p>
+        <p class="visible-sm visible-xs text-right"><last-modified change-date="factory.display.changeDate" changed-by="factory.display.changedBy"></last-modified></p>
         <!-- Indicates delete or destructive action -->
         <button id="deleteButton" type="button" class="btn btn-danger btn-toolbar pull-left" ng-click="confirmDelete()" require-role="da">
           Delete Display
         </button>
-        <span class="hidden-sm hidden-xs u_margin-right"><last-modified change-date="display.changeDate" changed-by="display.changedBy"></last-modified></span>
+        <span class="hidden-sm hidden-xs u_margin-right"><last-modified change-date="factory.display.changeDate" changed-by="factory.display.changedBy"></last-modified></span>
         <!-- Indicates cancel or non-destructive action -->
         <button id="cancelButton" type="button" ui-sref="apps.displays.list" class="btn btn-default btn-toolbar mr-2">
           {{'common.cancel' | translate}}

--- a/web/partials/displays/display-fields.html
+++ b/web/partials/displays/display-fields.html
@@ -93,7 +93,7 @@
               <span translate>displays-app.details.rpp-loading</span> <i class="fa fa-spinner fa-spin fa-fw"></i>
             </span>
 
-            <yes-no-toggle ng-model="factory.display.playerProAuthorized" ng-click="toggleProAuthorized" ng-disabled="updatingRPP || !playerLicenseFactory.isProToggleEnabled()" ng-hide="updatingRPP"></yes-no-toggle>
+            <yes-no-toggle ng-model="factory.display.playerProAuthorized" ng-change="toggleProAuthorized()" ng-disabled="updatingRPP || !playerLicenseFactory.isProToggleEnabled()" ng-hide="updatingRPP"></yes-no-toggle>
           </div>
         </div>
         <div class="text-danger mt-2" ng-show="errorUpdatingRPP">

--- a/web/partials/displays/display-fields.html
+++ b/web/partials/displays/display-fields.html
@@ -2,7 +2,7 @@
   <div class="row">
 
     <div class="col-sm-12 col-md-7 pb-2 pb-lg-0">
-      <stretchy-input class="mb-0 mr-auto" ng-model="display.name"></stretchy-input> 
+      <stretchy-input class="mb-0 mr-auto" ng-model="factory.display.name"></stretchy-input> 
     </div>
 
     <div class="col-sm-12 col-md-5 pl-lg-0">
@@ -18,12 +18,12 @@
           <div class="dropdown-menu playlist-menu" role="menu">
             <ul>
               <li>
-                <button type="button" class="btn-dropdown u_clickable" ng-hide="!displayService.statusLoading && (display | status) === 'notinstalled'" ng-disabled="!display.playerVersion" ng-click="playerActionsFactory.confirm(display.id, display.name, 'restart')" require-role="da">
+                <button type="button" class="btn-dropdown u_clickable" ng-hide="!displayService.statusLoading && (factory.display | status) === 'notinstalled'" ng-disabled="!factory.display.playerVersion" ng-click="playerActionsFactory.confirm(factory.display.id, factory.display.name, 'restart')" require-role="da">
                   <span translate>displays-app.fields.controls.restart.name</span>
                 </button>
               </li>
               <li>
-                <button type="button" class="btn-dropdown u_clickable" ng-hide="!displayService.statusLoading && (display | status) === 'notinstalled'" ng-disabled="!display.playerVersion || !canReboot(display)" ng-click="playerActionsFactory.confirm(display.id, display.name, 'reboot')" require-role="da">
+                <button type="button" class="btn-dropdown u_clickable" ng-hide="!displayService.statusLoading && (factory.display | status) === 'notinstalled'" ng-disabled="!factory.display.playerVersion || !canReboot(factory.display)" ng-click="playerActionsFactory.confirm(factory.display.id, factory.display.name, 'reboot')" require-role="da">
                   <span translate>displays-app.fields.controls.reboot.name</span>
                 </button>
               </li>
@@ -52,7 +52,7 @@
   <strong>{{playerActionsFactory.controlsError}}</strong>
 </div> 
 
-<div class="border-container text-center u_margin-md-top" ng-show="!factory.loadingDisplay && display.id && !displayService.statusLoading && (display | status) === 'notinstalled'">
+<div class="border-container text-center u_margin-md-top" ng-show="!factory.loadingDisplay && factory.display.id && !displayService.statusLoading && (factory.display | status) === 'notinstalled'">
   <div class="panel-body display-instructions-panel">
 
     <div class="form-group my-2">
@@ -68,7 +68,7 @@
         Install Rise Player On Your Media Player
       </button>
     </div>
-    <p>On startup of your media player enter this ID <strong>{{display.id}}</strong> to activate your display.</p>
+    <p>On startup of your media player enter this ID <strong>{{factory.display.id}}</strong> to activate your display.</p>
 
     <display-email></display-email>
   </div>
@@ -93,18 +93,7 @@
               <span translate>displays-app.details.rpp-loading</span> <i class="fa fa-spinner fa-spin fa-fw"></i>
             </span>
 
-            <div class="btn-group btn-group-justified" ng-hide="updatingRPP">
-              <button id="toggleLicenseOn" type="button" class="btn" ng-click="toggleProAuthorized()"  ng-disabled="updatingRPP || !playerLicenseFactory.isProToggleEnabled()"
-                ng-class="{'btn-toggle-blue-off' : !display.playerProAuthorized, 'btn-toggle-blue-on' : display.playerProAuthorized}">
-                Yes
-                <streamline-icon name="checkmark" ng-show="display.playerProAuthorized"></streamline-icon>
-              </button>
-              <button id="toggleLicenseOff" type="button" class="btn" ng-click="toggleProAuthorized()" ng-disabled="updatingRPP || !playerLicenseFactory.isProToggleEnabled()"
-                ng-class="{'btn-toggle-blue-off' : display.playerProAuthorized, 'btn-toggle-blue-on' : !display.playerProAuthorized}">
-                No
-                <streamline-icon name="checkmark" ng-show="!display.playerProAuthorized"></streamline-icon>
-              </button>
-            </div>
+            <yes-no-toggle ng-model="factory.display.playerProAuthorized" ng-click="toggleProAuthorized" ng-disabled="updatingRPP || !playerLicenseFactory.isProToggleEnabled()" ng-hide="updatingRPP"></yes-no-toggle>
           </div>
         </div>
         <div class="text-danger mt-2" ng-show="errorUpdatingRPP">
@@ -116,7 +105,7 @@
         <div class="row-entry">
           <label class="control-label pull-left mb-0" translate>displays-app.fields.player.id</label>
           <span class="mr-auto">
-            {{display.id}}
+            {{factory.display.id}}
           </span>
         </div>
       </div>
@@ -125,7 +114,7 @@
         <div class="row-entry">
           <label class="control-label pull-left mb-0" translate>displays-app.fields.player.resolution</label>
           <span class="mr-auto">
-            <span ng-show="display.playerVersion">{{display.width | resolution: display.height}}</span>
+            <span ng-show="factory.display.playerVersion">{{factory.display.width | resolution: factory.display.height}}</span>
           </span>
         </div>
       </div>
@@ -134,8 +123,8 @@
         <div class="row-entry">
           <label class="control-label pull-left mb-0" translate>displays-app.fields.player.lastConnection</label>
           <ng-include src="'partials/displays/display-details-license-required.html'"></ng-include>
-          <span class="mr-auto" ng-if="!factory.showLicenseRequired(display)">
-            {{display.lastConnectionTime | date:'d-MMM-yyyy h:mm a'}}
+          <span class="mr-auto" ng-if="!factory.showLicenseRequired()">
+            {{factory.display.lastConnectionTime | date:'d-MMM-yyyy h:mm a'}}
           </span>
         </div>
       </div>
@@ -143,14 +132,14 @@
       <!-- SCREENSHOT  -->
       <screenshot></screenshot>
 
-      <div class="list-group-item flex-row form-group mb-0" ng-hide="!displayService.statusLoading && (display | status) === 'notinstalled'">
+      <div class="list-group-item flex-row form-group mb-0" ng-hide="!displayService.statusLoading && (factory.display | status) === 'notinstalled'">
         <div class="row-entry">
           <label class="control-label pull-left mb-0" translate>displays-app.fields.player.status</label>
           <ng-include src="'partials/displays/display-details-license-required.html'"></ng-include>
-          <span class="mr-auto" ng-if="!factory.showLicenseRequired(display)">
+          <span class="mr-auto" ng-if="!factory.showLicenseRequired()">
             <i ng-if="displayService.statusLoading" class="fa fa-spinner fa-spin fa-fw"></i>
-            <span class="text-danger" ng-show="!displayService.statusLoading && (display | status) === 'offline'">Offline</span>
-            <span class="text-success" ng-show="!displayService.statusLoading && (display | status) === 'online'">Online</span>
+            <span class="text-danger" ng-show="!displayService.statusLoading && (factory.display | status) === 'offline'">Offline</span>
+            <span class="text-success" ng-show="!displayService.statusLoading && (factory.display | status) === 'online'">Online</span>
           </span>
         </div>
       </div>
@@ -160,26 +149,15 @@
           <label class="control-label pull-left mb-0" translate>displays-app.fields.player.rpp.monitoring</label>
           <ng-include src="'partials/displays/display-details-license-required.html'"></ng-include>
 
-          <div class="btn-group btn-group-justified" ng-if="!factory.showLicenseRequired(display)">
-            <button id="monitoringOn" type="button" class="btn" ng-click="display.monitoringEnabled = !display.monitoringEnabled" ng-disabled="factory.showLicenseRequired(display)"
-              ng-class="{'btn-toggle-blue-off' : !display.monitoringEnabled, 'btn-toggle-blue-on' : display.monitoringEnabled}">
-              Yes
-              <streamline-icon name="checkmark" ng-show="display.monitoringEnabled"></streamline-icon>
-            </button>
-            <button id="monitoringOff" type="button" class="btn" ng-click="display.monitoringEnabled = !display.monitoringEnabled" ng-disabled="factory.showLicenseRequired(display)"
-              ng-class="{'btn-toggle-blue-off' : display.monitoringEnabled, 'btn-toggle-blue-on' : !display.monitoringEnabled}">
-              No
-              <streamline-icon name="checkmark" ng-show="!display.monitoringEnabled"></streamline-icon>
-            </button>
-          </div>
+          <yes-no-toggle ng-model="factory.display.monitoringEnabled" ng-disabled="factory.showLicenseRequired()" ng-if="!factory.showLicenseRequired()"></yes-no-toggle>
         </div>
       </div>
 
-      <div class="list-group-item" ng-show="!factory.showLicenseRequired(display) && display.monitoringEnabled">
-        <timeline-basic-textbox timeline-string="display.monitoringSchedule" ng-disabled="!display.monitoringEnabled" />
+      <div class="list-group-item" ng-show="!factory.showLicenseRequired() && factory.display.monitoringEnabled">
+        <timeline-basic-textbox timeline-string="factory.display.monitoringSchedule" ng-disabled="!factory.display.monitoringEnabled" />
       </div>
 
-      <div class="list-group-item" ng-show="!factory.showLicenseRequired(display) && display.monitoringEnabled">
+      <div class="list-group-item" ng-show="!factory.showLicenseRequired() && factory.display.monitoringEnabled">
         <div class="flex-row form-group mb-0">
           <div class="row-entry">
             <label class="control-label pull-left mb-0" translate>displays-app.fields.player.rpp.email-recipients</label>
@@ -187,9 +165,9 @@
           </div>
         </div>
 
-        <div class="mt-2" ng-if="!factory.showLicenseRequired(display)">Separate multiple recipients by a comma.</div>
-        <div class="mt-3" ng-class="{ 'has-error': !displayDetails.monitoringEmails.$valid }" ng-if="!factory.showLicenseRequired(display)">
-          <emails-field name="monitoringEmails" ng-model="display.monitoringEmails"></emails-field>
+        <div class="mt-2" ng-if="!factory.showLicenseRequired()">Separate multiple recipients by a comma.</div>
+        <div class="mt-3" ng-class="{ 'has-error': !displayDetails.monitoringEmails.$valid }" ng-if="!factory.showLicenseRequired()">
+          <emails-field name="monitoringEmails" ng-model="factory.display.monitoringEmails"></emails-field>
           <p class="help-block validation-error-message-email" ng-show="!displayDetails.monitoringEmails.$valid" translate>
             displays-app.fields.player.rpp.invalid-email
           </p>
@@ -202,34 +180,19 @@
             <label class="control-label pull-left mb-0">Reboot Media Player Daily At</label>
             <ng-include src="'partials/displays/display-details-license-required.html'"></ng-include>
 
-            <div class="btn-group-checkbox" ng-if="!factory.showLicenseRequired(display)">
-              <input type="checkbox" id="restartEnabled" name="restartEnabled" ng-model="display.restartEnabled" ng-disabled="factory.showLicenseRequired(display)">
-
-              <div class="btn-group btn-group-justified">
-                <button id="restartOn" type="button" class="btn"
-                  ng-class="{'btn-toggle-blue-off' : !display.restartEnabled, 'btn-toggle-blue-on' : display.restartEnabled}">
-                  Yes
-                  <streamline-icon name="checkmark" ng-show="display.restartEnabled"></streamline-icon>
-                </button>
-                <button id="restartOff" type="button" class="btn"
-                  ng-class="{'btn-toggle-blue-off' : display.restartEnabled, 'btn-toggle-blue-on' : !display.restartEnabled}">
-                  No
-                  <streamline-icon name="checkmark" ng-show="!display.restartEnabled"></streamline-icon>
-                </button>
-              </div>
-            </div>
+            <yes-no-toggle ng-model="factory.display.restartEnabled" ng-disabled="factory.showLicenseRequired()" button-id="restartEnabled" ng-if="!factory.showLicenseRequired()"></yes-no-toggle>
           </div>
         </div>
 
-        <time-picker ng-model="display.restartTime" ng-show="!factory.showLicenseRequired(display) && display.restartEnabled"></time-picker>
+        <time-picker ng-model="factory.display.restartTime" ng-show="!factory.showLicenseRequired() && factory.display.restartEnabled"></time-picker>
 
-        <!-- <div ng-show="!factory.showLicenseRequired(display) && display.restartEnabled" class="input-group rise-date-picker radio-nested-input-group mt-3">
+        <!-- <div ng-show="!factory.showLicenseRequired() && factory.display.restartEnabled" class="input-group rise-date-picker radio-nested-input-group mt-3">
           <input type="text"
                  class="form-control"
                  readonly="true"
                  id="restartTime"
                  name="restartTime"
-                 ng-model="display.restartTime"
+                 ng-model="factory.display.restartTime"
                  ng-click="openTimePicker($event, 'restartTimePickerOpen')"
                  time-picker-popup
                  is-open="restartTimePickerOpen"
@@ -242,32 +205,32 @@
         </div> -->
       </div>
 
-      <div class="list-group-item" ng-if="!playerProFactory.isCROSLegacy(display) && !playerProFactory.isChromeOSPlayer(display)">
+      <div class="list-group-item" ng-if="!playerProFactory.isCROSLegacy(factory.display) && !playerProFactory.isChromeOSPlayer(factory.display)">
         <div class="flex-row form-group mb-0">
           <div class="row-entry">
             <label class="control-label pull-left mb-0" translate>displays-app.fields.player.displayControl.label</label>
             <ng-include src="'partials/displays/display-details-license-required.html'"></ng-include>
 
-            <span class="mr-auto" ng-if="!factory.showLicenseRequired(display)">
-              <a class="madero-link u_clickable" ng-click="configureDisplayControl(display)" require-role="da" translate>
+            <span class="mr-auto" ng-if="!factory.showLicenseRequired()">
+              <a class="madero-link u_clickable" ng-click="configureDisplayControl(factory.display)" require-role="da" translate>
                 Edit
               </a>
             </span>
           </div>
         </div>
 
-        <div class="mt-2" ng-show="!factory.showLicenseRequired(display) && !displayControlError">
+        <div class="mt-2" ng-show="!factory.showLicenseRequired() && !displayControlError">
           <span translate>displays-app.fields.player.displayControl.description</span>
         </div>
-        <div class="text-danger mt-2" ng-show="!factory.showLicenseRequired(display) && displayControlError">
+        <div class="text-danger mt-2" ng-show="!factory.showLicenseRequired() && displayControlError">
           <span translate>displays-app.fields.player.displayControl.unsupported</span>
         </div>
       </div>
 
-      <div class="list-group-item flex-row form-group mb-0" ng-show="(display.playerVersion || display.onlineStatus === 'online') && (playerProFactory.isCROSLegacy(display) || playerProFactory.isChromeOSPlayer(display))">
+      <div class="list-group-item flex-row form-group mb-0" ng-show="(factory.display.playerVersion || factory.display.onlineStatus === 'online') && (playerProFactory.isCROSLegacy(factory.display) || playerProFactory.isChromeOSPlayer(factory.display))">
         <div class="row-entry">
           <label class="control-label pull-left mb-0" translate>displays-app.fields.player.orientation.name</label>
-          <select class="form-control mr-auto w-auto" ng-model="display.orientation" integer-parser>
+          <select class="form-control mr-auto w-auto" ng-model="factory.display.orientation" integer-parser>
             <option value="0" translate>displays-app.fields.player.orientation.0</option>
             <option value="90" translate>displays-app.fields.player.orientation.90</option>
             <option value="180" translate>displays-app.fields.player.orientation.180</option>
@@ -281,108 +244,28 @@
           <label class="control-label pull-left mb-0" translate>displays-app.fields.address.useCompany</label>
           <ng-include src="'partials/displays/display-details-license-required.html'"></ng-include>
 
-          <div class="btn-group-checkbox" ng-if="!factory.showLicenseRequired(display)">
-            <input type="checkbox" id="useCompanyAddress" name="useCompanyAddress" ng-model="display.useCompanyAddress" ng-disabled="factory.showLicenseRequired(display)">
-            <div class="btn-group btn-group-justified">
-              <button id="useAddressOn" type="button" class="btn" ng-disabled="factory.showLicenseRequired(display)"
-                ng-class="{'btn-toggle-blue-off' : !display.useCompanyAddress, 'btn-toggle-blue-on' : display.useCompanyAddress}">
-                Yes
-                <streamline-icon name="checkmark" ng-show="display.useCompanyAddress"></streamline-icon>
-              </button>
-              <button id="useAddressOff" type="button" class="btn" ng-disabled="factory.showLicenseRequired(display)"
-                ng-class="{'btn-toggle-blue-off' : display.useCompanyAddress, 'btn-toggle-blue-on' : !display.useCompanyAddress}">
-                No
-                <streamline-icon name="checkmark" ng-show="!display.useCompanyAddress"></streamline-icon>
-              </button>
-            </div>
-          </div>
+          <yes-no-toggle ng-model="factory.display.useCompanyAddress" ng-disabled="factory.showLicenseRequired()" button-id="useCompanyAddress" ng-if="!factory.showLicenseRequired()"></yes-no-toggle>
         </div>
       </div>
 
-      <div ng-hide="display.useCompanyAddress" class="list-group-item address-fields">
-        <div class="form-group">
-          <label class="control-label" translate>displays-app.fields.address.description</label>
-          <input type="text" class="form-control" ng-model="display.addressDescription">
-        </div>
-
-        <div class="row">
-          <div class="col-md-6">
-            <div class="form-group">
-              <label class="control-label" translate>displays-app.fields.address.street</label>
-              <input type="text" class="form-control" ng-model="display.street" name="street">
-            </div>
-          </div>
-          <div class="col-md-6">
-            <div class="form-group">
-              <label class="control-label" translate>displays-app.fields.address.unit</label>
-              <input type="text" class="form-control" ng-model="display.unit" name="unit">
-            </div>
-          </div>
-        </div>
-
-        <div class="row">
-          <div class="col-md-6">
-            <div class="form-group">
-              <label class="control-label" translate>displays-app.fields.address.city</label>
-              <input type="text" class="form-control" ng-model="display.city" name="city">
-            </div>
-          </div>
-          <div class="col-md-6">
-            <div class="form-group">
-              <label class="control-label" translate>displays-app.fields.address.country.name</label>
-              <select class="form-control" ng-model="display.country" name="country" ng-options="c.code as c.name for c in countries" empty-select-parser>
-                <option value="" ng-show="false" translate>displays-app.fields.address.country.placeholder</option>
-              </select>
-            </div>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-md-6">
-            <div class="form-group">
-              <label class="control-label" translate>displays-app.fields.address.province.name</label>
-              <input type="text" class="form-control" ng-model="display.province" name="province" ng-if="display.country != 'US' && display.country != 'CA'" />
-              <select class="form-control selectpicker" ng-model="display.province" name="province" ng-options="c[1] as c[0] for c in regionsCA" ng-if="display.country == 'CA'" empty-select-parser>
-                <option value="" ng-show="false" translate>displays-app.fields.address.province.provincePlaceholder</option>
-              </select>
-              <select class="form-control selectpicker" ng-model="display.province" name="province" ng-options="c[1] as c[0] for c in regionsUS" ng-if="display.country == 'US'" empty-select-parser>
-                <option value="" ng-show="false" translate>displays-app.fields.address.province.statePlaceholder</option>
-              </select>
-            </div>
-          </div>
-          <div class="col-md-6">
-            <div class="form-group">
-              <label class="control-label" translate>displays-app.fields.address.postalCode</label>
-              <input type="text" class="form-control" ng-model="display.postalCode" name="postalCode">
-            </div>
-          </div>
-        </div>
-
-        <div class="form-group mb-0">
-          <label class="control-label" translate>displays-app.fields.address.timezone.name</label>
-          <select class="form-control" ng-model="display.timeZoneOffset" integer-parser>
-            <option value="" ng-show="false" translate>displays-app.fields.address.timezone.placeholder</option>
-            <option value="{{c[1]}}" ng-repeat="c in timezones">{{c[0]}}</option>
-          </select>
-        </div>
-
-      </div><!--display address-->
+      <display-address></display-address>
 
       <div class="list-group-item flex-row form-group mb-0">
         <div class="row-entry">
           <label class="control-label pull-left mb-0" translate>displays-app.fields.player.ipAddress</label>
           <ng-include src="'partials/displays/display-details-license-required.html'"></ng-include>
-          <span class="mr-auto" ng-if="!factory.showLicenseRequired(display)">
-            {{display.playerLocalIpAddress}}
+          <span class="mr-auto" ng-if="!factory.showLicenseRequired()">
+            {{factory.display.playerLocalIpAddress}}
           </span>
         </div>
       </div>
 
-      <div class="list-group-item flex-row form-group mb-0" ng-show="display.macAddress">
+      <div class="list-group-item flex-row form-group mb-0" ng-show="factory.display.macAddress">
         <div class="row-entry">
           <label class="control-label pull-left mb-0" translate>displays-app.fields.player.macAddress</label>
           <ng-include src="'partials/displays/display-details-license-required.html'"></ng-include>
-          <span class="mr-auto" ng-if="!factory.showLicenseRequired(display)">
-            {{display.macAddress}}
+          <span class="mr-auto" ng-if="!factory.showLicenseRequired()">
+            {{factory.display.macAddress}}
           </span>
         </div>
       </div>
@@ -391,7 +274,7 @@
         <div class="row-entry">
           <label class="control-label pull-left mb-0" translate>displays-app.fields.player.operatingSystem</label>
           <span class="mr-auto">
-            {{display.os}}
+            {{factory.display.os}}
           </span>
         </div>
       </div>
@@ -400,61 +283,61 @@
         <div class="row-entry">
           <label class="control-label pull-left mb-0 aligner-item--top" translate>displays-app.fields.player.playerVersion</label>
           <span class="mr-auto">
-            <div ng-show="display.playerName">{{display.playerName}}</div>
-            <div ng-show="display.playerVersion">{{display.playerVersion}}</div>
-            <div ng-show="display.playerVersion && playerProFactory.isOutdatedPlayer(display)" translate>
+            <div ng-show="factory.display.playerName">{{factory.display.playerName}}</div>
+            <div ng-show="factory.display.playerVersion">{{factory.display.playerVersion}}</div>
+            <div ng-show="factory.display.playerVersion && playerProFactory.isOutdatedPlayer(factory.display)" translate>
               displays-app.fields.player.version.notCurrent
             </div>
           </span>
         </div>
       </div>
 
-      <div class="list-group-item flex-row form-group mb-0" ng-show="display.viewerVersion">
+      <div class="list-group-item flex-row form-group mb-0" ng-show="factory.display.viewerVersion">
         <div class="row-entry">
           <label class="control-label pull-left mb-0" translate>displays-app.fields.player.viewerVersion</label>
           <span class="mr-auto">
-            {{display.viewerVersion}}
+            {{factory.display.viewerVersion}}
           </span>
         </div>
       </div>
-      <div class="list-group-item flex-row form-group mb-0" ng-show="display.browserVersion">
+      <div class="list-group-item flex-row form-group mb-0" ng-show="factory.display.browserVersion">
         <div class="row-entry">
           <label class="control-label pull-left mb-0" translate>displays-app.fields.player.browserVersion</label>
           <span class="mr-auto">
-            {{(display.browserName ? display.browserName + " " : "") + (display.browserVersion ? display.browserVersion : "")}}
+            {{(factory.display.browserName ? factory.display.browserName + " " : "") + (factory.display.browserVersion ? factory.display.browserVersion : "")}}
           </span>
         </div>
       </div>
 
-      <div class="list-group-item flex-row form-group mb-0" ng-show="display.serialNumber">
+      <div class="list-group-item flex-row form-group mb-0" ng-show="factory.display.serialNumber">
         <div class="row-entry">
           <label class="control-label pull-left mb-0" translate>displays-app.fields.player.serialNumber</label>
           <span class="mr-auto">
-            {{display.serialNumber}}
+            {{factory.display.serialNumber}}
           </span>
         </div>
       </div>
-      <div class="list-group-item flex-row form-group mb-0" ng-show="display.cpu">
+      <div class="list-group-item flex-row form-group mb-0" ng-show="factory.display.cpu">
         <div class="row-entry">
           <label class="control-label pull-left mb-0" translate>displays-app.fields.player.cpu</label>
           <span class="mr-auto">
-            {{display.cpu}}
+            {{factory.display.cpu}}
           </span>
         </div>
       </div>
-      <div class="list-group-item flex-row form-group mb-0" ng-show="display.hostName">
+      <div class="list-group-item flex-row form-group mb-0" ng-show="factory.display.hostName">
         <div class="row-entry">
           <label class="control-label pull-left mb-0" translate>displays-app.fields.player.hostName</label>
           <span class="mr-auto">
-            {{display.hostName}}
+            {{factory.display.hostName}}
           </span>
         </div>
       </div>
-      <div class="list-group-item flex-row form-group mb-0" ng-show="display.productName">
+      <div class="list-group-item flex-row form-group mb-0" ng-show="factory.display.productName">
         <div class="row-entry">
           <label class="control-label pull-left mb-0" translate>displays-app.fields.player.productName</label>
           <span class="mr-auto">
-            {{display.productName}}
+            {{factory.display.productName}}
           </span>
         </div>
       </div>
@@ -465,7 +348,7 @@
   <div class="preview-container" ng-show="selectedSchedule">
     <div class="row border-bottom u_padding-20-vertical mx-0 mb-4">
       <div class="col-sm-12 px-0 form-inline">
-        <label class="mr-auto" ng-show="!userState.hasRole('cp')">Schedule: {{display.scheduleName}}</label>
+        <label class="mr-auto" ng-show="!userState.hasRole('cp')">Schedule: {{factory.display.scheduleName}}</label>
         <preview-selector ng-model="selectedSchedule" additional-class="mr-auto mb-0" ng-show="userState.hasRole('cp')"></preview-selector>
 
         <span class="pull-right button-toolbar">

--- a/web/partials/displays/screenshot.html
+++ b/web/partials/displays/screenshot.html
@@ -4,16 +4,16 @@
     <div class="row-entry">
 
       <label class="control-label pull-left mb-0">Screenshot</label>
-      <span class="mr-auto" ng-show="screenshotState(display) === 'no-license'">
+      <span class="mr-auto" ng-show="screenshotState() === 'no-license'">
         <a href="" ng-click="confirmLicensing()" ng-show="userState.hasRole('da')">License Required</a>
         <span ng-show="!userState.hasRole('da')">License Required</span>
       </span>
-      <span id="notActivated" ng-show="screenshotState(display) !== 'no-license' && !displayService.statusLoading && (display | status) === 'notinstalled'">
+      <span id="notActivated" ng-show="screenshotState() !== 'no-license' && !displayService.statusLoading && (displayFactory.display | status) === 'notinstalled'">
         {{ 'displays-app.list.status.notActivated' | translate }}
       </span>
-      <span class="mr-auto" ng-show="reloadScreenshotEnabled(display) && !(!displayService.statusLoading && (display | status) === 'notinstalled')">
+      <span class="mr-auto" ng-show="reloadScreenshotEnabled() && !(!displayService.statusLoading && (displayFactory.display | status) === 'notinstalled')">
         <!-- online -->
-        <a id="btnUpdateScreenshot" class="u_icon-hover u_clickable" ng-click="screenshotFactory.requestScreenshot(display.id)">
+        <a id="btnUpdateScreenshot" class="u_icon-hover u_clickable" ng-click="screenshotFactory.requestScreenshot(displayFactory.display.id)">
           Update
         </a>
       </span>
@@ -22,31 +22,31 @@
     </div>
   </div>
 
-  <div class="display-screenshot" ng-show="!screenshotState(display)">
+  <div class="display-screenshot" ng-show="!screenshotState()">
     <div class="display-screenshot-info">
       <p class="text-gray">Screenshot not available.</p>
     </div>
   </div>
-  <div class="display-screenshot" ng-show="screenshotState(display) === 'no-license'">
+  <div class="display-screenshot" ng-show="screenshotState() === 'no-license'">
     <div class="display-screenshot-info">
       <p class="text-gray">License Required</p>
     </div>
   </div>
-  <div class="display-screenshot" ng-show="screenshotState(display) === 'screenshot-error'">
+  <div class="display-screenshot" ng-show="screenshotState() === 'screenshot-error'">
     <div class="display-screenshot-info">
       <p class="text-gray">There was a problem requesting the screenshot.</p>
     </div>
   </div>
-  <div class="display-screenshot" ng-show="screenshotState(display) === 'loading'">
+  <div class="display-screenshot" ng-show="screenshotState() === 'loading'">
     <div class="display-screenshot-info">
       <div class="app-loading-dots">
         <i class="fa fa-3x fa-spinner fa-spin fa-fw"></i>
       </div>
     </div>
   </div>
-  <img class="img-fluid" src="{{screenshotFactory.screenshot.imageUrl}}" ng-show="screenshotState(display) === 'screenshot-loaded'">
+  <img class="img-fluid" src="{{screenshotFactory.screenshot.imageUrl}}" ng-show="screenshotState() === 'screenshot-loaded'">
 
-  <div class="text-gray align-right mt-2" ng-show="screenshotState(display) === 'screenshot-loaded'">
+  <div class="text-gray align-right mt-2" ng-show="screenshotState() === 'screenshot-loaded'">
     <small>Updated {{screenshotFactory.screenshot.lastModified | date:'d-MMM-yyyy h:mm a'}}</small>
   </div>
 

--- a/web/scripts/common/directives/dtv-yes-no-toggle.js
+++ b/web/scripts/common/directives/dtv-yes-no-toggle.js
@@ -1,21 +1,24 @@
 'use strict';
 
 angular.module('risevision.apps.directives')
-  .directive('yesNoToggle', [
-    function () {
+  .directive('yesNoToggle', ['$timeout',
+    function ($timeout) {
       return {
         restrict: 'E',
         replace: true,
         require: 'ngModel',
         scope: {
           ngModel: '=',
-          ngClick: '=',
+          ngChange: '&',
           ngDisabled: '=',
           buttonId: '@'
         },
         templateUrl: 'partials/common/yes-no-toggle.html',
-        link: function () {
-          //
+        link: function ($scope) {
+          $scope.onChange = function() {
+            // Wait for $digest so ngModel is updated before triggering ngChange
+            $timeout($scope.ngChange);
+          };
         }
       };
     }

--- a/web/scripts/common/directives/dtv-yes-no-toggle.js
+++ b/web/scripts/common/directives/dtv-yes-no-toggle.js
@@ -1,0 +1,22 @@
+'use strict';
+
+angular.module('risevision.apps.directives')
+  .directive('yesNoToggle', [
+    function () {
+      return {
+        restrict: 'E',
+        replace: true,
+        require: 'ngModel',
+        scope: {
+          ngModel: '=',
+          ngClick: '=',
+          ngDisabled: '=',
+          buttonId: '@'
+        },
+        templateUrl: 'partials/common/yes-no-toggle.html',
+        link: function () {
+          //
+        }
+      };
+    }
+  ]);

--- a/web/scripts/displays/app.js
+++ b/web/scripts/displays/app.js
@@ -74,9 +74,11 @@ angular.module('risevision.apps')
           }],
           controller: 'displayDetails',
           resolve: {
-            displayId: ['canAccessApps', '$stateParams',
-              function (canAccessApps, $stateParams) {
+            displayId: ['canAccessApps', '$stateParams', 'displayFactory',
+              function (canAccessApps, $stateParams, displayFactory) {
                 return canAccessApps().then(function () {
+                  displayFactory.init();
+
                   return $stateParams.displayId;
                 });
               }
@@ -101,7 +103,7 @@ angular.module('risevision.apps')
                   displayFactory.newDisplay();
 
                   if ($stateParams.schedule) {
-                    return displayFactory.setAssignedSchedule($stateParams.schedule);
+                    displayFactory.setAssignedSchedule($stateParams.schedule);
                   }
                 });
               }

--- a/web/scripts/displays/controllers/ctr-display-add.js
+++ b/web/scripts/displays/controllers/ctr-display-add.js
@@ -4,8 +4,8 @@ angular.module('risevision.displays.controllers')
   .controller('displayAdd', ['$scope', '$loading', 'displayFactory', 'playerLicenseFactory',
     function ($scope, $loading, displayFactory, playerLicenseFactory) {
       $scope.factory = displayFactory;
-      $scope.display = displayFactory.display;
       $scope.playerLicenseFactory = playerLicenseFactory;
+      $scope.selectedSchedule = null;
 
       $scope.$watch('factory.loadingDisplay', function (loading) {
         if (loading) {

--- a/web/scripts/displays/controllers/ctr-display-details.js
+++ b/web/scripts/displays/controllers/ctr-display-details.js
@@ -48,7 +48,7 @@ angular.module('risevision.displays.controllers')
         } else {
           confirmModal('displays-app.details.unsavedTitle',
             'displays-app.details.unsavedWarning',
-            'Yes', 'No', 'madero-style centered-modal',
+            'Save', 'Discard', 'madero-style centered-modal',
             'partials/components/confirm-modal/madero-confirm-modal.html', 'sm')
             .then(function () {
               // do what you need if user presses ok

--- a/web/scripts/displays/directives/dtv-display-address.js
+++ b/web/scripts/displays/directives/dtv-display-address.js
@@ -1,0 +1,18 @@
+'use strict';
+
+angular.module('risevision.displays.directives')
+  .directive('displayAddress', ['COUNTRIES', 'REGIONS_CA', 'REGIONS_US', 'TIMEZONES',
+    function (COUNTRIES, REGIONS_CA, REGIONS_US, TIMEZONES) {
+      return {
+        restrict: 'E',
+        replace: true,
+        templateUrl: 'partials/displays/display-address.html',
+        link: function ($scope) {
+          $scope.countries = COUNTRIES;
+          $scope.regionsCA = REGIONS_CA;
+          $scope.regionsUS = REGIONS_US;
+          $scope.timezones = TIMEZONES;
+        } //link()
+      };
+    }
+  ]);

--- a/web/scripts/displays/directives/dtv-display-email.js
+++ b/web/scripts/displays/directives/dtv-display-email.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.displays.directives')
-  .directive('displayEmail', ['$loading', 'displayEmail', 'processErrorCode', 'EMAIL_REGEX',
-    function ($loading, displayEmail, processErrorCode, EMAIL_REGEX) {
+  .directive('displayEmail', ['$loading', 'displayEmail', 'displayFactory', 'processErrorCode', 'EMAIL_REGEX',
+    function ($loading, displayEmail, displayFactory, processErrorCode, EMAIL_REGEX) {
       return {
         restrict: 'E',
         templateUrl: 'partials/displays/display-email.html',
@@ -31,7 +31,7 @@ angular.module('risevision.displays.directives')
             $scope.emailSent = false;
             $scope.emailError = false;
 
-            displayEmail.send($scope.display.id, $scope.email)
+            displayEmail.send(displayFactory.display.id, $scope.email)
               .then(function () {
                 $scope.emailSent = true;
                 $scope.email = null;

--- a/web/scripts/displays/directives/dtv-display-fields.js
+++ b/web/scripts/displays/directives/dtv-display-fields.js
@@ -28,8 +28,6 @@ angular.module('risevision.displays.directives')
             displayFactory.display.playerProAssigned = playerProAuthorized;
             displayFactory.display.playerProAuthorized = company.playerProAvailableLicenseCount > 0 &&
               playerProAuthorized;
-
-            playerLicenseFactory.toggleDisplayLicenseLocal(playerProAuthorized);
           };
 
           var _updateDisplayLicense = function() {
@@ -43,6 +41,8 @@ angular.module('risevision.displays.directives')
             enableCompanyProduct(displayFactory.display.companyId, PLAYER_PRO_PRODUCT_CODE, apiParams)
               .then(function () {
                 _updateDisplayLicenseLocal();
+
+                playerLicenseFactory.toggleDisplayLicenseLocal(displayFactory.display.playerProAuthorized);
               })
               .catch(function (err) {
                 $scope.errorUpdatingRPP = processErrorCode(err);

--- a/web/scripts/displays/directives/dtv-display-fields.js
+++ b/web/scripts/displays/directives/dtv-display-fields.js
@@ -1,37 +1,32 @@
 'use strict';
 
 angular.module('risevision.displays.directives')
-  .directive('displayFields', ['$sce', 'userState', 'display', 'playerLicenseFactory', 'playerProFactory', 
-    'displayControlFactory', 'playerActionsFactory', 'scheduleFactory', 'enableCompanyProduct', 'plansFactory',
+  .directive('displayFields', ['$sce', 'userState', 'display', 'displayFactory', 'playerLicenseFactory',
+    'playerProFactory', 'displayControlFactory', 'playerActionsFactory', 'scheduleFactory', 
+    'enableCompanyProduct', 'plansFactory',
     'processErrorCode', 'messageBox', 'confirmModal',
-    'COUNTRIES', 'REGIONS_CA', 'REGIONS_US', 'TIMEZONES', 'SHARED_SCHEDULE_URL', 'PLAYER_PRO_PRODUCT_CODE',
-    function ($sce, userState, display, playerLicenseFactory, playerProFactory, displayControlFactory,
-      playerActionsFactory, scheduleFactory, enableCompanyProduct, plansFactory, 
+    'SHARED_SCHEDULE_URL', 'PLAYER_PRO_PRODUCT_CODE',
+    function ($sce, userState, display, displayFactory, playerLicenseFactory, playerProFactory,
+      displayControlFactory, playerActionsFactory, scheduleFactory, enableCompanyProduct, plansFactory, 
       processErrorCode, messageBox, confirmModal,
-      COUNTRIES, REGIONS_CA, REGIONS_US, TIMEZONES, SHARED_SCHEDULE_URL, PLAYER_PRO_PRODUCT_CODE) {
+      SHARED_SCHEDULE_URL, PLAYER_PRO_PRODUCT_CODE) {
       return {
         restrict: 'E',
         templateUrl: 'partials/displays/display-fields.html',
         link: function ($scope) {
           $scope.userState = userState;
-          $scope.countries = COUNTRIES;
-          $scope.regionsCA = REGIONS_CA;
-          $scope.regionsUS = REGIONS_US;
-          $scope.timezones = TIMEZONES;
-
           $scope.displayService = display;
           $scope.playerProFactory = playerProFactory;
           $scope.playerActionsFactory = playerActionsFactory;
 
-          $scope.selectedSchedule = null;
           $scope.updatingRPP = false;
 
           var _updateDisplayLicenseLocal = function() {
-            var playerProAuthorized = !$scope.display.playerProAuthorized;
+            var playerProAuthorized = displayFactory.display.playerProAuthorized;
             var company = userState.getCopyOfSelectedCompany(true);
 
-            $scope.display.playerProAssigned = playerProAuthorized;
-            $scope.display.playerProAuthorized = company.playerProAvailableLicenseCount > 0 &&
+            displayFactory.display.playerProAssigned = playerProAuthorized;
+            displayFactory.display.playerProAuthorized = company.playerProAvailableLicenseCount > 0 &&
               playerProAuthorized;
 
             playerLicenseFactory.toggleDisplayLicenseLocal(playerProAuthorized);
@@ -39,24 +34,24 @@ angular.module('risevision.displays.directives')
 
           var _updateDisplayLicense = function() {
             var apiParams = {};
-            var playerProAuthorized = !$scope.display.playerProAuthorized;
+            var playerProAuthorized = displayFactory.display.playerProAuthorized;
 
             $scope.errorUpdatingRPP = false;
             $scope.updatingRPP = true;
-            apiParams[$scope.display.id] = playerProAuthorized;
+            apiParams[displayFactory.display.id] = playerProAuthorized;
 
-            enableCompanyProduct($scope.display.companyId, PLAYER_PRO_PRODUCT_CODE, apiParams)
+            enableCompanyProduct(displayFactory.display.companyId, PLAYER_PRO_PRODUCT_CODE, apiParams)
               .then(function () {
                 _updateDisplayLicenseLocal();
               })
               .catch(function (err) {
                 $scope.errorUpdatingRPP = processErrorCode(err);
 
-                $scope.display.playerProAuthorized = !playerProAuthorized;
+                displayFactory.display.playerProAuthorized = !playerProAuthorized;
               })
               .finally(function () {
                 if (!playerProAuthorized) {
-                  $scope.display.monitoringEnabled = false;
+                  displayFactory.display.monitoringEnabled = false;
                 }
 
                 $scope.updatingRPP = false;
@@ -64,11 +59,11 @@ angular.module('risevision.displays.directives')
           };
 
           $scope.toggleProAuthorized = function () {
-            if (!playerLicenseFactory.isProAvailable($scope.display)) {
-              $scope.display.playerProAuthorized = false;
+            if (!playerLicenseFactory.isProAvailable(displayFactory.display)) {
+              displayFactory.display.playerProAuthorized = false;
               plansFactory.confirmAndPurchase();
             } else {
-              if ($scope.display.id) {
+              if (displayFactory.display.id) {
                 _updateDisplayLicense();
               } else {
                 _updateDisplayLicenseLocal();
@@ -77,8 +72,8 @@ angular.module('risevision.displays.directives')
           };
 
           $scope.$watch('selectedSchedule', function (newSchedule, oldSchedule) {
-            var isChangingSchedule = oldSchedule || (!oldSchedule && !display.hasSchedule($scope.display));
-            if (isChangingSchedule && scheduleFactory.requiresLicense(newSchedule) && !$scope.display.playerProAuthorized) {
+            var isChangingSchedule = oldSchedule || (!oldSchedule && !display.hasSchedule(displayFactory.display));
+            if (isChangingSchedule && scheduleFactory.requiresLicense(newSchedule) && !displayFactory.display.playerProAuthorized) {
               confirmModal('Assign license?',
                 'You\'ve selected a schedule that contains presentations. In order to show this schedule on this display, you need to license it. Assign license now?',
                 'Yes', 'No', 'madero-style centered-modal',
@@ -143,8 +138,8 @@ angular.module('risevision.displays.directives')
           $scope.$on('risevision.company.updated', function () {
             var company = userState.getCopyOfSelectedCompany(true);
 
-            $scope.display.playerProAuthorized = $scope.display.playerProAuthorized ||
-              company.playerProAvailableLicenseCount > 0 && $scope.display.playerProAssigned;
+            displayFactory.display.playerProAuthorized = displayFactory.display.playerProAuthorized ||
+              company.playerProAvailableLicenseCount > 0 && displayFactory.display.playerProAssigned;
           });
 
         } //link()

--- a/web/scripts/displays/directives/dtv-screenshot.js
+++ b/web/scripts/displays/directives/dtv-screenshot.js
@@ -11,10 +11,10 @@ angular.module('risevision.displays.directives')
         link: function ($scope) {
           $scope.screenshotFactory = screenshotFactory;
 
-          $scope.screenshotState = function (display) {
-            if (displayFactory.showLicenseRequired(display)) {
+          $scope.screenshotState = function () {
+            if (displayFactory.showLicenseRequired()) {
               return 'no-license';
-            } else if (!display || displayService.statusLoading || screenshotFactory.screenshotLoading) {
+            } else if (!displayFactory.display || displayService.statusLoading || screenshotFactory.screenshotLoading) {
               return 'loading';
             } else if (screenshotFactory.screenshot && screenshotFactory.screenshot.lastModified) {
               return 'screenshot-loaded';
@@ -25,23 +25,23 @@ angular.module('risevision.displays.directives')
             return '';
           };
 
-          $scope.reloadScreenshotEnabled = function (display) {
-            if (!display) {
+          $scope.reloadScreenshotEnabled = function () {
+            if (!displayFactory.display) {
               return false;
             }
 
             var statusFilter = $filter('status');
 
-            if (displayFactory.showLicenseRequired(display)) {
+            if (displayFactory.showLicenseRequired()) {
               return false;
             } else if (displayService.statusLoading || screenshotFactory.screenshotLoading || !screenshotFactory
               .screenshot) {
               return false;
-            } else if (display.os && display.os.indexOf('cros') === 0) {
+            } else if (displayFactory.display.os && displayFactory.display.os.indexOf('cros') === 0) {
               return false;
-            } else if (!playerProFactory.isScreenshotCompatiblePlayer(display)) {
+            } else if (!playerProFactory.isScreenshotCompatiblePlayer(displayFactory.display)) {
               return false;
-            } else if (statusFilter(display) === 'online') {
+            } else if (statusFilter(displayFactory.display) === 'online') {
               return true;
             }
 

--- a/web/scripts/displays/services/svc-display-factory.js
+++ b/web/scripts/displays/services/svc-display-factory.js
@@ -1,10 +1,10 @@
 'use strict';
 
 angular.module('risevision.displays.services')
-  .factory('displayFactory', ['$rootScope', '$q', '$state', '$modal', '$loading', '$log',
+  .factory('displayFactory', ['$rootScope', '$q', '$state', '$log',
     'userState', 'display', 'displayTracker', 'scheduleFactory', 'playerLicenseFactory',
     'processErrorCode',
-    function ($rootScope, $q, $state, $modal, $loading, $log, userState, display, displayTracker,
+    function ($rootScope, $q, $state, $log, userState, display, displayTracker,
       scheduleFactory, playerLicenseFactory, processErrorCode) {
       var factory = {};
       var _displayId;

--- a/web/scripts/displays/services/svc-display-factory.js
+++ b/web/scripts/displays/services/svc-display-factory.js
@@ -27,7 +27,9 @@ angular.module('risevision.displays.services')
           'restartEnabled': true,
           'restartTime': '02:00',
           'monitoringEnabled': true,
-          'useCompanyAddress': true
+          'useCompanyAddress': true,
+          'playerProAssigned': false,
+          'playerProAuthorized': false
         };
 
         _clearMessages();
@@ -39,6 +41,11 @@ angular.module('risevision.displays.services')
         displayTracker('Add Display');
 
         factory.init();
+
+        if (playerLicenseFactory.isProAvailable(factory.display)) {
+          factory.display.playerProAssigned = true;
+          factory.display.playerProAuthorized = true;
+        }
       };
 
       factory.getDisplay = function (displayId) {
@@ -81,34 +88,34 @@ angular.module('risevision.displays.services')
         display.add(factory.display)
           .then(function (resp) {
             if (resp && resp.item && resp.item.id) {
-              factory.display = resp.item;
-
-              playerLicenseFactory.toggleDisplayLicenseLocal(true);
+              if (factory.display.playerProAuthorized) {
+                playerLicenseFactory.toggleDisplayLicenseLocal(true);                
+              }
 
               displayTracker('Display Created', resp.item.id, resp.item
                 .name);
 
               $rootScope.$broadcast('displayCreated', resp.item);
 
-              return scheduleFactory.addToDistribution(factory.display, selectedSchedule);
+              return scheduleFactory.addToDistribution(resp.item, selectedSchedule)
+                .then(function() {            
+                  if ($state.current.name === 'apps.displays.add') {
+                    $state.go('apps.displays.details', {
+                      displayId: resp.item.id
+                    });
+                  }
+
+                  deferred.resolve();
+                })
+                .catch(function () {
+                  factory.apiError = scheduleFactory.apiError;
+                  deferred.reject();
+                });
             } else {
               return $q.reject();
             }
           }, function (e) {
             _showErrorMessage('add', e);
-            deferred.reject();
-          })
-          .then(function() {            
-            if ($state.current.name === 'apps.displays.add') {
-              $state.go('apps.displays.details', {
-                displayId: factory.display.id
-              });
-            }
-
-            deferred.resolve();
-          })
-          .catch(function () {
-            factory.apiError = scheduleFactory.apiError;
             deferred.reject();
           })
           .finally(function () {
@@ -133,16 +140,16 @@ angular.module('risevision.displays.services')
             displayTracker('Display Updated', _displayId,
               factory.display.name);
 
-            return scheduleFactory.addToDistribution(factory.display, selectedSchedule);
+            return scheduleFactory.addToDistribution(factory.display, selectedSchedule)
+              .then(function() {
+                deferred.resolve();
+              })
+              .catch(function () {
+                factory.apiError = scheduleFactory.apiError;
+                deferred.reject();
+              });
           }, function (e) {
             _showErrorMessage('update', e);
-            deferred.reject();
-          })
-          .then(function() {
-            deferred.resolve();
-          })
-          .catch(function () {
-            factory.apiError = scheduleFactory.apiError;
             deferred.reject();
           })
           .finally(function () {

--- a/web/scripts/displays/services/svc-display.js
+++ b/web/scripts/displays/services/svc-display.js
@@ -157,8 +157,8 @@
           add: function (display) {
             var deferred = $q.defer();
 
-            var fields = pick.apply(this, [display].concat(
-              DISPLAY_WRITABLE_FIELDS));
+            var fields = pick.apply(this, [display].concat(DISPLAY_WRITABLE_FIELDS));
+            fields.assignLicense = display.playerProAuthorized;
             var obj = {
               'companyId': userState.getSelectedCompanyId(),
               'data': fields

--- a/web/scripts/schedules/services/svc-schedule-factory.js
+++ b/web/scripts/schedules/services/svc-schedule-factory.js
@@ -246,7 +246,7 @@ angular.module('risevision.schedules.services')
       };
 
       factory.addToDistribution = function (display, schedule) {
-        if (!schedule || schedule.id === display.scheduleId) {
+        if (!schedule || !schedule.id || schedule.id === display.scheduleId) {
           return $q.resolve();
         } else {
           $log.info('Adding to Distribution: ', display.id, schedule.id);


### PR DESCRIPTION
## Description
Remove scope inheritance for display object

Use displayFactory.display instead
Update all references

Use confirmModal for actions
Add yes no toggle directive
Add display address directive

[stage-2]

## Motivation and Context
Fixes inconsistencies of using the display object
Should allow easier isolation of scopes on the display page

## How Has This Been Tested?
Tested various functionality in the local environment.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No