### PR TITLE
Conditionally license display based on toggle

### DIFF
--- a/web/partials/common/yes-no-toggle.html
+++ b/web/partials/common/yes-no-toggle.html
@@ -1,5 +1,5 @@
 <div class="btn-group-checkbox">
-  <input type="checkbox" id="{{buttonId}}" name="{{buttonId}}" ng-model="ngModel" ng-click="ngClick()" ng-disabled="ngDisabled">
+  <input type="checkbox" id="{{buttonId}}" name="{{buttonId}}" ng-model="ngModel" ng-change="onChange()" ng-disabled="ngDisabled">
 
   <div class="btn-group btn-group-justified">
     <button type="button" class="btn" ng-disabled="ngDisabled"

--- a/web/partials/displays/display-fields.html
+++ b/web/partials/displays/display-fields.html
@@ -93,7 +93,7 @@
               <span translate>displays-app.details.rpp-loading</span> <i class="fa fa-spinner fa-spin fa-fw"></i>
             </span>
 
-            <yes-no-toggle ng-model="factory.display.playerProAuthorized" ng-click="toggleProAuthorized" ng-disabled="updatingRPP || !playerLicenseFactory.isProToggleEnabled()" ng-hide="updatingRPP"></yes-no-toggle>
+            <yes-no-toggle ng-model="factory.display.playerProAuthorized" ng-change="toggleProAuthorized()" ng-disabled="updatingRPP || !playerLicenseFactory.isProToggleEnabled()" ng-hide="updatingRPP"></yes-no-toggle>
           </div>
         </div>
         <div class="text-danger mt-2" ng-show="errorUpdatingRPP">

--- a/web/scripts/common/directives/dtv-yes-no-toggle.js
+++ b/web/scripts/common/directives/dtv-yes-no-toggle.js
@@ -1,21 +1,24 @@
 'use strict';
 
 angular.module('risevision.apps.directives')
-  .directive('yesNoToggle', [
-    function () {
+  .directive('yesNoToggle', ['$timeout',
+    function ($timeout) {
       return {
         restrict: 'E',
         replace: true,
         require: 'ngModel',
         scope: {
           ngModel: '=',
-          ngClick: '=',
+          ngChange: '&',
           ngDisabled: '=',
           buttonId: '@'
         },
         templateUrl: 'partials/common/yes-no-toggle.html',
-        link: function () {
-          //
+        link: function ($scope) {
+          $scope.onChange = function() {
+            // Wait for $digest so ngModel is updated before triggering ngChange
+            $timeout($scope.ngChange);
+          };
         }
       };
     }

--- a/web/scripts/displays/app.js
+++ b/web/scripts/displays/app.js
@@ -74,9 +74,11 @@ angular.module('risevision.apps')
           }],
           controller: 'displayDetails',
           resolve: {
-            displayId: ['canAccessApps', '$stateParams',
-              function (canAccessApps, $stateParams) {
+            displayId: ['canAccessApps', '$stateParams', 'displayFactory',
+              function (canAccessApps, $stateParams, displayFactory) {
                 return canAccessApps().then(function () {
+                  displayFactory.init();
+
                   return $stateParams.displayId;
                 });
               }
@@ -101,7 +103,7 @@ angular.module('risevision.apps')
                   displayFactory.newDisplay();
 
                   if ($stateParams.schedule) {
-                    return displayFactory.setAssignedSchedule($stateParams.schedule);
+                    displayFactory.setAssignedSchedule($stateParams.schedule);
                   }
                 });
               }

--- a/web/scripts/displays/directives/dtv-display-fields.js
+++ b/web/scripts/displays/directives/dtv-display-fields.js
@@ -28,8 +28,6 @@ angular.module('risevision.displays.directives')
             displayFactory.display.playerProAssigned = playerProAuthorized;
             displayFactory.display.playerProAuthorized = company.playerProAvailableLicenseCount > 0 &&
               playerProAuthorized;
-
-            playerLicenseFactory.toggleDisplayLicenseLocal(playerProAuthorized);
           };
 
           var _updateDisplayLicense = function() {
@@ -43,6 +41,8 @@ angular.module('risevision.displays.directives')
             enableCompanyProduct(displayFactory.display.companyId, PLAYER_PRO_PRODUCT_CODE, apiParams)
               .then(function () {
                 _updateDisplayLicenseLocal();
+
+                playerLicenseFactory.toggleDisplayLicenseLocal(displayFactory.display.playerProAuthorized);
               })
               .catch(function (err) {
                 $scope.errorUpdatingRPP = processErrorCode(err);

--- a/web/scripts/displays/services/svc-display-factory.js
+++ b/web/scripts/displays/services/svc-display-factory.js
@@ -41,6 +41,11 @@ angular.module('risevision.displays.services')
         displayTracker('Add Display');
 
         factory.init();
+
+        if (playerLicenseFactory.isProAvailable(factory.display)) {
+          factory.display.playerProAssigned = true;
+          factory.display.playerProAuthorized = true;
+        }
       };
 
       factory.getDisplay = function (displayId) {
@@ -83,20 +88,20 @@ angular.module('risevision.displays.services')
         display.add(factory.display)
           .then(function (resp) {
             if (resp && resp.item && resp.item.id) {
-              factory.display = resp.item;
-
-              playerLicenseFactory.toggleDisplayLicenseLocal(true);
+              if (factory.display.playerProAuthorized) {
+                playerLicenseFactory.toggleDisplayLicenseLocal(true);                
+              }
 
               displayTracker('Display Created', resp.item.id, resp.item
                 .name);
 
               $rootScope.$broadcast('displayCreated', resp.item);
 
-              return scheduleFactory.addToDistribution(factory.display, selectedSchedule)
+              return scheduleFactory.addToDistribution(resp.item, selectedSchedule)
                 .then(function() {            
                   if ($state.current.name === 'apps.displays.add') {
                     $state.go('apps.displays.details', {
-                      displayId: factory.display.id
+                      displayId: resp.item.id
                     });
                   }
 

--- a/web/scripts/displays/services/svc-display-factory.js
+++ b/web/scripts/displays/services/svc-display-factory.js
@@ -27,7 +27,9 @@ angular.module('risevision.displays.services')
           'restartEnabled': true,
           'restartTime': '02:00',
           'monitoringEnabled': true,
-          'useCompanyAddress': true
+          'useCompanyAddress': true,
+          'playerProAssigned': false,
+          'playerProAuthorized': false
         };
 
         _clearMessages();
@@ -90,25 +92,25 @@ angular.module('risevision.displays.services')
 
               $rootScope.$broadcast('displayCreated', resp.item);
 
-              return scheduleFactory.addToDistribution(factory.display, selectedSchedule);
+              return scheduleFactory.addToDistribution(factory.display, selectedSchedule)
+                .then(function() {            
+                  if ($state.current.name === 'apps.displays.add') {
+                    $state.go('apps.displays.details', {
+                      displayId: factory.display.id
+                    });
+                  }
+
+                  deferred.resolve();
+                })
+                .catch(function () {
+                  factory.apiError = scheduleFactory.apiError;
+                  deferred.reject();
+                });
             } else {
               return $q.reject();
             }
           }, function (e) {
             _showErrorMessage('add', e);
-            deferred.reject();
-          })
-          .then(function() {            
-            if ($state.current.name === 'apps.displays.add') {
-              $state.go('apps.displays.details', {
-                displayId: factory.display.id
-              });
-            }
-
-            deferred.resolve();
-          })
-          .catch(function () {
-            factory.apiError = scheduleFactory.apiError;
             deferred.reject();
           })
           .finally(function () {
@@ -133,16 +135,16 @@ angular.module('risevision.displays.services')
             displayTracker('Display Updated', _displayId,
               factory.display.name);
 
-            return scheduleFactory.addToDistribution(factory.display, selectedSchedule);
+            return scheduleFactory.addToDistribution(factory.display, selectedSchedule)
+              .then(function() {
+                deferred.resolve();
+              })
+              .catch(function () {
+                factory.apiError = scheduleFactory.apiError;
+                deferred.reject();
+              });
           }, function (e) {
             _showErrorMessage('update', e);
-            deferred.reject();
-          })
-          .then(function() {
-            deferred.resolve();
-          })
-          .catch(function () {
-            factory.apiError = scheduleFactory.apiError;
             deferred.reject();
           })
           .finally(function () {

--- a/web/scripts/displays/services/svc-display.js
+++ b/web/scripts/displays/services/svc-display.js
@@ -157,8 +157,8 @@
           add: function (display) {
             var deferred = $q.defer();
 
-            var fields = pick.apply(this, [display].concat(
-              DISPLAY_WRITABLE_FIELDS));
+            var fields = pick.apply(this, [display].concat(DISPLAY_WRITABLE_FIELDS));
+            fields.assignLicense = display.playerProAuthorized;
             var obj = {
               'companyId': userState.getSelectedCompanyId(),
               'data': fields


### PR DESCRIPTION
## Description
Conditionally license display based on toggle

Uses specific Core version now default
Fix toggling issues due to ngModel & digest cycle
Reset factory before loading another display
Fix error returns from add/update calls

[stage-19]

## Motivation and Context
Allow users to toggle whether they want a Display to be licensed or not.
Fix various other issues.

## How Has This Been Tested?
Tested changes locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No