### PR TITLE
License new display if available

### DIFF
--- a/web/scripts/displays/directives/dtv-display-fields.js
+++ b/web/scripts/displays/directives/dtv-display-fields.js
@@ -28,8 +28,6 @@ angular.module('risevision.displays.directives')
             displayFactory.display.playerProAssigned = playerProAuthorized;
             displayFactory.display.playerProAuthorized = company.playerProAvailableLicenseCount > 0 &&
               playerProAuthorized;
-
-            playerLicenseFactory.toggleDisplayLicenseLocal(playerProAuthorized);
           };
 
           var _updateDisplayLicense = function() {
@@ -43,6 +41,8 @@ angular.module('risevision.displays.directives')
             enableCompanyProduct(displayFactory.display.companyId, PLAYER_PRO_PRODUCT_CODE, apiParams)
               .then(function () {
                 _updateDisplayLicenseLocal();
+
+                playerLicenseFactory.toggleDisplayLicenseLocal(displayFactory.display.playerProAuthorized);
               })
               .catch(function (err) {
                 $scope.errorUpdatingRPP = processErrorCode(err);

--- a/web/scripts/displays/services/svc-display-factory.js
+++ b/web/scripts/displays/services/svc-display-factory.js
@@ -41,6 +41,11 @@ angular.module('risevision.displays.services')
         displayTracker('Add Display');
 
         factory.init();
+
+        if (playerLicenseFactory.isProAvailable(factory.display)) {
+          factory.display.playerProAssigned = true;
+          factory.display.playerProAuthorized = true;
+        }
       };
 
       factory.getDisplay = function (displayId) {
@@ -83,20 +88,20 @@ angular.module('risevision.displays.services')
         display.add(factory.display)
           .then(function (resp) {
             if (resp && resp.item && resp.item.id) {
-              factory.display = resp.item;
-
-              playerLicenseFactory.toggleDisplayLicenseLocal(true);
+              if (factory.display.playerProAuthorized) {
+                playerLicenseFactory.toggleDisplayLicenseLocal(true);                
+              }
 
               displayTracker('Display Created', resp.item.id, resp.item
                 .name);
 
               $rootScope.$broadcast('displayCreated', resp.item);
 
-              return scheduleFactory.addToDistribution(factory.display, selectedSchedule)
+              return scheduleFactory.addToDistribution(resp.item, selectedSchedule)
                 .then(function() {            
                   if ($state.current.name === 'apps.displays.add') {
                     $state.go('apps.displays.details', {
-                      displayId: factory.display.id
+                      displayId: resp.item.id
                     });
                   }
 


### PR DESCRIPTION
## Description
License new display if available

No longer toggle local license until add is complete
Do not trust display.add response, license information is wrong

[stage-18]

## Motivation and Context
We want the Display to be licensed, the user can toggle not to.

## How Has This Been Tested?
Tested changes locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No