### PR TITLE
No longer use Add Display Modal for Not Activated status

### DIFF
--- a/test/e2e/displays/cases/displaylist.js
+++ b/test/e2e/displays/cases/displaylist.js
@@ -73,7 +73,7 @@ var DisplayListScenarios = function() {
 
       it('should show display list Install Player button', function () {
         helper.wait(displaysListPage.getFirstRowStatus(), 'Install Player Button');
-        expect(displaysListPage.getFirstRowStatus().getAttribute('ng-click')).to.eventually.equal('displayFactory.addDisplayModal(display)');
+        expect(displaysListPage.getFirstRowStatus().getAttribute('ui-sref')).to.eventually.equal('apps.displays.change({displayId: display.id, companyId: display.companyId})');
       });
     });
   });

--- a/web/partials/displays/displays-list.html
+++ b/web/partials/displays/displays-list.html
@@ -78,21 +78,6 @@
             <div ng-show="getDisplayType(display) === 'standard'">
               <span translate>displays-app.list.player.type.standard</span>
             </div>
-            <div ng-show="getDisplayType(display) === 'unsupported'">
-              <span class="text-danger">
-                <i class="fa fa-times"></i>
-                <span translate>displays-app.list.player.type.unsupported</span>
-              </span>
-              <a ng-click="displayFactory.addDisplayModal(display)" translate>
-                displays-app.list.player.cta.upgrade
-              </a>
-            </div>
-            <div ng-show="getDisplayType(display) === '3rd-party'">
-              <span translate>displays-app.list.player.type.3rdParty</span>
-              <a ng-click="openUnsupportedHelpLink()" translate>
-                displays-app.list.player.cta.getSupport
-              </a>
-            </div>
           </td>
           <td class="table-body__cell hidden-xs display-schedule">
             <a class="u_ellipsis-md u_icon-hover schedule-view" ng-if="displayService.hasSchedule(display)" ui-sref="apps.schedules.details({ scheduleId: display.scheduleId, cid: display.companyId })" target="_blank">
@@ -121,7 +106,7 @@
               <i class="fa fa-check"></i> Online
             </span>
             <!-- Not Installed and finished Loading -->
-            <a class="u_icon-hover" ng-if="!displayService.statusLoading && playerNotInstalled(display)" ng-click="displayFactory.addDisplayModal(display)">
+            <a class="u_icon-hover" ng-if="!displayService.statusLoading && playerNotInstalled(display)" ui-sref="apps.displays.change({displayId: display.id, companyId: display.companyId})">
               {{ 'displays-app.list.status.notActivated' | translate }}
             </a>
           </td>


### PR DESCRIPTION
## Description

- Not Activated status opens Display Details page
- Remove no longer used Display Type conditions

## Motivation and Context
Display Improvements epic

## How Has This Been Tested?
Locally and on stage-1.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
