### PR TITLE
Schedule Preview Selector UI changes

### DIFF
--- a/web/partials/schedules/preview-selector-tooltip.html
+++ b/web/partials/schedules/preview-selector-tooltip.html
@@ -1,4 +1,4 @@
-<span class="preview-selector-tooltip">
+<span id="preview-selector-tooltip" class="preview-selector-tooltip">
   <div class="row">
     <div class="col-xs-12">
       <search-filter filter-config="filterConfig" search="search" do-search="schedules.doSearch" icon-set="madero"></search-filter>

--- a/web/partials/schedules/preview-selector-tooltip.html
+++ b/web/partials/schedules/preview-selector-tooltip.html
@@ -12,21 +12,13 @@
     rv-spinner-start-active="1"
   >
     <div class="flex-row" ng-repeat="schedule in schedules.items.list">
-      <div class="row-entry">
-        <div class="madero-checkbox u_clickable" ng-click="selectSchedule(schedule)">
-          <input type="checkbox" ng-checked="isSelected(schedule)" tabindex="1">
-          <label>
-            <streamline-icon name="checkmark" width="14" height="12"></streamline-icon>
-          </label>
-        </div>
-        <div class="mr-auto u_clickable u_text-ellipsis" ng-click="selectSchedule(schedule)">
+      <div class="row-entry mb-3">
+        <a class="madero-link mr-auto u_text-ellipsis" href="" ng-click="select(schedule)">
           {{schedule.name}}
-        </div>
-        <div class="u_float-left mr-3">
-          <a class="madero-link" ui-sref="apps.schedules.details({scheduleId: schedule.id})" link-cid>
-            Edit
-          </a>
-        </div>
+        </a>
+        <a class="madero-link mr-3" ui-sref="apps.schedules.details({scheduleId: schedule.id})" link-cid>
+          Edit
+        </a>
       </div>
     </div>
 
@@ -37,16 +29,6 @@
       No Results Found
     </div>
   </div>
-
-  <div class="row">
-    <div class="col-xs-6">
-      <button type="button" class="btn btn-default btn-block" ng-click="toggleTooltip()">Cancel</button>
-    </div>
-    <div class="col-xs-6">
-      <button type="button" class="btn btn-primary btn-block" ng-click="select()">Select</button>
-    </div>
-  </div>
-  <hr/>
 
   <div class="row">
     <div class="col-xs-12">

--- a/web/scripts/schedules/directives/dtv-preview-selector.js
+++ b/web/scripts/schedules/directives/dtv-preview-selector.js
@@ -63,16 +63,8 @@ angular.module('risevision.schedules.directives')
             $scope.showTooltip = !$scope.showTooltip;
           };
 
-          $scope.selectSchedule = function (schedule) {
-            selected = schedule;
-          };
-
-          $scope.isSelected = function (schedule) {
-            return selected && selected.id === schedule.id;
-          };
-
-          $scope.select = function () {
-            $scope.ngModel = selected;
+          $scope.select = function (schedule) {
+            $scope.ngModel = schedule;
 
             $scope.toggleTooltip();
           };

--- a/web/scripts/schedules/directives/dtv-preview-selector.js
+++ b/web/scripts/schedules/directives/dtv-preview-selector.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.schedules.directives')
-  .directive('previewSelector', ['$timeout', '$loading', 'ScrollingListService', 'schedule',
-    function ($timeout, $loading, ScrollingListService, schedule) {
+  .directive('previewSelector', ['$timeout', '$loading', 'ScrollingListService', 'schedule', '$document',
+    function ($timeout, $loading, ScrollingListService, schedule, $document) {
       return {
         restrict: 'E',
         templateUrl: 'partials/schedules/preview-selector.html',
@@ -29,16 +29,31 @@ angular.module('risevision.schedules.directives')
             }
           });
 
+          var _closeTooltip = function(event) {
+            var tooltipContent = angular.element('#preview-selector-tooltip');
+            if (tooltipContent && tooltipContent[0].contains(event.target) || 
+              tooltipElement[0].contains(event.target) ) {
+              return;
+            }
+            $timeout(function () {
+              $scope.toggleTooltip();
+            });
+          };
+
           $scope.$watch('showTooltip', function () {
             if ($scope.showTooltip) {
               $scope.schedules = new ScrollingListService(schedule.list, $scope.search);
               selected = $scope.ngModel;
 
               $timeout(function () {
+                $document.bind('click', _closeTooltip);
+                $document.bind('touchstart', _closeTooltip);
                 tooltipElement.trigger('show');
               });
             } else {
               $timeout(function () {
+                $document.unbind('click', _closeTooltip);
+                $document.unbind('touchstart', _closeTooltip);
                 tooltipElement.trigger('hide');
               });
             }

--- a/web/scripts/schedules/directives/dtv-preview-selector.js
+++ b/web/scripts/schedules/directives/dtv-preview-selector.js
@@ -31,8 +31,8 @@ angular.module('risevision.schedules.directives')
 
           var _closeTooltip = function(event) {
             var tooltipContent = angular.element('#preview-selector-tooltip');
-            if (tooltipContent && tooltipContent[0].contains(event.target) || 
-              tooltipElement[0].contains(event.target) ) {
+            if (tooltipContent && tooltipContent[0] && tooltipContent[0].contains(event.target) || 
+              tooltipElement && tooltipElement[0] && tooltipElement[0].contains(event.target) ) {
               return;
             }
             $timeout(function () {


### PR DESCRIPTION
## Description
Update Preview Selector UI to get closer to the mockups (we decided to keep Search even though not present in the mockups).
Also, handle clicks outside the modal to close it, since we no longer have a Cancel button to close it.

## Motivation and Context
Display Improvements epic

## How Has This Been Tested?
Locally and on stage-1.


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
