### PR TITLE
Reset screenshot object on add display

### DIFF
--- a/test/unit/displays/app.tests.js
+++ b/test/unit/displays/app.tests.js
@@ -20,6 +20,12 @@ describe('app:', function() {
           }
         });
 
+        $provide.service('screenshotFactory',function(){
+          return {
+            screenshot: 'old screenshot'
+          }
+        });
+
       });
 
       inject(function ($injector) {
@@ -27,6 +33,7 @@ describe('app:', function() {
         $location = $injector.get('$location');
         userState = $injector.get('userState');
         displayFactory = $injector.get('displayFactory');
+        screenshotFactory = $injector.get('screenshotFactory');
         canAccessApps = $injector.get('canAccessApps');
 
         sinon.stub($state, 'go');
@@ -38,7 +45,7 @@ describe('app:', function() {
       });
   });
 
-  var $state, $location, userState, displayFactory, canAccessApps;
+  var $state, $location, userState, displayFactory, screenshotFactory, canAccessApps;
 
   describe('state apps.displays.change:',function(){
 
@@ -95,9 +102,11 @@ describe('app:', function() {
     });
 
     it('should add new schedule',function(done){
-      $state.get('apps.displays.add').resolve.scheduleInfo[3]({}, canAccessApps, displayFactory);
+      $state.get('apps.displays.add').resolve.scheduleInfo[4]({}, canAccessApps, displayFactory, screenshotFactory);
       setTimeout(function() {
         canAccessApps.should.have.been.called;
+
+        expect(screenshotFactory.screenshot).to.not.be.ok;
 
         displayFactory.newDisplay.should.have.been.called;
         displayFactory.setAssignedSchedule.should.not.have.been.called;
@@ -107,9 +116,11 @@ describe('app:', function() {
     });
 
     it('should add new schedule with a presentation item',function(done){
-      $state.get('apps.displays.add').resolve.scheduleInfo[3]({schedule: 'item'}, canAccessApps, displayFactory);
+      $state.get('apps.displays.add').resolve.scheduleInfo[4]({schedule: 'item'}, canAccessApps, displayFactory, screenshotFactory);
       setTimeout(function() {
         canAccessApps.should.have.been.called;
+
+        expect(screenshotFactory.screenshot).to.not.be.ok;
 
         displayFactory.newDisplay.should.have.been.called;
         displayFactory.setAssignedSchedule.should.have.been.calledWith('item');

--- a/web/scripts/displays/app.js
+++ b/web/scripts/displays/app.js
@@ -97,10 +97,11 @@ angular.module('risevision.apps')
           },
           controller: 'displayAdd',
           resolve: {
-            scheduleInfo: ['$stateParams', 'canAccessApps', 'displayFactory',
-              function ($stateParams, canAccessApps, displayFactory) {
+            scheduleInfo: ['$stateParams', 'canAccessApps', 'displayFactory', 'screenshotFactory',
+              function ($stateParams, canAccessApps, displayFactory, screenshotFactory) {
                 return canAccessApps().then(function () {
                   displayFactory.newDisplay();
+                  delete screenshotFactory.screenshot;
 
                   if ($stateParams.schedule) {
                     displayFactory.setAssignedSchedule($stateParams.schedule);


### PR DESCRIPTION
## Description
Reset screenshot object on add display

Ensure old screenshot doesn't persist

[stage-19]

## Motivation and Context
Fixes issue where screenshot persists from the old Display when adding a new one.

Ideally screenshot should be handled in the displayFactory when adding and managing a Display, however that would create a cross dependency. Would require refactoring to implement.

## How Has This Been Tested?
Tested changes locally, updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No