### PR TITLE
Fix #1974 - Move Scrollbar inside Templates modal 

### DIFF
--- a/web/partials/editor/store-products-modal.html
+++ b/web/partials/editor/store-products-modal.html
@@ -73,19 +73,19 @@
                 <div class="text-muted text-center u_padding-lg"><span translate>editor-app.storeProduct.content.noResults</span></div>
               </div>
 
+              <div id="suggestTemplate" class="col-sm-12 text-center" ng-if="factory.search.category === 'Templates' && isEducationCustomer && !factory.loadingItems">
+                <h3 translate>editor-app.storeProduct.templates.cantFind</h3>
+                <a translate href="https://docs.google.com/forms/d/1slHKxGxywkiSakMukDr4dMGLmhzhYhoU0F2BHP8FSd4/viewform" target="_blank">
+                  editor-app.storeProduct.templates.suggest
+                </a>
+              </div>
+
             </div>
           </div>
         </div><!--panel-body-->
       </div><!--panel-->
 
     </section>
-
-    <div id="suggestTemplate" class="text-center" ng-if="factory.search.category === 'Templates' && isEducationCustomer && !factory.loadingItems">
-      <h3 translate>editor-app.storeProduct.templates.cantFind</h3>
-      <a translate href="https://docs.google.com/forms/d/1slHKxGxywkiSakMukDr4dMGLmhzhYhoU0F2BHP8FSd4/viewform" target="_blank">
-        editor-app.storeProduct.templates.suggest
-      </a>
-    </div>
 
     <a id="addWidgetByUrl" class="btn btn-default" href="#" ng-click="addWidgetByUrl()" ng-if="factory.search.category === 'Content'">
       {{'editor-app.addWidget.title' | translate}} <i class="fa fa-code icon-right"></i>

--- a/web/scss/ui-components/template-picker.scss
+++ b/web/scss/ui-components/template-picker.scss
@@ -1,4 +1,10 @@
 .product-grid {
+
+  .panel {
+    max-height: calc(100vh - 275px);
+    overflow-y: auto;
+  }
+
   .product-grid_image {
     overflow: hidden;
     background: #222;


### PR DESCRIPTION
## Description
Move scrollbar inside Templates modal to avoid dismissing it when clicking outside scrollbar.

## Motivation and Context
Fix #1974.

## How Has This Been Tested?
Locally with different resolution and on [stage-1].

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
