### PR TITLE
Detect all displays schedule and assign the display to it

### DIFF
--- a/test/unit/displays/controllers/ctr-display-add.tests.js
+++ b/test/unit/displays/controllers/ctr-display-add.tests.js
@@ -13,6 +13,15 @@ describe('controller: display add', function() {
         addDisplay: sinon.spy()
       };
     });
+    $provide.service('scheduleFactory', function() {
+      return {
+        getAllDisplaysSchedule: function() {
+          this.deferred = Q.defer();
+
+          return this.deferred.promise;
+        }
+      };
+    });
     $provide.service('$loading',function(){
       return {
         start: sandbox.stub(),
@@ -24,10 +33,11 @@ describe('controller: display add', function() {
     });
 
   }));
-  var $scope, $loading, displayFactory;
+  var $scope, $loading, displayFactory, scheduleFactory;
   beforeEach(function(){
     inject(function($injector, $controller){
       displayFactory = $injector.get('displayFactory');
+      scheduleFactory = $injector.get('scheduleFactory');
       $loading = $injector.get('$loading');
 
       var $rootScope = $injector.get('$rootScope');
@@ -48,17 +58,31 @@ describe('controller: display add', function() {
     expect($scope).to.be.ok;
     expect($scope.factory).to.be.ok;
     expect($scope.playerLicenseFactory).to.be.ok;
+    expect($scope.selectedSchedule).to.be.null;
 
     expect($scope.save).to.be.a('function');
   });
 
-  it('should initialize', function(done) {
+  describe('All Displays Schedule:', function() {
+    it('should initialize the display with the all displays schedule', function(done) {
+      scheduleFactory.deferred.resolve('schedule');
 
-    setTimeout(function() {
-      expect($scope.selectedSchedule).to.be.null;
+      setTimeout(function() {
+        expect($scope.selectedSchedule).to.equal('schedule');
 
-      done();
-    }, 10);
+        done();
+      }, 10);
+    });
+
+    it('should not assign schedule if not found', function(done) {
+      scheduleFactory.deferred.resolve();
+
+      setTimeout(function() {
+        expect($scope.selectedSchedule).to.be.null;
+
+        done();
+      }, 10);
+    });
   });
 
   describe('spinner:', function() {

--- a/test/unit/schedules/directives/dtv-preview-selector.tests.js
+++ b/test/unit/schedules/directives/dtv-preview-selector.tests.js
@@ -71,6 +71,9 @@ describe('directive: preview-selector', function() {
   
   it('should initialize', function() {
     expect($scope.showTooltip).to.be.false;
+    expect($scope.filterConfig).to.deep.equal({
+      placeholder: 'Search schedules'
+    });
     expect($scope.search).to.deep.equal({
       sortBy: 'changeDate',
       reverse: true,

--- a/test/unit/schedules/services/svc-schedule-factory.tests.js
+++ b/test/unit/schedules/services/svc-schedule-factory.tests.js
@@ -132,6 +132,7 @@ describe('service: scheduleFactory:', function() {
     expect(scheduleFactory.updateSchedule).to.be.a('function');
     expect(scheduleFactory.deleteSchedule).to.be.a('function');
 
+    expect(scheduleFactory.getAllDisplaysSchedule).to.be.a('function');
     expect(scheduleFactory.checkFreeDisplays).to.be.a('function');
     expect(scheduleFactory.hasFreeDisplays).to.be.a('function');
     expect(scheduleFactory.requiresLicense).to.be.a('function');
@@ -609,6 +610,49 @@ describe('service: scheduleFactory:', function() {
     });
   });
 
+  describe('getAllDisplaysSchedule:', function(){
+
+    it('should check for all displays schedule', function(done) {
+      var schedule = {};
+      returnList = {
+        items: [
+          schedule
+        ]
+      };
+      scheduleFactory.getAllDisplaysSchedule()
+        .then(function(result){
+          scheduleListSpy.should.have.been.calledWith({filter: 'distributeToAll:true'});
+
+          expect(result).to.equal(schedule);
+
+          done();
+        });
+    });
+
+    it('should return nothing if there is no all displays schedule', function(done) {
+      returnList = {
+        items: []
+      };
+      scheduleFactory.getAllDisplaysSchedule()
+        .then(function(result){
+          expect(result).to.not.be.ok;
+
+          done();
+        });
+    });
+
+    it('should resolve and return nothing if there is an error loading list', function(done) {
+      returnList = false;
+      scheduleFactory.getAllDisplaysSchedule()
+      .then(function(result){
+        expect(result).to.not.be.ok;
+
+        done();
+      });
+    });
+
+  });
+
   describe('addToDistribution:', function() {
     beforeEach(function() {
       sinon.spy(scheduleFactory,'forceUpdateSchedule');
@@ -630,6 +674,20 @@ describe('service: scheduleFactory:', function() {
 
     it('should handle missing schedule id', function(done) {
       var schedule = {};
+      var display = { id: 'displayId' };
+
+      scheduleFactory.addToDistribution(display, schedule);
+      setTimeout(function() {
+        scheduleFactory.forceUpdateSchedule.should.not.have.been.called;
+        done();
+      },10);
+    });
+
+    it('should handle all displays schedule', function(done) {
+      var schedule = {
+        id: 'scheduleId',
+        distributeToAll: true
+      };
       var display = { id: 'displayId' };
 
       scheduleFactory.addToDistribution(display, schedule);

--- a/web/scripts/displays/controllers/ctr-display-add.js
+++ b/web/scripts/displays/controllers/ctr-display-add.js
@@ -2,10 +2,18 @@
 
 angular.module('risevision.displays.controllers')
   .controller('displayAdd', ['$scope', '$log', '$loading', 'displayFactory', 'playerLicenseFactory',
-    function ($scope, $log, $loading, displayFactory, playerLicenseFactory) {
+    'scheduleFactory',
+    function ($scope, $log, $loading, displayFactory, playerLicenseFactory, scheduleFactory) {
       $scope.factory = displayFactory;
       $scope.playerLicenseFactory = playerLicenseFactory;
       $scope.selectedSchedule = null;
+
+      scheduleFactory.getAllDisplaysSchedule()
+        .then(function (result) {
+          if (result) {
+            $scope.selectedSchedule = result;
+          }
+        });
 
       $scope.$watch('factory.loadingDisplay', function (loading) {
         if (loading) {

--- a/web/scripts/schedules/directives/dtv-preview-selector.js
+++ b/web/scripts/schedules/directives/dtv-preview-selector.js
@@ -18,6 +18,10 @@ angular.module('risevision.schedules.directives')
           var tooltipElement = angular.element(element[0].querySelector('#preview-selector'));
           $scope.showTooltip = false;
 
+          $scope.filterConfig = {
+            placeholder: 'Search schedules'
+          };
+
           $scope.search = {
             sortBy: 'changeDate',
             reverse: true,

--- a/web/scripts/schedules/services/svc-schedule-factory.js
+++ b/web/scripts/schedules/services/svc-schedule-factory.js
@@ -115,6 +115,17 @@ angular.module('risevision.schedules.services')
         return deferred.promise;
       };
 
+      factory.getAllDisplaysSchedule = function () {
+        return schedule.list({
+          filter: 'distributeToAll:true'
+        }).then(function (result) {
+          if (result && result.items && result.items.length > 0) {
+            return result.items[0];
+          }
+        })
+        .catch(function () {});
+      };
+
       factory.hasFreeDisplays = function () {
         var distribution = factory.schedule.distribution ? factory.schedule.distribution : [];
 
@@ -254,7 +265,7 @@ angular.module('risevision.schedules.services')
       };
 
       factory.addToDistribution = function (display, schedule) {
-        if (!schedule || !schedule.id || schedule.id === display.scheduleId) {
+        if (!schedule || !schedule.id || schedule.id === display.scheduleId || schedule.distributeToAll) {
           return $q.resolve();
         } else {
           $log.info('Adding to Distribution: ', display.id, schedule.id);


### PR DESCRIPTION
## Description
Detect all displays schedule and assign the display to it

Do not update Schedule with Display if set to distributeToAll

[stage-17]

## Motivation and Context
The All Displays schedule will automatically receive that Display on save, so we are just making that clear to the User in this case.

## How Has This Been Tested?
Tested changes locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No