### PR TITLE
Set max-size on preview-selector to prevent line breaks

### DIFF
--- a/web/scss/sections/displays.scss
+++ b/web/scss/sections/displays.scss
@@ -63,10 +63,12 @@
     }
   }
 
-  .btn-schedule-selector {
-    span {
-      @media (min-width: $screen-md) {
-        max-width: 170px;
+  .form-inline {
+    .btn-schedule-selector {
+      span {
+        @media (min-width: $screen-md) {
+          max-width: 170px;
+        }
       }
     }
   }

--- a/web/scss/sections/displays.scss
+++ b/web/scss/sections/displays.scss
@@ -63,6 +63,14 @@
     }
   }
 
+  .btn-schedule-selector {
+    span {
+      @media (min-width: $screen-md) {
+        max-width: 170px;
+      }
+    }
+  }
+
   .btn-group-checkbox {
     position: relative;
 


### PR DESCRIPTION
## Description
Set max-size on preview-selector to prevent line breaks on long names

## Motivation and Context
Fix for https://github.com/Rise-Vision/rise-vision-apps/issues/1994

## How Has This Been Tested?
Visually confirmed locally and on [stage-1]

Sample: https://apps-stage-1.risevision.com/displays/details/A5ASMD8QX9YK?cid=554d3ef9-78b7-4726-8f46-c1ec140c166d

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
