### PR TITLE
Remove help links when no results occur from financial search

### DIFF
--- a/web/locales/en/template.json
+++ b/web/locales/en/template.json
@@ -46,10 +46,7 @@
       "world-indexes": "Most Popular World Indexes"
     },
     "no-results": {
-      "title": "No Results Found",
-      "question": "Can't find what you're looking for?",
-      "verify": "Verify the instrument is valid.",
-      "contact": "Contact support@risevision.com for help."
+      "title": "No Results Found"
     },
     "search-category": {
       "bonds": "Search Bonds",

--- a/web/partials/template-editor/components/component-financial.html
+++ b/web/partials/template-editor/components/component-financial.html
@@ -53,19 +53,6 @@
   <div class="instrument-selector te-scrollable-container">
   <div class="instrument-selector-no-results" ng-show="!instrumentSearch.length || instrumentSearch.length === 0">
     <h2 translate>template.financial.no-results.title</h2>
-    <div translate>template.financial.no-results.question</div>
-    <div>
-      <a target="_blank" href="https://help.risevision.com/hc/en-us/articles/115001426846-Verify-a-stock-symbol-is-valid">
-        <i class="fa fa-question-circle"></i>
-        <span translate>template.financial.no-results.verify</span>
-      </a>
-    </div>
-    <div>
-      <a target="_blank" href="mailto:support@risevision.com">
-        <i class="fa fa-question-circle"></i>
-        <span translate>template.financial.no-results.contact</span>
-      </a>
-    </div>
   </div>
 
   <div class="instrument-selector-popular" ng-show="popularResults">{{ getPopularTitle() | translate }}</div>


### PR DESCRIPTION
## Description
When a user searches for a financial stock and it is not found, we are no longer displaying help links as they are outdated. 

## Motivation and Context
Fixes issue #1981 

## How Has This Been Tested?
On staging with financial template - https://apps-stage-8.risevision.com/templates/edit/53c01baa-24e4-4dc8-8cc8-f668b50bddfd/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
