### PR TITLE
Always set source as socialMedia when sharing Schedule on social networks

### DIFF
--- a/test/unit/schedules/controllers/ctr-shared-schedule-popover.tests.js
+++ b/test/unit/schedules/controllers/ctr-shared-schedule-popover.tests.js
@@ -119,7 +119,6 @@ describe('controller: SharedSchedulePopoverController', function() {
 
   describe('shareOnSocial', function() {
     beforeEach(function() {
-      $scope.currentTab = 'socialMedia';
       sinon.stub($window, 'open');
     });
     afterEach(function() {

--- a/web/scripts/schedules/controllers/ctr-shared-schedule-popover.js
+++ b/web/scripts/schedules/controllers/ctr-shared-schedule-popover.js
@@ -64,6 +64,7 @@ USER_FIRST_NAME')
 
       $scope.shareOnSocial = function (network) {
         $scope.trackScheduleShared({
+          source: 'socialMedia',
           network: network
         });
         var encodedLink = encodeURIComponent($scope.getLink());
@@ -89,7 +90,7 @@ USER_FIRST_NAME')
 
       $scope.trackScheduleShared = function (extraProperties) {
         var properties = extraProperties || {};
-        properties.source = $scope.currentTab;
+        properties.source = properties.source || $scope.currentTab;
 
         scheduleTracker('schedule shared', $scope.schedule.id, $scope.schedule.name, properties);
       };


### PR DESCRIPTION
## Description
Always set source as socialMedia when sharing Schedule on social networks (i.e. no longer rely on $scope.currentTab value).

## Motivation and Context
Due to a UI change `source` was being set as `link` given we no longer have a social network tab. 

## How Has This Been Tested?
Locally. Staged at [stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
