### PR TITLE
Send publish event when adding legacy presentation

### DIFF
--- a/test/unit/editor/services/svc-editor-factory.tests.js
+++ b/test/unit/editor/services/svc-editor-factory.tests.js
@@ -306,7 +306,13 @@ describe('service: editorFactory:', function() {
 
           setTimeout(function(){
             expect(currentState).to.equal('apps.editor.workspace.artboard');
+            expect(presentationTracker).to.have.been.calledTwice;
             expect(presentationTracker).to.have.been.calledWith('Presentation Created',
+              'presentationId', 'some presentation', {
+                presentationType: 'Presentation',
+                sharedTemplate: 'blank'
+            });
+            expect(presentationTracker).to.have.been.calledWith('Presentation Published',
               'presentationId', 'some presentation', {
                 presentationType: 'Presentation',
                 sharedTemplate: 'blank'
@@ -362,7 +368,13 @@ describe('service: editorFactory:', function() {
 
           setTimeout(function(){
             expect(currentState).to.equal('apps.editor.workspace.artboard');
+            expect(presentationTracker).to.have.been.calledTwice;
             expect(presentationTracker).to.have.been.calledWith('Presentation Created',
+              'presentationId', 'some presentation', {
+                presentationType: 'Presentation',
+                sharedTemplate: 'blank'
+            });
+            expect(presentationTracker).to.have.been.calledWith('Presentation Published',
               'presentationId', 'some presentation', {
                 presentationType: 'Presentation',
                 sharedTemplate: 'blank'
@@ -908,7 +920,13 @@ describe('service: editorFactory:', function() {
       editorFactory.save();
 
       setTimeout(function(){
+        expect(presentationTracker).to.have.been.calledTwice;
         expect(presentationTracker).to.have.been.calledWith('Presentation Created',
+          'presentationId', 'some presentation', {
+            presentationType: 'Presentation',
+            sharedTemplate: 'blank'
+        });
+        expect(presentationTracker).to.have.been.calledWith('Presentation Published',
           'presentationId', 'some presentation', {
             presentationType: 'Presentation',
             sharedTemplate: 'blank'

--- a/web/scripts/editor/services/svc-editor-factory.js
+++ b/web/scripts/editor/services/svc-editor-factory.js
@@ -183,6 +183,10 @@ angular.module('risevision.editor.services')
                 presentationType: 'Presentation',
                 sharedTemplate: 'blank'
               });
+              presentationTracker('Presentation Published', resp.item.id, resp.item.name, {
+                presentationType: 'Presentation',
+                sharedTemplate: 'blank'
+              });
 
               $rootScope.$broadcast('presentationCreated');
 


### PR DESCRIPTION
## Description
Send publish event when adding legacy presentation

[stage-19]

## Motivation and Context
When saving a legacy Presentation it is Published automatically. We are missing the Publish event in these cases.

## How Has This Been Tested?
Tested changes on the staged version to ensure event is sent to Segment. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No