### PR TITLE
Detect and track display activation

### DIFF
--- a/test/unit/components/logging/svc-display-tracker.tests.js
+++ b/test/unit/components/logging/svc-display-tracker.tests.js
@@ -6,11 +6,12 @@ describe('service: display tracker:', function() {
     $provide.service('$q', function() {return Q;});
     $provide.service('userState',function(){
       return {
-        getSelectedCompanyId: function() {
-          return "companyId";
-        }, 
+        getUsername: sinon.stub().returns('userId'),
+        getUserEmail: sinon.stub().returns('userEmail'),
+        getSelectedCompanyId: sinon.stub().returns('companyId'),
+        getSelectedCompanyName: sinon.stub().returns('companyName'),
         _restoreState: function(){}
-      }
+      };
     });
     $provide.service('analyticsFactory',function(){
       return {
@@ -45,20 +46,43 @@ describe('service: display tracker:', function() {
   });
   
   it('should call analytics service',function(){
-    displayTracker('Display Updated', 'displayId', 'displayName', 'downloadType');
+    displayTracker('Display Updated', 'displayId', 'displayName');
 
     expect(eventName).to.equal('Display Updated');
-    expect(eventData).to.deep.equal({displayId: 'displayId', displayName: 'displayName', companyId: 'companyId', downloadType: 'downloadType'});
+    expect(eventData).to.deep.equal({
+      displayId: 'displayId', 
+      displayName: 'displayName', 
+      userId: 'userId',
+      email: 'userEmail',
+      companyId: 'companyId',
+      companyName: 'companyName'});
     bQSpy.should.not.have.been.called;
   });
 
-  it('should track Player Download event to BQ',function(){
-    displayTracker('Player Download', 'displayId', 'displayName', 'downloadType');
-    bQSpy.should.have.been.calledWith('Player Download', 'displayId');
+  it('should append additional properties',function(){
+    displayTracker('Display Updated', 'displayId', 'displayName', {
+      property1: 'value1',
+      property2: 'value2'
+    });
+
+    expect(eventName).to.equal('Display Updated');
+    expect(eventData).to.deep.equal({
+      displayId: 'displayId', 
+      displayName: 'displayName', 
+      userId: 'userId',
+      email: 'userEmail',
+      companyId: 'companyId',
+      companyName: 'companyName',
+      property1: 'value1',
+      property2: 'value2'
+    });
+
+    bQSpy.should.not.have.been.called;
   });
 
   it('should track Display Created event to BQ',function(){
-    displayTracker('Display Created', 'displayId', 'displayName', 'downloadType');
+    displayTracker('Display Created', 'displayId', 'displayName');
+
     bQSpy.should.have.been.calledWith('Display Created', 'displayId');
   });
 

--- a/test/unit/displays/services/svc-display-activation-tracker.tests.js
+++ b/test/unit/displays/services/svc-display-activation-tracker.tests.js
@@ -1,0 +1,156 @@
+'use strict';
+describe('service: display activation tracker', function() {
+  beforeEach(module('risevision.displays.services'));
+
+  beforeEach(module(function ($provide) {
+    $provide.service('userState',function(){
+      return {
+        getUsername: sinon.stub().returns('username'), 
+        isSubcompanySelected: sinon.stub().returns(false),
+        getCopyOfProfile: sinon.stub().returns({}),
+        updateUserProfile: sinon.stub(),
+        _restoreState: function(){}
+      }
+    });
+    $provide.service('analyticsFactory',function(){
+      return {
+        identify: sinon.stub(), 
+        load: function(){}
+      }
+    });
+    $provide.service('updateUser', function() {
+      return sinon.stub().returns(Q.resolve({
+        item: 'updatedUser'
+      }));
+    });
+    $provide.service('displayTracker', function() {
+      return sinon.stub();
+    });
+
+  }));
+  
+  var displayActivationTracker, userState, analyticsFactory, updateUser, displayTracker;
+  beforeEach(function(){
+    inject(function($injector){
+      userState = $injector.get('userState');
+      analyticsFactory = $injector.get('analyticsFactory');
+      updateUser = $injector.get('updateUser');
+      displayTracker = $injector.get('displayTracker');
+      displayActivationTracker = $injector.get('displayActivationTracker');
+    });
+  });
+
+  it('should exist',function(){
+    expect(displayActivationTracker).to.be.ok;
+    expect(displayActivationTracker).to.be.a('function');
+  });
+  
+  it('should return early if subcompany is selected',function(){
+    userState.isSubcompanySelected.returns(true);
+
+    displayActivationTracker([]);
+
+    userState.isSubcompanySelected.should.have.been.called;
+    userState.getCopyOfProfile.should.not.have.been.called;
+
+    analyticsFactory.identify.should.not.have.been.called;
+    displayTracker.should.not.have.been.called;
+  });
+
+  it('should return early if setting exists',function(){
+    userState.getCopyOfProfile.returns({
+      settings: {
+        firstDisplayActivationDate: '2020-08-21T15:19:02.716Z'
+      }
+    });
+
+    displayActivationTracker([{
+      lastConnectionTime: '2020-08-21T15:19:02.716Z'
+    }]);
+
+    userState.isSubcompanySelected.should.have.been.called;
+    userState.getCopyOfProfile.should.have.been.called;
+
+    analyticsFactory.identify.should.not.have.been.called;
+    displayTracker.should.not.have.been.called;
+  });
+
+  describe('displays list:', function() {
+    it('should not track if lastConnectionTime is not available',function(){
+      displayActivationTracker([{
+        id: 'displayId1',
+        name: 'displayName1'
+      },{
+        id: 'displayId2',
+        name: 'displayName2'
+      }]);
+
+      userState.isSubcompanySelected.should.have.been.called;
+      userState.getCopyOfProfile.should.have.been.called;
+
+      analyticsFactory.identify.should.not.have.been.called;
+      displayTracker.should.not.have.been.called;
+    });
+
+    it('should track earliest lastConnectionTime',function(){
+      displayActivationTracker([{
+        id: 'displayId1',
+        name: 'displayName1',
+        lastConnectionTime: '2019-08-21T15:19:02.716Z'
+      },{
+        id: 'displayId2',
+        name: 'displayName2',
+        lastConnectionTime: '2020-08-21T15:19:02.716Z'
+      },{
+        id: 'displayId3',
+        name: 'displayName3',
+        lastConnectionTime: '2017-08-21T15:19:02.716Z'
+      }]);
+
+      analyticsFactory.identify.should.have.been.calledWith('username', {
+        firstDisplayActivationDate: '2017-08-21T15:19:02.716Z'
+      });
+      displayTracker.should.have.been.calledWith('first display activated', 'displayId3', 'displayName3', {
+        firstDisplayActivationDate: '2017-08-21T15:19:02.716Z'
+      });
+    });
+
+  });
+
+  it('should track event, send identify',function(){
+    displayActivationTracker([{
+      id: 'displayId',
+      name: 'displayName',
+      lastConnectionTime: '2020-08-21T15:19:02.716Z'
+    }]);
+
+    analyticsFactory.identify.should.have.been.calledWith('username', {
+      firstDisplayActivationDate: '2020-08-21T15:19:02.716Z'
+    });
+    displayTracker.should.have.been.calledWith('first display activated', 'displayId', 'displayName', {
+      firstDisplayActivationDate: '2020-08-21T15:19:02.716Z'
+    });
+
+  });
+
+  it('should update user settings',function(done){
+    displayActivationTracker([{
+      id: 'displayId',
+      name: 'displayName',
+      lastConnectionTime: '2020-08-21T15:19:02.716Z'
+    }]);
+
+    setTimeout(function() {
+      updateUser.should.have.been.calledWith('username', {
+        settings: {
+          firstDisplayActivationDate: '2020-08-21T15:19:02.716Z'
+        }
+      });
+      userState.updateUserProfile.should.have.been.calledWith('updatedUser');
+
+      done();
+    }, 10);
+
+  });
+
+});

--- a/test/unit/displays/services/svc-display.tests.js
+++ b/test/unit/displays/services/svc-display.tests.js
@@ -60,6 +60,9 @@ describe('service: display:', function() {
       }
     });
 
+    $provide.service('displayActivationTracker', function() {
+      return sinon.stub();
+    });
     $provide.service('coreAPILoader',function () {
       return function(){
         var deferred = Q.defer();
@@ -240,7 +243,7 @@ describe('service: display:', function() {
       };
     });
   }));
-  var display, returnList, searchString, sortString, $timeout, $rootScope;
+  var display, returnList, searchString, sortString, $timeout, $rootScope, displayActivationTracker;
   beforeEach(function(){
     returnList = true;
     searchString = '';
@@ -248,13 +251,14 @@ describe('service: display:', function() {
 
     inject(function($injector, _$timeout_){
       display = $injector.get('display');
+      displayActivationTracker = $injector.get('displayActivationTracker');
       $rootScope = $injector.get('$rootScope');
       $timeout = _$timeout_;
     });
   });
 
   it('should exist',function(){
-    expect(display).to.be.truely;
+    expect(display).to.be.ok;
     expect(display.list).to.be.a('function');
     expect(display.get).to.be.a('function');
     expect(display.add).to.be.a('function');
@@ -271,7 +275,7 @@ describe('service: display:', function() {
 
       display.list({})
       .then(function(result){
-        expect(result).to.be.truely;
+        expect(result).to.be.ok;
         expect(result.items).to.be.an.array;
         items = result.items;
         expect(result.items).to.have.length.above(0);
@@ -284,6 +288,8 @@ describe('service: display:', function() {
             });
 
             broadcastSpy.should.have.been.calledWith('displaysLoaded', items);
+
+            displayActivationTracker.should.have.been.calledWith(items);
 
             done();
           });
@@ -353,9 +359,9 @@ describe('service: display:', function() {
 
       display.get('display1')
       .then(function(result){
-        expect(result).to.be.truely;
+        expect(result).to.be.ok;
         item = result.item;
-        expect(result.item).to.be.truely;
+        expect(result.item).to.be.ok;
         expect(result.item).to.have.property("name");
         $timeout.flush();
         setTimeout(function() {
@@ -363,6 +369,8 @@ describe('service: display:', function() {
           expect(item.lastConnectionTime.getTime()).to.not.equal(CONNECTION_TIME);
 
           broadcastSpy.should.have.been.calledWith('displaysLoaded', [item]);
+
+          displayActivationTracker.should.have.been.calledWith([item]);
 
           done();
         });
@@ -397,8 +405,8 @@ describe('service: display:', function() {
     it('should add a display',function(done){
       display.add(displayObject)
       .then(function(result){
-        expect(result).to.be.truely;
-        expect(result.item).to.be.truely;
+        expect(result).to.be.ok;
+        expect(result.item).to.be.ok;
         expect(result.item).to.have.property("name");
         expect(result.item).to.have.property("id");
         expect(result.item.id).to.equal("display1");
@@ -437,8 +445,8 @@ describe('service: display:', function() {
     it('should update a display',function(done){
       display.update(displayObject.id, displayObject)
       .then(function(result){
-        expect(result).to.be.truely;
-        expect(result.item).to.be.truely;
+        expect(result).to.be.ok;
+        expect(result.item).to.be.ok;
 
         done();
       })
@@ -448,8 +456,8 @@ describe('service: display:', function() {
     it('should remove extra properties',function(done){
       display.update(displayObject.id, displayObject)
       .then(function(result){
-        expect(result).to.be.truely;
-        expect(result.item).to.be.truely;
+        expect(result).to.be.ok;
+        expect(result.item).to.be.ok;
         expect(result.item).to.not.have.property("connected");
 
         done();
@@ -474,8 +482,8 @@ describe('service: display:', function() {
     it('should delete a display',function(done){
       display.delete('display1')
         .then(function(result){
-          expect(result).to.be.truely;
-          expect(result.item).to.be.truely;
+          expect(result).to.be.ok;
+          expect(result.item).to.be.ok;
 
           done();
         })
@@ -499,8 +507,8 @@ describe('service: display:', function() {
     it('should restart a display',function(done){
       display.restart('display1')
         .then(function(result){
-          expect(result).to.be.truely;
-          expect(result.item).to.be.truely;
+          expect(result).to.be.ok;
+          expect(result.item).to.be.ok;
 
           done();
         })
@@ -524,8 +532,8 @@ describe('service: display:', function() {
     it('should reboot a display',function(done){
       display.reboot('display1')
         .then(function(result){
-          expect(result).to.be.truely;
-          expect(result.item).to.be.truely;
+          expect(result).to.be.ok;
+          expect(result.item).to.be.ok;
 
           done();
         })
@@ -547,7 +555,7 @@ describe('service: display:', function() {
 
   describe('hasSchedule', function() {
     it('should validate if a display has an associated schedule', function() {
-      expect(display.hasSchedule({ scheduleId: "1" })).to.be.truely;
+      expect(display.hasSchedule({ scheduleId: "1" })).to.be.ok;
       expect(display.hasSchedule({ scheduleId: "" })).to.be.falsey;
       expect(display.hasSchedule({ scheduleId: "DEMO" })).to.be.falsey;
     });
@@ -581,8 +589,8 @@ describe('service: display:', function() {
     it('should upload the control file', function(done) {
       display.uploadControlFile('display1', 'contents')
         .then(function(result) {
-          expect(result).to.be.truely;
-          expect(result.item).to.be.truely;
+          expect(result).to.be.ok;
+          expect(result.item).to.be.ok;
 
           done();
         })
@@ -606,8 +614,8 @@ describe('service: display:', function() {
 	it('should send setup email', function(done) {
 	  display.sendSetupEmail('display1', 'email@company.com')
 	    .then(function(result) {
-	      expect(result).to.be.truely;
-	      expect(result.item).to.be.truely;
+	      expect(result).to.be.ok;
+	      expect(result.item).to.be.ok;
 
 	      done();
 	    })

--- a/web/index.html
+++ b/web/index.html
@@ -386,6 +386,7 @@
   <script src="scripts/displays/services/svc-display.js"></script>
   <script src="scripts/displays/services/svc-display-factory.js"></script>
   <script src="scripts/displays/services/svc-display-status-factory.js"></script>
+  <script src="scripts/displays/services/svc-display-activation-tracker.js"></script>
   <script src="scripts/displays/services/svc-player-actions-factory.js"></script>
   <script src="scripts/displays/services/svc-screenshot-factory.js"></script>
   <script src="scripts/displays/services/svc-screenshot-requester.js"></script>

--- a/web/scripts/components/logging/svc-display-tracker.js
+++ b/web/scripts/components/logging/svc-display-tracker.js
@@ -2,21 +2,26 @@
 
 angular.module('risevision.common.components.logging')
   .value('DISPLAY_EVENTS_TO_BQ', [
-    'Display Created',
-    'Player Download'
+    'Display Created'
   ])
   .factory('displayTracker', ['userState', 'analyticsFactory',
     'bigQueryLogging', 'DISPLAY_EVENTS_TO_BQ',
     function (userState, analyticsFactory, bigQueryLogging,
       DISPLAY_EVENTS_TO_BQ) {
-      return function (eventName, displayId, displayName, downloadType) {
+      return function (eventName, displayId, displayName, eventProperties) {
         if (eventName) {
-          analyticsFactory.track(eventName, {
+          eventProperties = eventProperties || {};
+          angular.extend(eventProperties, {
             displayId: displayId,
             displayName: displayName,
+            userId: userState.getUsername(),
+            email: userState.getUserEmail(),
             companyId: userState.getSelectedCompanyId(),
-            downloadType: downloadType
+            companyName: userState.getSelectedCompanyName()
           });
+
+          analyticsFactory.track(eventName, eventProperties);
+
           if (DISPLAY_EVENTS_TO_BQ.indexOf(eventName) !== -1) {
             bigQueryLogging.logEvent(eventName, displayId);
           }

--- a/web/scripts/displays/services/svc-display-activation-tracker.js
+++ b/web/scripts/displays/services/svc-display-activation-tracker.js
@@ -1,0 +1,61 @@
+'use strict';
+
+angular.module('risevision.displays.services')
+  .service('displayActivationTracker', ['$log', 'userState', 'analyticsFactory', 'displayTracker',
+    'updateUser',
+    function ($log, userState, analyticsFactory, displayTracker, updateUser) {
+      var _checkActiveDisplay = function(displays) {
+        return _.reduce(displays, function(result, display) {
+          if (!display.lastConnectionTime) {
+            return result;
+          } else if (!result) {
+            return display;
+          } else {
+            var newTime = new Date(display.lastConnectionTime);
+            var resultTime = new Date(result.lastConnectionTime);
+            return newTime > resultTime ? result : display;  
+          }
+        }, null);
+      };
+
+      var _updateUserSettings = function(firstDisplayActivationDate) {
+        var settings = {};
+        settings.firstDisplayActivationDate = firstDisplayActivationDate;
+
+        return updateUser(userState.getUsername(), {
+            settings: settings
+          })
+          .then(function (resp) {
+            userState.updateUserProfile(resp.item);
+          });
+      };
+
+      return function (displays) {
+        if (userState.isSubcompanySelected()) {
+          return;
+        }
+
+        var profile = userState.getCopyOfProfile();
+
+        if (profile && profile.settings && profile.settings.firstDisplayActivationDate) {
+          return;
+        }
+
+        var activeDisplay = _checkActiveDisplay(displays);
+
+        if (activeDisplay && activeDisplay.lastConnectionTime) {
+          $log.info('Active display found', activeDisplay);
+
+          analyticsFactory.identify(userState.getUsername(), {
+            firstDisplayActivationDate: activeDisplay.lastConnectionTime
+          });
+
+          displayTracker('first display activated', activeDisplay.id, activeDisplay.name, {
+            firstDisplayActivationDate: activeDisplay.lastConnectionTime
+          });
+
+          _updateUserSettings(activeDisplay.lastConnectionTime);
+        }
+      };
+    }
+  ]);

--- a/web/scripts/displays/services/svc-display.js
+++ b/web/scripts/displays/services/svc-display.js
@@ -17,10 +17,10 @@
       'postalCode'
     ])
     .service('display', ['$rootScope', '$q', '$log', 'coreAPILoader',
-      'userState', 'displayStatusFactory', 'screenshotRequester', 'pick',
+      'userState', 'displayStatusFactory', 'screenshotRequester', 'pick', 'displayActivationTracker',
       'DISPLAY_WRITABLE_FIELDS', 'DISPLAY_SEARCH_FIELDS', 'PLAYER_PRO_PRODUCT_CODE',
       function ($rootScope, $q, $log, coreAPILoader, userState,
-        displayStatusFactory, screenshotRequester, pick,
+        displayStatusFactory, screenshotRequester, pick, displayActivationTracker,
         DISPLAY_WRITABLE_FIELDS, DISPLAY_SEARCH_FIELDS, PLAYER_PRO_PRODUCT_CODE) {
 
         var companiesStatus = {};
@@ -109,6 +109,8 @@
                     console.error('Failed to load status of displays.', e);
                   })
                   .finally(function () {
+                    displayActivationTracker(result.items);
+
                     service.statusLoading = false;
                   });
               }
@@ -143,6 +145,8 @@
 
                     $rootScope.$broadcast('displaysLoaded', [item]);
                   }).finally(function () {
+                    displayActivationTracker([item]);
+
                     service.statusLoading = false;
                   });
                 }


### PR DESCRIPTION
## Description
Detect and track display activation

Check both when loading displays and display get
Check user settings to see if activation was tracked
Do not track if in a subcompany
Track as event and identify property
Track date of the earliest active display date

[stage-2]

## Motivation and Context
Add tracking for a Display being activated during a User session. For Onboarding messages.

## How Has This Been Tested?
Tested changes locally. Tested tracking on Staging where segment is enabled. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No