### PR TITLE
Add routes for add user and plans modal

### DIFF
--- a/test/unit/app.tests.js
+++ b/test/unit/app.tests.js
@@ -2,34 +2,140 @@
 
 describe('app:', function() {
   beforeEach(function () {
-      angular.module('risevision.apps.partials',[]);
+    angular.module('risevision.apps.partials',[]);
 
-      module('risevision.apps');
+    module('risevision.apps');
 
-      module(function ($provide) {
-        $provide.service('canAccessApps',function(){
-          return sinon.spy(function() {
-            return Q.resolve("auth");
-          })
-        });
-
-        $provide.service('plansFactory',function(){
-          return {
-            showPlansModal: sinon.stub()
-          };
-        });
+    module(function ($provide) {
+      $provide.service('canAccessApps',function(){
+        return sinon.spy(function() {
+          return Q.resolve("auth");
+        })
       });
 
-      inject(function ($injector) {
-        $state = $injector.get('$state');
-        canAccessApps = $injector.get('canAccessApps');
-        plansFactory = $injector.get('plansFactory');
-        $rootScope = $injector.get('$rootScope');
-        $location = $injector.get('$location');
+      $provide.service('plansFactory',function(){
+        return {
+          showPurchaseOptions: sinon.stub()
+        };
       });
+
+      $provide.service('$modal', function() {
+        return {
+          open: sinon.stub().returns({result: Q.resolve()})
+        }
+      });
+
+    });
+
+    inject(function ($injector) {
+      $state = $injector.get('$state');
+      canAccessApps = $injector.get('canAccessApps');
+      plansFactory = $injector.get('plansFactory');
+      $rootScope = $injector.get('$rootScope');
+      $location = $injector.get('$location');
+      $modal = $injector.get('$modal');
+    });
   });
 
-  var $state, canAccessApps, plansFactory, $rootScope, $location;
+  var $state, canAccessApps, plansFactory, $rootScope, $location, $modal;
+
+  describe('state apps.plans:',function(){
+    it('should register state',function(){
+      var state = $state.get('apps.plans');
+      expect(state).to.be.ok;
+      expect(state.url).to.equal('/plans?cid');
+      expect(state.controller).to.be.ok;
+    });
+
+    it('should redirect to home',function(done){
+      var $location = {
+        search: function() { 
+          return {};
+        },
+        replace: sinon.spy()
+      };
+      sinon.spy($state,'go');
+      
+      $state.get('apps.plans').controller[2]($location, $state);
+      setTimeout(function() {
+        $location.replace.should.have.been.called;
+        $state.go.should.have.been.calledWith('apps.launcher.home');
+
+        done();
+      }, 10);
+    });
+
+  });
+
+  describe('state apps.users.add:',function(){
+    it('should register parent',function(){
+      var state = $state.get('apps.users');
+      expect(state).to.be.ok;
+      expect(state.url).to.equal('?cid');
+      expect(state.abstract).to.be.true;
+      expect(state.template).to.equal('<div ui-view></div>');
+    });
+
+    it('should register state',function(){
+      var state = $state.get('apps.users.add');
+      expect(state).to.be.ok;
+      expect(state.url).to.equal('/users/add');
+      expect(state.controller).to.be.ok;
+    });
+
+    it('should redirect to home',function(done){
+      var $location = {
+        search: function() { 
+          return {};
+        },
+        replace: sinon.spy()
+      };
+      sinon.spy($state,'go');
+      
+      $state.get('apps.users.add').controller[2]($location, $state);
+      setTimeout(function() {
+        $location.replace.should.have.been.called;
+        $state.go.should.have.been.calledWith('apps.launcher.home');
+
+        done();
+      }, 10);
+    });
+
+  });
+
+  describe('onboarding links', function() {
+    it('should check next state and show purchase options', function(done) {
+      $state.go('apps.plans');
+      $rootScope.$digest();
+
+      setTimeout(function() {
+        expect(plansFactory.showPurchaseOptions).to.have.been.called;
+        expect($modal.open).to.not.have.been.called;
+
+        done();
+      }, 10);
+
+    });
+
+    it('should check next state and show add user modal', function(done) {
+      $state.go('apps.users.add');
+      $rootScope.$digest();
+
+      setTimeout(function() {
+        expect(plansFactory.showPurchaseOptions).to.not.have.been.called;
+        $modal.open.should.have.been.calledWith({
+          templateUrl: 'partials/common-header/user-settings-modal.html',
+          controller: 'AddUserModalCtrl',
+          resolve: sinon.match.object
+        });
+
+        done();
+      }, 10);
+
+    });
+
+
+  });
 
   describe('state common.auth.signup:',function(){
     it('should register state',function(){
@@ -78,7 +184,7 @@ describe('app:', function() {
 
       $state.get('common.auth.signup').controller[4]($location, $state, canAccessApps, plansFactory);
       setTimeout(function() {
-        expect(plansFactory.showPlansModal).to.have.been.called;
+        expect(plansFactory.showPurchaseOptions).to.have.been.called;
         done();
       }, 10);
     });
@@ -299,4 +405,5 @@ describe('app:', function() {
     });
 
   });
+
 });

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -70,6 +70,30 @@ angular.module('risevision.apps', [
           template: '<div ui-view></div>'
         })
 
+        .state('apps.plans', {
+          url: '/plans?cid',
+          controller: ['$location', '$state',
+            function ($location, $state) {
+              $location.replace();
+              $state.go('apps.launcher.home');
+            }
+          ]
+        })
+        .state('apps.users', {
+          abstract: true,
+          url: '?cid',
+          template: '<div ui-view></div>'
+        })
+        .state('apps.users.add', {
+          url: '/users/add',
+          controller: ['$location', '$state',
+            function ($location, $state) {
+              $location.replace();
+              $state.go('apps.launcher.home');
+            }
+          ]
+        })
+
         .state('common.auth.signup', {
           url: '/signup',
           controller: ['$location', '$state', 'canAccessApps', 'plansFactory',
@@ -80,7 +104,7 @@ angular.module('risevision.apps', [
 
               canAccessApps(true).then(function () {
                 if (showProduct) {
-                  plansFactory.showPlansModal();
+                  plansFactory.showPurchaseOptions();
                 }
 
                 $location.replace();
@@ -168,6 +192,37 @@ angular.module('risevision.apps', [
           $state.go($state.current, null, {
             reload: true
           });
+        }
+      });
+    }
+  ])
+  .run(['$rootScope', '$modal', 'canAccessApps', 'userState', 'plansFactory',
+    function ($rootScope, $modal, canAccessApps, userState, plansFactory) {
+      $rootScope.$on('$stateChangeStart', function (event, toState, toParams, fromState, fromParams) {
+        if (toState.name === 'apps.plans') {
+          canAccessApps().then(function () {
+            plansFactory.showPurchaseOptions();
+          });
+
+          if (fromState.name) {
+            event.preventDefault();            
+          }
+        } else if (toState.name === 'apps.users.add') {
+          canAccessApps().then(function () {
+            $modal.open({
+              templateUrl: 'partials/common-header/user-settings-modal.html',
+              controller: 'AddUserModalCtrl',
+              resolve: {
+                companyId: function () {
+                  return userState.getSelectedCompanyId();
+                }
+              }
+            });
+          });
+          
+          if (fromState.name) {
+            event.preventDefault();            
+          }
         }
       });
     }


### PR DESCRIPTION
## Description
Add routes for add user and plans modal

Reject route transition to keep same page
Update plans modal open for signup page

[stage-19]

## Motivation and Context
New links for the Onboarding epic.

## How Has This Been Tested?
Tested various scenarios locally with both opening in a new tab and existing tab. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No