### PR TITLE
Fix the signup?show_product=true route

### DIFF
--- a/test/unit/app.tests.js
+++ b/test/unit/app.tests.js
@@ -8,9 +8,7 @@ describe('app:', function() {
 
     module(function ($provide) {
       $provide.service('canAccessApps',function(){
-        return sinon.spy(function() {
-          return Q.resolve("auth");
-        })
+        return sinon.stub().returns(Q.resolve("auth"));
       });
 
       $provide.service('plansFactory',function(){
@@ -110,6 +108,8 @@ describe('app:', function() {
       $rootScope.$digest();
 
       setTimeout(function() {
+        canAccessApps.should.have.been.calledWith(false);
+
         expect(plansFactory.showPurchaseOptions).to.have.been.called;
         expect($modal.open).to.not.have.been.called;
 
@@ -126,6 +126,8 @@ describe('app:', function() {
       $rootScope.$digest();
 
       setTimeout(function() {
+        canAccessApps.should.have.been.calledWith(true);
+
         expect(plansFactory.showPurchaseOptions).to.have.been.called;
         expect($modal.open).to.not.have.been.called;
 
@@ -134,11 +136,13 @@ describe('app:', function() {
 
     });
 
-    it('should not show purchase options for /signup', function(done) {
+    it('should not show purchase options for /signup without show_product', function(done) {
       $state.go('common.auth.signup');
       $rootScope.$digest();
 
       setTimeout(function() {
+        canAccessApps.should.not.have.been.called;
+
         expect(plansFactory.showPurchaseOptions).to.not.have.been.called;
         expect($modal.open).to.not.have.been.called;
 
@@ -153,6 +157,8 @@ describe('app:', function() {
       $rootScope.$digest();
 
       setTimeout(function() {
+        canAccessApps.should.have.been.called;
+
         expect(plansFactory.showPurchaseOptions).to.not.have.been.called;
         $modal.open.should.have.been.calledWith({
           templateUrl: 'partials/common-header/user-settings-modal.html',
@@ -198,19 +204,26 @@ describe('app:', function() {
       expect(state.controller).to.be.ok;
     });
 
-    it('should redirect to home',function(){
+    it('should redirect to home',function(done){
       var $location = {
         replace: sinon.spy()
       };
       sinon.spy($state,'go');
       
-      $state.get('common.auth.signup').controller[2]($location, $state);
+      $state.get('common.auth.signup').controller[3]($location, $state, canAccessApps);
 
       $rootScope.$digest();
 
-      $location.replace.should.have.been.called;
-      $state.go.should.have.been.calledWith('apps.home');
+      canAccessApps.should.have.been.calledWith(true);
+
+      setTimeout(function() {
+        $location.replace.should.have.been.called;
+        $state.go.should.have.been.calledWith('apps.home');
+
+        done();
+      }, 10);
     });
+
   });
 
   describe('state common.auth.signin:',function(){

--- a/test/unit/app.tests.js
+++ b/test/unit/app.tests.js
@@ -31,13 +31,14 @@ describe('app:', function() {
       $state = $injector.get('$state');
       canAccessApps = $injector.get('canAccessApps');
       plansFactory = $injector.get('plansFactory');
+      userState = $injector.get('userState');
       $rootScope = $injector.get('$rootScope');
       $location = $injector.get('$location');
       $modal = $injector.get('$modal');
     });
   });
 
-  var $state, canAccessApps, plansFactory, $rootScope, $location, $modal;
+  var $state, canAccessApps, plansFactory, userState, $rootScope, $location, $modal;
 
   describe('state apps.plans:',function(){
     it('should register state',function(){
@@ -104,7 +105,7 @@ describe('app:', function() {
   });
 
   describe('onboarding links', function() {
-    it('should check next state and show purchase options', function(done) {
+    it('should show purchase options for apps.plans', function(done) {
       $state.go('apps.plans');
       $rootScope.$digest();
 
@@ -117,7 +118,37 @@ describe('app:', function() {
 
     });
 
+    it('should show purchase options for /signup?show_product=true', function(done) {
+      sinon.stub($location, 'search').returns({
+        show_product: true
+      });
+      $state.go('common.auth.signup');
+      $rootScope.$digest();
+
+      setTimeout(function() {
+        expect(plansFactory.showPurchaseOptions).to.have.been.called;
+        expect($modal.open).to.not.have.been.called;
+
+        done();
+      }, 10);
+
+    });
+
+    it('should not show purchase options for /signup', function(done) {
+      $state.go('common.auth.signup');
+      $rootScope.$digest();
+
+      setTimeout(function() {
+        expect(plansFactory.showPurchaseOptions).to.not.have.been.called;
+        expect($modal.open).to.not.have.been.called;
+
+        done();
+      }, 10);
+    });
+
     it('should check next state and show add user modal', function(done) {
+      sinon.stub(userState, 'getSelectedCompanyId').returns('selectedCompanyId');
+
       $state.go('apps.users.add');
       $rootScope.$digest();
 
@@ -128,10 +159,10 @@ describe('app:', function() {
           controller: 'AddUserModalCtrl',
           resolve: sinon.match.object
         });
+        expect($modal.open.getCall(0).args[0].resolve.companyId()).to.equal('selectedCompanyId');
 
         done();
       }, 10);
-
     });
 
 
@@ -167,65 +198,18 @@ describe('app:', function() {
       expect(state.controller).to.be.ok;
     });
 
-    it('should redirect to home',function(done){
-      var canAccessApps = function() {
-        return Q.resolve();
-      };
+    it('should redirect to home',function(){
       var $location = {
-        search: function() { 
-          return {};
-        },
         replace: sinon.spy()
       };
-
       sinon.spy($state,'go');
       
-      $state.get('common.auth.signup').controller[4]($location, $state, canAccessApps, plansFactory);
-      setTimeout(function() {
-        $location.replace.should.have.been.called;
-        $state.go.should.have.been.calledWith('apps.home');
+      $state.get('common.auth.signup').controller[2]($location, $state);
 
-        done();
-      }, 10);
-    });
+      $rootScope.$digest();
 
-    it('should redirect to store product if signed in',function(done){
-      var STORE_URL = "https://store.risevision.com/";
-      var IN_RVA_PATH = "product/productId/?cid=companyId";
-
-      var userState = {
-        getSelectedCompanyId: function() {
-          return 'cid123'
-        }
-      };
-      var canAccessApps = function() {
-        return Q.resolve()
-      };
-      var $location = {search: function() {return {show_product:123}}};
-      var $window = {location:{}}
-
-      $state.get('common.auth.signup').controller[4]($location, $state, canAccessApps, plansFactory);
-      setTimeout(function() {
-        expect(plansFactory.showPurchaseOptions).to.have.been.called;
-        done();
-      }, 10);
-    });
-
-    it('should not redirect to store product if not signed in',function(done){
-      var canAccessApps = function() {
-        return Q.reject();
-      };
-
-      var $location = {search: function() {return {show_product:123}}};
-
-      sinon.spy($state,'go');
-      $state.get('common.auth.signup').controller[4]($location, $state, canAccessApps, plansFactory);
-
-      setTimeout(function() {
-        $state.go.should.not.have.been.called;
-
-        done();
-      }, 10);
+      $location.replace.should.have.been.called;
+      $state.go.should.have.been.calledWith('apps.home');
     });
   });
 

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -105,10 +105,12 @@ angular.module('risevision.apps', [
 
         .state('common.auth.signup', {
           url: '/signup',
-          controller: ['$location', '$state',
-            function ($location, $state) {
-              $location.replace();
-              $state.go('apps.home');
+          controller: ['$location', '$state', 'canAccessApps',
+            function ($location, $state, canAccessApps) {
+              canAccessApps(true).then(function () {
+                $location.replace();
+                $state.go('apps.home');
+              });
             }
           ]
         })
@@ -200,7 +202,7 @@ angular.module('risevision.apps', [
         // jshint camelcase:true
 
         if (toState.name === 'apps.plans' || (toState.name === 'common.auth.signup' && showProduct)) {
-          canAccessApps().then(function () {
+          canAccessApps(toState.name === 'common.auth.signup').then(function () {
             plansFactory.showPurchaseOptions();
           });
 

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -105,20 +105,10 @@ angular.module('risevision.apps', [
 
         .state('common.auth.signup', {
           url: '/signup',
-          controller: ['$location', '$state', 'canAccessApps', 'plansFactory',
-            function ($location, $state, canAccessApps, plansFactory) {
-              // jshint camelcase:false
-              var showProduct = $location.search().show_product;
-              // jshint camelcase:true
-
-              canAccessApps(true).then(function () {
-                if (showProduct) {
-                  plansFactory.showPurchaseOptions();
-                }
-
-                $location.replace();
-                $state.go('apps.home');
-              });
+          controller: ['$location', '$state',
+            function ($location, $state) {
+              $location.replace();
+              $state.go('apps.home');
             }
           ]
         })
@@ -202,10 +192,14 @@ angular.module('risevision.apps', [
       });
     }
   ])
-  .run(['$rootScope', '$modal', 'canAccessApps', 'userState', 'plansFactory',
-    function ($rootScope, $modal, canAccessApps, userState, plansFactory) {
+  .run(['$rootScope', '$location', '$modal', 'canAccessApps', 'userState', 'plansFactory',
+    function ($rootScope, $location, $modal, canAccessApps, userState, plansFactory) {
       $rootScope.$on('$stateChangeStart', function (event, toState, toParams, fromState, fromParams) {
-        if (toState.name === 'apps.plans') {
+        // jshint camelcase:false
+        var showProduct = $location.search().show_product;
+        // jshint camelcase:true
+
+        if (toState.name === 'apps.plans' || (toState.name === 'common.auth.signup' && showProduct)) {
           canAccessApps().then(function () {
             plansFactory.showPurchaseOptions();
           });


### PR DESCRIPTION
## Description
Fix the signup?show_product=true route

Use new methodology for opening the modal

Ensure `canAccessApps` is called with `true` so the redirect goes to the Sign Up form rather than Sign In.

[stage-19]

## Motivation and Context
Fix issue where the plans modal does not show; Chargebee Subscription does still show.

## How Has This Been Tested?
Tested changes locally; updated unit tests.

Fixed failing e2e tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No