### PR TITLE
Fix border bottom for Display and Schedule lists

### DIFF
--- a/web/scss/core/madero-style.scss
+++ b/web/scss/core/madero-style.scss
@@ -64,8 +64,16 @@
       .list-group-item {
         @extend .border-top;
 
+        border-radius: 0px;
+
         &:first-child {
           border-top: 0;
+        }
+
+        &:last-child {
+          @extend .border-bottom;
+
+          margin-bottom: -1px !important;
         }
       }
     }


### PR DESCRIPTION
## Description
Fix border bottom for Display and Schedule lists

[stage-16]

## Motivation and Context
Border was incorrect colour and was rounded.
Also remove double border if element is touching the bottom of the panel for longer lists.

## How Has This Been Tested?
Tested changes locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No