### PR TITLE
HTTP alert for Share Schedule popover

### DIFF
--- a/test/unit/schedules/controllers/ctr-shared-schedule-popover.tests.js
+++ b/test/unit/schedules/controllers/ctr-shared-schedule-popover.tests.js
@@ -4,6 +4,10 @@ describe('controller: SharedSchedulePopoverController', function() {
   beforeEach(module(function ($provide) {
     $provide.value('SHARED_SCHEDULE_URL','https://preview.risevision.com/?type=sharedschedule&id=SCHEDULE_ID');
 
+    $provide.service("scheduleFactory", function() {
+       return {};
+     });
+
     $provide.service("scheduleTracker", function() {
        return sinon.stub();
      });
@@ -45,7 +49,7 @@ describe('controller: SharedSchedulePopoverController', function() {
   
   it('should exist',function(){
     expect($scope).to.be.ok;
-    expect($scope.hasHttpContent).to.be.ok;
+    expect($scope.scheduleFactory).to.be.ok;
     expect($scope.isScheduleDetails).to.be.ok;
     expect($scope.copyToClipboard).to.be.a('function');
     expect($scope.getLink).to.be.a('function');
@@ -55,7 +59,6 @@ describe('controller: SharedSchedulePopoverController', function() {
 
   it('should initilize values', function() {
     expect($scope.currentTab).to.equal('link');
-    expect($scope.hasHttpContent).to.be.true;
     expect($scope.isScheduleDetails).to.be.true;
   });
 

--- a/test/unit/schedules/controllers/ctr-shared-schedule-popover.tests.js
+++ b/test/unit/schedules/controllers/ctr-shared-schedule-popover.tests.js
@@ -14,11 +14,20 @@ describe('controller: SharedSchedulePopoverController', function() {
         _restoreState: sinon.stub()
       };
     });
+
+    $provide.service('$state', function() {
+      return $state = {
+        current: {
+          name: 'apps.schedules.details'
+        }
+      };
+    });
   }));
-  var $scope, $window, scheduleTracker;
+  var $scope, $window, scheduleTracker, $state, $controller;
 
   beforeEach(function(){
-    inject(function($injector,$rootScope, $controller){
+    inject(function($injector,$rootScope){
+      $controller = $injector.get('$controller');
       $scope = $rootScope.$new();
       $window = $injector.get('$window');
       scheduleTracker = $injector.get('scheduleTracker');
@@ -36,6 +45,8 @@ describe('controller: SharedSchedulePopoverController', function() {
   
   it('should exist',function(){
     expect($scope).to.be.ok;
+    expect($scope.hasHttpContent).to.be.ok;
+    expect($scope.isScheduleDetails).to.be.ok;
     expect($scope.copyToClipboard).to.be.a('function');
     expect($scope.getLink).to.be.a('function');
     expect($scope.getEmbedCode).to.be.a('function');
@@ -44,6 +55,8 @@ describe('controller: SharedSchedulePopoverController', function() {
 
   it('should initilize values', function() {
     expect($scope.currentTab).to.equal('link');
+    expect($scope.hasHttpContent).to.be.true;
+    expect($scope.isScheduleDetails).to.be.true;
   });
 
   it('should handle null schedule:', function() {
@@ -56,6 +69,26 @@ describe('controller: SharedSchedulePopoverController', function() {
 
   it('getLink', function() {
     expect($scope.getLink()).to.equal('https://preview.risevision.com/?type=sharedschedule&id=scheduleId');
+  });
+
+  describe('isScheduleDetails:', function() {
+    it('should should set isScheduleDetails to false if not in schedule details page', function() {
+      $state.current.name = 'apps.schedules.list';
+      $controller('SharedSchedulePopoverController', {
+        $scope: $scope
+      });
+      $scope.$digest();
+      expect($scope.isScheduleDetails).to.be.false;
+    });
+
+    it('should should set isScheduleDetails to true if visiting schedule details page', function() {
+      $state.current.name = 'apps.schedules.details';
+      $controller('SharedSchedulePopoverController', {
+        $scope: $scope
+      });
+      $scope.$digest();
+      expect($scope.isScheduleDetails).to.be.true;
+    });
   });
 
   describe('getEnterpriseLink', function() {

--- a/web/partials/schedules/share-schedule-popover.html
+++ b/web/partials/schedules/share-schedule-popover.html
@@ -158,5 +158,15 @@
     </div>
   </div>
 
+  <div ng-show="hasHttpContent" class="madero-style alert alert-danger text-md text-danger p-4 mt-3 mb-0" role="alert">
+    <p ng-show="!isScheduleDetails">
+      Some content in this schedule won't be shown.
+      <br/>
+      <a class="madero-link" href="#" ui-sref="apps.schedules.details({ scheduleId: schedule.id, cid: schedule.companyId })">Fix this.</a>
+    </p>
+    <p ng-show="isScheduleDetails">
+      Some playlist items in your schedule are using an insecure URL (HTTP) and won't be shown. Use secure URLs (HTTPS) instead.
+    </p>
+  </div>
 
 </div>

--- a/web/partials/schedules/share-schedule-popover.html
+++ b/web/partials/schedules/share-schedule-popover.html
@@ -158,13 +158,13 @@
     </div>
   </div>
 
-  <div ng-show="hasHttpContent" class="madero-style alert alert-danger text-md text-danger p-4 mt-3 mb-0" role="alert">
+  <div ng-show="scheduleFactory.hasInsecureUrls(schedule)" class="madero-style alert alert-danger text-md text-danger p-4 mt-3 mb-0" role="alert">
     <p ng-show="!isScheduleDetails">
       Some content in this schedule won't be shown.
       <br/>
       <a class="madero-link" href="#" ui-sref="apps.schedules.details({ scheduleId: schedule.id, cid: schedule.companyId })">Fix this.</a>
     </p>
-    <p ng-show="isScheduleDetails">
+    <p ng-show="isScheduleDetails" class="mt-0">
       Some playlist items in your schedule are using an insecure URL (HTTP) and won't be shown. Use secure URLs (HTTPS) instead.
     </p>
   </div>

--- a/web/scripts/schedules/controllers/ctr-shared-schedule-popover.js
+++ b/web/scripts/schedules/controllers/ctr-shared-schedule-popover.js
@@ -22,9 +22,11 @@ Let me know if you have any questions.\n\
 Regards,\n\
 USER_FIRST_NAME')
   .controller('SharedSchedulePopoverController', ['$scope', '$window', 'scheduleTracker', 'userState',
-    'SHARED_SCHEDULE_URL', 'SHARED_SCHEDULE_EMBED_CODE', 'SHARED_SCHEDULE_INVITE_MESSAGE',
+    'SHARED_SCHEDULE_URL', 'SHARED_SCHEDULE_EMBED_CODE', 'SHARED_SCHEDULE_INVITE_MESSAGE', '$state',
     function ($scope, $window, scheduleTracker, userState,
-      SHARED_SCHEDULE_URL, SHARED_SCHEDULE_EMBED_CODE, SHARED_SCHEDULE_INVITE_MESSAGE) {
+      SHARED_SCHEDULE_URL, SHARED_SCHEDULE_EMBED_CODE, SHARED_SCHEDULE_INVITE_MESSAGE, $state) {
+      $scope.hasHttpContent = true; //TODO
+      $scope.isScheduleDetails = $state.current.name === 'apps.schedules.details';
       $scope.currentTab = 'link';
 
       $scope.getLink = function () {

--- a/web/scripts/schedules/controllers/ctr-shared-schedule-popover.js
+++ b/web/scripts/schedules/controllers/ctr-shared-schedule-popover.js
@@ -21,11 +21,11 @@ Here\'s how to install (promise, it only takes 2 minutes):\n\
 Let me know if you have any questions.\n\
 Regards,\n\
 USER_FIRST_NAME')
-  .controller('SharedSchedulePopoverController', ['$scope', '$window', 'scheduleTracker', 'userState',
+  .controller('SharedSchedulePopoverController', ['$scope', '$window', 'scheduleFactory', 'scheduleTracker', 'userState',
     'SHARED_SCHEDULE_URL', 'SHARED_SCHEDULE_EMBED_CODE', 'SHARED_SCHEDULE_INVITE_MESSAGE', '$state',
-    function ($scope, $window, scheduleTracker, userState,
+    function ($scope, $window, scheduleFactory, scheduleTracker, userState,
       SHARED_SCHEDULE_URL, SHARED_SCHEDULE_EMBED_CODE, SHARED_SCHEDULE_INVITE_MESSAGE, $state) {
-      $scope.hasHttpContent = true; //TODO
+      $scope.scheduleFactory = scheduleFactory;
       $scope.isScheduleDetails = $state.current.name === 'apps.schedules.details';
       $scope.currentTab = 'link';
 

--- a/web/scss/sections/template-editor-layout.scss
+++ b/web/scss/sections/template-editor-layout.scss
@@ -931,6 +931,10 @@ $short-phone-height: 570px;
     font-size: 12px;
   }
 
+  .text-md {
+    font-size: 14px;
+  }
+
   .text-lg {
     font-size: 16px;
   }


### PR DESCRIPTION
## Description
UI style and HTTP error message conditionally shown if the user is visiting schedule details or not.

## Motivation and Context
Why is this change required? What problem does it solve?

## How Has This Been Tested?
Tested locally. Staged on [stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
