### PR TITLE
Fix size limit for stretchy elements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,7 @@
     "oauthio-web": "0.6.2",
     "oclazyload": "^1.1.0",
     "Sortable": "^1.4.2",
-    "stretchy": "https://github.com/Rise-Vision/stretchy.git#fix/limit-size",
+    "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages",
     "xmlToJSON.js": "^1.3.2",
     "moment": "^2.24.0",
     "angularjs-slider": "^7.0.0"

--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,7 @@
     "oauthio-web": "0.6.2",
     "oclazyload": "^1.1.0",
     "Sortable": "^1.4.2",
-    "stretchy": "https://github.com/Rise-Vision/stretchy.git#gh-pages",
+    "stretchy": "https://github.com/Rise-Vision/stretchy.git#fix/limit-size",
     "xmlToJSON.js": "^1.3.2",
     "moment": "^2.24.0",
     "angularjs-slider": "^7.0.0"

--- a/web/partials/template-editor/footer.html
+++ b/web/partials/template-editor/footer.html
@@ -3,7 +3,7 @@
     <div>
       <last-modified change-date="factory.presentation.changeDate" changed-by="factory.presentation.changedBy"></last-modified>
       •
-      <span id="autoSavingDesktop" ng-if="hasContentEditorRole()">
+      <span ng-if="hasContentEditorRole()">
         <span ng-show="!factory.savingPresentation && factory.isUnsaved()">
           Unsaved changes
         </span>

--- a/web/scss/sections/template-editor-layout.scss
+++ b/web/scss/sections/template-editor-layout.scss
@@ -446,6 +446,11 @@ $short-phone-height: 570px;
   overflow: hidden;
   white-space: nowrap;
 
+  #autoSavingDesktop {
+    display: inline-block;
+    width: 117px;
+  }
+
   last-modified {
     .text-muted {
       color: $madero-black;      


### PR DESCRIPTION
## Description
Fix size limit for stretchy elements

Fixes issue where if name is too long buttons are
pushed off screen

Fixed width for auto-saving text; allows calculations
to be made based on the longest element with
All changes saved...

[stage-18]

## Motivation and Context
Issue is very apparent when adding the last modified to the template editor.

## How Has This Been Tested?
Tested changes locally with both Template Editor and Schedules/Presentations name fields at various resolutions and name sizes.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No