### PR TITLE
Remove HTTP warning from Viewer preview

### DIFF
--- a/test/unit/editor/services/svc-editor-factory.tests.js
+++ b/test/unit/editor/services/svc-editor-factory.tests.js
@@ -818,7 +818,7 @@ describe('service: editorFactory:', function() {
 
           setTimeout(function() {
             $windowOpenSpy.should.have.been.called.twice;
-            $windowOpenSpy.should.have.been.calledWith('http://rvaviewer-test.appspot.com/?type=presentation&id=presentationId&notifyHttpError=true', 'rvPresentationPreview');
+            $windowOpenSpy.should.have.been.calledWith('http://rvaviewer-test.appspot.com/?type=presentation&id=presentationId', 'rvPresentationPreview');
             addEventSpy.should.have.been.called;
 
             done();
@@ -834,7 +834,7 @@ describe('service: editorFactory:', function() {
           .then(function() {
             setTimeout(function() {
               $windowOpenSpy.should.have.been.called.twice;
-              $windowOpenSpy.should.have.been.calledWith('http://rvaviewer-test.appspot.com/?type=presentation&id=presentationId&notifyHttpError=true', 'rvPresentationPreview');
+              $windowOpenSpy.should.have.been.calledWith('http://rvaviewer-test.appspot.com/?type=presentation&id=presentationId', 'rvPresentationPreview');
 
               done();
             }, 10);
@@ -863,7 +863,7 @@ describe('service: editorFactory:', function() {
       editorFactory.preview('presentationId');
 
       setTimeout(function() {
-        $windowOpenSpy.should.have.been.calledWith('http://rvaviewer-test.appspot.com/?type=presentation&id=presentationId&notifyHttpError=true', 'rvPresentationPreview');
+        $windowOpenSpy.should.have.been.calledWith('http://rvaviewer-test.appspot.com/?type=presentation&id=presentationId', 'rvPresentationPreview');
         done();
       }, 10);
     });

--- a/web/scripts/editor/services/svc-editor-factory.js
+++ b/web/scripts/editor/services/svc-editor-factory.js
@@ -481,7 +481,7 @@ angular.module('risevision.editor.services')
 
       var _getPreviewUrl = function (presentationId) {
         if (presentationId) {
-          return VIEWER_URL + '/?type=presentation&id=' + presentationId + '&notifyHttpError=true';
+          return VIEWER_URL + '/?type=presentation&id=' + presentationId;
         }
         return null;
       };


### PR DESCRIPTION
## Description
Remove HTTP warning from Viewer preview

Revert "Add URL parameter to viewer preview (#2038)"
This reverts commit 272e7e76c683708f94df585e01f870a8167765f0.

[stage-16]

## Motivation and Context
Partial fix for #2046 

## How Has This Been Tested?
Tested changes in the staging environment.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No