### PR TITLE
No longer wait for spinner to show

### DIFF
--- a/test/e2e/template-editor/pages/presentationListPage.js
+++ b/test/e2e/template-editor/pages/presentationListPage.js
@@ -49,7 +49,7 @@ var PresentationListPage = function() {
 
   this.loadCurrentCompanyPresentationList = function() {
     helper.clickWhenClickable(templateEditorPage.getPresentationsListLink(), 'Presentations List');
-    helper.wait(this.getPresentationsLoader(), 'Presentation loader');
+    browser.sleep(500);
     helper.waitDisappear(this.getPresentationsLoader(), 'Presentation loader');
   }
 


### PR DESCRIPTION
## Description
No longer wait for spinner to show

Loading the home page will always be editor so chances are
spinner is already there or hidden

[stage-2]

## Motivation and Context
Fix e2e test failures.

## How Has This Been Tested?
Tests passed without the template editor failure.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No