### PR TITLE
Use ISO string instead of Date for firstDisplayActivationDate trait

### DIFF
--- a/test/unit/displays/services/svc-display-activation-tracker.tests.js
+++ b/test/unit/displays/services/svc-display-activation-tracker.tests.js
@@ -65,7 +65,7 @@ describe('service: display activation tracker', function() {
     });
 
     displayActivationTracker([{
-      lastConnectionTime: '2020-08-21T15:19:02.716Z'
+      lastConnectionTime: new Date('2020-08-21T15:19:02.716Z')
     }]);
 
     userState.isSubcompanySelected.should.have.been.called;
@@ -96,15 +96,15 @@ describe('service: display activation tracker', function() {
       displayActivationTracker([{
         id: 'displayId1',
         name: 'displayName1',
-        lastConnectionTime: '2019-08-21T15:19:02.716Z'
+        lastConnectionTime: new Date('2019-08-21T15:19:02.716Z')
       },{
         id: 'displayId2',
         name: 'displayName2',
-        lastConnectionTime: '2020-08-21T15:19:02.716Z'
+        lastConnectionTime: new Date('2020-08-21T15:19:02.716Z')
       },{
         id: 'displayId3',
         name: 'displayName3',
-        lastConnectionTime: '2017-08-21T15:19:02.716Z'
+        lastConnectionTime: new Date('2017-08-21T15:19:02.716Z')
       }]);
 
       analyticsFactory.identify.should.have.been.calledWith('username', {
@@ -121,7 +121,7 @@ describe('service: display activation tracker', function() {
     displayActivationTracker([{
       id: 'displayId',
       name: 'displayName',
-      lastConnectionTime: '2020-08-21T15:19:02.716Z'
+      lastConnectionTime: new Date('2020-08-21T15:19:02.716Z')
     }]);
 
     analyticsFactory.identify.should.have.been.calledWith('username', {
@@ -137,13 +137,13 @@ describe('service: display activation tracker', function() {
     displayActivationTracker([{
       id: 'displayId',
       name: 'displayName',
-      lastConnectionTime: '2020-08-21T15:19:02.716Z'
+      lastConnectionTime: new Date('2020-08-21T15:19:02.716Z')
     }]);
 
     setTimeout(function() {
       updateUser.should.have.been.calledWith('username', {
         settings: {
-          firstDisplayActivationDate: '2020-08-21T15:19:02.716Z'
+          firstDisplayActivationDate: new Date('2020-08-21T15:19:02.716Z').toISOString()
         }
       });
       userState.updateUserProfile.should.have.been.calledWith('updatedUser');

--- a/web/scripts/displays/services/svc-display-activation-tracker.js
+++ b/web/scripts/displays/services/svc-display-activation-tracker.js
@@ -46,15 +46,17 @@ angular.module('risevision.displays.services')
         if (activeDisplay && activeDisplay.lastConnectionTime) {
           $log.info('Active display found', activeDisplay);
 
+          var activationDate = activeDisplay.lastConnectionTime.toISOString();
+
           analyticsFactory.identify(userState.getUsername(), {
-            firstDisplayActivationDate: activeDisplay.lastConnectionTime
+            firstDisplayActivationDate: activationDate
           });
 
           displayTracker('first display activated', activeDisplay.id, activeDisplay.name, {
-            firstDisplayActivationDate: activeDisplay.lastConnectionTime
+            firstDisplayActivationDate: activationDate
           });
 
-          _updateUserSettings(activeDisplay.lastConnectionTime);
+          _updateUserSettings(activationDate);
         }
       };
     }


### PR DESCRIPTION
[stage-1]

## Description
Use ISO string instead of Date object for firstDisplayActivationDate trait.
It seems GTM/Segment can't handle Date objects properly. Other date properties that we populate on identify are ISO strings too and Segment parses a date from them. This will follow suit.

## Motivation and Context
`firstDisplayActivationDate` was not being populated on identify() calls in GTM/Segment.

## How Has This Been Tested?
Validated locally and on stage-1 with real display.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
