### PR TITLE
Use CSS to set draggable mirror offset

### DIFF
--- a/test/e2e/schedules/cases/add-distribution.js
+++ b/test/e2e/schedules/cases/add-distribution.js
@@ -64,6 +64,7 @@ var AddDistributionScenarios = function() {
 
         it('should show a table for listing displays', function () {
           helper.waitDisappear(distributionModalPage.getDistributionListLoader()).then(function () {
+            helper.wait(distributionModalPage.getDistributionListTable(), 'Distribution Table');
             expect(distributionModalPage.getDistributionListTable().isDisplayed()).to.eventually.be.true;
           });
           

--- a/test/e2e/schedules/cases/add-url.js
+++ b/test/e2e/schedules/cases/add-url.js
@@ -54,6 +54,7 @@ var AddUrlScenarios = function() {
           before(function () {
             scheduleAddPage.getAddUrlItemButton().click();
             helper.wait(playlistItemModalPage.getPlaylistItemModal(), 'Add URL Item');
+            browser.sleep(500);
           });
 
           it('should open the Add URL Modal', function () {

--- a/test/e2e/schedules/cases/playlist.js
+++ b/test/e2e/schedules/cases/playlist.js
@@ -84,6 +84,7 @@ var PlaylistScenarios = function() {
           scheduleAddPage.getPlaylistItems().get(0).element(by.id('playlistItemNameCell')).click();
 
           helper.wait(playlistItemModalPage.getPlaylistItemModal(), 'Edit Playist Modal');
+          browser.sleep(500);
 
           expect(playlistItemModalPage.getPlaylistItemModal().isDisplayed()).to.eventually.be.true;
           expect(playlistItemModalPage.getModalTitle().getText()).to.eventually.equal('Edit Playlist Item');

--- a/web/partials/schedules/playlist.html
+++ b/web/partials/schedules/playlist.html
@@ -6,14 +6,14 @@
       </div>
 
       <div ng-click="manage(playlistItem)" class="playlist-item-name mr-auto w-75 u_clickable">
-        <p class="madero-link u_remove-bottom" id="playlistItemNameCell" ng-if="playlistItem.type !== 'presentation'"><strong>{{playlistItem.name}}</strong></p>
-        <p class="madero-link u_remove-bottom" id="presentationNameCell" ng-if="playlistItem.type === 'presentation'"><strong presentation-name="playlistItem.objectReference">Presentation Item</strong></p>
+        <p class="madero-link u_remove-bottom u_ellipsis-lg" id="playlistItemNameCell" ng-if="playlistItem.type !== 'presentation'"><strong>{{playlistItem.name}}</strong></p>
+        <p class="madero-link u_remove-bottom u_ellipsis-lg" id="presentationNameCell" ng-if="playlistItem.type === 'presentation'"><strong presentation-name="playlistItem.objectReference">Presentation Item</strong></p>
         <p class="text-sm text-gray u_remove-bottom">
           <span class="text-gray" ng-show="factory.hasInsecureUrl(playlistItem)"><strong class="text-danger">Insecure URL</strong> • </span>
           {{ factory.getItemTimeline(playlistItem) }} • {{ playlistItem.playUntilDone ? 'Play Until Done' : playlistItem.duration + 's' }} • {{ factory.getItemTransition(playlistItem) }}
         </p>
       </div>
-      <div class="u_float-left mr-0">
+      <div class="u_float-left mr-0 flex-row">
         <button type="button" class="btn-icon u_align-middle" id="duplicateButton" ng-click="factory.duplicatePlaylistItem(playlistItem)">
           <img src="../images/icon-copy.svg" width="16" height="18">
         </button>

--- a/web/scripts/common/directives/dtv-rv-sortable.js
+++ b/web/scripts/common/directives/dtv-rv-sortable.js
@@ -18,8 +18,6 @@ angular.module('risevision.apps.directives')
             mirror: {
               appendTo: $scope.appendTo,
               constrainDimensions: true,
-              cursorOffsetX: 10,
-              cursorOffsetY: 10,
               xAxis: false
             }
           });

--- a/web/scss/sections/schedules.scss
+++ b/web/scss/sections/schedules.scss
@@ -18,7 +18,7 @@
     }
 
     .list-group-item {
-      height: 62px;
+      min-height: 62px;
       padding-top: 0px;
       padding-bottom: 0px;
     }

--- a/web/scss/ui-components/lists.scss
+++ b/web/scss/ui-components/lists.scss
@@ -210,6 +210,15 @@
       }
 }
 
+
+/* rvSortable List
+   ========================================================================== */
+.draggable-mirror {
+  left: 10px !important;
+  top: 10px !important;
+}
+
+
 // For RV Store Only
 .store.grid-list {
   /* Small devices  */


### PR DESCRIPTION
## Description
Due to a limitation of the Draggable library, scrolling offset was not taken into account when dragging on a touch device, causing the mirror to be positioned incorrectly.
Instead of using cursorOffsetY, we are now using CSS top property to position the mirror element.

## Motivation and Context
Fix #2053.

## How Has This Been Tested?
Locally and validated on a real Android/Chrome device. [stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
