### PR TITLE
Handle long Schedule Playlist item names and timelines

### DIFF
--- a/web/partials/schedules/playlist.html
+++ b/web/partials/schedules/playlist.html
@@ -6,14 +6,14 @@
       </div>
 
       <div ng-click="manage(playlistItem)" class="playlist-item-name mr-auto w-75 u_clickable">
-        <p class="madero-link u_remove-bottom" id="playlistItemNameCell" ng-if="playlistItem.type !== 'presentation'"><strong>{{playlistItem.name}}</strong></p>
-        <p class="madero-link u_remove-bottom" id="presentationNameCell" ng-if="playlistItem.type === 'presentation'"><strong presentation-name="playlistItem.objectReference">Presentation Item</strong></p>
+        <p class="madero-link u_remove-bottom u_ellipsis-lg" id="playlistItemNameCell" ng-if="playlistItem.type !== 'presentation'"><strong>{{playlistItem.name}}</strong></p>
+        <p class="madero-link u_remove-bottom u_ellipsis-lg" id="presentationNameCell" ng-if="playlistItem.type === 'presentation'"><strong presentation-name="playlistItem.objectReference">Presentation Item</strong></p>
         <p class="text-sm text-gray u_remove-bottom">
           <span class="text-gray" ng-show="factory.hasInsecureUrl(playlistItem)"><strong class="text-danger">Insecure URL</strong> • </span>
           {{ factory.getItemTimeline(playlistItem) }} • {{ playlistItem.playUntilDone ? 'Play Until Done' : playlistItem.duration + 's' }} • {{ factory.getItemTransition(playlistItem) }}
         </p>
       </div>
-      <div class="u_float-left mr-0">
+      <div class="u_float-left mr-0 flex-row">
         <button type="button" class="btn-icon u_align-middle" id="duplicateButton" ng-click="factory.duplicatePlaylistItem(playlistItem)">
           <img src="../images/icon-copy.svg" width="16" height="18">
         </button>

--- a/web/scss/sections/schedules.scss
+++ b/web/scss/sections/schedules.scss
@@ -18,7 +18,7 @@
     }
 
     .list-group-item {
-      height: 62px;
+      min-height: 62px;
       padding-top: 0px;
       padding-bottom: 0px;
     }


### PR DESCRIPTION
## Description
- Use ellipsis on long Playlist Item names
- Allow Playlist Item row to expand to accommodate long timeline descriptions
- Fix playlist item buttons alignment on mobile as mentioned in https://github.com/Rise-Vision/rise-vision-apps/issues/2053

## Motivation and Context
Fix #2060 and fix buttons alignment for https://github.com/Rise-Vision/rise-vision-apps/issues/2053

## How Has This Been Tested?
Visually confirmed on [stage-20].
Sample: https://apps-stage-20.risevision.com/schedules/details/acb6db17-c885-40b3-9a01-610504c62112?cid=fcf1cc14-71ea-4c9b-b380-5b8d755dbe05%3Fcid%3Dfcf1cc14-71ea-4c9b-b380-5b8d755dbe05

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
