### PR TITLE
Fix Orientation field clipping

### DIFF
--- a/web/locales/en/displays-app.json
+++ b/web/locales/en/displays-app.json
@@ -168,7 +168,7 @@
         "90": "Portrait",
         "180": "Landscape (flipped)",
         "270": "Portrait (flipped)",
-        "name": "Rotation:"
+        "name": "Rotation"
       },
       "playerVersion": "Player Version",
       "resolution": "Resolution",

--- a/web/partials/displays/display-fields.html
+++ b/web/partials/displays/display-fields.html
@@ -212,12 +212,14 @@
       <div class="list-group-item flex-row form-group mb-0" ng-show="(factory.display.playerVersion || factory.display.onlineStatus === 'online') && (playerProFactory.isCROSLegacy(factory.display) || playerProFactory.isChromeOSPlayer(factory.display))">
         <div class="row-entry">
           <label class="control-label pull-left mb-0" translate>displays-app.fields.player.orientation.name</label>
-          <select class="form-control mr-auto w-auto" ng-model="factory.display.orientation" integer-parser>
-            <option value="0" translate>displays-app.fields.player.orientation.0</option>
-            <option value="90" translate>displays-app.fields.player.orientation.90</option>
-            <option value="180" translate>displays-app.fields.player.orientation.180</option>
-            <option value="270" translate>displays-app.fields.player.orientation.270</option>
-          </select>
+          <span class="mr-auto">
+            <select class="form-control" ng-model="factory.display.orientation" integer-parser>
+              <option value="0" translate>displays-app.fields.player.orientation.0</option>
+              <option value="90" translate>displays-app.fields.player.orientation.90</option>
+              <option value="180" translate>displays-app.fields.player.orientation.180</option>
+              <option value="270" translate>displays-app.fields.player.orientation.270</option>
+            </select>
+          </span>
         </div>
       </div>
 


### PR DESCRIPTION
## Description
Fix Orientation field clipping
Remove colon from field name for consistency with other fields

## Motivation and Context
https://trello.com/c/D9Rbwssf/6633-apps-rotation-field-clipped-in-side-by-side-fields-list-not-in-xs-1

## How Has This Been Tested?
Visually confirmed locally an on [stage-19]
Sample: https://apps-stage-19.risevision.com/displays/details/5XGJYEJ4CWWP?cid=a0f452b9-7162-4f5c-b786-f32c3b1fc0a3%3Fcid%3Da0f452b9-7162-4f5c-b786-f32c3b1fc0a3

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
