### PR TITLE
Show online/offline count in Displays List

### DIFF
--- a/test/unit/displays/controllers/ctr-displays-list.tests.js
+++ b/test/unit/displays/controllers/ctr-displays-list.tests.js
@@ -49,14 +49,20 @@ describe('controller: displays list', function() {
     $provide.service('playerLicenseFactory', function() {
       return {};
     });
+    $provide.service('displaySummaryFactory', function() {
+      return {
+        loadSummary: sandbox.stub()
+      };
+    });
   }));
-  var $scope, $loading, $filter, $window;
+  var $scope, $loading, $filter, $window, displaySummaryFactory;
   beforeEach(function(){
     inject(function($injector,$rootScope, $controller){
       $scope = $rootScope.$new();
       $scope.listLimit = 5;
       $filter = $injector.get('$filter');
       $loading = $injector.get('$loading');
+      displaySummaryFactory = $injector.get('displaySummaryFactory');
       $window = $injector.get('$window');
       $controller('displaysList', {
         $scope : $scope,
@@ -82,6 +88,7 @@ describe('controller: displays list', function() {
 
     expect($scope.displayFactory).to.be.ok;
     expect($scope.playerLicenseFactory).to.be.ok;
+    expect($scope.displaySummaryFactory).to.be.ok;
   });
 
   it('should init the scope objects',function(){
@@ -89,6 +96,8 @@ describe('controller: displays list', function() {
     expect($scope.search).to.have.property('count');
     expect($scope.search).to.have.property('reverse');
     expect($scope.search.count).to.equal(5);
+
+    displaySummaryFactory.loadSummary.should.have.been.caled;
   });
 
   describe('$loading: ', function() {

--- a/test/unit/displays/services/svc-display-summary-factory.tests.js
+++ b/test/unit/displays/services/svc-display-summary-factory.tests.js
@@ -1,0 +1,60 @@
+'use strict';
+
+describe('Services: displaySummaryFactory', function() {
+  beforeEach(module('risevision.displays.services'));
+  beforeEach(module(function ($provide) {
+    $provide.service('display', function () {
+      return {
+        summary: sandbox.stub().returns(Q.resolve({online: 1}))
+      };
+    });
+    $provide.factory('processErrorCode', function() {
+      return sandbox.stub().returns('processedError');
+    });
+  }));
+
+  var sandbox, display, factory;
+
+  beforeEach(function() {
+    sandbox = sinon.sandbox.create();
+
+    inject(function($injector) {
+      display =  $injector.get('display');
+      factory = $injector.get('displaySummaryFactory');
+    });
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  it('should exist', function() {
+    expect(factory).to.be.ok;
+
+    expect(factory.loadSummary).to.be.a('function');
+  });
+
+  describe('loadSummary:', function() {
+    it('should load display summary and populate variable', function (done) {
+      factory.loadSummary().then(function() {
+        display.summary.should.have.been.called;
+
+        expect(factory.summary).to.deep.equal({online: 1});
+        expect(factory.apiError).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should handle failures', function (done) {
+      display.summary.returns(Q.reject());
+
+      factory.loadSummary().then(function() {
+        display.summary.should.have.been.called;
+
+        expect(factory.apiError).to.equal('processedError');
+        expect(factory.summary).to.be.undefined;
+        done();
+      });
+    });
+  });
+});

--- a/test/unit/displays/services/svc-display.tests.js
+++ b/test/unit/displays/services/svc-display.tests.js
@@ -76,7 +76,7 @@ describe('service: display:', function() {
               sortString = obj.sort;
 
               var def = Q.defer();
-              if (returnList) {
+              if (returnResult) {
                 def.resolve({
                   result : {
                     nextPageToken : 1,
@@ -236,6 +236,22 @@ describe('service: display:', function() {
                 def.reject("API Failed");
               }
               return def.promise;
+            },
+            summary: function(obj) {
+              expect(obj).to.be.ok;
+
+              var def = Q.defer();
+              if (returnResult) {
+                def.resolve({
+                  result: {
+                    companyId: obj.companyId,
+                    online: 1
+                  }
+                });
+              } else {
+                def.reject("API Failed");
+              }
+              return def.promise;
             }
           }
         });
@@ -243,9 +259,9 @@ describe('service: display:', function() {
       };
     });
   }));
-  var display, returnList, searchString, sortString, $timeout, $rootScope, displayActivationTracker;
+  var display, returnResult, searchString, sortString, $timeout, $rootScope, displayActivationTracker;
   beforeEach(function(){
-    returnList = true;
+    returnResult = true;
     searchString = '';
     sortString='';
 
@@ -338,7 +354,7 @@ describe('service: display:', function() {
     });
 
     it("should handle failure to get list correctly",function(done){
-      returnList = false;
+      returnResult = false;
 
       display.list({})
       .then(function(displays) {
@@ -645,6 +661,32 @@ describe('service: display:', function() {
     });
 
     it('should handle has free displays failures', function(done) {
+      display.hasFreeDisplays().then(function() {
+        done('it should have failed');
+      },function(){
+        done();
+      });
+    });
+  });
+
+  describe('summary:', function() {
+
+    it('should retrieve summary for provided company', function(done) {
+      display.summary('companyId').then(function(result) {
+        expect(result).to.deep.equal({online: 1, companyId: 'companyId'});
+        done();
+      });
+    });
+
+    it('should retrieve summary with selected company if none is provided', function(done) {
+      display.summary().then(function(result) {
+        expect(result).to.deep.equal({online: 1, companyId: 'TEST_COMP_ID'});
+        done();
+      });
+    });
+
+    it('should handle request failures', function(done) {
+      returnResult = false;
       display.hasFreeDisplays().then(function() {
         done('it should have failed');
       },function(){

--- a/test/unit/displays/services/svc-player-license-factory.tests.js
+++ b/test/unit/displays/services/svc-player-license-factory.tests.js
@@ -84,21 +84,21 @@ describe('Services: playerLicenseFactory', function() {
       currentPlanFactory.currentPlan.playerProTotalLicenseCount = 0;
       currentPlanFactory.currentPlan.playerProAvailableLicenseCount = 0;
 
-      expect(playerLicenseFactory.getUsedLicenseString()).to.equal('0 Licensed Displays | 0 Licenses Available');
+      expect(playerLicenseFactory.getUsedLicenseString()).to.equal('0 Licensed Displays / 0 Licenses Available');
     });
 
     it('should handle 1 case', function () {
       currentPlanFactory.currentPlan.playerProTotalLicenseCount = 2;
       currentPlanFactory.currentPlan.playerProAvailableLicenseCount = 1;
 
-      expect(playerLicenseFactory.getUsedLicenseString()).to.equal('1 Licensed Display | 1 License Available');
+      expect(playerLicenseFactory.getUsedLicenseString()).to.equal('1 Licensed Display / 1 License Available');
     });
 
     it('should handle multiples case', function () {
       currentPlanFactory.currentPlan.playerProTotalLicenseCount = 4;
       currentPlanFactory.currentPlan.playerProAvailableLicenseCount = 2;
 
-      expect(playerLicenseFactory.getUsedLicenseString()).to.equal('2 Licensed Displays | 2 Licenses Available');
+      expect(playerLicenseFactory.getUsedLicenseString()).to.equal('2 Licensed Displays / 2 Licenses Available');
     });
 
   });

--- a/web/index.html
+++ b/web/index.html
@@ -370,6 +370,7 @@
   <script src="scripts/displays/services/svc-display-factory.js"></script>
   <script src="scripts/displays/services/svc-display-status-factory.js"></script>
   <script src="scripts/displays/services/svc-display-activation-tracker.js"></script>
+  <script src="scripts/displays/services/svc-display-summary-factory.js"></script>
   <script src="scripts/displays/services/svc-player-actions-factory.js"></script>
   <script src="scripts/displays/services/svc-screenshot-factory.js"></script>
   <script src="scripts/displays/services/svc-screenshot-requester.js"></script>

--- a/web/partials/displays/displays-list.html
+++ b/web/partials/displays/displays-list.html
@@ -3,10 +3,11 @@
     <!-- App Title -->
     <div class="app-header-title">
       <h1 class="m-0" id="title">Displays</h1>
-      <div>
-        <span ng-show="playerLicenseFactory.hasProfessionalLicenses()">
-          {{ playerLicenseFactory.getUsedLicenseString() }}
-        </span>
+      <div ng-show="playerLicenseFactory.hasProfessionalLicenses()">
+        {{ playerLicenseFactory.getUsedLicenseString() }}
+      </div>
+      <div ng-show="displaySummaryFactory.summary">
+        {{displaySummaryFactory.summary.online}} Online Displays / {{displaySummaryFactory.summary.offline}} Offline Displays
       </div>
     </div>
   </div>

--- a/web/scripts/displays/controllers/ctr-displays-list.js
+++ b/web/scripts/displays/controllers/ctr-displays-list.js
@@ -3,9 +3,9 @@
 angular.module('risevision.displays.controllers')
   .controller('displaysList', ['$scope', '$rootScope', 'userState', 'display',
     'ScrollingListService', '$loading', '$filter', 'displayFactory', 'playerLicenseFactory',
-    'displayStatusFactory',
+    'displayStatusFactory', 'displaySummaryFactory',
     function ($scope, $rootScope, userState, display, ScrollingListService, $loading,
-      $filter, displayFactory, playerLicenseFactory, displayStatusFactory) {
+      $filter, displayFactory, playerLicenseFactory, displayStatusFactory, displaySummaryFactory) {
       $scope.search = {
         sortBy: 'name',
         count: $scope.listLimit,
@@ -19,6 +19,9 @@ angular.module('risevision.displays.controllers')
       $scope.displayService = display;
       $scope.playerLicenseFactory = playerLicenseFactory;
       $scope.displayStatusFactory = displayStatusFactory;
+      $scope.displaySummaryFactory = displaySummaryFactory;
+
+      displaySummaryFactory.loadSummary();
 
       $scope.filterConfig = {
         placeholder: $filter('translate')(

--- a/web/scripts/displays/services/svc-display-summary-factory.js
+++ b/web/scripts/displays/services/svc-display-summary-factory.js
@@ -1,0 +1,29 @@
+'use strict';
+
+angular.module('risevision.displays.services')
+  .factory('displaySummaryFactory', ['display', 'processErrorCode',
+    function (display, processErrorCode) {
+      var factory = {
+        summary: undefined
+      };
+
+      factory.loadSummary = function () {
+        factory.summary = undefined;
+        factory.summaryLoading = true;
+
+        return display.summary()
+          .then(function (summary) {
+            factory.summary = summary;
+          })
+          .catch(function (err) {
+            factory.apiError = processErrorCode(err);
+            console.log('Error requesting display summary', err);
+          })
+          .finally(function(){
+            factory.summaryLoading = false;
+          });
+      };
+
+      return factory;
+    }
+  ]);

--- a/web/scripts/displays/services/svc-display.js
+++ b/web/scripts/displays/services/svc-display.js
@@ -359,6 +359,28 @@
               });
 
             return deferred.promise;
+          },
+          summary: function(companyId) {
+            companyId = companyId || userState.getSelectedCompanyId();
+            var deferred = $q.defer();
+
+            $log.debug('summary called with', companyId);
+            coreAPILoader().then(function (coreApi) {
+                return coreApi.display.summary({
+                  'companyId': companyId,
+                  'includeSubcompanies': false
+                });
+              })
+              .then(function (resp) {
+                $log.debug('summary resp', resp);
+                deferred.resolve(resp.result);
+              })
+              .then(null, function (e) {
+                console.error('Failed to retrieve summary.', e);
+                deferred.reject(e);
+              });
+
+            return deferred.promise;
           }
         };
 

--- a/web/scripts/displays/services/svc-player-license-factory.js
+++ b/web/scripts/displays/services/svc-player-license-factory.js
@@ -10,7 +10,7 @@ angular.module('risevision.displays.services')
       factory.getUsedLicenseString = function () {
         return factory.getProUsedLicenseCount() +
           ' Licensed Display' + (factory.getProUsedLicenseCount() !== 1 ? 's' : '') +
-          ' | ' + factory.getProAvailableLicenseCount() +
+          ' / ' + factory.getProAvailableLicenseCount() +
           ' License' + (factory.getProAvailableLicenseCount() !== 1 ? 's' : '') +
           ' Available';
       };


### PR DESCRIPTION
## Description
Call `core.display.summary` on Display List page load to populate online/offline displays count.
If request fails for some reason, we simply don't show the count.

## Motivation and Context
Network Management epic

## How Has This Been Tested?
Validated successful/failed requests and changing selected company.
[stage-1]


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
