### PR TITLE
Add close button to multi action panel

### DIFF
--- a/test/unit/components/scrolling-list/svc-scrolling-list-service.tests.js
+++ b/test/unit/components/scrolling-list/svc-scrolling-list-service.tests.js
@@ -47,6 +47,7 @@ describe("service: ScrollingListService:", function() {
     expect(scrollingListService.doSearch).to.be.a("function");
     expect(scrollingListService.load).to.be.a("function");
     
+    expect(scrollingListService.getSelected).to.be.a("function");
     expect(scrollingListService.select).to.be.a("function");
     expect(scrollingListService.selectAll).to.be.a("function");
   });
@@ -256,6 +257,21 @@ describe("service: ScrollingListService:", function() {
         done();
       },10);
     });
+  });
+
+  it('getSelected:', function() {
+    expect(scrollingListService.getSelected()).to.have.length(0);
+
+    scrollingListService.select(scrollingListService.items.list[0]);
+    scrollingListService.select(scrollingListService.items.list[5]);
+
+    expect(scrollingListService.getSelected()).to.have.length(2);
+    expect(scrollingListService.getSelected()[1]).to.equal(scrollingListService.items.list[5]);
+
+    scrollingListService.select(scrollingListService.items.list[0]);
+
+    expect(scrollingListService.getSelected()).to.have.length(1);
+    expect(scrollingListService.getSelected()[0]).to.equal(scrollingListService.items.list[5]);
   });
 
   describe('select:', function() {

--- a/test/unit/components/scrolling-list/svc-scrolling-list-service.tests.js
+++ b/test/unit/components/scrolling-list/svc-scrolling-list-service.tests.js
@@ -50,6 +50,7 @@ describe("service: ScrollingListService:", function() {
     expect(scrollingListService.getSelected).to.be.a("function");
     expect(scrollingListService.select).to.be.a("function");
     expect(scrollingListService.selectAll).to.be.a("function");
+    expect(scrollingListService.deselectAll).to.be.a("function");
   });
 
   it("should init the service objects",function(){
@@ -356,6 +357,40 @@ describe("service: ScrollingListService:", function() {
       expect(scrollingListService.search.selectAll).to.be.true;
     });
 
+  });
+
+  describe('deselectAll:', function() {
+    beforeEach(function() {
+      sinon.spy(scrollingListService, 'selectAll');
+    });
+
+    it('should toggle the selectAll flag to false', function() {
+      scrollingListService.search.selectAll = true;
+
+      scrollingListService.deselectAll();
+
+      expect(scrollingListService.search.selectAll).to.be.false;
+    });
+
+    it('should deselect items', function() {
+      scrollingListService.select(scrollingListService.items.list[0]);
+      scrollingListService.select(scrollingListService.items.list[5]);
+
+      scrollingListService.deselectAll();
+
+      expect(scrollingListService.getSelected()).to.have.length(0);
+      expect(scrollingListService.items.list[0].selected).to.be.false;
+      expect(scrollingListService.items.list[5].selected).to.be.false;
+    });
+  });
+
+  it('should not do anything if list is empty', function() {
+    scrollingListService.items.list = [];
+    scrollingListService.search.selectAll = true;
+
+    scrollingListService.deselectAll();
+
+    expect(scrollingListService.search.selectAll).to.be.true;
   });
 
 });

--- a/web/partials/displays/displays-list.html
+++ b/web/partials/displays/displays-list.html
@@ -31,6 +31,38 @@
       </div>
     </div>
 
+    <div class="flex-row button-toolbar-md-folded multi-actions-panel u_margin-md-top" ng-show="displays.getSelected().length > 0" require-role="da">
+      <div class="col-sm-4 pl-0">
+        <strong>{{displays.getSelected().length}}</strong>
+        <span class="text-gray">
+          Display<span ng-show="displays.getSelected().length > 1">s</span> selected. 
+          <span ng-hide="displays.search.selectAll"><a class="madero-link u_clickable" ng-click="displays.selectAll()"> Select all</a>.</span>
+        </span>
+      </div>
+      <div class="col-sm-8 pl-0">
+        <div>
+          <label class="mr-2">Actions:</label>
+          <div class="btn-group" dropdown>
+            <button id="displaysActionsButton" type="button" dropdown-toggle class="form-control btn-select btn-toolbar-wide flex-row mt-0">
+              <div class="row-entry">
+                <span class="text-gray mr-auto">Choose an action</span>
+                <span class="text-gray pl-2"><i class="fa fa-sort"></i></span>
+              </div>
+            </button>
+            <div class="dropdown-menu playlist-menu" role="menu">
+              <ul>
+                <li>
+                  <button type="button" class="btn-dropdown u_clickable" ng-click="">
+                    <span>Delete</span>
+                  </button>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div class="madero-style alert alert-warning u_margin-md-top" ng-show="search.query">
       <strong translate>displays-app.list.searchNotification</strong>
     </div>

--- a/web/partials/displays/displays-list.html
+++ b/web/partials/displays/displays-list.html
@@ -31,36 +31,41 @@
       </div>
     </div>
 
-    <div class="flex-row button-toolbar-md-folded multi-actions-panel u_margin-md-top" ng-show="displays.getSelected().length > 0" require-role="da">
-      <div class="col-sm-4 pl-0">
-        <strong>{{displays.getSelected().length}}</strong>
-        <span class="text-gray">
-          Display<span ng-show="displays.getSelected().length > 1">s</span> selected. 
-          <span ng-hide="displays.search.selectAll"><a class="madero-link u_clickable" ng-click="displays.selectAll()"> Select all</a>.</span>
-        </span>
-      </div>
-      <div class="col-sm-8 pl-0">
-        <div>
-          <label class="mr-2">Actions:</label>
-          <div class="btn-group" dropdown>
-            <button id="displaysActionsButton" type="button" dropdown-toggle class="form-control btn-select btn-toolbar-wide flex-row mt-0">
-              <div class="row-entry">
-                <span class="text-gray mr-auto">Choose an action</span>
-                <span class="text-gray pl-2"><i class="fa fa-sort"></i></span>
+    <div class="flex-row multi-actions-panel u_margin-md-top" ng-show="displays.getSelected().length > 0" require-role="da">
+      <div class="flex-row button-toolbar-md-folded w-100">
+        <div class="col-sm-5 pl-0">
+          <strong>{{displays.getSelected().length}}</strong>
+          <span class="text-gray">
+            Display<span ng-show="displays.getSelected().length > 1">s</span> selected. 
+            <span ng-hide="displays.search.selectAll"><a class="madero-link u_clickable" ng-click="displays.selectAll()"> Select all</a>.</span>
+          </span>
+        </div>
+        <div class="col-sm-7 pl-0">
+          <div>
+            <label class="mr-2">Actions:</label>
+            <div class="btn-group" dropdown>
+              <button id="displaysActionsButton" type="button" dropdown-toggle class="form-control btn-select btn-toolbar-wide flex-row mt-0">
+                <div class="row-entry">
+                  <span class="text-gray mr-auto">Choose an action</span>
+                  <span class="text-gray pl-2"><i class="fa fa-sort"></i></span>
+                </div>
+              </button>
+              <div class="dropdown-menu playlist-menu" role="menu">
+                <ul>
+                  <li>
+                    <button type="button" class="btn-dropdown u_clickable" ng-click="">
+                      <span>Delete</span>
+                    </button>
+                  </li>
+                </ul>
               </div>
-            </button>
-            <div class="dropdown-menu playlist-menu" role="menu">
-              <ul>
-                <li>
-                  <button type="button" class="btn-dropdown u_clickable" ng-click="">
-                    <span>Delete</span>
-                  </button>
-                </li>
-              </ul>
             </div>
           </div>
         </div>
       </div>
+      <button type="button" class="close" ng-click="displays.deselectAll()" data-dismiss="modal" aria-hidden="true">
+        <streamline-icon name="close" width="15" height="15"></streamline-icon>
+      </button>
     </div>
 
     <div class="madero-style alert alert-warning u_margin-md-top" ng-show="search.query">

--- a/web/scripts/components/scrolling-list/svc-scrolling-list-service.js
+++ b/web/scripts/components/scrolling-list/svc-scrolling-list-service.js
@@ -76,6 +76,20 @@ angular.module('risevision.common.components.scrolling-list')
           factory.load();
         };
 
+        factory.getSelected = function () {
+          return _.filter(factory.items.list, {
+            selected: true
+          });
+        };
+
+        var _allSelected = function () {
+          var deselectedIndex = _.findIndex(factory.items.list, function (item) {
+            return !item.selected;
+          });
+
+          return deselectedIndex === -1;
+        };
+
         factory.select = function (item) {
           if (!item) {
             return;
@@ -83,11 +97,7 @@ angular.module('risevision.common.components.scrolling-list')
 
           item.selected = !item.selected;
 
-          var deselectedIndex = _.findIndex(factory.items.list, function (item) {
-            return !item.selected;
-          });
-
-          factory.search.selectAll = deselectedIndex === -1;          
+          factory.search.selectAll = _allSelected();
         };
 
         factory.selectAll = function () {

--- a/web/scripts/components/scrolling-list/svc-scrolling-list-service.js
+++ b/web/scripts/components/scrolling-list/svc-scrolling-list-service.js
@@ -112,6 +112,18 @@ angular.module('risevision.common.components.scrolling-list')
           });
         };
 
+        factory.deselectAll = function () {
+          if (!factory.items.list.length) {
+            return;
+          }
+
+          factory.search.selectAll = false;
+
+          factory.items.list.forEach(function(item) {
+            item.selected = false;
+          });
+        };
+
         return factory;
       };
     }

--- a/web/scss/core/madero-style.scss
+++ b/web/scss/core/madero-style.scss
@@ -357,6 +357,16 @@
   .multi-actions-panel {
     background-color: $lighter-gray;
     padding: 25px;
+
+    .close {
+      svg {
+        fill: #999;
+      }
+
+      &:hover, &:focus {
+        opacity: 1;
+      }
+    }
   }
 
 }

--- a/web/scss/core/madero-style.scss
+++ b/web/scss/core/madero-style.scss
@@ -137,13 +137,19 @@
     .button-toolbar-md-folded {
       display: block;
 
+      & > * > * {
+        margin-top: 1rem !important;
+      }
+
+      & > *:first-child > * {
+        margin-top: 0 !important;
+      }
+
       .button-toolbar {
         display: block;
       }
 
       .btn-toolbar, .btn-toolbar-wide {
-        margin-top: 1rem !important;
-
         width: 100%;
       }
     }
@@ -346,6 +352,11 @@
       background-attachment: local, local, scroll, scroll;
       background-clip: padding-box; /* fix right border on Chrome */
     }
+  }
+
+  .multi-actions-panel {
+    background-color: $lighter-gray;
+    padding: 25px;
   }
 
 }

--- a/web/scss/core/madero-style.scss
+++ b/web/scss/core/madero-style.scss
@@ -359,6 +359,8 @@
     padding: 25px;
 
     .close {
+      width: auto;
+
       svg {
         fill: #999;
       }


### PR DESCRIPTION
## Description
Add close button to multi action panel

Button resets all selections which closes the panel

[stage-19]

## Motivation and Context
Network Management epic

## How Has This Been Tested?
Tested changes locally at various resolutions and updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No