### PR TITLE
Add display deletion functionality

### DIFF
--- a/test/unit/displays/controllers/ctr-displays-list.tests.js
+++ b/test/unit/displays/controllers/ctr-displays-list.tests.js
@@ -22,7 +22,8 @@ describe('controller: displays list', function() {
         return {
           search: {},
           loadingItems: false,
-          doSearch: function() {}
+          doSearch: function() {},
+          getSelectedAction: sinon.stub().returns('action')
         };
       };
     });
@@ -44,7 +45,9 @@ describe('controller: displays list', function() {
     });
     
     $provide.service('displayFactory', function() {
-      return {};
+      return {
+        deleteDisplayByObject: 'deleteDisplayByObject'
+      };
     });
     $provide.service('playerLicenseFactory', function() {
       return {};
@@ -82,6 +85,13 @@ describe('controller: displays list', function() {
 
     expect($scope.displayFactory).to.be.ok;
     expect($scope.playerLicenseFactory).to.be.ok;
+  });
+
+  it('deleteDisplays:', function() {
+    expect($scope.deleteDisplays).to.be.ok;
+    expect($scope.deleteDisplays).to.equal('action');
+
+    $scope.displays.getSelectedAction.should.have.been.calledWith('deleteDisplayByObject', true)
   });
 
   it('should init the scope objects',function(){

--- a/web/partials/displays/displays-list.html
+++ b/web/partials/displays/displays-list.html
@@ -53,7 +53,7 @@
               <div class="dropdown-menu playlist-menu" role="menu">
                 <ul>
                   <li>
-                    <button type="button" class="btn-dropdown u_clickable" ng-click="">
+                    <button type="button" class="btn-dropdown u_clickable" ng-click="deleteDisplays()">
                       <span>Delete</span>
                     </button>
                   </li>

--- a/web/scripts/displays/controllers/ctr-displays-list.js
+++ b/web/scripts/displays/controllers/ctr-displays-list.js
@@ -14,6 +14,8 @@ angular.module('risevision.displays.controllers')
       };
 
       $scope.displays = new ScrollingListService(display.list, $scope.search);
+      $scope.deleteDisplays = $scope.displays.getSelectedAction(displayFactory.deleteDisplayByObject, true);
+
       $scope.selectedCompayId = userState.getSelectedCompanyId();
       $scope.displayFactory = displayFactory;
       $scope.displayService = display;


### PR DESCRIPTION
## Description
Add display deletion functionality

Use common function generated by scrolling list service
Remove displays from list as operations succeed

[stage-19]

## Motivation and Context
Network Management epic

## How Has This Been Tested?
Tested changes locally. Updated unit tests. Will validate with larger scale deletion tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No