### PR TITLE
Fix #2073 - Template gallery in "Add From Template" is misaligned.

### DIFF
--- a/web/scss/ui-components/template-picker.scss
+++ b/web/scss/ui-components/template-picker.scss
@@ -18,7 +18,7 @@
     padding: 1em;
     h4 {
       margin-top:0;
-      max-height: 2em;
+      height: 2em;
     }
   }
 }

--- a/web/scss/ui-components/template-picker.scss
+++ b/web/scss/ui-components/template-picker.scss
@@ -18,6 +18,7 @@
     padding: 1em;
     h4 {
       margin-top:0;
+      max-height: 2em;
     }
   }
 }


### PR DESCRIPTION
## Description
Set max size on template name to prevent item to grow and misalign the list.

Note: We use angular-truncate to limit the template name length so another alternative was to decrease the allowed length. But as side effect, some names would be too short and we would have seen a lot of names with ellipsis.

## Motivation and Context
Why is this change required? What problem does it solve?

## How Has This Been Tested?
Visually confirmed locally and on [stage-20]


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
