### PR TITLE
Fix Storage encoding and template editor auto-saving E2E tests

### DIFF
--- a/test/e2e/storage/cases/upload.js
+++ b/test/e2e/storage/cases/upload.js
@@ -37,8 +37,7 @@ var UploadScenarios = function() {
       });
 
       it('should hide Upload panel when finished',function(){
-        this.timeout(55000);
-        helper.waitDisappear(storageSelectorModalPage.getUploadPanel(), 'Storage Upload Panel');
+        helper.waitDisappear(storageSelectorModalPage.getUploadPanel(), 'Storage Upload Panel', 90000);
         expect(storageSelectorModalPage.getUploadPanel().isDisplayed()).to.eventually.be.false;
       });
 

--- a/test/e2e/template-editor/pages/templateEditorPage.js
+++ b/test/e2e/template-editor/pages/templateEditorPage.js
@@ -127,6 +127,7 @@ var TemplateEditorPage = function() {
   };
 
   this.waitForAutosave = function() {
+    browser.sleep(500);
     savedText.isDisplayed().then(function(isDisplayed) {
       if (!isDisplayed) {
         //wait for presentation to be auto-saved


### PR DESCRIPTION
## Description
Use browser.wait timeout for encoding panel to disappear.
Adds a delay to allow `savedText` to disappear before checking for it

## Motivation and Context
Fix e2e failures

## How Has This Been Tested?
E2E tests pass

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
