### PR TITLE
Add delay for resetting operation stats

### DIFF
--- a/test/unit/components/scrolling-list/svc-batch-operations.tests.js
+++ b/test/unit/components/scrolling-list/svc-batch-operations.tests.js
@@ -129,10 +129,10 @@ describe("service: BatchOperations:", function() {
 
     it('should finish the batches and resolve', function(done) {
       batchOperations.batch(items, method).then(function() {
-        expect(batchOperations.isActive).to.be.false;
-        expect(batchOperations.progress).to.equal(0);
-        expect(batchOperations.totalItemCount).to.equal(0);
-        expect(batchOperations.completedItemCount).to.equal(0);
+        expect(batchOperations.isActive).to.be.true;
+        expect(batchOperations.progress).to.equal(100);
+        expect(batchOperations.totalItemCount).to.equal(8);
+        expect(batchOperations.completedItemCount).to.equal(8);
 
         done();
       });
@@ -150,12 +150,38 @@ describe("service: BatchOperations:", function() {
           // flush one more time to validate queue limit
           $timeout.flush(500);
 
-          $timeout.verifyNoPendingTasks();
-
           expect(batchOperations.isActive).to.be.true;
           expect(batchOperations.progress).to.equal(75);
           expect(batchOperations.totalItemCount).to.equal(8);
           expect(batchOperations.completedItemCount).to.equal(6);
+        }, 10);
+
+      }, 10);
+    });
+
+    it('should reset batch after 2 seconds of completion', function(done) {
+      batchOperations.batch(items, method).then(function() {
+        // flush one more time to bypass reset delay
+        $timeout.flush(2000);
+
+        $timeout.verifyNoPendingTasks();
+
+        expect(batchOperations.isActive).to.be.false;
+        expect(batchOperations.progress).to.equal(0);
+        expect(batchOperations.totalItemCount).to.equal(0);
+        expect(batchOperations.completedItemCount).to.equal(0);
+
+        done();
+      });
+
+      setTimeout(function() {
+        $timeout.flush(500);
+
+        setTimeout(function() {
+          $timeout.flush(500);
+
+          // flush one more time to validate queue limit
+          $timeout.flush(500);
         }, 10);
 
       }, 10);

--- a/web/partials/displays/displays-list.html
+++ b/web/partials/displays/displays-list.html
@@ -76,7 +76,7 @@
       <div class="multi-actions-progress-panel">
         <p class="mb-0"><strong>Bulk delete in progress.</strong></p>
         <p>Please don’t navigate away from this page.</p>
-        <div class="progress">
+        <div class="progress my-4">
           <div class="progress-bar" role="progressbar" aria-valuenow="{{displays.operations.progress}}.0"
           aria-valuemin="0" aria-valuemax="100" ng-style="{ 'width': displays.operations.progress + '%' }"></div>
         </div>

--- a/web/scripts/components/scrolling-list/svc-batch-operations.js
+++ b/web/scripts/components/scrolling-list/svc-batch-operations.js
@@ -43,7 +43,7 @@ angular.module('risevision.common.components.scrolling-list')
                 if (svc.totalItemCount === svc.completedItemCount) {
                   deferred.resolve();
 
-                  _reset();
+                  $timeout(_reset.bind(null, svc.completedItemCount), 2000);
                 }
               });
           };


### PR DESCRIPTION
## Description
Add delay for resetting operation stats

Correct margin for progress bar

[stage-18]

## Motivation and Context
Show the progress bar after completion for a 2 seconds.

## How Has This Been Tested?
Tested changes locally, updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No