### PR TITLE
Increase script timeout to fix video encoding E2E failures

### DIFF
--- a/test/e2e/storage/cases/upload.js
+++ b/test/e2e/storage/cases/upload.js
@@ -37,8 +37,10 @@ var UploadScenarios = function() {
       });
 
       it('should hide Upload panel when finished',function(){
+        browser.driver.manage().timeouts().setScriptTimeout(90000);
         helper.waitDisappear(storageSelectorModalPage.getUploadPanel(), 'Storage Upload Panel', 90000);
         expect(storageSelectorModalPage.getUploadPanel().isDisplayed()).to.eventually.be.false;
+        browser.driver.manage().timeouts().setScriptTimeout(30000);
       });
 
       it('should list uploaded file',function(){


### PR DESCRIPTION
## Description
Increase script timeout to accommodate encoding task
[stage-1]


## Motivation and Context
Fix e2e tests

## How Has This Been Tested?
[Test](https://app.circleci.com/pipelines/github/Rise-Vision/rise-vision-apps/4481/workflows/8e22de8b-5ffa-40fb-893b-1d8c8762a17b/jobs/72542) passed after 47 seconds vs previous limit of 30s.
`should hide Upload panel when finished (47911ms)`


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
