### PR TITLE
Refresh list after delete operation

### DIFF
--- a/test/unit/components/scrolling-list/svc-scrolling-list-service.tests.js
+++ b/test/unit/components/scrolling-list/svc-scrolling-list-service.tests.js
@@ -509,7 +509,8 @@ describe("service: ScrollingListService:", function() {
     });
 
     it('should remove items if flag is set', function(done) {
-      scrollingListService.operations.batch.returns(Q.resolve());
+      var deferred = Q.defer();
+      scrollingListService.operations.batch.returns(deferred.promise);
 
       scrollingListService.select(scrollingListService.items.list[0]);
       scrollingListService.select(scrollingListService.items.list[5]);
@@ -525,6 +526,27 @@ describe("service: ScrollingListService:", function() {
 
       setTimeout(function() {
         expect(scrollingListService.items.list).to.have.length(38);
+
+        done();
+      }, 10);
+    });
+
+    it('should refresh items if flag is set', function(done) {
+      sinon.spy(scrollingListService, 'doSearch');
+
+      scrollingListService.operations.batch.returns(Q.resolve());
+
+      scrollingListService.select(scrollingListService.items.list[0]);
+      scrollingListService.select(scrollingListService.items.list[5]);
+
+      var actionCall = sinon.stub().returns(Q.resolve());
+      var action = scrollingListService.getSelectedAction(actionCall, true);
+
+      // call the action
+      action();
+
+      setTimeout(function() {
+        scrollingListService.doSearch.should.have.been.called;
 
         done();
       }, 10);

--- a/web/scripts/components/scrolling-list/svc-scrolling-list-service.js
+++ b/web/scripts/components/scrolling-list/svc-scrolling-list-service.js
@@ -152,8 +152,13 @@ angular.module('risevision.common.components.scrolling-list')
                 });
             };
 
-            factory.operations.batch(selected, execute)
+            return factory.operations.batch(selected, execute)
               .finally(function() {  
+                if (removeFromList) {
+                  // reload list
+                  factory.doSearch();                  
+                }
+
                 if (listError) {
                   factory.errorMessage = 'Something went wrong.';
                   factory.apiError = 'We weren’t able to delete one or more of the selected ' + 


### PR DESCRIPTION
## Description
Refresh list after delete operation

[stage-19]

## Motivation and Context
Fixes issues where the list could be left empty after a full page of deletions.

## How Has This Been Tested?
Tested changes locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No