### PR TITLE
Move delete notification to common code

### DIFF
--- a/test/unit/common/controllers/ctr-bulk-delete-modal.tests.js
+++ b/test/unit/common/controllers/ctr-bulk-delete-modal.tests.js
@@ -1,6 +1,6 @@
 'use strict';
 describe('controller: bulk delete modal', function() {
-  beforeEach(module('risevision.displays.controllers'));
+  beforeEach(module('risevision.apps.controllers'));
   beforeEach(module(function ($provide) {
     $provide.service('$modalInstance',function() {
       return {
@@ -20,9 +20,9 @@ describe('controller: bulk delete modal', function() {
   beforeEach(function() {   
     sandbox = sinon.sandbox.create();
     selectedItems = [
-      {id: 'display1', companyId: 'companyId'},
-      {id: 'display2', companyId: 'subCompanyId'},
-      {id: 'display3', companyId: 'subCompanyId'}
+      {id: 'item1', companyId: 'companyId'},
+      {id: 'item2', companyId: 'subCompanyId'},
+      {id: 'item3', companyId: 'subCompanyId'}
     ];
 
     inject(function($injector, $rootScope, _$controller_) {
@@ -35,7 +35,8 @@ describe('controller: bulk delete modal', function() {
         $scope : $scope,
         $modalInstance: $modalInstance,
         userState: userState,
-        selectedItems: selectedItems
+        selectedItems: selectedItems,
+        itemName: 'Item'
       });
 
       $scope.$digest();
@@ -48,8 +49,9 @@ describe('controller: bulk delete modal', function() {
 
   it('should exist', function() {
     expect($scope).to.be.ok;
-    expect($scope.companyDisplays).to.be.ok;
-    expect($scope.subCompanyDisplays).to.be.ok;
+    expect($scope.itemName).to.equal('Item');
+    expect($scope.companyItems).to.be.ok;
+    expect($scope.subCompanyItems).to.be.ok;
     expect($scope.expectedText).to.be.ok;
     expect($scope.inputText).to.be.null;
     expect($scope.delete).to.be.a('function');
@@ -57,9 +59,9 @@ describe('controller: bulk delete modal', function() {
     expect($scope.dismiss).to.be.a('function');
   });
 
-  it('should count company and subcompany displays', function() {
-    expect($scope.companyDisplays).to.equal(1);
-    expect($scope.subCompanyDisplays).to.equal(2);
+  it('should count company and subcompany items', function() {
+    expect($scope.companyItems).to.equal(1);
+    expect($scope.subCompanyItems).to.equal(2);
     expect($scope.expectedText).to.equal('3');
   });
   

--- a/test/unit/common/directives/dtv-batch-operations.tests.js
+++ b/test/unit/common/directives/dtv-batch-operations.tests.js
@@ -1,23 +1,41 @@
 'use strict';
 describe('directive: batch-operations', function() {
-  var $scope,
+  var $compile,
+      $rootScope,
+      $scope,
       element;
+  var $modal;
   beforeEach(module('risevision.apps.directives'));
   beforeEach(module(function ($provide) {
-
+    $provide.service('$modal', function() {
+      return {
+        open: sinon.stub().returns({result: Q.resolve()})
+      }
+    });
   }));
-  beforeEach(inject(function($compile, $rootScope, $templateCache){
-    $rootScope.listObject = 'listObject';
-    $rootScope.listOperations = 'listOperations';
 
+  beforeEach(inject(function(_$compile_, _$rootScope_, $injector, $templateCache){
+    $modal = $injector.get('$modal');
+
+    $compile = _$compile_;
+    $rootScope = _$rootScope_;
     $templateCache.put('partials/common/batch-operations.html', '<p>mock</p>');
+  }));
 
+  function compileDirective() {
     element = $compile('<batch-operations list-object="listObject" list-operations="listOperations"></batch-operations>')($rootScope.$new());
     $rootScope.$digest();
     $scope = element.isolateScope();   
-  }));
+  }
 
   describe('batch-operations:', function () {
+    beforeEach(function() {
+      $rootScope.listObject = 'listObject';
+      $rootScope.listOperations = 'listOperations';
+
+      compileDirective();
+    });
+
     it('should compile', function() {
       expect(element[0].outerHTML).to.equal('<batch-operations list-object="listObject" list-operations="listOperations" class="ng-scope ng-isolate-scope"><p>mock</p></batch-operations>');
     });
@@ -25,6 +43,82 @@ describe('directive: batch-operations', function() {
     it('should initialize scope', function() {
       expect($scope.listObject).to.equal('listObject');
       expect($scope.listOperations).to.equal('listOperations');
+    });
+
+  });
+
+  describe('operations:', function() {
+    
+    it('should not do anything if operations are not found', function() {
+      $rootScope.listOperations = {
+        name: 'Items',
+        operations: [{
+          name: 'Operation',
+          actionCall: 'actionCall'
+        }]
+      };
+
+      compileDirective();        
+
+      expect($scope.listOperations.operations[0].actionCall).to.equal('actionCall');
+    });
+
+    describe('Delete:', function() {
+      var deleteAction;
+
+      beforeEach(function() {
+        deleteAction = sinon.spy();
+
+        $rootScope.listObject = {
+          getSelected: sinon.stub().returns('selectedItems'),
+          getSelectedAction: sinon.stub().returns(deleteAction)
+        };
+
+        $rootScope.listOperations = {
+          name: 'Items',
+          operations: [{
+            name: 'Delete',
+            actionCall: 'actionCall'
+          }]
+        };
+
+        compileDirective();        
+      });
+
+      it('should find and update delete operation', function() {
+        expect($scope.listOperations.operations[0].actionCall).to.be.a('function');
+      });
+
+      it('should get delete action', function() {
+        $scope.listObject.getSelectedAction.should.have.been.calledWith('actionCall', true);
+      });
+
+      it('should open confirmation modal', function() {
+        $scope.listOperations.operations[0].actionCall();
+
+        $modal.open.should.have.been.calledWithMatch({
+          templateUrl: 'partials/common/bulk-delete-confirmation-modal.html',
+          controller: 'BulkDeleteModalCtrl',
+          windowClass: 'madero-style centered-modal',
+          size: 'sm'
+        });        
+
+        var params = $modal.open.getCall(0).args[0];
+        expect(params.resolve.selectedItems()).to.equal('selectedItems');
+        expect(params.resolve.itemName()).to.equal('Items');
+
+      });
+
+      it('should perform operation if user confirms', function(done) {
+        $scope.listOperations.operations[0].actionCall();
+
+        setTimeout(function() {
+          deleteAction.should.have.been.called;
+
+          done();
+        });
+      });
+
     });
 
   });

--- a/test/unit/displays/controllers/ctr-displays-list.tests.js
+++ b/test/unit/displays/controllers/ctr-displays-list.tests.js
@@ -99,6 +99,7 @@ describe('controller: displays list', function() {
     expect($scope.listOperations.operations).to.have.length(1);
     expect($scope.listOperations.operations[0].name).to.equal('Delete');
     expect($scope.listOperations.operations[0].actionCall).to.equal('deleteDisplayByObject');
+    expect($scope.listOperations.operations[0].requireRole).to.equal('da');
   });
 
   it('should init the scope objects',function(){

--- a/test/unit/displays/controllers/ctr-displays-list.tests.js
+++ b/test/unit/displays/controllers/ctr-displays-list.tests.js
@@ -22,8 +22,7 @@ describe('controller: displays list', function() {
         return {
           search: {},
           loadingItems: false,
-          doSearch: function() {},
-          getSelectedAction: sinon.stub().returns('action')
+          doSearch: function() {}
         };
       };
     });
@@ -99,8 +98,7 @@ describe('controller: displays list', function() {
     expect($scope.listOperations.name).to.equal('Display');
     expect($scope.listOperations.operations).to.have.length(1);
     expect($scope.listOperations.operations[0].name).to.equal('Delete');
-    expect($scope.listOperations.operations[0].actionCall).to.be.a('function');
-    // $scope.displays.getSelectedAction.should.have.been.calledWith('deleteDisplayByObject', true)
+    expect($scope.listOperations.operations[0].actionCall).to.equal('deleteDisplayByObject');
   });
 
   it('should init the scope objects',function(){

--- a/web/index.html
+++ b/web/index.html
@@ -325,6 +325,7 @@
   <!-- common -->
   <script src="scripts/common/app.js"></script>
   <script src="scripts/common/controllers/ctr-app.js"></script>
+  <script src="scripts/common/controllers/ctr-bulk-delete-modal.js"></script>
 
   <script src="scripts/common/directives/dtv-page-title.js"></script>
   <script src="scripts/common/directives/dtv-rv-sortable.js"></script>
@@ -401,7 +402,6 @@
   <script src="scripts/displays/controllers/ctr-display-add.js"></script>
   <script src="scripts/displays/controllers/ctr-alerts.js"></script>
   <script src="scripts/displays/controllers/ctr-display-control-modal.js"></script>
-  <script src="scripts/displays/controllers/ctr-bulk-delete-modal.js"></script>
 
   <!-- editor -->
   <script src="scripts/editor/app.js"></script>

--- a/web/partials/common/batch-operations.html
+++ b/web/partials/common/batch-operations.html
@@ -19,7 +19,12 @@
           </button>
           <div class="dropdown-menu playlist-menu" role="menu">
             <ul>
-              <li ng-repeat="operation in listOperations.operations" require-role="da">
+              <li ng-if="!listOperations.operations.length">
+                <div class="btn-dropdown">
+                  <span class="text-gray">None</span>
+                </div>
+              </li>
+              <li ng-repeat="operation in listOperations.operations">
                 <button type="button" class="btn-dropdown u_clickable" ng-click="operation.actionCall()">
                   <span>{{operation.name}}</span>
                 </button>

--- a/web/partials/common/batch-operations.html
+++ b/web/partials/common/batch-operations.html
@@ -3,7 +3,7 @@
     <div class="col-sm-5 pl-0">
       <strong>{{listObject.getSelected().length}}</strong>
       <span class="text-gray">
-        {{listObject.name}}<span ng-show="listObject.getSelected().length > 1">s</span> selected. 
+        {{listOperations.name}}<span ng-show="listObject.getSelected().length > 1">s</span> selected. 
         <span ng-hide="listObject.search.selectAll"><a class="madero-link u_clickable" ng-click="listObject.selectAll()"> Select all</a>.</span>
       </span>
     </div>

--- a/web/partials/common/bulk-delete-confirmation-modal.html
+++ b/web/partials/common/bulk-delete-confirmation-modal.html
@@ -8,12 +8,12 @@
   <div class="modal-body mb-2" stop-event="touchend">
     <h4 class="mb-3">Are you sure you want to permanently delete?</h4>
     <p class="align-left">
-      <span ng-if="companyDisplays">
-        <strong>{{companyDisplays}}</strong> display<span ng-show="companyDisplays > 1">s</span> from your company.
+      <span ng-if="companyItems">
+        <strong>{{companyItems}}</strong> {{itemName | lowercase}}<span ng-show="companyItems > 1">s</span> from your company.
         <br/>
       </span>
-      <span ng-if="subCompanyDisplays">
-        <strong>{{subCompanyDisplays}}</strong> display<span ng-show="subCompanyDisplays > 1">s</span> from your sub-companies.
+      <span ng-if="subCompanyItems">
+        <strong>{{subCompanyItems}}</strong> {{itemName | lowercase}}<span ng-show="subCompanyItems > 1">s</span> from your sub-companies.
         <br/>
       </span>
       <br/>

--- a/web/scripts/common/controllers/ctr-bulk-delete-modal.js
+++ b/web/scripts/common/controllers/ctr-bulk-delete-modal.js
@@ -1,17 +1,18 @@
 'use strict';
-angular.module('risevision.displays.controllers')
-  .controller('BulkDeleteModalCtrl', ['$scope', '$modalInstance', 'userState', 'selectedItems', 
-    function ($scope, $modalInstance, userState, selectedItems) {
-      $scope.companyDisplays = 0;
-      $scope.subCompanyDisplays = 0;
+angular.module('risevision.apps.controllers')
+  .controller('BulkDeleteModalCtrl', ['$scope', '$modalInstance', 'userState', 'selectedItems', 'itemName',
+    function ($scope, $modalInstance, userState, selectedItems, itemName) {
+      $scope.itemName = itemName;
+      $scope.companyItems = 0;
+      $scope.subCompanyItems = 0;
       $scope.inputText = null;
       $scope.expectedText = selectedItems.length.toString();
 
       angular.forEach(selectedItems, function(display) {
         if (display.companyId === userState.getSelectedCompanyId()) {
-          $scope.companyDisplays++;
+          $scope.companyItems++;
         } else {
-          $scope.subCompanyDisplays++;
+          $scope.subCompanyItems++;
         }
       });
 

--- a/web/scripts/common/directives/dtv-batch-operations.js
+++ b/web/scripts/common/directives/dtv-batch-operations.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.apps.directives')
-  .directive('batchOperations', [
-    function () {
+  .directive('batchOperations', ['$modal',
+    function ($modal) {
       return {
         restrict: 'E',
         scope: {
@@ -10,7 +10,31 @@ angular.module('risevision.apps.directives')
           listOperations: '=',
         },
         templateUrl: 'partials/common/batch-operations.html',
-        link: function () {
+        link: function ($scope) {
+          if ($scope.listOperations && $scope.listOperations.operations && $scope.listObject) {
+            var deleteOperation = _.find($scope.listOperations.operations, {
+              name: 'Delete'
+            });
+
+            if (deleteOperation) {
+              var deleteAction = $scope.listObject.getSelectedAction(deleteOperation.actionCall, true);
+
+              deleteOperation.actionCall = function() {
+                $modal.open({
+                  templateUrl: 'partials/common/bulk-delete-confirmation-modal.html',
+                  controller: 'BulkDeleteModalCtrl',
+                  windowClass: 'madero-style centered-modal',
+                  size: 'sm',
+                  resolve: {
+                    selectedItems: $scope.listObject.getSelected,
+                    itemName: function() {
+                      return $scope.listOperations.name;
+                    }
+                  }
+                }).result.then(deleteAction);
+              };
+            }
+          }
         } //link()
       };
     }

--- a/web/scripts/common/directives/dtv-batch-operations.js
+++ b/web/scripts/common/directives/dtv-batch-operations.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.apps.directives')
-  .directive('batchOperations', ['$modal',
-    function ($modal) {
+  .directive('batchOperations', ['$modal', 'userState',
+    function ($modal, userState) {
       return {
         restrict: 'E',
         scope: {
@@ -11,7 +11,17 @@ angular.module('risevision.apps.directives')
         },
         templateUrl: 'partials/common/batch-operations.html',
         link: function ($scope) {
-          if ($scope.listOperations && $scope.listOperations.operations && $scope.listObject) {
+          var _filterByRole = function() {
+            _.remove($scope.listOperations.operations, function(operation) {
+              if (!operation.requireRole) {
+                return false;
+              }
+
+              return !userState.hasRole(operation.requireRole);
+            });            
+          };
+
+          var _updateDelete = function() {
             var deleteOperation = _.find($scope.listOperations.operations, {
               name: 'Delete'
             });
@@ -34,6 +44,11 @@ angular.module('risevision.apps.directives')
                 }).result.then(deleteAction);
               };
             }
+          };
+
+          if ($scope.listOperations && $scope.listOperations.operations && $scope.listObject) {
+            _filterByRole();
+            _updateDelete();
           }
         } //link()
       };

--- a/web/scripts/displays/controllers/ctr-displays-list.js
+++ b/web/scripts/displays/controllers/ctr-displays-list.js
@@ -18,7 +18,8 @@ angular.module('risevision.displays.controllers')
         name: 'Display',
         operations: [{
           name: 'Delete',
-          actionCall: displayFactory.deleteDisplayByObject
+          actionCall: displayFactory.deleteDisplayByObject,
+          requireRole: 'da'
         }]
       };
 

--- a/web/scripts/displays/controllers/ctr-displays-list.js
+++ b/web/scripts/displays/controllers/ctr-displays-list.js
@@ -18,17 +18,7 @@ angular.module('risevision.displays.controllers')
         name: 'Display',
         operations: [{
           name: 'Delete',
-          actionCall: function() {
-            $modal.open({
-              templateUrl: 'partials/displays/bulk-delete-confirmation-modal.html',
-              controller: 'BulkDeleteModalCtrl',
-              windowClass: 'madero-style centered-modal',
-              size: 'sm',
-              resolve: {
-                selectedItems: $scope.displays.getSelected
-              }
-            }).result.then($scope.displays.getSelectedAction(displayFactory.deleteDisplayByObject, true));
-          }
+          actionCall: displayFactory.deleteDisplayByObject
         }]
       };
 


### PR DESCRIPTION
## Description
Move delete notification to common code

Add modal function to the delete operation

[stage-19]

## Motivation and Context
Allow operations to be ported to other pages.

## How Has This Been Tested?
Tested changes locally, updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No