### PR TITLE
Temporary disable Summary until issue is fixed

### DIFF
--- a/test/unit/displays/controllers/ctr-displays-list.tests.js
+++ b/test/unit/displays/controllers/ctr-displays-list.tests.js
@@ -108,7 +108,7 @@ describe('controller: displays list', function() {
     expect($scope.search).to.have.property('reverse');
     expect($scope.search.count).to.equal(5);
 
-    displaySummaryFactory.loadSummary.should.have.been.caled;
+    // displaySummaryFactory.loadSummary.should.have.been.caled;
   });
 
   describe('$loading: ', function() {

--- a/web/scripts/displays/controllers/ctr-displays-list.js
+++ b/web/scripts/displays/controllers/ctr-displays-list.js
@@ -30,7 +30,8 @@ angular.module('risevision.displays.controllers')
       $scope.displayStatusFactory = displayStatusFactory;
       $scope.displaySummaryFactory = displaySummaryFactory;
 
-      displaySummaryFactory.loadSummary();
+      // Temporary disable Summary until issue https://github.com/Rise-Vision/core/issues/810 is fixed
+      // displaySummaryFactory.loadSummary();
 
       $scope.filterConfig = {
         placeholder: $filter('translate')(


### PR DESCRIPTION
## Description
Temporary disable Summary until issue https://github.com/Rise-Vision/core/issues/810 is fixed

## Motivation and Context
Issue https://github.com/Rise-Vision/core/issues/810

## How Has This Been Tested?
Visually confirmed the counter no longer shows and request is not made.
[stage-20]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
