### PR TITLE
Pass batch operation name and use it for wording

### DIFF
--- a/test/unit/common/directives/dtv-batch-operations.tests.js
+++ b/test/unit/common/directives/dtv-batch-operations.tests.js
@@ -4,7 +4,7 @@ describe('directive: batch-operations', function() {
       $rootScope,
       $scope,
       element;
-  var $modal, $state, userState;
+  var $window, $modal, $state, userState;
   beforeEach(module('risevision.apps.directives'));
   beforeEach(module(function ($provide) {
     $provide.service('$modal', function() {
@@ -27,6 +27,7 @@ describe('directive: batch-operations', function() {
   }));
 
   beforeEach(inject(function(_$compile_, _$rootScope_, $injector, $templateCache){
+    $window = $injector.get('$window');
     $modal = $injector.get('$modal');
     $state = $injector.get('$state');
     userState = $injector.get('userState');
@@ -173,6 +174,148 @@ describe('directive: batch-operations', function() {
       });
     });
 
+  });
+
+  describe('detect navigation:', function() {
+    beforeEach(function() {
+      $rootScope.listOperations = 'listOperations';
+      $rootScope.listObject = {
+        operations: {
+          activeOperation: '',
+          cancel: sinon.spy()
+        }
+      };
+
+      compileDirective();
+    });
+
+    describe('$stateChangeStart:', function() {
+      it('should notify when changing URL if an operation is active',function() {
+        $scope.listObject.operations.activeOperation = 'Operation';
+
+        $rootScope.$broadcast('$stateChangeStart',{name:'newState'});
+        $scope.$apply();
+
+        $modal.open.should.have.been.calledWithMatch({
+          templateUrl: 'partials/components/confirm-modal/madero-confirm-modal.html',
+          controller: 'confirmModalController',
+          windowClass: 'madero-style centered-modal',
+          size: 'sm',
+        });        
+
+        var params = $modal.open.getCall(0).args[0];
+        expect(params.resolve.confirmationTitle()).to.contain('operation');
+        expect(params.resolve.confirmationMessage()).to.contain('operation');
+        expect(params.resolve.confirmationButton()).to.be.ok;
+        expect(params.resolve.cancelButton()).to.be.ok;
+      });
+
+      it('should not notify when changing URL if is no active operation',function(){
+        $rootScope.$broadcast('$stateChangeStart',{name:'newState'});
+        $scope.$apply();
+
+        $modal.open.should.not.have.been.called;
+      });
+
+      it('should cancel operation and redirect if user accepts',function(done){
+        var state = {name:'newState'};
+        $scope.listObject.operations.activeOperation = 'Operation';
+
+        $rootScope.$broadcast('$stateChangeStart', state);
+        $scope.$apply();
+
+        $modal.open.should.have.been.called;
+
+        setTimeout(function() {
+          $scope.listObject.operations.cancel.should.have.been.called;
+
+          $state.go.should.have.been.calledWith({name:'newState'}, undefined);
+
+          $modal.open.should.have.been.calledOnce;
+
+          done();
+        }, 10);
+      });
+
+      it('should bypass check on navigation confirm',function(done){
+        var state = {name:'newState'};
+        $scope.listObject.operations.activeOperation = 'Operation';
+
+        $rootScope.$broadcast('$stateChangeStart', state);
+        $scope.$apply();
+
+        $modal.open.should.have.been.called;
+
+        setTimeout(function() {
+          $scope.listObject.operations.cancel.should.have.been.called;
+
+          $state.go.should.have.been.calledWith({name:'newState'}, undefined);
+
+          $modal.open.should.have.been.calledOnce;
+
+          $rootScope.$broadcast('$stateChangeStart', state);
+          $scope.$apply();
+
+          $modal.open.should.have.been.calledOnce;
+
+          setTimeout(function() {
+            $scope.listObject.operations.cancel.should.have.been.calledOnce;
+
+            $state.go.should.have.been.calledOnce;
+
+            $modal.open.should.have.been.calledOnce;
+
+            done();
+          }, 10);
+        }, 10);
+      });
+
+      it('should proceed with the operation if the users cancels',function(done){
+        $modal.open.returns({result: Q.reject()});
+        var state = {name:'newState'};
+        $scope.listObject.operations.activeOperation = 'Operation';
+
+        $rootScope.$broadcast('$stateChangeStart', state);
+        $scope.$apply();
+
+        $modal.open.should.have.been.called;
+
+        setTimeout(function() {
+          $scope.listObject.operations.cancel.should.not.have.been.called;
+
+          $state.go.should.not.have.been.called;
+
+          $modal.open.should.have.been.calledOnce;
+
+          done();
+        }, 10);
+      });
+
+    });
+
+    describe('onbeforeunload:', function() {
+      it('should notify unsaved changes when closing window',function(){
+        $scope.listObject.operations.activeOperation = 'Operation';
+        $scope.$apply();
+
+        var result = $window.onbeforeunload();
+        expect(result).to.equal('Cancel bulk action?');
+      });
+
+      it('should not notify unsaved changes when closing window if there are no changes',function(){    
+        var result = $window.onbeforeunload();
+        expect(result).to.be.undefined;
+      });
+
+      it('should stop listening for window close on $destroy',function(){
+        expect($window.onbeforeunload).to.be.a('function');
+        $rootScope.$broadcast('$destroy');
+        $scope.$apply();
+        expect($window.onbeforeunload).to.be.null;
+      });
+
+    });
+    
   });
 
 });

--- a/test/unit/components/scrolling-list/svc-scrolling-list-service.tests.js
+++ b/test/unit/components/scrolling-list/svc-scrolling-list-service.tests.js
@@ -413,7 +413,7 @@ describe("service: ScrollingListService:", function() {
     });
 
     it('should return early if no items are selected', function() {
-      var action = scrollingListService.getSelectedAction(sinon.stub().returns(Q.resolve()));
+      var action = scrollingListService.getSelectedAction(sinon.stub().returns(Q.resolve()), 'actionName');
 
       action();
 
@@ -425,14 +425,14 @@ describe("service: ScrollingListService:", function() {
       scrollingListService.select(scrollingListService.items.list[5]);
 
       var actionCall = sinon.stub().returns(Q.resolve());
-      var action = scrollingListService.getSelectedAction(actionCall);
+      var action = scrollingListService.getSelectedAction(actionCall, 'actionName');
 
       action();
 
       scrollingListService.operations.batch.should.have.been.calledWith([
         scrollingListService.items.list[0],
         scrollingListService.items.list[5]
-      ], sinon.match.func);
+      ], sinon.match.func, 'actionName');
     });
 
     it('should clear error messages', function() {
@@ -442,7 +442,7 @@ describe("service: ScrollingListService:", function() {
       scrollingListService.errorMessage = "errorMessage";
       scrollingListService.apiError = "apiError";
 
-      var action = scrollingListService.getSelectedAction(sinon.stub().returns(Q.resolve()));
+      var action = scrollingListService.getSelectedAction(sinon.stub().returns(Q.resolve()), 'actionName');
 
       action();
       
@@ -458,7 +458,7 @@ describe("service: ScrollingListService:", function() {
       scrollingListService.select(scrollingListService.items.list[5]);
 
       var actionCall = sinon.stub().returns(Q.resolve());
-      var action = scrollingListService.getSelectedAction(actionCall);
+      var action = scrollingListService.getSelectedAction(actionCall, 'actionName');
 
       // call the action
       action();
@@ -487,7 +487,7 @@ describe("service: ScrollingListService:", function() {
       scrollingListService.select(scrollingListService.items.list[5]);
 
       var actionCall = sinon.stub().returns(Q.reject());
-      var action = scrollingListService.getSelectedAction(actionCall);
+      var action = scrollingListService.getSelectedAction(actionCall, 'actionName');
 
       // call the action
       action();
@@ -516,7 +516,7 @@ describe("service: ScrollingListService:", function() {
       scrollingListService.select(scrollingListService.items.list[5]);
 
       var actionCall = sinon.stub().returns(Q.resolve());
-      var action = scrollingListService.getSelectedAction(actionCall, true);
+      var action = scrollingListService.getSelectedAction(actionCall, 'actionName', true);
 
       // call the action
       action();
@@ -540,7 +540,7 @@ describe("service: ScrollingListService:", function() {
       scrollingListService.select(scrollingListService.items.list[5]);
 
       var actionCall = sinon.stub().returns(Q.resolve());
-      var action = scrollingListService.getSelectedAction(actionCall, true);
+      var action = scrollingListService.getSelectedAction(actionCall, 'actionName', true);
 
       // call the action
       action();

--- a/web/partials/common/batch-operations.html
+++ b/web/partials/common/batch-operations.html
@@ -1,4 +1,4 @@
-<div class="flex-row multi-actions-panel u_padding-20 u_margin-md-top" ng-show="listObject.getSelected().length > 0 && !listObject.operations.isActive">
+<div class="flex-row multi-actions-panel u_padding-20 u_margin-md-top" ng-show="listObject.getSelected().length > 0 && !listObject.operations.activeOperation">
   <div class="flex-row button-toolbar-md-folded w-100">
     <div class="col-sm-5 pl-0">
       <strong>{{listObject.getSelected().length}}</strong>
@@ -40,9 +40,9 @@
   </button>
 </div>
 
-<div class="border-container text-center u_padding-20 u_margin-md-top" ng-show="listObject.operations.isActive">
+<div class="border-container text-center u_padding-20 u_margin-md-top" ng-show="listObject.operations.activeOperation">
   <div class="multi-actions-progress-panel">
-    <p class="mb-0"><strong>Bulk delete in progress.</strong></p>
+    <p class="mb-0"><strong>Bulk {{listObject.operations.activeOperation | lowercase}} in progress.</strong> <a class="madero-link u_clickable" ng-click="listObject.operations.cancel()">Cancel</a></p>
     <p>Please don’t navigate away from this page.</p>
     <div class="progress my-4">
       <div class="progress-bar" role="progressbar" aria-valuenow="{{listObject.operations.progress}}.0"

--- a/web/scripts/common/directives/dtv-batch-operations.js
+++ b/web/scripts/common/directives/dtv-batch-operations.js
@@ -21,34 +21,36 @@ angular.module('risevision.apps.directives')
             });            
           };
 
-          var _updateDelete = function() {
-            var deleteOperation = _.find($scope.listOperations.operations, {
-              name: 'Delete'
+          var _updateListActions = function() {
+            _.each($scope.listOperations.operations, function(operation) {
+
+              if (operation.name === 'Delete') {
+                var deleteAction = $scope.listObject.getSelectedAction(operation.actionCall, operation.name, true);
+
+                operation.actionCall = function() {
+                  $modal.open({
+                    templateUrl: 'partials/common/bulk-delete-confirmation-modal.html',
+                    controller: 'BulkDeleteModalCtrl',
+                    windowClass: 'madero-style centered-modal',
+                    size: 'sm',
+                    resolve: {
+                      selectedItems: $scope.listObject.getSelected,
+                      itemName: function() {
+                        return $scope.listOperations.name;
+                      }
+                    }
+                  }).result.then(deleteAction);
+                };
+              } else {
+                operation.actionCall = $scope.listObject.getSelectedAction(operation.actionCall, operation.name);
+              }
             });
 
-            if (deleteOperation) {
-              var deleteAction = $scope.listObject.getSelectedAction(deleteOperation.actionCall, true);
-
-              deleteOperation.actionCall = function() {
-                $modal.open({
-                  templateUrl: 'partials/common/bulk-delete-confirmation-modal.html',
-                  controller: 'BulkDeleteModalCtrl',
-                  windowClass: 'madero-style centered-modal',
-                  size: 'sm',
-                  resolve: {
-                    selectedItems: $scope.listObject.getSelected,
-                    itemName: function() {
-                      return $scope.listOperations.name;
-                    }
-                  }
-                }).result.then(deleteAction);
-              };
-            }
           };
 
           if ($scope.listOperations && $scope.listOperations.operations && $scope.listObject) {
             _filterByRole();
-            _updateDelete();
+            _updateListActions();
           }
         } //link()
       };

--- a/web/scripts/components/scrolling-list/svc-scrolling-list-service.js
+++ b/web/scripts/components/scrolling-list/svc-scrolling-list-service.js
@@ -125,7 +125,7 @@ angular.module('risevision.common.components.scrolling-list')
           });
         };
 
-        factory.getSelectedAction = function(actionCall, removeFromList) {
+        factory.getSelectedAction = function(actionCall, name, removeFromList) {
           return function() {
             var selected = factory.getSelected();
             var listError = false;
@@ -152,17 +152,17 @@ angular.module('risevision.common.components.scrolling-list')
                 });
             };
 
-            return factory.operations.batch(selected, execute)
+            return factory.operations.batch(selected, execute, name)
               .finally(function() {  
                 if (removeFromList) {
                   // reload list
-                  factory.doSearch();                  
+                  factory.doSearch();
                 }
 
                 if (listError) {
                   factory.errorMessage = 'Something went wrong.';
-                  factory.apiError = 'We weren’t able to delete one or more of the selected ' + 
-                    factory.search.name.toLowerCase() + '. Please try again.';                  
+                  factory.apiError = 'We weren’t able to ' + name.toLowerCase() + ' one or more of the selected ' + 
+                    factory.search.name.toLowerCase() + 's. Please try again.';                  
                 }
               });
           };


### PR DESCRIPTION
## Description
Pass batch operation name and use it for wording

Fix issue where only Delete operations are processed
via `getSelectedAction`

Refactor `isActive` flag to just use the name
Add Cancel button and allow cancelling the operation
Queue more operations on completion instead of timeout

[stage-2]

## Motivation and Context
Allow multiple operations to be queued, by fixing functionality and allowing a variable name.

Allow Cancelling operations (will also be used for the navigation detection functionality).

Refactoring.

## How Has This Been Tested?
Tested various scenarios locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No