### PR TITLE
Detect and prompt if user navigates during an operation

### DIFF
--- a/test/unit/common/directives/dtv-batch-operations.tests.js
+++ b/test/unit/common/directives/dtv-batch-operations.tests.js
@@ -4,7 +4,7 @@ describe('directive: batch-operations', function() {
       $rootScope,
       $scope,
       element;
-  var $modal, $state, userState;
+  var $window, $modal, $state, userState;
   beforeEach(module('risevision.apps.directives'));
   beforeEach(module(function ($provide) {
     $provide.service('$modal', function() {
@@ -27,6 +27,7 @@ describe('directive: batch-operations', function() {
   }));
 
   beforeEach(inject(function(_$compile_, _$rootScope_, $injector, $templateCache){
+    $window = $injector.get('$window');
     $modal = $injector.get('$modal');
     $state = $injector.get('$state');
     userState = $injector.get('userState');
@@ -173,6 +174,148 @@ describe('directive: batch-operations', function() {
       });
     });
 
+  });
+
+  describe('detect navigation:', function() {
+    beforeEach(function() {
+      $rootScope.listOperations = 'listOperations';
+      $rootScope.listObject = {
+        operations: {
+          activeOperation: '',
+          cancel: sinon.spy()
+        }
+      };
+
+      compileDirective();
+    });
+
+    describe('$stateChangeStart:', function() {
+      it('should notify when changing URL if an operation is active',function() {
+        $scope.listObject.operations.activeOperation = 'Operation';
+
+        $rootScope.$broadcast('$stateChangeStart',{name:'newState'});
+        $scope.$apply();
+
+        $modal.open.should.have.been.calledWithMatch({
+          templateUrl: 'partials/components/confirm-modal/madero-confirm-modal.html',
+          controller: 'confirmModalController',
+          windowClass: 'madero-style centered-modal',
+          size: 'sm',
+        });        
+
+        var params = $modal.open.getCall(0).args[0];
+        expect(params.resolve.confirmationTitle()).to.contain('operation');
+        expect(params.resolve.confirmationMessage()).to.contain('operation');
+        expect(params.resolve.confirmationButton()).to.be.ok;
+        expect(params.resolve.cancelButton()).to.be.ok;
+      });
+
+      it('should not notify when changing URL if is no active operation',function(){
+        $rootScope.$broadcast('$stateChangeStart',{name:'newState'});
+        $scope.$apply();
+
+        $modal.open.should.not.have.been.called;
+      });
+
+      it('should cancel operation and redirect if user accepts',function(done){
+        var state = {name:'newState'};
+        $scope.listObject.operations.activeOperation = 'Operation';
+
+        $rootScope.$broadcast('$stateChangeStart', state);
+        $scope.$apply();
+
+        $modal.open.should.have.been.called;
+
+        setTimeout(function() {
+          $scope.listObject.operations.cancel.should.have.been.called;
+
+          $state.go.should.have.been.calledWith({name:'newState'}, undefined);
+
+          $modal.open.should.have.been.calledOnce;
+
+          done();
+        }, 10);
+      });
+
+      it('should bypass check on navigation confirm',function(done){
+        var state = {name:'newState'};
+        $scope.listObject.operations.activeOperation = 'Operation';
+
+        $rootScope.$broadcast('$stateChangeStart', state);
+        $scope.$apply();
+
+        $modal.open.should.have.been.called;
+
+        setTimeout(function() {
+          $scope.listObject.operations.cancel.should.have.been.called;
+
+          $state.go.should.have.been.calledWith({name:'newState'}, undefined);
+
+          $modal.open.should.have.been.calledOnce;
+
+          $rootScope.$broadcast('$stateChangeStart', state);
+          $scope.$apply();
+
+          $modal.open.should.have.been.calledOnce;
+
+          setTimeout(function() {
+            $scope.listObject.operations.cancel.should.have.been.calledOnce;
+
+            $state.go.should.have.been.calledOnce;
+
+            $modal.open.should.have.been.calledOnce;
+
+            done();
+          }, 10);
+        }, 10);
+      });
+
+      it('should proceed with the operation if the users cancels',function(done){
+        $modal.open.returns({result: Q.reject()});
+        var state = {name:'newState'};
+        $scope.listObject.operations.activeOperation = 'Operation';
+
+        $rootScope.$broadcast('$stateChangeStart', state);
+        $scope.$apply();
+
+        $modal.open.should.have.been.called;
+
+        setTimeout(function() {
+          $scope.listObject.operations.cancel.should.not.have.been.called;
+
+          $state.go.should.not.have.been.called;
+
+          $modal.open.should.have.been.calledOnce;
+
+          done();
+        }, 10);
+      });
+
+    });
+
+    describe('onbeforeunload:', function() {
+      it('should notify unsaved changes when closing window',function(){
+        $scope.listObject.operations.activeOperation = 'Operation';
+        $scope.$apply();
+
+        var result = $window.onbeforeunload();
+        expect(result).to.equal('Cancel bulk action?');
+      });
+
+      it('should not notify unsaved changes when closing window if there are no changes',function(){    
+        var result = $window.onbeforeunload();
+        expect(result).to.be.undefined;
+      });
+
+      it('should stop listening for window close on $destroy',function(){
+        expect($window.onbeforeunload).to.be.a('function');
+        $rootScope.$broadcast('$destroy');
+        $scope.$apply();
+        expect($window.onbeforeunload).to.be.null;
+      });
+
+    });
+    
   });
 
 });


### PR DESCRIPTION
## Description
Detect and prompt if user navigates during an operation

Detect both navigation within and outside of the app

[stage-19]

## Motivation and Context
Network Management epic

## How Has This Been Tested?
Tested changes locally with various scenarios. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No