### PR TITLE
Show deletion conflict error for Presentations delete

### DIFF
--- a/test/unit/components/scrolling-list/svc-scrolling-list-service.tests.js
+++ b/test/unit/components/scrolling-list/svc-scrolling-list-service.tests.js
@@ -435,79 +435,6 @@ describe("service: ScrollingListService:", function() {
       ], sinon.match.func, 'actionName');
     });
 
-    it('should clear error messages', function() {
-      scrollingListService.select(scrollingListService.items.list[0]);
-      scrollingListService.select(scrollingListService.items.list[5]);
-
-      scrollingListService.errorMessage = "errorMessage";
-      scrollingListService.apiError = "apiError";
-
-      var action = scrollingListService.getSelectedAction(sinon.stub().returns(Q.resolve()), 'actionName');
-
-      action();
-      
-      expect(scrollingListService.errorMessage).to.not.be.ok;
-      expect(scrollingListService.apiError).to.not.be.ok;
-    });
-
-    it('should not populate error fields if calls were successful', function(done) {
-      var deferred = Q.defer();
-      scrollingListService.operations.batch.returns(deferred.promise);
-
-      scrollingListService.select(scrollingListService.items.list[0]);
-      scrollingListService.select(scrollingListService.items.list[5]);
-
-      var actionCall = sinon.stub().returns(Q.resolve());
-      var action = scrollingListService.getSelectedAction(actionCall, 'actionName');
-
-      // call the action
-      action();
-      // Resolve the batch execute function
-      scrollingListService.operations.batch.getCall(0).args[1](scrollingListService.items.list[0]);
-
-      setTimeout(function() {
-        // resolve the batch promise
-        deferred.resolve();
-
-        setTimeout(function() {
-          expect(scrollingListService.errorMessage).to.not.be.ok;
-          expect(scrollingListService.apiError).to.not.be.ok;
-
-          done();
-        }, 10);
-
-      }, 10);
-    });
-
-    it('should handle api errors', function(done) {
-      var deferred = Q.defer();
-      scrollingListService.operations.batch.returns(deferred.promise);
-
-      scrollingListService.select(scrollingListService.items.list[0]);
-      scrollingListService.select(scrollingListService.items.list[5]);
-
-      var actionCall = sinon.stub().returns(Q.reject());
-      var action = scrollingListService.getSelectedAction(actionCall, 'actionName');
-
-      // call the action
-      action();
-      // Resolve the batch execute function
-      scrollingListService.operations.batch.getCall(0).args[1](scrollingListService.items.list[0]);
-
-      setTimeout(function() {
-        // resolve the batch promise
-        deferred.resolve();
-
-        setTimeout(function() {
-          expect(scrollingListService.errorMessage).to.be.ok;
-          expect(scrollingListService.apiError).to.be.ok;
-
-          done();
-        }, 10);
-
-      }, 10);
-    });
-
     it('should remove items if flag is set', function(done) {
       var deferred = Q.defer();
       scrollingListService.operations.batch.returns(deferred.promise);
@@ -531,25 +458,186 @@ describe("service: ScrollingListService:", function() {
       }, 10);
     });
 
-    it('should refresh items if flag is set', function(done) {
-      sinon.spy(scrollingListService, 'doSearch');
+    describe('errors:', function() {
+      it('should clear error messages', function() {
+        scrollingListService.select(scrollingListService.items.list[0]);
+        scrollingListService.select(scrollingListService.items.list[5]);
 
-      scrollingListService.operations.batch.returns(Q.resolve());
+        scrollingListService.errorMessage = "errorMessage";
+        scrollingListService.apiError = "apiError";
 
-      scrollingListService.select(scrollingListService.items.list[0]);
-      scrollingListService.select(scrollingListService.items.list[5]);
+        var action = scrollingListService.getSelectedAction(sinon.stub().returns(Q.resolve()), 'actionName');
 
-      var actionCall = sinon.stub().returns(Q.resolve());
-      var action = scrollingListService.getSelectedAction(actionCall, 'actionName', true);
+        action();
+        
+        expect(scrollingListService.errorMessage).to.not.be.ok;
+        expect(scrollingListService.apiError).to.not.be.ok;
+      });
 
-      // call the action
-      action();
+      it('should not populate error fields if calls were successful', function(done) {
+        var deferred = Q.defer();
+        scrollingListService.operations.batch.returns(deferred.promise);
 
-      setTimeout(function() {
-        scrollingListService.doSearch.should.have.been.called;
+        scrollingListService.select(scrollingListService.items.list[0]);
+        scrollingListService.select(scrollingListService.items.list[5]);
 
-        done();
-      }, 10);
+        var actionCall = sinon.stub().returns(Q.resolve());
+        var action = scrollingListService.getSelectedAction(actionCall, 'actionName');
+
+        // call the action
+        action();
+        // Resolve the batch execute function
+        scrollingListService.operations.batch.getCall(0).args[1](scrollingListService.items.list[0]);
+
+        setTimeout(function() {
+          // resolve the batch promise
+          deferred.resolve();
+
+          setTimeout(function() {
+            expect(scrollingListService.errorMessage).to.not.be.ok;
+            expect(scrollingListService.apiError).to.not.be.ok;
+
+            done();
+          }, 10);
+
+        }, 10);
+      });
+
+      it('should handle api errors', function(done) {
+        var deferred = Q.defer();
+        scrollingListService.operations.batch.returns(deferred.promise);
+
+        scrollingListService.select(scrollingListService.items.list[0]);
+        scrollingListService.select(scrollingListService.items.list[5]);
+
+        var actionCall = sinon.stub().returns(Q.reject());
+        var action = scrollingListService.getSelectedAction(actionCall, 'actionName');
+
+        // call the action
+        action();
+        // Resolve the batch execute function
+        scrollingListService.operations.batch.getCall(0).args[1](scrollingListService.items.list[0]);
+
+        setTimeout(function() {
+          // resolve the batch promise
+          deferred.resolve();
+
+          setTimeout(function() {
+            expect(scrollingListService.errorMessage).to.be.ok;
+            expect(scrollingListService.apiError).to.be.ok;
+
+            done();
+          }, 10);
+
+        }, 10);
+      });
+
+      it('should not overwrite existing error messages', function(done) {
+        var deferred = Q.defer();
+        scrollingListService.operations.batch.returns(deferred.promise);
+
+        scrollingListService.select(scrollingListService.items.list[0]);
+        scrollingListService.select(scrollingListService.items.list[5]);
+
+        var actionCall = sinon.stub().returns(Q.reject());
+        var action = scrollingListService.getSelectedAction(actionCall, 'actionName');
+
+        // call the action
+        action();
+
+        scrollingListService.errorMessage = 'existingMessage';
+        scrollingListService.apiError = 'existingError';
+
+        // Resolve the batch execute function
+        scrollingListService.operations.batch.getCall(0).args[1](scrollingListService.items.list[0]);
+
+        setTimeout(function() {
+          // resolve the batch promise
+          deferred.resolve();
+
+          setTimeout(function() {
+            expect(scrollingListService.errorMessage).to.equal('existingMessage');
+            expect(scrollingListService.apiError).to.equal('existingError');
+
+            done();
+          }, 10);
+
+        }, 10);
+      });
+
+    });
+
+    describe('refresh:', function() {
+      beforeEach(function() {
+        sinon.spy(scrollingListService, 'doSearch');
+      });
+
+      it('should not refresh items for regular operations', function(done) {
+        scrollingListService.operations.batch.returns(Q.resolve());
+
+        scrollingListService.select(scrollingListService.items.list[0]);
+        scrollingListService.select(scrollingListService.items.list[5]);
+
+        var actionCall = sinon.stub().returns(Q.resolve());
+        var action = scrollingListService.getSelectedAction(actionCall, 'actionName');
+
+        // call the action
+        action();
+
+        setTimeout(function() {
+          scrollingListService.doSearch.should.not.have.been.called;
+
+          done();
+        }, 10);
+      });
+
+      it('should refresh items if Delete flag is set', function(done) {
+        scrollingListService.operations.batch.returns(Q.resolve());
+
+        scrollingListService.select(scrollingListService.items.list[0]);
+        scrollingListService.select(scrollingListService.items.list[5]);
+
+        var actionCall = sinon.stub().returns(Q.resolve());
+        var action = scrollingListService.getSelectedAction(actionCall, 'actionName', true);
+
+        // call the action
+        action();
+
+        setTimeout(function() {
+          scrollingListService.doSearch.should.have.been.called;
+
+          done();
+        }, 10);
+      });
+
+      it('should not refresh the list on error', function(done) {
+        var deferred = Q.defer();
+        scrollingListService.operations.batch.returns(deferred.promise);
+
+        scrollingListService.select(scrollingListService.items.list[0]);
+        scrollingListService.select(scrollingListService.items.list[5]);
+
+        var actionCall = sinon.stub().returns(Q.reject());
+        var action = scrollingListService.getSelectedAction(actionCall, 'actionName');
+
+        // call the action
+        action();
+        // Resolve the batch execute function
+        scrollingListService.operations.batch.getCall(0).args[1](scrollingListService.items.list[0]);
+
+        setTimeout(function() {
+          // resolve the batch promise
+          deferred.resolve();
+
+          setTimeout(function() {
+            scrollingListService.doSearch.should.not.have.been.called;
+
+            done();
+          }, 10);
+
+        }, 10);
+      });
+      
     });
 
   });

--- a/web/partials/editor/presentation-list.html
+++ b/web/partials/editor/presentation-list.html
@@ -33,7 +33,7 @@
       <table id="presentationListTable" class="table">
         <thead class="table-header">
           <tr class="table-header__row u_clickable">
-            <th id="tableHeaderName" class="table-header__cell col-sm-8">
+            <th class="table-header__cell col-sm-8">
               <div class="flex-row">
                 <madero-checkbox ng-click="presentations.selectAll()" ng-value="search.selectAll"></madero-checkbox>
                 <div class="u_clickable" id="tableHeaderName" ng-click="presentations.sortBy('name')">
@@ -42,11 +42,11 @@
                 </div>
               </div>
             </th>
-            <th id="tableHeaderStatus" class="table-header__cell col-sm-2 hidden-xs"  ng-click="presentations.sortBy('revisionStatusName')">
+            <th id="tableHeaderStatus" class="table-header__cell col-sm-2"  ng-click="presentations.sortBy('revisionStatusName')">
               {{'editor-app.list.heading.status'  | translate}}
               <i ng-if="search.sortBy === 'revisionStatusName'" class="fa" ng-class="{false: 'fa-caret-up', true: 'fa-caret-down'}[search.reverse]"></i>
             </th>
-            <th id="tableHeaderChangeDate" class="table-header__cell col-sm-2 hidden-xs" ng-click="presentations.sortBy('changeDate')">
+            <th id="tableHeaderChangeDate" class="table-header__cell col-sm-2" ng-click="presentations.sortBy('changeDate')">
               {{'editor-app.list.heading.changeDate' | translate}}
               <i ng-if="search.sortBy === 'changeDate'" class="fa" ng-class="{false: 'fa-caret-up', true: 'fa-caret-down'}[search.reverse]"></i>
             </th>
@@ -61,8 +61,8 @@
                 <a class="madero-link u_ellipsis-lg" ui-sref="apps.editor.templates.edit({presentationId: presentation.id})" ng-if="isHtmlPresentation(presentation)"><strong>{{presentation.name}}</strong></a>
               </div>
             </td>
-            <td class="table-body__cell hidden-xs"><span ng-class="{'text-danger': presentation.revisionStatusName==='Revised'}">{{presentation.revisionStatusName | presentationStatus}}</span></td>
-            <td class="table-body__cell hidden-xs">{{presentation.changeDate | date:'d-MMM-yyyy h:mm a'}} by {{presentation.changedBy | username}}</td>
+            <td class="table-body__cell"><span ng-class="{'text-danger': presentation.revisionStatusName==='Revised'}">{{presentation.revisionStatusName | presentationStatus}}</span></td>
+            <td class="table-body__cell">{{presentation.changeDate | date:'d-MMM-yyyy h:mm a'}} by {{presentation.changedBy | username}}</td>
           </tr>
 
           <!-- If no search results -->

--- a/web/scripts/components/scrolling-list/svc-scrolling-list-service.js
+++ b/web/scripts/components/scrolling-list/svc-scrolling-list-service.js
@@ -153,16 +153,16 @@ angular.module('risevision.common.components.scrolling-list')
             };
 
             return factory.operations.batch(selected, execute, name)
-              .finally(function() {  
-                if (removeFromList) {
+              .then(function() {
+                if (!listError && removeFromList) {
                   // reload list
                   factory.doSearch();
                 }
 
-                if (listError) {
+                if (listError && !factory.errorMessage) {
                   factory.errorMessage = 'Something went wrong.';
                   factory.apiError = 'We weren’t able to ' + name.toLowerCase() + ' one or more of the selected ' + 
-                    factory.search.name.toLowerCase() + 's. Please try again.';                  
+                    factory.search.name.toLowerCase() + '. Please try again.';                  
                 }
               });
           };

--- a/web/scripts/editor/controllers/ctr-presentation-list.js
+++ b/web/scripts/editor/controllers/ctr-presentation-list.js
@@ -3,10 +3,10 @@ angular.module('risevision.editor.controllers')
   .value('PRESENTATION_SEARCH', {
     filter: ''
   })
-  .controller('PresentationListController', ['$q', '$scope',
+  .controller('PresentationListController', ['$scope',
     'ScrollingListService', 'presentation', 'editorFactory', 'templateEditorFactory', '$loading',
     '$filter', 'presentationUtils', 'PRESENTATION_SEARCH',
-    function ($q, $scope, ScrollingListService, presentation, editorFactory, templateEditorFactory,
+    function ($scope, ScrollingListService, presentation, editorFactory, templateEditorFactory,
       $loading, $filter, presentationUtils, PRESENTATION_SEARCH) {
       $scope.search = {
         sortBy: 'changeDate',
@@ -21,7 +21,17 @@ angular.module('risevision.editor.controllers')
         name: 'Presentation',
         operations: [{
           name: 'Delete',
-          actionCall: editorFactory.deletePresentationByObject,
+          actionCall: function(presentation) {
+            return editorFactory.deletePresentationByObject(presentation)
+              .catch(function(e) {
+                if (e.status === 409) {
+                  $scope.presentations.errorMessage = 'Some presentations could not be deleted.';
+                  $scope.presentations.apiError = 'These presentations are used in one or more schedules. To delete them, please remove them from the schedules they are being used in, and try again.'; 
+                }
+
+                throw e;
+              });
+          },
           requireRole: 'cp'
         }]
       };


### PR DESCRIPTION
## Description
Show deletion conflict error for Presentations delete

No longer refresh the list on errors

[stage-19]

## Motivation and Context
Inform users that their Presentation is used in a Schedule on deletion.

## How Has This Been Tested?
Tested changes locally; updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No