### PR TITLE
Add beforeBatchAction function support

### DIFF
--- a/test/unit/components/scrolling-list/directives/dtv-batch-operations.tests.js
+++ b/test/unit/components/scrolling-list/directives/dtv-batch-operations.tests.js
@@ -134,11 +134,11 @@ describe('directive: batch-operations', function() {
         });
 
         it('should find and update delete operation', function() {
-          expect($scope.listOperations.operations[0].actionCall).to.be.a('function');
+          expect($scope.listOperations.operations[0].beforeBatchAction).to.be.a('function');
         });
 
         it('should open confirmation modal', function() {
-          $scope.listOperations.operations[0].actionCall();
+          $scope.listOperations.operations[0].beforeBatchAction();
 
           $modal.open.should.have.been.calledWithMatch({
             templateUrl: 'partials/common/bulk-delete-confirmation-modal.html',
@@ -150,17 +150,13 @@ describe('directive: batch-operations', function() {
           var params = $modal.open.getCall(0).args[0];
           expect(params.resolve.selectedItems()).to.equal('selectedItems');
           expect(params.resolve.itemName()).to.equal('Items');
-
         });
 
         it('should perform operation if user confirms', function(done) {
-          $scope.listOperations.operations[0].actionCall();
-
-          setTimeout(function() {
-            deleteAction.should.have.been.called;
-
-            done();
-          }, 10);
+          $scope.listOperations.operations[0].beforeBatchAction()
+            .then(function() {
+              done();              
+            });
         });
 
       });

--- a/web/scripts/components/scrolling-list/directives/dtv-batch-operations.js
+++ b/web/scripts/components/scrolling-list/directives/dtv-batch-operations.js
@@ -24,10 +24,8 @@ angular.module('risevision.common.components.scrolling-list')
           var _updateDeleteAction = function() {
             _.each($scope.listOperations.operations, function(operation) {
               if (operation.isDelete) {
-                var deleteAction = operation.actionCall;
-
-                operation.actionCall = function() {
-                  $modal.open({
+                operation.beforeBatchAction = function() {
+                  return $modal.open({
                     templateUrl: 'partials/common/bulk-delete-confirmation-modal.html',
                     controller: 'BulkDeleteModalCtrl',
                     windowClass: 'madero-style centered-modal',
@@ -38,7 +36,7 @@ angular.module('risevision.common.components.scrolling-list')
                         return $scope.listOperations.name;
                       }
                     }
-                  }).result.then(deleteAction);
+                  }).result;
                 };
               }
             });


### PR DESCRIPTION
## Description
Add beforeBatchAction function support

Use it for delete functionality

Split out error and execute code

[stage-2]

## Motivation and Context
Allow operations to be performed before the batch, potentially cancelling the batch.

## How Has This Been Tested?
Tested changes locally, updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No