### PR TITLE
Docker Hub Authentication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,9 @@ jobs:
     working_directory: ~/rise-vision-apps
     docker: &BUILDIMAGE
       - image: jenkinsrise/apps-node:8.9.4-stretch
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD 
     steps:
       - checkout
       - run:
@@ -217,7 +220,9 @@ workflows:
   version: 2
   test_and_deploy:
     jobs: 
-      - dependencies
+      - dependencies:
+          context:
+            - docker-hub-creds
       - test_unit:
           requires:
             - dependencies


### PR DESCRIPTION
## Description
Adds Docker Hub Authentication to the build process via Context variables ([documentation](https://docs.google.com/document/d/1DnMlIuWEKBL_qCTbYYUsAgTKPIOUk2XADPqFBrzfS_Q/edit#))

_Note_: I would expect that `context:` should be added to each job, but by adding to one looks like all got access to it, so I avoided duplication and added it to only one.

## Motivation and Context
https://trello.com/c/odGlth2d/6688-action-required-how-to-avoid-docker-hub-rate-limits-for-your-circleci-builds-1

## How Has This Been Tested?
Confirmed that Image Pull is no longer anonymous and build succeeded. [stage-1]

Before:
<img width="1145" alt="Screen Shot 2020-10-16 at 3 05 21 PM" src="https://user-images.githubusercontent.com/7738553/96294622-0c0ab600-0fc3-11eb-8471-1db4f33a88b7.png">


After: 
<img width="1146" alt="Screen Shot 2020-10-16 at 3 05 14 PM" src="https://user-images.githubusercontent.com/7738553/96294648-1331c400-0fc3-11eb-8ff8-43f48ea631a7.png">



## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
