### PR TITLE
Force delete when bulk deleting

### DIFF
--- a/test/unit/editor/controllers/ctr-presentation-list.tests.js
+++ b/test/unit/editor/controllers/ctr-presentation-list.tests.js
@@ -19,7 +19,7 @@ describe('controller: Presentation List', function() {
     });
     $provide.service('editorFactory', function() {
       return {
-        deletePresentationByObject: sinon.stub().returns(Q.resolve())
+        deletePresentationByObject: sinon.stub().returns('delete')
       };
     });
     $provide.service('templateEditorFactory', function() {
@@ -92,53 +92,10 @@ describe('controller: Presentation List', function() {
 
     describe('delete:', function(done) {
       it('should delete presentation on actionCall', function() {
-        $scope.listOperations.operations[0].actionCall('presentationObject')
-          .then(function() {
-            editorFactory.deletePresentationByObject.should.have.been.calledWith('presentationObject', true);
+        expect($scope.listOperations.operations[0].actionCall('presentationObject')).to.equal('delete');
 
-            done();
-          })
-          .catch(function() {
-            done('error');
-          });
+        editorFactory.deletePresentationByObject.should.have.been.calledWith('presentationObject', true);
       });
-
-      it('should handle deletion errors', function(done) {
-        editorFactory.deletePresentationByObject.returns(Q.reject('error'));
-
-        $scope.listOperations.operations[0].actionCall('presentationObject')
-          .then(function() {
-            done('error');
-          })
-          .catch(function(e) {
-            expect($scope.presentations.errorMessage).to.not.be.ok;
-            expect($scope.presentations.apiError).to.not.be.ok;
-
-            expect(e).to.equal('error');
-
-            done();
-          });
-      });   
-
-      it('should handle conflict 409 errors', function(done) {
-        var error = {
-          status: 409
-        }
-        editorFactory.deletePresentationByObject.returns(Q.reject(error));
-
-        $scope.listOperations.operations[0].actionCall('presentationObject')
-          .then(function() {
-            done('error');
-          })
-          .catch(function(e) {
-            expect($scope.presentations.errorMessage).to.be.ok;
-            expect($scope.presentations.apiError).to.be.ok;
-
-            expect(e).to.equal(error);
-
-            done();
-          });
-      });   
     });
 
   });

--- a/test/unit/editor/controllers/ctr-presentation-list.tests.js
+++ b/test/unit/editor/controllers/ctr-presentation-list.tests.js
@@ -94,7 +94,7 @@ describe('controller: Presentation List', function() {
       it('should delete presentation on actionCall', function() {
         $scope.listOperations.operations[0].actionCall('presentationObject')
           .then(function() {
-            editorFactory.deletePresentationByObject.should.have.been.calledWith('presentationObject');
+            editorFactory.deletePresentationByObject.should.have.been.calledWith('presentationObject', true);
 
             done();
           })

--- a/test/unit/editor/services/svc-presentation.tests.js
+++ b/test/unit/editor/services/svc-presentation.tests.js
@@ -33,158 +33,145 @@ describe('service: presentation:', function() {
     });
 
     $provide.service('coreAPILoader',function () {
-      return function(){
-        var deferred = Q.defer();
-                
-        deferred.resolve({
-          presentation: {
-            list: function(obj){
-              expect(obj).to.be.ok;
-              
-              searchString = obj.search;
-              sortString = obj.sort;
-
-              var def = Q.defer();
-              if (returnList) {
-                def.resolve({
-                  result : {
-                    nextPageToken : 1,
-                    items : [{}]
-                  }
-                });
-              } else {
-                def.reject("API Failed");
-              }
-              return def.promise;
-            },
-            get: function(obj){
-              expect(obj).to.be.ok;
-              
-              var def = Q.defer();
-              if (obj.id) {
-                def.resolve({
-                  result: {
-                    item: {
-                      "id": "presentation1",
-                      "companyId": "TEST_COMP_ID",
-                      "name": "Test Presentation",
-                      "creationDate": "2012-04-02T14:19:36.000Z"
-                    }
-                  }
-                });
-              } else {
-                def.reject("API Failed");
-              }
-              return def.promise;
-            },
-            add: function(obj) {
-              expect(obj).to.be.ok;
-              expect(obj.companyId).to.equal('TEST_COMP_ID');
-              expect(obj).to.have.property("data");
-              
-              var def = Q.defer();
-              if (obj.data.name) {
-                expect(obj.data).to.have.property("name");
-                expect(obj.data).to.not.have.property("id");
-                
-                obj.data.id = "presentation1"
-                
-                def.resolve({
-                  result: {
-                    item: obj.data
-                  }
-                });
-              } else {
-                def.reject("API Failed");
-              }
-              return def.promise;
-            },
-            patch: function(obj) {
-              expect(obj).to.be.ok;
-              expect(obj.id).to.equal('presentation1');
-              expect(obj.data).to.be.ok;
-              
-              var def = Q.defer();
-              if (obj.data.name) {
-                expect(obj.data).to.have.property("name");
-                
-                def.resolve({
-                  result: {
-                    item: obj.data
-                  }
-                });
-              } else {
-                def.reject("API Failed");
-              }
-              return def.promise;
-            },
-            delete: function(obj) {
-              expect(obj).to.be.ok;
-
-              var def = Q.defer();
-              if (obj.id) {
-                def.resolve({
-                  item: {}
-                });
-              } else {
-                def.reject("API Failed");
-              }
-              return def.promise;
-            },
-            publish: function(obj) {
-              expect(obj).to.be.ok;
-
-              var def = Q.defer();
-              if (obj.id) {
-                def.resolve({
-                  item: "Published."
-                });
-              } else {
-                def.reject("API Failed");
-              }
-              return def.promise;
-            },
-            restore: function(obj) {
-              expect(obj).to.be.ok;
-
-              var def = Q.defer();
-              if (obj.id) {
-                def.resolve({
-                  result: {
-                    item: {
-                      id: obj.id,
-                      companyId: "TEST_COMP_ID",
-                      name: "Test Presentation",
-                      publish: 0 
-                    }  
-                  }                  
-                });
-              } else {
-                def.reject("API Failed");
-              }
-              return def.promise;
-            }
-          }
-        });
-        return deferred.promise;
-      };
+      return sinon.stub().returns(Q.resolve(coreApi));
     });
 
   }));
-  var presentation, returnList, searchString, sortString, isRiseAdmin;
+  var presentation, coreApi, returnList, searchString, sortString, isRiseAdmin;
   beforeEach(function(){
     returnList = true;
     searchString = '';
     sortString='';
     isRiseAdmin = false;
-    
+
+    coreApi = {
+      presentation: {
+        list: function(obj){
+          expect(obj).to.be.ok;
+          
+          searchString = obj.search;
+          sortString = obj.sort;
+
+          var def = Q.defer();
+          if (returnList) {
+            def.resolve({
+              result : {
+                nextPageToken : 1,
+                items : [{}]
+              }
+            });
+          } else {
+            def.reject("API Failed");
+          }
+          return def.promise;
+        },
+        get: function(obj){
+          expect(obj).to.be.ok;
+          
+          var def = Q.defer();
+          if (obj.id) {
+            def.resolve({
+              result: {
+                item: {
+                  "id": "presentation1",
+                  "companyId": "TEST_COMP_ID",
+                  "name": "Test Presentation",
+                  "creationDate": "2012-04-02T14:19:36.000Z"
+                }
+              }
+            });
+          } else {
+            def.reject("API Failed");
+          }
+          return def.promise;
+        },
+        add: function(obj) {
+          expect(obj).to.be.ok;
+          expect(obj.companyId).to.equal('TEST_COMP_ID');
+          expect(obj).to.have.property("data");
+          
+          var def = Q.defer();
+          if (obj.data.name) {
+            expect(obj.data).to.have.property("name");
+            expect(obj.data).to.not.have.property("id");
+            
+            obj.data.id = "presentation1"
+            
+            def.resolve({
+              result: {
+                item: obj.data
+              }
+            });
+          } else {
+            def.reject("API Failed");
+          }
+          return def.promise;
+        },
+        patch: function(obj) {
+          expect(obj).to.be.ok;
+          expect(obj.id).to.equal('presentation1');
+          expect(obj.data).to.be.ok;
+          
+          var def = Q.defer();
+          if (obj.data.name) {
+            expect(obj.data).to.have.property("name");
+            
+            def.resolve({
+              result: {
+                item: obj.data
+              }
+            });
+          } else {
+            def.reject("API Failed");
+          }
+          return def.promise;
+        },
+        delete: sinon.stub().returns(Q.resolve({
+          item: {}
+        })),
+        publish: function(obj) {
+          expect(obj).to.be.ok;
+
+          var def = Q.defer();
+          if (obj.id) {
+            def.resolve({
+              item: "Published."
+            });
+          } else {
+            def.reject("API Failed");
+          }
+          return def.promise;
+        },
+        restore: function(obj) {
+          expect(obj).to.be.ok;
+
+          var def = Q.defer();
+          if (obj.id) {
+            def.resolve({
+              result: {
+                item: {
+                  id: obj.id,
+                  companyId: "TEST_COMP_ID",
+                  name: "Test Presentation",
+                  publish: 0 
+                }  
+              }                  
+            });
+          } else {
+            def.reject("API Failed");
+          }
+          return def.promise;
+        }
+      }
+    };
+
     inject(function($injector){
       presentation = $injector.get('presentation');
     });
   });
 
   it('should exist',function(){
-    expect(presentation).to.be.truely;
+    expect(presentation).to.be.ok;
     expect(presentation.list).to.be.a('function');
     expect(presentation.get).to.be.a('function');
   });
@@ -193,7 +180,7 @@ describe('service: presentation:', function() {
     it('should return a list of presentations',function(done){
       presentation.list({})
       .then(function(result){
-        expect(result).to.be.truely;
+        expect(result).to.be.ok;
         expect(result.items).to.be.an.array;
         expect(result.items).to.have.length.above(0);
         done();
@@ -270,8 +257,8 @@ describe('service: presentation:', function() {
     it('should return a presentation',function(done){
       presentation.get('presentation1')
       .then(function(result){
-        expect(result).to.be.truely;
-        expect(result.item).to.be.truely;
+        expect(result).to.be.ok;
+        expect(result.item).to.be.ok;
         expect(result.item).to.have.property("name");
         
         done();
@@ -300,8 +287,8 @@ describe('service: presentation:', function() {
     it('should add a presentation',function(done){
       presentation.add(presentationObject)
       .then(function(result){
-        expect(result).to.be.truely;
-        expect(result.item).to.be.truely;
+        expect(result).to.be.ok;
+        expect(result.item).to.be.ok;
         expect(result.item).to.have.property("name");
         expect(result.item).to.have.property("id");
         expect(result.item.id).to.equal("presentation1");
@@ -318,8 +305,8 @@ describe('service: presentation:', function() {
 
       presentation.add(presentationObject)
       .then(function(result){
-        expect(result).to.be.truely;
-        expect(result.item).to.be.truely;
+        expect(result).to.be.ok;
+        expect(result.item).to.be.ok;
         expect(result.item).to.have.property("isStoreProduct");
         expect(result.item.isStoreProduct).to.be.true;
         
@@ -335,8 +322,8 @@ describe('service: presentation:', function() {
 
       presentation.add(presentationObject)
       .then(function(result){
-        expect(result).to.be.truely;
-        expect(result.item).to.be.truely;
+        expect(result).to.be.ok;
+        expect(result.item).to.be.ok;
         expect(result.item).to.have.property("isStoreProduct");
         expect(result.item.isStoreProduct).to.be.false;
         
@@ -352,8 +339,8 @@ describe('service: presentation:', function() {
       
       presentation.add(presentationObject)
       .then(function(result){
-        expect(result).to.be.truely;
-        expect(result.item).to.be.truely;
+        expect(result).to.be.ok;
+        expect(result.item).to.be.ok;
         expect(result.item).to.not.have.property("isStoreProduct");
         
         done();
@@ -384,8 +371,8 @@ describe('service: presentation:', function() {
     it('should update a presentation',function(done){
       presentation.update(presentationObject.id, presentationObject)
       .then(function(result){
-        expect(result).to.be.truely;
-        expect(result.item).to.be.truely;
+        expect(result).to.be.ok;
+        expect(result.item).to.be.ok;
         
         done();
       })
@@ -399,8 +386,8 @@ describe('service: presentation:', function() {
 
       presentation.update(presentationObject.id, presentationObject)
       .then(function(result){
-        expect(result).to.be.truely;
-        expect(result.item).to.be.truely;
+        expect(result).to.be.ok;
+        expect(result.item).to.be.ok;
         expect(result.item).to.have.property("isStoreProduct");
         expect(result.item.isStoreProduct).to.be.true;
         
@@ -416,8 +403,8 @@ describe('service: presentation:', function() {
 
       presentation.update(presentationObject.id, presentationObject)
       .then(function(result){
-        expect(result).to.be.truely;
-        expect(result.item).to.be.truely;
+        expect(result).to.be.ok;
+        expect(result.item).to.be.ok;
         expect(result.item).to.have.property("isStoreProduct");
         expect(result.item.isStoreProduct).to.be.false;
         
@@ -432,8 +419,8 @@ describe('service: presentation:', function() {
       
       presentation.update(presentationObject.id, presentationObject)
       .then(function(result){
-        expect(result).to.be.truely;
-        expect(result.item).to.be.truely;
+        expect(result).to.be.ok;
+        expect(result.item).to.be.ok;
         expect(result.item).to.not.have.property("isStoreProduct");
         
         done();
@@ -445,8 +432,8 @@ describe('service: presentation:', function() {
     it('should remove extra properties',function(done){
       presentation.update(presentationObject.id, presentationObject)
       .then(function(result){
-        expect(result).to.be.truely;
-        expect(result.item).to.be.truely;
+        expect(result).to.be.ok;
+        expect(result.item).to.be.ok;
         expect(result.item).to.not.have.property("connected");
         
         done();
@@ -468,11 +455,32 @@ describe('service: presentation:', function() {
   });
 
   describe('delete:',function(){
-    it('should delete a presentation',function(done){
+    it('should call the delete API and delete the presentation',function(done){
       presentation.delete('presentation1')
         .then(function(result){
-          expect(result).to.be.truely;
-          expect(result.item).to.be.truely;
+          expect(result).to.be.ok;
+          expect(result.item).to.be.ok;
+
+          coreApi.presentation.delete.should.have.been.calledWith({
+            id: 'presentation1',
+            force: undefined
+          });
+
+          done();
+        })
+        .then(null,done);
+    });
+
+    it('should attach force delete parameter',function(done){
+      presentation.delete('presentation1', true)
+        .then(function(result){
+          expect(result).to.be.ok;
+          expect(result.item).to.be.ok;
+
+          coreApi.presentation.delete.should.have.been.calledWith({
+            id: 'presentation1',
+            force: true
+          });
 
           done();
         })
@@ -480,6 +488,8 @@ describe('service: presentation:', function() {
     });
 
     it("should handle failure to delete presentation",function(done){
+      coreApi.presentation.delete.returns(Q.reject('API Failed'));
+
       presentation.delete()
         .then(function(result) {
           done(result);
@@ -496,8 +506,8 @@ describe('service: presentation:', function() {
     it('should publish a presentation',function(done){
       presentation.publish('presentation1')
         .then(function(result){
-          expect(result).to.be.truely;
-          expect(result.item).to.be.truely;
+          expect(result).to.be.ok;
+          expect(result.item).to.be.ok;
           expect(result.item).to.equal("Published.");
           done();
         })
@@ -521,8 +531,8 @@ describe('service: presentation:', function() {
     it('should restore a presentation',function(done){
       presentation.restore('presentation1')
         .then(function(result){
-          expect(result).to.be.truely;
-          expect(result.item).to.be.truely;
+          expect(result).to.be.ok;
+          expect(result.item).to.be.ok;
           expect(result.item).to.have.property("name");
           expect(result.item).to.have.property("publish");
           expect(result.item).to.have.property("id");

--- a/web/scripts/editor/controllers/ctr-presentation-list.js
+++ b/web/scripts/editor/controllers/ctr-presentation-list.js
@@ -21,7 +21,7 @@ angular.module('risevision.editor.controllers')
         operations: [{
           name: 'Delete',
           actionCall: function(presentation) {
-            return editorFactory.deletePresentationByObject(presentation)
+            return editorFactory.deletePresentationByObject(presentation, true)
               .catch(function(e) {
                 if (e.status === 409) {
                   $scope.presentations.errorMessage = 'Some presentations could not be deleted.';

--- a/web/scripts/editor/controllers/ctr-presentation-list.js
+++ b/web/scripts/editor/controllers/ctr-presentation-list.js
@@ -21,15 +21,7 @@ angular.module('risevision.editor.controllers')
         operations: [{
           name: 'Delete',
           actionCall: function(presentation) {
-            return editorFactory.deletePresentationByObject(presentation, true)
-              .catch(function(e) {
-                if (e.status === 409) {
-                  $scope.presentations.errorMessage = 'Some presentations could not be deleted.';
-                  $scope.presentations.apiError = 'These presentations are used in one or more schedules. To delete them, please remove them from the schedules they are being used in, and try again.'; 
-                }
-
-                throw e;
-              });
+            return editorFactory.deletePresentationByObject(presentation, true);
           },
           requireRole: 'cp'
         }]

--- a/web/scripts/editor/services/svc-editor-factory.js
+++ b/web/scripts/editor/services/svc-editor-factory.js
@@ -259,8 +259,8 @@ angular.module('risevision.editor.services')
         }
       };
 
-      factory.deletePresentationByObject = function (presentationObject) {
-        return presentation.delete(presentationObject.id)
+      factory.deletePresentationByObject = function (presentationObject, forceDelete) {
+        return presentation.delete(presentationObject.id, forceDelete)
           .then(function () {
             presentationTracker('Presentation Deleted', presentationObject.id, presentationObject.name);
           });

--- a/web/scripts/editor/services/svc-presentation.js
+++ b/web/scripts/editor/services/svc-presentation.js
@@ -136,11 +136,12 @@ angular.module('risevision.editor.services')
 
           return deferred.promise;
         },
-        delete: function (presentationId) {
+        delete: function (presentationId, forceDelete) {
           var deferred = $q.defer();
 
           var obj = {
-            'id': presentationId
+            'id': presentationId,
+            'force': forceDelete
           };
 
           $log.debug('delete presentation called with', presentationId);


### PR DESCRIPTION
## Description
Force delete when bulk deleting

[stage-18]

## Motivation and Context
Network Management epic.

Prevent errors in the UI for Deleting Presentations that are already in Schedules. Because we are adding a new field in the list, it will be obvious to the User where those Presentations are used.

## How Has This Been Tested?
Tested changes locally with the updated Core version. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No