### PR TITLE
Add Shared Presentations button to empty presentations message

### DIFF
--- a/web/partials/editor/presentation-list.html
+++ b/web/partials/editor/presentation-list.html
@@ -86,6 +86,9 @@
       <div class="form-group my-4">
         <label translate>editor-app.list.empty</label>
       </div>
+      <button id="sharedTemplatesButton" ng-click="editorFactory.addFromSharedTemplateModal()" class="btn btn-default btn-toolbar-wide mb-2" translate>
+          editor-app.sharedTemplates.title
+        </button>
       <button id="presentationAddButton" class="btn btn-primary btn-toolbar-wide mb-2" ng-click="editorFactory.addPresentationModal()" translate>
         editor-app.list.actions.add
       </button>


### PR DESCRIPTION

## Description
Include a summary of the change. If this is fixing a defect, ensure to link to the issue this is fixing. 

## Motivation and Context
Fix #2142


## How Has This Been Tested?
Locally and on [stage-1]
Sample: https://apps-stage-1.risevision.com/editor/list?cid=edadf0d9-ca3c-4347-9115-a75e1528e2f0

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
