### PR TITLE
Update plans and purchase routing

### DIFF
--- a/test/unit/app.tests.js
+++ b/test/unit/app.tests.js
@@ -38,34 +38,6 @@ describe('app:', function() {
 
   var $state, canAccessApps, plansFactory, userState, $rootScope, $location, $modal;
 
-  describe('state apps.plans.home:',function(){
-    it('should register state',function(){
-      var state = $state.get('apps.plans.home');
-      expect(state).to.be.ok;
-      expect(state.url).to.equal('/plans');
-      expect(state.controller).to.be.ok;
-    });
-
-    xit('should redirect to home',function(done){
-      var $location = {
-        search: function() { 
-          return {};
-        },
-        replace: sinon.spy()
-      };
-      sinon.spy($state,'go');
-      
-      $state.get('apps.plans.home').controller[2]($location, $state);
-      setTimeout(function() {
-        $location.replace.should.have.been.called;
-        $state.go.should.have.been.calledWith('apps.home.home');
-
-        done();
-      }, 10);
-    });
-
-  });
-
   describe('state apps.users.add:',function(){
     it('should register parent',function(){
       var state = $state.get('apps.users');
@@ -103,53 +75,6 @@ describe('app:', function() {
   });
 
   describe('onboarding links', function() {
-    xit('should show purchase options for apps.plans.home', function(done) {
-      $state.go('apps.plans.home');
-      $rootScope.$digest();
-
-      setTimeout(function() {
-        canAccessApps.should.have.been.calledWith(false);
-
-        expect(plansFactory.showPurchaseOptions).to.have.been.called;
-        expect($modal.open).to.not.have.been.called;
-
-        done();
-      }, 10);
-
-    });
-
-    it('should show purchase options for /signup?show_product=true', function(done) {
-      sinon.stub($location, 'search').returns({
-        show_product: true
-      });
-      $state.go('common.auth.signup');
-      $rootScope.$digest();
-
-      setTimeout(function() {
-        canAccessApps.should.have.been.calledWith(true);
-
-        expect(plansFactory.showPurchaseOptions).to.have.been.called;
-        expect($modal.open).to.not.have.been.called;
-
-        done();
-      }, 10);
-
-    });
-
-    it('should not show purchase options for /signup without show_product', function(done) {
-      $state.go('common.auth.signup');
-      $rootScope.$digest();
-
-      setTimeout(function() {
-        canAccessApps.should.not.have.been.called;
-
-        expect(plansFactory.showPurchaseOptions).to.not.have.been.called;
-        expect($modal.open).to.not.have.been.called;
-
-        done();
-      }, 10);
-    });
-
     it('should check next state and show add user modal', function(done) {
       sinon.stub(userState, 'getSelectedCompanyId').returns('selectedCompanyId');
 
@@ -170,7 +95,6 @@ describe('app:', function() {
         done();
       }, 10);
     });
-
 
   });
 
@@ -204,14 +128,35 @@ describe('app:', function() {
       expect(state.controller).to.be.ok;
     });
 
-    it('should redirect to home',function(done){
+    it('should show purchase options for /signup?show_product=true', function(done) {
       var $location = {
+        search: sinon.stub().returns({
+          show_product: true
+        }),
         replace: sinon.spy()
       };
       sinon.spy($state,'go');
-      
       $state.get('common.auth.signup').controller[3]($location, $state, canAccessApps);
+      $rootScope.$digest();
 
+      canAccessApps.should.have.been.calledWith(true);
+
+      setTimeout(function() {
+        $location.replace.should.have.been.called;
+        expect($state.go).to.have.been.calledWith('apps.plans.home');
+
+        done();
+      }, 10);
+
+    });
+
+    it('should redirect to home', function(done){
+      var $location = {
+        search: sinon.stub().returns({}),
+        replace: sinon.spy()
+      };
+      sinon.spy($state,'go');
+      $state.get('common.auth.signup').controller[3]($location, $state, canAccessApps);
       $rootScope.$digest();
 
       canAccessApps.should.have.been.calledWith(true);

--- a/test/unit/plans/app.tests.js
+++ b/test/unit/plans/app.tests.js
@@ -1,0 +1,121 @@
+'use strict';
+
+describe('app:', function() {
+  beforeEach(function () {
+    angular.module('risevision.apps.partials',[]);
+
+    module('risevision.apps');
+
+    module(function ($provide) {
+      $provide.service('canAccessApps',function(){
+        return sinon.stub().returns(Q.resolve("auth"));
+      });
+
+      $provide.service('currentPlanFactory',function(){
+        return {
+          isSubscribed: sinon.stub().returns(true),
+          isParentPlan: sinon.stub().returns(false),
+          currentPlan: {
+            isPurchasedByParent: false,
+            subscriptionId: 'subscriptionId'
+          }
+        };
+      });
+
+      $provide.service('messageBox', function() {
+        return messageBoxStub = sinon.stub();
+      });
+
+    });
+
+    inject(function ($injector) {
+      $state = $injector.get('$state');
+      canAccessApps = $injector.get('canAccessApps');
+      currentPlanFactory = $injector.get('currentPlanFactory');
+      $rootScope = $injector.get('$rootScope');
+
+      sinon.spy($state, 'go');
+    });
+  });
+
+  var $state, canAccessApps, currentPlanFactory, userState, $rootScope, messageBoxStub;
+
+  describe('state apps.plans.home:',function(){
+    it('should register state',function(){
+      var state = $state.get('apps.plans.home');
+      expect(state).to.be.ok;
+      expect(state.url).to.equal('/plans');
+      expect(state.controller).to.equal('PlansCtrl');
+    });
+
+    it('should go to billing page/edit subscription if company has a plan and manages it', function(done) {
+      $state.go('apps.plans.home');
+      $rootScope.$digest();
+
+      canAccessApps.should.have.been.called;
+
+      setTimeout(function(){
+        expect($state.go).to.have.been.calledWith('apps.billing.home', {edit: 'subscriptionId'});
+
+        expect(messageBoxStub).to.not.have.been.called;
+        done();
+      },10);
+    });
+
+    it('should show a message if company has a plan but it is managed by a parent company', function(done) {
+      currentPlanFactory.currentPlan.isPurchasedByParent = true
+
+      $state.go('apps.plans.home');
+      $rootScope.$digest();
+
+      canAccessApps.should.have.been.called;
+
+      setTimeout(function(){
+        expect(messageBoxStub).to.have.been.calledWith(
+          'You can\'t edit your current plan.',
+          'Your plan is managed by your parent company. Please contact your account administrator for additional licenses.',
+          'Ok', 'madero-style centered-modal', 'partials/template-editor/message-box.html', 'sm'
+        );
+
+        expect($state.go).to.have.been.calledWith('apps.home');
+        expect($state.go).to.not.have.been.calledWith('apps.billing.home', {edit: 'subscriptionId'});
+        done();
+      },10);
+    });
+
+    it('should show plan admin email if available', function(done) {
+      currentPlanFactory.currentPlan.isPurchasedByParent = true      
+      currentPlanFactory.currentPlan.parentPlanContactEmail = 'test@email.com';
+
+      $state.go('apps.plans.home');
+      $rootScope.$digest();
+
+      setTimeout(function(){
+        expect(messageBoxStub).to.have.been.calledWith(
+          'You can\'t edit your current plan.',
+          'Your plan is managed by your parent company. Please contact your account administrator at test@email.com for additional licenses.',
+          'Ok', 'madero-style centered-modal', 'partials/template-editor/message-box.html', 'sm'
+        );
+
+        done();
+      },10);
+    });
+
+    it('should stay on the Plans page if company is not subscribed to a plan', function(done) {
+      currentPlanFactory.isSubscribed.returns(false);
+
+      $state.go('apps.plans.home');
+      $rootScope.$digest();
+
+      setTimeout(function(){
+        expect(messageBoxStub).to.not.have.been.called;
+        $state.go.should.have.been.calledOnce;
+
+        done();
+      },10);
+    });
+
+  });
+
+
+});

--- a/test/unit/plans/services/svc-plans-factory-spec.js
+++ b/test/unit/plans/services/svc-plans-factory-spec.js
@@ -27,14 +27,6 @@ describe("Services: plans factory", function() {
         updateCompanySettings: sinon.stub()
       };
     });
-    $provide.service("currentPlanFactory", function() {
-      return {
-        currentPlan: {
-          subscriptionId: 'subscriptionId'
-        },
-        isSubscribed: sinon.stub().returns(true)
-      };
-    });
     $provide.service("$state", function() {
       return {
         go: sinon.stub()
@@ -43,13 +35,10 @@ describe("Services: plans factory", function() {
     $provide.factory('confirmModal', function() {
        return confirmModalStub = sinon.stub().returns(Q.resolve());
     });
-    $provide.factory('messageBox', function() {
-       return messageBoxStub = sinon.stub();
-    });
   }));
 
-  var sandbox, $modal, userState, plansFactory, analyticsFactory, currentPlanFactory, $state,
-    confirmModalStub, messageBoxStub, VOLUME_PLAN;
+  var sandbox, $modal, userState, plansFactory, analyticsFactory, $state,
+    confirmModalStub, VOLUME_PLAN;
 
   beforeEach(function() {
     sandbox = sinon.sandbox.create();
@@ -59,7 +48,6 @@ describe("Services: plans factory", function() {
       userState =  $injector.get("userState");
       plansFactory = $injector.get("plansFactory");
       analyticsFactory = $injector.get("analyticsFactory");
-      currentPlanFactory  = $injector.get("currentPlanFactory");
       $state = $injector.get("$state");
 
       var plansByType = _.keyBy($injector.get("PLANS_LIST"), "type");
@@ -85,63 +73,10 @@ describe("Services: plans factory", function() {
     $state.go.should.have.been.calledWith('apps.plans.home');
   });
 
-  describe("showPurchaseOptions: ", function() {
-    it('should go to billing page/edit subscription if company has a plan and manages it', function(done) {
-      plansFactory.showPurchaseOptions();
+  it("showPurchaseOptions: ", function() {
+    plansFactory.showPurchaseOptions();
 
-      setTimeout(function(){
-        expect($state.go).to.have.been.calledWith('apps.billing.home', {edit: 'subscriptionId'});
-
-        expect(messageBoxStub).to.not.have.been.called;
-        done();
-      },10);
-    });
-
-    it('should show a message if company has a plan but it is managed by a parent company', function(done) {
-      currentPlanFactory.currentPlan.isPurchasedByParent = true
-      plansFactory.showPurchaseOptions();
-
-      setTimeout(function(){
-        expect(messageBoxStub).to.have.been.calledWith(
-          'You can\'t edit your current plan.',
-          'Your plan is managed by your parent company. Please contact your account administrator for additional licenses.',
-          'Ok', 'madero-style centered-modal', 'partials/template-editor/message-box.html', 'sm'
-        );
-
-        expect($state.go).to.not.have.been.called;
-        done();
-      },10);
-    });
-
-    it('should show plan admin email if available', function(done) {
-      currentPlanFactory.currentPlan.isPurchasedByParent = true      
-      currentPlanFactory.currentPlan.parentPlanContactEmail = 'test@email.com';
-
-      plansFactory.showPurchaseOptions();
-
-      setTimeout(function(){
-        expect(messageBoxStub).to.have.been.calledWith(
-          'You can\'t edit your current plan.',
-          'Your plan is managed by your parent company. Please contact your account administrator at test@email.com for additional licenses.',
-          'Ok', 'madero-style centered-modal', 'partials/template-editor/message-box.html', 'sm'
-        );
-
-        expect($state.go).to.not.have.been.called;
-        done();
-      },10);
-    });
-
-    it('should open Plans Modal if company is not subscribed to a plan', function(done) {
-      currentPlanFactory.isSubscribed.returns(false);
-
-      plansFactory.showPurchaseOptions();
-
-      setTimeout(function(){
-        $state.go.should.have.been.calledWith('apps.plans.home');
-
-        done();
-      },10);
-    });
+    $state.go.should.have.been.calledWith('apps.plans.home');
   });
 
   describe("confirmAndPurchase:", function(){

--- a/test/unit/purchase/services/svc-purchase-factory-spec.js
+++ b/test/unit/purchase/services/svc-purchase-factory-spec.js
@@ -107,7 +107,7 @@ describe("Services: purchase factory", function() {
 
   it("should exist", function() {
     expect(purchaseFactory).to.be.ok;
-    expect(purchaseFactory.showPurchaseModal).to.be.a("function");
+    expect(purchaseFactory.purchasePlan).to.be.a("function");
     expect(purchaseFactory.showTaxExemptionModal).to.be.a("function");
     expect(purchaseFactory.validatePaymentMethod).to.be.a("function");
     expect(purchaseFactory.getEstimate).to.be.a("function");
@@ -118,7 +118,7 @@ describe("Services: purchase factory", function() {
     expect(purchaseFactory.loading).to.be.false;
   });
 
-  describe("showPurchaseModal: ", function() {
+  describe("purchasePlan: ", function() {
     beforeEach(function() {
       clock = sinon.useFakeTimers();
     });
@@ -128,7 +128,7 @@ describe("Services: purchase factory", function() {
     });
 
     it("should show purchase modal", function() {
-      purchaseFactory.showPurchaseModal({});
+      purchaseFactory.purchasePlan({});
 
       expect($state.go).to.have.been.calledWith('apps.purchase.home');
       expect(purchaseFlowTracker.trackProductAdded).to.have.been.called;
@@ -136,7 +136,7 @@ describe("Services: purchase factory", function() {
 
     it("should initialize selected plan, attach addresses and clean contact info", function() {
       var plan = { name: "PlanA"};
-      purchaseFactory.showPurchaseModal(plan, true);
+      purchaseFactory.purchasePlan(plan, true);
       
       expect(purchaseFactory.purchase).to.be.ok;
 
@@ -172,7 +172,7 @@ describe("Services: purchase factory", function() {
 
     it("should initialize payment methods", function() {
       var plan = { name: "PlanA"};
-      purchaseFactory.showPurchaseModal(plan, true);
+      purchaseFactory.purchasePlan(plan, true);
       
       expect(purchaseFactory.purchase).to.be.ok;
       expect(purchaseFactory.purchase.paymentMethods).to.be.ok;
@@ -194,7 +194,7 @@ describe("Services: purchase factory", function() {
     it("should initialize invoice due date 30 days from now", function() {
       var newDate = new Date();
       var plan = { name: "PlanA"};
-      purchaseFactory.showPurchaseModal(plan, true);
+      purchaseFactory.purchasePlan(plan, true);
 
       expect(purchaseFactory.purchase.paymentMethods.invoiceDate).to.be.ok;
       expect(purchaseFactory.purchase.paymentMethods.invoiceDate).to.be.a("date");

--- a/web/partials/plans/app-plans.html
+++ b/web/partials/plans/app-plans.html
@@ -9,6 +9,6 @@
       rv-on="display-count-changed:refreshButton">
     </pricing-component>
 
-    <button type="button" ng-disabled="!pricingAtLeastOneDisplay" ng-click="showPurchaseModal()" id="subscribeButton">I Want To Subscribe</button>
+    <button type="button" ng-disabled="!pricingAtLeastOneDisplay" ng-click="purchasePlan()" id="subscribeButton">I Want To Subscribe</button>
   </div>
 </div>

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -99,9 +99,17 @@ angular.module('risevision.apps', [
           url: '/signup',
           controller: ['$location', '$state', 'canAccessApps',
             function ($location, $state, canAccessApps) {
-              canAccessApps(true).then(function () {
+              // jshint camelcase:false
+              var showProduct = $location.search().show_product;
+              // jshint camelcase:true
+
+              return canAccessApps(true).then(function () {
                 $location.replace();
-                $state.go('apps.home');
+                if (showProduct) {
+                  $state.go('apps.plans.home');
+                } else {
+                  $state.go('apps.home');
+                }
               });
             }
           ]
@@ -186,22 +194,10 @@ angular.module('risevision.apps', [
       });
     }
   ])
-  .run(['$rootScope', '$location', '$modal', 'canAccessApps', 'userState', 'plansFactory',
-    function ($rootScope, $location, $modal, canAccessApps, userState, plansFactory) {
+  .run(['$rootScope', '$modal', 'canAccessApps', 'userState',
+    function ($rootScope, $modal, canAccessApps, userState) {
       $rootScope.$on('$stateChangeStart', function (event, toState, toParams, fromState, fromParams) {
-        // jshint camelcase:false
-        var showProduct = $location.search().show_product;
-        // jshint camelcase:true
-
-        if (toState.name === 'common.auth.signup' && showProduct) {
-          canAccessApps(toState.name === 'common.auth.signup').then(function () {
-            plansFactory.showPurchaseOptions();
-          });
-
-          if (fromState.name) {
-            event.preventDefault();
-          }
-        } else if (toState.name === 'apps.users.add') {
+        if (toState.name === 'apps.users.add') {
           canAccessApps().then(function () {
             $modal.open({
               templateUrl: 'partials/common-header/user-settings-modal.html',

--- a/web/scripts/plans/app.js
+++ b/web/scripts/plans/app.js
@@ -26,9 +26,28 @@
             }],
             controller: 'PlansCtrl',
             resolve: {
-              canAccessApps: ['canAccessApps',
-                function (canAccessApps) {
-                  return canAccessApps();
+              canAccessApps: ['$state', 'canAccessApps', 'currentPlanFactory', 'messageBox',
+                function ($state, canAccessApps, currentPlanFactory, messageBox) {
+                  return canAccessApps()
+                    .then(function() {
+                      if (currentPlanFactory.isSubscribed() && !currentPlanFactory.isParentPlan()) {
+                        if (currentPlanFactory.currentPlan.isPurchasedByParent) {
+                          var contactInfo = currentPlanFactory.currentPlan.parentPlanContactEmail ? ' at ' +
+                            currentPlanFactory.currentPlan.parentPlanContactEmail : '';
+                          messageBox(
+                            'You can\'t edit your current plan.',
+                            'Your plan is managed by your parent company. Please contact your account administrator' +
+                            contactInfo + ' for additional licenses.',
+                            'Ok', 'madero-style centered-modal', 'partials/template-editor/message-box.html', 'sm'
+                          );
+                          $state.go('apps.home');
+                        } else {
+                          $state.go('apps.billing.home', {
+                            edit: currentPlanFactory.currentPlan.subscriptionId
+                          });
+                        }
+                      }
+                    });
                 }
               ]
             }

--- a/web/scripts/plans/controllers/ctr-plans.js
+++ b/web/scripts/plans/controllers/ctr-plans.js
@@ -47,7 +47,7 @@ angular.module('risevision.apps.plans')
           component.displayCount > 0;
       };
 
-      $scope.showPurchaseModal = function () {
+      $scope.purchasePlan = function () {
         var component = document.querySelector('pricing-component');
 
         var displays = component.displayCount;
@@ -60,7 +60,7 @@ angular.module('risevision.apps.plans')
           return;
         }
 
-        purchaseFactory.showPurchaseModal({
+        purchaseFactory.purchasePlan({
           name: plan,
           productId: volumePlan.productId,
           productCode: volumePlan.productCode,

--- a/web/scripts/plans/services/svc-plans-factory.js
+++ b/web/scripts/plans/services/svc-plans-factory.js
@@ -160,13 +160,16 @@
       proLicenseCount: 0
     }])
     .factory('plansFactory', ['$modal', 'userState', 'PLANS_LIST', 'analyticsFactory',
-      'currentPlanFactory', '$state', 'confirmModal', 'messageBox',
-      function ($modal, userState, PLANS_LIST, analyticsFactory, currentPlanFactory, $state,
-        confirmModal, messageBox) {
+      '$state', 'confirmModal',
+      function ($modal, userState, PLANS_LIST, analyticsFactory, $state, confirmModal) {
         var _factory = {};
 
         _factory.showPlansModal = function () {
           $state.go('apps.plans.home');
+        };
+
+        _factory.showPurchaseOptions = function () {
+          _factory.showPlansModal();
         };
 
         _factory.confirmAndPurchase = function () {
@@ -177,27 +180,6 @@
             .then(function () {
               _factory.showPurchaseOptions();
             });
-        };
-
-        _factory.showPurchaseOptions = function () {
-          if (currentPlanFactory.isSubscribed()) {
-            if (currentPlanFactory.currentPlan.isPurchasedByParent) {
-              var contactInfo = currentPlanFactory.currentPlan.parentPlanContactEmail ? ' at ' +
-                currentPlanFactory.currentPlan.parentPlanContactEmail : '';
-              messageBox(
-                'You can\'t edit your current plan.',
-                'Your plan is managed by your parent company. Please contact your account administrator' +
-                contactInfo + ' for additional licenses.',
-                'Ok', 'madero-style centered-modal', 'partials/template-editor/message-box.html', 'sm'
-              );
-            } else {
-              $state.go('apps.billing.home', {
-                edit: currentPlanFactory.currentPlan.subscriptionId
-              });
-            }
-          } else {
-            _factory.showPlansModal();
-          }
         };
 
         _factory.showUnlockThisFeatureModal = function () {

--- a/web/scripts/purchase/app.js
+++ b/web/scripts/purchase/app.js
@@ -19,9 +19,15 @@ angular.module('risevision.apps')
           }],
           controller: 'PurchaseCtrl',
           resolve: {
-            canAccessApps: ['canAccessApps',
-              function (canAccessApps) {
-                return canAccessApps();
+            canAccessApps: ['$state', 'canAccessApps', 'purchaseFactory',
+              function ($state, canAccessApps, purchaseFactory) {
+                return canAccessApps()
+                  .then(function() {
+                    // Purchase has not been initialized
+                    if (!purchaseFactory.purchase) {
+                      $state.go('apps.plans.home');
+                    }
+                  });
               }
             ]
           }

--- a/web/scripts/purchase/services/svc-purchase-factory.js
+++ b/web/scripts/purchase/services/svc-purchase-factory.js
@@ -51,7 +51,7 @@
           purchaseFlowTracker.trackProductAdded(factory.purchase.plan);
         };
 
-        factory.showPurchaseModal = function (plan, isMonthly) {
+        factory.purchasePlan = function (plan, isMonthly) {
           _init(plan, isMonthly);
 
           $state.go('apps.purchase.home');


### PR DESCRIPTION
## Description
Update plans and purchase routing

Plans routing now determines if billing, plans
or an alert should be shown to the user

Purchase now redirects to plans if a purchase is not
initialized

Simplify sign up route logic as per previous iteration

[stage-19]

## Motivation and Context
Fix and refactor routing.

## How Has This Been Tested?
Tested changes locally; updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No