### PR TITLE
Do not allow users to add/edit http urls

### DIFF
--- a/test/e2e/schedules/cases/add-url.js
+++ b/test/e2e/schedules/cases/add-url.js
@@ -109,7 +109,7 @@ var AddUrlScenarios = function() {
               expect(playlistItemModalPage.getInsecureUrlMessage().isDisplayed()).to.eventually.be.true;
             });
 
-            xit('Save button should be disabled', function () {
+            it('Save button should be disabled', function () {
               expect(playlistItemModalPage.getSaveButton().isEnabled()).to.eventually.be.false;
             });
           });

--- a/test/unit/components/url-field/dtv-http-validator.tests.js
+++ b/test/unit/components/url-field/dtv-http-validator.tests.js
@@ -26,22 +26,14 @@ describe("directive: http validator", function() {
     form = $scope.form;
     
     $scope.$digest();
-
-    $scope.ngModelCtrl = element.children('input').data().$ngModelController;
   }));
-
-  it('should initialize', function() {
-    expect($scope.ngModelCtrl).to.be.ok;
-    expect($scope.ngModelCtrl.warnings).to.be.ok;
-  });
 
   it("should not pass with insecure urls", function() {
     var value = 'http://shouldfail.com';
 
     form.url.$setViewValue(value);
     $scope.$digest();
-    // expect(form.url.$valid).to.be.false;
-    expect($scope.ngModelCtrl.warnings.httpUrl).to.be.true;
+    expect(form.url.$valid).to.be.false;
 
     insecureUrl.should.have.been.calledWith(value);
   });
@@ -53,8 +45,7 @@ describe("directive: http validator", function() {
 
     form.url.$setViewValue(value);
     $scope.$digest();
-    // expect(form.url.$valid).to.be.true;
-    expect($scope.ngModelCtrl.warnings.httpUrl).to.be.false;
+    expect(form.url.$valid).to.be.true;
 
     insecureUrl.should.have.been.calledWith(value);
   });

--- a/web/partials/components/url-field/messages.html
+++ b/web/partials/components/url-field/messages.html
@@ -6,5 +6,6 @@
 	<span ng-if="ngModelCtrl.responseHeaderValidatorError === 'content-type'">Invalid content type. Please provide a webpage, image, audio or video URL.</span>
 	<span ng-if="ngModelCtrl.responseHeaderValidatorError !== 'content-type' && ngModelCtrl.responseHeaderValidatorError !== 'not-reachable'">The owner of the Web Page at the URL provided does not allow the page to be embedded within an iFrame. If possible, please contact the Web Page owner to discuss ( <a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options">X-Frame-Options</a> / <a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors">Content-Security-Policy</a>).</span>
 </p>
+<p ng-message="httpUrl" class="text-danger">Please use secure URLs (HTTPs). Insecure URLs (HTTP) aren't supported.</p>
 <p ng-message="fileType" class="text-danger">{{ngModelCtrl.customErrorMessage}}</p>
 <p ng-message-default class="text-danger">Invalid field.</p>

--- a/web/partials/components/url-field/url-field.html
+++ b/web/partials/components/url-field/url-field.html
@@ -9,7 +9,6 @@
   <ng-messages role="alert" for="ngModelCtrl.$error" ng-if="ngModelCtrl.$invalid && ngModelCtrl.$dirty">
     <ng-messages-include src="partials/components/url-field/messages.html"></ng-messages-include>
   </ng-messages>
-  <p class="text-danger" ng-show="ngModelCtrl.warnings.httpUrl && !(ngModelCtrl.$invalid && ngModelCtrl.$dirty)">Please use secure URLs (HTTPs). Insecure URLs (HTTP) aren't supported.</p>
   
   <div class="checkbox" ng-show="showSkipValidation()">
     <label class="input-url-remove-validation">

--- a/web/scripts/components/url-field/dtv-http-validator.js
+++ b/web/scripts/components/url-field/dtv-http-validator.js
@@ -9,12 +9,11 @@ angular.module('risevision.widget.common.url-field.http-validator', [
         require: 'ngModel',
         restrict: 'A',
         link: function (scope, elem, attr, ngModelCtrl) {
-          ngModelCtrl.warnings = ngModelCtrl.warnings || {};
           var validator = function (value) {
             if (insecureUrl(value)) {
-              ngModelCtrl.warnings.httpUrl = true;
+              ngModelCtrl.$setValidity('httpUrl', false);
             } else {
-              ngModelCtrl.warnings.httpUrl = false;
+              ngModelCtrl.$setValidity('httpUrl', true);
             }
 
             return value;


### PR DESCRIPTION
## Description
Do not allow users to add/edit http urls

[stage-16]

Revert https://github.com/Rise-Vision/rise-vision-apps/pull/2032

## Motivation and Context
After Nov 1 we will not allow Users to add/edit HTTP urls.

## How Has This Been Tested?
Tested changes locally. Updated tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No