### PR TITLE
Use HTTPS for Rise Player download links

### DIFF
--- a/web/partials/displays/download-player-modal.html
+++ b/web/partials/displays/download-player-modal.html
@@ -10,12 +10,12 @@
       <strong>Windows</strong>
       <ul>
         <li>
-          <a class="madero-link" href="http://install-versions.risevision.com/installer-win-32.exe">
+          <a class="madero-link" href="https://storage.googleapis.com/install-versions.risevision.com/installer-win-32.exe">
             Download for Windows 10 (32-bit)
           </a>
         </li>
         <li>
-          <a class="madero-link" id="downloadWindows64" href="http://install-versions.risevision.com/installer-win-64.exe">
+          <a class="madero-link" id="downloadWindows64" href="https://storage.googleapis.com/install-versions.risevision.com/installer-win-64.exe">
             Download for Windows 10 (64-bit)
           </a>
         </li>
@@ -25,12 +25,12 @@
       <strong>Linux</strong>
       <ul>
         <li>
-          <a class="madero-link" href="http://install-versions.risevision.com/installer-lnx-32.sh">
+          <a class="madero-link" href="https://storage.googleapis.com/install-versions.risevision.com/installer-lnx-32.sh">
             Download for Ubuntu 18.04 LTS (32-bit)
           </a>
         </li>
         <li>
-          <a class="madero-link" href="http://install-versions.risevision.com/installer-lnx-64.sh">
+          <a class="madero-link" href="https://storage.googleapis.com/install-versions.risevision.com/installer-lnx-64.sh">
             Download for Ubuntu 18.04 LTS (64-bit)
           </a>
         </li>
@@ -50,7 +50,7 @@
       <strong>Raspberry Pi</strong>
       <ul>
         <li>
-          <a class="madero-link" href="http://install-versions.risevision.com/installer-lnx-armv7l.sh">
+          <a class="madero-link" href="https://storage.googleapis.com/install-versions.risevision.com/installer-lnx-armv7l.sh">
             Download for Raspberry Pi
           </a>
         </li>


### PR DESCRIPTION
## Description
Use HTTPS links to download players to prevent Chrome 86 blocks.

## Motivation and Context
Fix #2163

## How Has This Been Tested?
Locally and on [stage-20]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
