### PR TITLE
Fix color picker closing in presentation properties

### DIFF
--- a/test/unit/editor/services/svc-editor-factory.tests.js
+++ b/test/unit/editor/services/svc-editor-factory.tests.js
@@ -122,15 +122,12 @@ describe('service: editorFactory:', function() {
         removeEventListenerVisibilityAPI : function() {}
       };
     });
-    $provide.service('$modal',function(){
+    $provide.service('$modal', function() {
       return {
-        open: function() {
-          return {
-            result: Q.resolve({rvaEntityId: 'id1'})
-          }
-        }
-      };
+        open: sinon.stub().returns({result: Q.resolve({rvaEntityId: 'id1'})})
+      }
     });
+
     $provide.service('processErrorCode', function() {
       return processErrorCode = sinon.spy(function() { return 'error'; });
     });
@@ -188,6 +185,7 @@ describe('service: editorFactory:', function() {
     expect(editorFactory.savingPresentation).to.be.false;
     expect(editorFactory.apiError).to.not.be.truely;
 
+    expect(editorFactory.openPresentationProperties).to.be.a('function');
     expect(editorFactory.newPresentation).to.be.a('function');
     expect(editorFactory.getPresentation).to.be.a('function');
     expect(editorFactory.addPresentation).to.be.a('function');
@@ -208,6 +206,15 @@ describe('service: editorFactory:', function() {
     expect(editorFactory.presentationId).to.not.be.ok;
   });
 
+  it('openPresentationProperties:', function() {
+    editorFactory.openPresentationProperties();
+
+    $modal.open.should.have.been.calledWithMatch({
+      templateUrl: 'partials/editor/presentation-properties-modal.html',
+      size: 'md',
+      controller: 'PresentationPropertiesModalController'
+    });
+  });
 
   it('newPresentation: should reset the presentation',function(){
     editorFactory.presentation.id = 'presentationId';
@@ -335,8 +342,6 @@ describe('service: editorFactory:', function() {
 
     it('should create first Schedule when adding first presentation',function(done){
       updatePresentation = true;
-
-      var $modalOpenSpy = sinon.spy($modal, 'open');
 
       editorFactory.addPresentation();
 
@@ -811,12 +816,10 @@ describe('service: editorFactory:', function() {
   });
 
   it('addFromSharedTemplateModal: ', function(done) {
-    var $modalOpenSpy = sinon.spy($modal, 'open');
-
     editorFactory.addFromSharedTemplateModal();
     expect(presentationTracker).to.have.been.calledWith("Add Presentation from Shared Template");
 
-    $modalOpenSpy.should.have.been.calledWith({
+    $modal.open.should.have.been.calledWith({
       templateUrl: 'partials/editor/shared-templates-modal.html',
       size: 'md',
       controller: 'SharedTemplatesModalController'

--- a/web/scripts/common-header/dtv-common-header.js
+++ b/web/scripts/common-header/dtv-common-header.js
@@ -73,17 +73,13 @@ angular.module('risevision.common.header', [
                   // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/which
                   var leftButton = 1;
                   if (e.which === leftButton) {
-                    $modalStack.getTop().key.dismiss();
+                    var modalContent = modal.querySelector('.modal-content');
+
+                    if (!modalContent.contains(e.target)) {
+                      $modalStack.getTop().key.dismiss();
+                    }
                   }
                 });
-
-                // Sometimes there are other elements with the .modal class that don't have .modal-content
-                var modalContent = modal.querySelector('.modal-content');
-                if (modalContent) {
-                  modalContent.addEventListener('mousedown', function (e) {
-                    e.stopPropagation();
-                  });
-                }
               }
             });
 


### PR DESCRIPTION
## Description
Fix color picker closing in presentation properties

Update the modal drag and drop logic
No longer prevent event, but just don't close
modal when the click happens within

[stage-17]

## Motivation and Context
Fix for #2176 
Introduced with https://github.com/Rise-Vision/common-header/pull/1016

## How Has This Been Tested?
Tested changes locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No