### PR TITLE
Assume companies spinner already disappeared if it fails to show

### DIFF
--- a/test/e2e/common-header/pages/commonHeaderPage.js
+++ b/test/e2e/common-header/pages/commonHeaderPage.js
@@ -154,7 +154,10 @@
       if (subCompanyName) {
         var name = skipSuffix ? subCompanyName : this.addStageSuffix(subCompanyName).split('-').join('');
         selectSubcompanyModalFilter.sendKeys(name);
-        helper.wait(selectSubcompanyModalLoader, "Load Companies");
+        helper.wait(selectSubcompanyModalLoader, "Load Companies")
+        .catch(function(err) {
+          console.log('Load Companies never appeared; assume it already disappeared.', err);
+        });
         helper.waitDisappear(selectSubcompanyModalLoader, "Load Companies");
       }
     }


### PR DESCRIPTION
## Description
Assume companies spinner already disappeared if it fails to show

[stage-16]

## Motivation and Context
Improve e2e test operation
Similar to https://github.com/Rise-Vision/rise-vision-apps/pull/2178 but for the Company selector.

## How Has This Been Tested?
No code changes. e2e tests pass.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No