### PR TITLE
Fix toggle not enabled on licensed subcompany display

### DIFF
--- a/web/partials/displays/display-fields.html
+++ b/web/partials/displays/display-fields.html
@@ -93,7 +93,7 @@
               <span translate>displays-app.details.rpp-loading</span> <i class="fa fa-spinner fa-spin fa-fw"></i>
             </span>
 
-            <yes-no-toggle ng-model="factory.display.playerProAuthorized" ng-change="toggleProAuthorized()" ng-disabled="updatingRPP || !playerLicenseFactory.isProToggleEnabled()" ng-hide="updatingRPP"></yes-no-toggle>
+            <yes-no-toggle ng-model="factory.display.playerProAuthorized" ng-change="toggleProAuthorized()" ng-disabled="updatingRPP || !playerLicenseFactory.isProToggleEnabled(factory.display)" ng-hide="updatingRPP"></yes-no-toggle> 
           </div>
         </div>
         <div class="text-danger mt-2" ng-show="errorUpdatingRPP">


### PR DESCRIPTION
## Description
Add missing display parameter to function

## Motivation and Context
Fix toggle not enabled on licensed subcompany display

## How Has This Been Tested?
Locally and on [stage-1]
Sample: https://apps-stage-1.risevision.com/displays/details/2BY9V7P2H8QW?cid=e02668c7-83ad-409e-9d77-0985e4c3abdc

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
