### PR TITLE
Do not report unit test coverage on `gulp watch`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -155,7 +155,7 @@ gulp.task('watch', function () {
   gulp.watch(partialsHTMLFiles, ['html2js']);
   gulp.watch(['./web/pricing-component.mjs'], ['pricing']);
   gulp.watch(['./web/tmp/partials.js', './web/scripts/**/*.js', './web/tmp/css/*.css', './web/index.html'], ['browser-sync-reload']);
-  gulp.watch(unitTestFiles, ['test:unit']);
+  gulp.watch(unitTestFiles, ['test:unit:nocoverage']);
 });
 
 


### PR DESCRIPTION
## Description
Do not report unit test coverage on `gulp watch`.

## Motivation and Context
Coverage reports make it hard to visualize what unit tests failed. Removing it from the watch process.

## How Has This Been Tested?
Validated locally - dev change

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
