### PR TITLE
Test Rise Player download links

### DIFF
--- a/test/e2e/displays/pages/downloadPlayerModalPage.js
+++ b/test/e2e/displays/pages/downloadPlayerModalPage.js
@@ -3,7 +3,12 @@ var DownloadPlayerModalPage = function() {
   var downloadPlayerModal = element(by.css('.download-player-modal'));
   var title = element(by.css('.modal-body h4'));
 
-  var downloadWindows64Button = element(by.id('downloadWindows64'));
+  var downloadWindows32Link = element(by.id('downloadWindows32'));
+  var downloadWindows64Link = element(by.id('downloadWindows64'));
+  var downloadUbuntu32Link = element(by.id('downloadUbuntu32'));
+  var downloadUbuntu64Link = element(by.id('downloadUbuntu64'));
+  var downloadRaspberryLink = element(by.id('downloadRaspberry'));
+
   var dismissButton = element(by.id('dismissButton'));
 
   this.getDownloadPlayerModal = function() {
@@ -14,8 +19,24 @@ var DownloadPlayerModalPage = function() {
     return title;
   };
 
-  this.getDownloadWindows64Button = function() {
-    return downloadWindows64Button;
+  this.getDownloadWindows32Link = function() {
+    return downloadWindows32Link;
+  };
+
+  this.getDownloadWindows64Link = function() {
+    return downloadWindows64Link;
+  };
+
+  this.getDownloadUbuntu32Link = function() {
+    return downloadUbuntu32Link;
+  };
+
+  this.getDownloadUbuntu64Link = function() {
+    return downloadUbuntu64Link;
+  };
+
+  this.getDownloadRaspberryLink = function() {
+    return downloadRaspberryLink;
   };
 
   this.getDismissButton = function() {

--- a/web/partials/displays/download-player-modal.html
+++ b/web/partials/displays/download-player-modal.html
@@ -10,7 +10,7 @@
       <strong>Windows</strong>
       <ul>
         <li>
-          <a class="madero-link" href="https://storage.googleapis.com/install-versions.risevision.com/installer-win-32.exe">
+          <a class="madero-link" id="downloadWindows32" href="https://storage.googleapis.com/install-versions.risevision.com/installer-win-32.exe">
             Download for Windows 10 (32-bit)
           </a>
         </li>
@@ -25,12 +25,12 @@
       <strong>Linux</strong>
       <ul>
         <li>
-          <a class="madero-link" href="https://storage.googleapis.com/install-versions.risevision.com/installer-lnx-32.sh">
+          <a class="madero-link" id="downloadUbuntu32" href="https://storage.googleapis.com/install-versions.risevision.com/installer-lnx-32.sh">
             Download for Ubuntu 18.04 LTS (32-bit)
           </a>
         </li>
         <li>
-          <a class="madero-link" href="https://storage.googleapis.com/install-versions.risevision.com/installer-lnx-64.sh">
+          <a class="madero-link" id="downloadUbuntu64" href="https://storage.googleapis.com/install-versions.risevision.com/installer-lnx-64.sh">
             Download for Ubuntu 18.04 LTS (64-bit)
           </a>
         </li>
@@ -50,7 +50,7 @@
       <strong>Raspberry Pi</strong>
       <ul>
         <li>
-          <a class="madero-link" href="https://storage.googleapis.com/install-versions.risevision.com/installer-lnx-armv7l.sh">
+          <a class="madero-link" id="downloadRaspberry" href="https://storage.googleapis.com/install-versions.risevision.com/installer-lnx-armv7l.sh">
             Download for Raspberry Pi
           </a>
         </li>


### PR DESCRIPTION
## Description
Add tests to confirm Player download links are HTTPS to prevent mixed content blocks from Chrome 86+.
Also, added a HEAD request to one of the files to confirm the link is working.

## Motivation and Context
https://trello.com/c/DksEfWzD/6771-issue-2163-follow-up-detect-dead-player-download-links-1

## How Has This Been Tested?
Tests pass [stage-19]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
