### PR TITLE
Use ng-show to prevent stripe elements from resetting

### DIFF
--- a/test/e2e/registration/cases/checkout.js
+++ b/test/e2e/registration/cases/checkout.js
@@ -69,6 +69,8 @@
 
           expect(purchaseFlowPage.getBillingAddressPage().isDisplayed()).to.eventually.be.true;
           expect(purchaseFlowPage.getEmailField().isDisplayed()).to.eventually.be.true;
+
+          expect(purchaseFlowPage.getReviewEstimatePage().isDisplayed()).to.eventually.be.true;
         });
 
         it("should fill out billing address", function() {
@@ -104,6 +106,8 @@
           expect(purchaseFlowPage.getCardName().isDisplayed()).to.eventually.be.true;
 
           expect(purchaseFlowPage.getPaymentMethodSelected().getText()).to.eventually.contain('Credit Card');
+
+          expect(purchaseFlowPage.getPayButton().isDisplayed()).to.eventually.be.true;
         });
 
         it("should switch to invoice me form", function() {
@@ -112,6 +116,8 @@
           expect(purchaseFlowPage.getPaymentMethodSelected().getText()).to.eventually.contain('Invoice Me');
 
           expect(purchaseFlowPage.getGenerateInvoiceForm().isDisplayed()).to.eventually.be.true;
+
+          expect(purchaseFlowPage.getInvoiceButton().isDisplayed()).to.eventually.be.true;
 
           console.log('Purchase using Invoice Me');
         });
@@ -137,12 +143,9 @@
         it("should purchase",function() {
           expect(purchaseFlowPage.getReviewPurchasePage().isDisplayed()).to.eventually.be.true;
 
-          // Wait for other responses to complete and update Chargebee address for the Company
-          browser.sleep(10000);
+          browser.sleep(1000);
 
-          expect(purchaseFlowPage.getPayButton().isDisplayed()).to.eventually.be.true;
-
-          helper.clickWhenClickable(purchaseFlowPage.getPayButton(), 'Purchase flow Pay Button');
+          helper.clickWhenClickable(purchaseFlowPage.getInvoiceButton(), 'Purchase flow Invoice Button');
 
           helper.waitForSpinner();
           helper.waitDisappear(purchaseFlowPage.getReviewPurchasePage(), 'Review Purchase Page');

--- a/test/e2e/registration/pages/purchaseFlowPage.js
+++ b/test/e2e/registration/pages/purchaseFlowPage.js
@@ -36,8 +36,10 @@ var PurchaseFlowPage = function() {
   var cardExpYr = element(by.id('new-card-expiry-year'));
   var cardCVC = element(by.id('new-card-cvc'));
 
+  var reviewEstimatePage = element(by.id('checkout-estimate-summary'));
   var reviewPurchasePage = element(by.id('checkout-purchase-summary'));
   var payButton = element(by.id('payButton'));
+  var invoiceButton = element(by.id('invoiceButton'));
 
   var checkoutSuccessPage = element(by.id('checkout-success'));
   var checkoutDoneButton = element(by.id('doneButton'));
@@ -161,12 +163,20 @@ var PurchaseFlowPage = function() {
     return cardExpYr;
   }
 
+  this.getReviewEstimatePage = function() {
+    return reviewEstimatePage;
+  };
+
   this.getReviewPurchasePage = function() {
     return reviewPurchasePage;
   };
 
   this.getPayButton = function() {
     return payButton;
+  };
+
+  this.getInvoiceButton = function() {
+    return invoiceButton;
   };
 
   this.getCheckoutSuccessPage = function() {

--- a/test/unit/purchase/controllers/ctr-purchase-spec.js
+++ b/test/unit/purchase/controllers/ctr-purchase-spec.js
@@ -128,6 +128,26 @@ describe("controller: purchase", function() {
       }, 10);
     });
 
+    it("should increment step if other forms are invalid", function(done) {
+      $scope.form.billingAddressForm = {
+        $valid: true
+      };
+
+      $scope.form.reviewSubscriptionForm = {
+        $valid: false
+      };
+
+      $scope.validateAddress({});
+
+      addressFactory.validateAddress.should.have.been.called;
+
+      setTimeout(function() {
+        $scope.setNextStep.should.have.been.called;
+
+        done();
+      }, 10);
+    });
+
     it("should validate and proceed to next step", function(done) {
       $scope.validateAddress({}, "contact");
 
@@ -287,32 +307,6 @@ describe("controller: purchase", function() {
 
   describe("setNextStep: ", function() {
     it("should increment step", function() {
-      $scope.setNextStep();
-
-      expect($scope.currentStep).to.equal(1);
-    });
-
-    it("should not increment step if the corresponding form is invalid", function() {
-      $scope.setCurrentStep(1);
-
-      $scope.form.billingAddressForm = {
-        $valid: false
-      };
-
-      $scope.setNextStep();
-
-      expect($scope.currentStep).to.equal(1);
-    });
-
-    it("should increment step if other forms are invalid", function() {
-      $scope.form.billingAddressForm = {
-        $valid: true
-      };
-
-      $scope.form.reviewSubscriptionForm = {
-        $valid: false
-      };
-
       $scope.setNextStep();
 
       expect($scope.currentStep).to.equal(1);

--- a/test/unit/purchase/controllers/ctr-purchase-spec.js
+++ b/test/unit/purchase/controllers/ctr-purchase-spec.js
@@ -15,14 +15,14 @@ describe("controller: purchase", function() {
       }
     });
     $provide.service("addressFactory", function() {
-      return addressFactory = {
-        validateAddress: function(addressObject) {
+      return {
+        validateAddress: sinon.spy(function(addressObject) {
           if (!validate) {
             addressObject.validationError = true;
           }
 
           return Q.resolve();
-        },
+        }),
         updateContact: sandbox.stub(),
         updateAddress: sandbox.stub()
       };
@@ -54,6 +54,7 @@ describe("controller: purchase", function() {
       $scope = $rootScope.$new();
       $state = $injector.get("$state");
       $loading = $injector.get("$loading");
+      addressFactory = $injector.get("addressFactory");
       purchaseFactory = $injector.get('purchaseFactory');
       helpWidgetFactory = $injector.get('helpWidgetFactory');
 
@@ -81,6 +82,7 @@ describe("controller: purchase", function() {
 
     expect($scope.validateAddress).to.be.a("function");
     expect($scope.completePayment).to.be.a("function");
+    expect($scope.completeCardPayment).to.be.a("function");
     expect($scope.setNextStep).to.be.a("function");
     expect($scope.setPreviousStep).to.be.a("function");
     expect($scope.setCurrentStep).to.be.a("function");
@@ -112,10 +114,12 @@ describe("controller: purchase", function() {
 
     it("should not validate if the corresponding form is invalid", function(done) {
       $scope.form.billingAddressForm = {
-        $invalid: true
+        $valid: false
       };
 
       $scope.validateAddress({});
+
+      addressFactory.validateAddress.should.not.have.been.called;
 
       setTimeout(function() {
         $scope.setNextStep.should.not.have.been.called;
@@ -126,6 +130,8 @@ describe("controller: purchase", function() {
 
     it("should validate and proceed to next step", function(done) {
       $scope.validateAddress({}, "contact");
+
+      addressFactory.validateAddress.should.have.been.called;
 
       setTimeout(function() {
         addressFactory.updateContact.should.have.been.calledWith("contact");
@@ -140,6 +146,8 @@ describe("controller: purchase", function() {
       validate = false;
       $scope.validateAddress({});
 
+      addressFactory.validateAddress.should.have.been.called;
+
       setTimeout(function() {
         $scope.setNextStep.should.not.have.been.called;
 
@@ -149,23 +157,67 @@ describe("controller: purchase", function() {
 
   });
 
-  describe("completePayment: ", function() {
+  describe('completePayment:', function() {
     beforeEach(function() {
       sandbox.spy($scope, "setNextStep");
       $scope.setCurrentStep(1);
     });
 
-    it("should not validate if the corresponding form is invalid", function(done) {
+    it("should complete payment even if the corresponding form is invalid", function() {
       $scope.form.billingAddressForm = {
-        $invalid: true
+        $valid: false
       };
 
-      $scope.completePayment({});
+      $scope.completePayment();
+
+      purchaseFactory.completePayment.should.have.been.called;
+    });
+
+    it("should complete payment and proceed", function(done) {
+      $scope.completePayment();
+
+      setTimeout(function() {
+        purchaseFactory.completePayment.should.have.been.called;
+
+        $scope.setNextStep.should.have.been.called;
+
+        done();
+      }, 10);
+    });
+
+    it("should not proceed if there are errors", function(done) {
+      purchaseFactory.completePayment.returns(Q.reject());
+
+      $scope.completePayment();
+
+      setTimeout(function() {
+        purchaseFactory.completePayment.should.have.been.called;
+
+        $scope.setNextStep.should.not.have.been.called;
+
+        done();
+      }, 10);
+    });
+
+  });
+
+  describe("completeCardPayment: ", function() {
+    beforeEach(function() {
+      sandbox.spy($scope, "completePayment");
+      $scope.setCurrentStep(1);
+    });
+
+    it("should not validate if the corresponding form is invalid", function(done) {
+      $scope.form.billingAddressForm = {
+        $valid: false
+      };
+
+      $scope.completeCardPayment({});
 
       purchaseFactory.validatePaymentMethod.should.not.have.been.called;
 
       setTimeout(function() {
-        $scope.setNextStep.should.not.have.been.called;
+        $scope.completePayment.should.not.have.been.called;
 
         done();
       }, 10);
@@ -173,14 +225,14 @@ describe("controller: purchase", function() {
 
     describe('validatePaymentMethod:', function() {
       it("should validate and proceed", function(done) {
-        $scope.completePayment('cardElement');
+        $scope.completeCardPayment('cardElement');
 
         purchaseFactory.validatePaymentMethod.should.have.been.calledWith('cardElement');
 
         setTimeout(function() {
           purchaseFactory.preparePaymentIntent.should.have.been.called;
 
-          $scope.setNextStep.should.have.been.called;
+          $scope.completePayment.should.have.been.called;
 
           done();
         }, 10);
@@ -189,14 +241,14 @@ describe("controller: purchase", function() {
       it("should not proceed if there are errors", function(done) {
         purchaseFactory.validatePaymentMethod.returns(Q.reject());
 
-        $scope.completePayment();
+        $scope.completeCardPayment();
 
         purchaseFactory.validatePaymentMethod.should.have.been.called;
 
         setTimeout(function() {
           purchaseFactory.preparePaymentIntent.should.not.have.been.called;
 
-          $scope.setNextStep.should.not.have.been.called;
+          $scope.completePayment.should.not.have.been.called;
 
           done();
         }, 10);
@@ -206,13 +258,11 @@ describe("controller: purchase", function() {
 
     describe('preparePaymentIntent:', function() {
       it("should prepare intent and proceed", function(done) {
-        $scope.completePayment('cardElement');
+        $scope.completeCardPayment('cardElement');
 
         setTimeout(function() {
           purchaseFactory.preparePaymentIntent.should.have.been.called;
           purchaseFactory.completePayment.should.have.been.called;
-
-          $scope.setNextStep.should.have.been.called;
 
           done();
         }, 10);
@@ -221,58 +271,16 @@ describe("controller: purchase", function() {
       it("should not proceed if there are errors", function(done) {
         purchaseFactory.preparePaymentIntent.returns(Q.reject());
 
-        $scope.completePayment();
+        $scope.completeCardPayment();
 
         setTimeout(function() {
           purchaseFactory.preparePaymentIntent.should.have.been.called;
           purchaseFactory.completePayment.should.not.have.been.called;
 
-          $scope.setNextStep.should.not.have.been.called;
-
           done();
         }, 10);
       });
 
-    });
-    
-    describe('completePayment:', function() {
-      it("should complete payment and proceed", function(done) {
-        $scope.completePayment('cardElement');
-
-        setTimeout(function() {
-          purchaseFactory.completePayment.should.have.been.called;
-
-          $scope.setNextStep.should.have.been.called;
-
-          done();
-        }, 10);
-      });
-
-      it("should not proceed if there are errors", function(done) {
-        purchaseFactory.completePayment.returns(Q.reject());
-
-        $scope.completePayment();
-
-        setTimeout(function() {
-          purchaseFactory.completePayment.should.have.been.called;
-
-          $scope.setNextStep.should.not.have.been.called;
-
-          done();
-        }, 10);
-      });
-
-    });
-
-    it("should not proceed if there are errors", function(done) {
-      purchaseFactory.purchase.checkoutError = "error";
-      $scope.completePayment({});
-
-      setTimeout(function() {
-        $scope.setNextStep.should.not.have.been.called;
-
-        done();
-      }, 10);
     });
 
   });
@@ -288,7 +296,7 @@ describe("controller: purchase", function() {
       $scope.setCurrentStep(1);
 
       $scope.form.billingAddressForm = {
-        $invalid: true
+        $valid: false
       };
 
       $scope.setNextStep();
@@ -302,7 +310,7 @@ describe("controller: purchase", function() {
       };
 
       $scope.form.reviewSubscriptionForm = {
-        $invalid: true
+        $valid: false
       };
 
       $scope.setNextStep();

--- a/test/unit/purchase/controllers/ctr-purchase-spec.js
+++ b/test/unit/purchase/controllers/ctr-purchase-spec.js
@@ -305,6 +305,46 @@ describe("controller: purchase", function() {
 
   });
 
+  describe("_refreshEstimate:", function() {
+    it('should not refresh the estimate on step 0', function() {
+      $scope.setCurrentStep(0);
+
+      purchaseFactory.getEstimate.should.not.have.been.called;
+    });
+
+    it('should refresh the estimate on step 1', function() {
+      $scope.setCurrentStep(1);
+
+      purchaseFactory.getEstimate.should.have.been.called;
+    });
+
+    it('should refresh the estimate on step 2', function() {
+      $scope.setCurrentStep(2);
+
+      purchaseFactory.getEstimate.should.have.been.called;
+    });
+
+    it('should not refresh the estimate on step 3', function() {
+      $scope.setCurrentStep(3);
+
+      purchaseFactory.getEstimate.should.not.have.been.called;
+    });
+
+    it('should refresh the estimate on setNextStep', function() {
+      $scope.setCurrentStep(0);
+      $scope.setNextStep();
+
+      purchaseFactory.getEstimate.should.have.been.called;
+    });
+
+    it('should not refresh the estimate on setPreviousStep', function() {
+      $scope.setCurrentStep(3);
+      $scope.setPreviousStep();
+
+      purchaseFactory.getEstimate.should.not.have.been.called;
+    });
+  });
+
   describe("setNextStep: ", function() {
     it("should increment step", function() {
       $scope.setNextStep();

--- a/test/unit/purchase/directives/dtv-payment-methods-spec.js
+++ b/test/unit/purchase/directives/dtv-payment-methods-spec.js
@@ -53,27 +53,12 @@ describe("directive: payment methods", function() {
   });
 
   describe('initializeStripeElements:', function() {
-    beforeEach(function() {
-      $scope.paymentMethods = {};
+    beforeEach(function(done) {
+      setTimeout(function() {
+        done();
+      }, 10);
     });
-
-    it('should not call initialize', function() {
-      stripeService.initializeStripeElements.should.not.have.been.called;
-    });
-
-    it('should not initialize for invoice', function() {
-      $scope.paymentMethods.paymentMethod = 'invoice';
-
-      $scope.$digest();
-
-      stripeService.initializeStripeElements.should.not.have.been.called;
-    });
-
-    it('should initialize for card', function() {
-      $scope.paymentMethods.paymentMethod = 'card';
-
-      $scope.$digest();
-
+    it('should initialize', function() {
       stripeService.initializeStripeElements.should.have.been.calledWith([
         'cardNumber',
         'cardExpiry',
@@ -81,86 +66,47 @@ describe("directive: payment methods", function() {
       ], sinon.match.object);
     });
 
-    it('should initialize elements and add them to the scope', function(done) {
-      $scope.paymentMethods.paymentMethod = 'card';
-
-      $scope.$digest();
-
-      setTimeout(function() {
-        expect($scope['cardNumber']).to.be.an('object');
-        expect($scope['cardExpiry']).to.be.an('object');
-        expect($scope['cardCvc']).to.be.an('object');
-
-        done();
-      }, 10);
+    it('should initialize elements and add them to the scope', function() {
+      expect($scope['cardNumber']).to.be.an('object');
+      expect($scope['cardExpiry']).to.be.an('object');
+      expect($scope['cardCvc']).to.be.an('object');
     });
 
-    it('should initialize handlers', function(done) {
-      $scope.paymentMethods.paymentMethod = 'card';
+    it('should initialize handlers', function() {
+      $scope['cardNumber'].mount.should.have.been.calledWith('#new-card-number');
 
-      $scope.$digest();
-
-      setTimeout(function() {
-        $scope['cardNumber'].mount.should.have.been.calledWith('#new-card-number');
-
-        $scope['cardNumber'].on.should.have.been.calledTwice;
-        $scope['cardNumber'].on.should.have.been.calledWith('blur', sinon.match.func);
-        $scope['cardNumber'].on.should.have.been.calledWith('change', sinon.match.func);
-
-        done();
-      }, 10);
+      $scope['cardNumber'].on.should.have.been.calledTwice;
+      $scope['cardNumber'].on.should.have.been.calledWith('blur', sinon.match.func);
+      $scope['cardNumber'].on.should.have.been.calledWith('change', sinon.match.func);
     });
 
-    it('should $digest on blur', function(done) {
-      $scope.paymentMethods.paymentMethod = 'card';
+    it('should $digest on blur', function() {
+      sinon.spy($scope, '$digest');
 
-      $scope.$digest();
+      $scope['cardNumber'].on.getCall(0).args[1]();
 
-      setTimeout(function() {
-        sinon.spy($scope, '$digest');
-
-        $scope['cardNumber'].on.getCall(0).args[1]();
-
-        $scope.$digest.should.have.been.called;
-
-        done();
-      }, 10);
+      $scope.$digest.should.have.been.called;
     });
 
-    it('should add dirty class and $digest on change', function(done) {
-      $scope.paymentMethods.paymentMethod = 'card';
+    it('should add dirty class and $digest on change', function() {
+      var cardElement = angular.element('<div id="new-card-number"/>').appendTo('body');
 
-      $scope.$digest();
+      sinon.spy($scope, '$digest');
 
-      setTimeout(function() {
-        var cardElement = angular.element('<div id="new-card-number"/>').appendTo('body');
+      $scope['cardNumber'].on.getCall(1).args[1]();
 
-        sinon.spy($scope, '$digest');
+      expect(cardElement[0].className).to.contain('dirty');
+      $scope.$digest.should.have.been.called;
 
-        $scope['cardNumber'].on.getCall(1).args[1]();
-
-        expect(cardElement[0].className).to.contain('dirty');
-        $scope.$digest.should.have.been.called;
-
-        element.remove();
-        done();
-      }, 10);
+      element.remove();
     });
 
-    it('should handle failure to get element', function(done) {
-      $scope.paymentMethods.paymentMethod = 'card';
+    it('should handle failure to get element', function() {
+      sinon.spy($scope, '$digest');
 
-      $scope.$digest();
+      $scope['cardNumber'].on.getCall(1).args[1]();
 
-      setTimeout(function() {
-        sinon.spy($scope, '$digest');
-
-        $scope['cardNumber'].on.getCall(1).args[1]();
-
-        $scope.$digest.should.have.been.called;
-
-        done();
-      }, 10);
+      $scope.$digest.should.have.been.called;
     });
 
   });

--- a/test/unit/purchase/directives/dtv-purchase-summary-spec.js
+++ b/test/unit/purchase/directives/dtv-purchase-summary-spec.js
@@ -48,10 +48,6 @@ describe("directive: purchase summary", function() {
     expect($scope.showTaxExemptionModal).to.be.a("function");
   });
 
-  it("should load estimate", function() {
-    purchaseFactory.getEstimate.should.have.been.called;
-  });
-
   describe("getAdditionalDisplaysPrice: ", function() {
     it("should return monthly price based on license number", function() {
       $scope.purchase.plan = {
@@ -82,7 +78,7 @@ describe("directive: purchase summary", function() {
     it("should not get estimate if coupon code is blank", function() {
       $scope.applyCouponCode();
 
-      purchaseFactory.getEstimate.should.have.been.calledOnce;
+      purchaseFactory.getEstimate.should.not.have.been.called;
     });
 
     it("should get estimate", function() {
@@ -90,7 +86,7 @@ describe("directive: purchase summary", function() {
 
       $scope.applyCouponCode();
 
-      purchaseFactory.getEstimate.should.have.been.calledTwice;
+      purchaseFactory.getEstimate.should.have.been.calledOnce;
     });
 
     it("should hide coupon form if an error is not returned", function(done) {
@@ -131,7 +127,7 @@ describe("directive: purchase summary", function() {
       expect($scope.addCoupon).to.be.false;
       expect($scope.purchase.couponCode).to.not.be.ok;
 
-      purchaseFactory.getEstimate.should.have.been.calledOnce;
+      purchaseFactory.getEstimate.should.not.have.been.called;
     });
 
     it("should refresh estimate on estimate error", function() {
@@ -139,7 +135,7 @@ describe("directive: purchase summary", function() {
 
       $scope.clearCouponCode();
 
-      purchaseFactory.getEstimate.should.have.been.calledTwice;
+      purchaseFactory.getEstimate.should.have.been.calledOnce;
     });
   });
 
@@ -155,7 +151,7 @@ describe("directive: purchase summary", function() {
       $scope.showTaxExemptionModal();
 
       setTimeout(function() {
-        purchaseFactory.getEstimate.should.have.been.calledTwice;
+        purchaseFactory.getEstimate.should.have.been.calledOnce;
 
         done();        
       }, 10);
@@ -166,7 +162,7 @@ describe("directive: purchase summary", function() {
       $scope.showTaxExemptionModal();
 
       setTimeout(function() {
-        purchaseFactory.getEstimate.should.have.been.calledOnce;
+        purchaseFactory.getEstimate.should.not.have.been.called;
 
         done();        
       }, 10);

--- a/web/partials/purchase/app-purchase.html
+++ b/web/partials/purchase/app-purchase.html
@@ -6,10 +6,10 @@
 
   <div rv-spinner rv-spinner-key="purchase-loader" rv-spinner-start-active="1"></div>
 
-  <plan-picker ng-if="currentStep === 0"></plan-picker>
-  <billing-address ng-if="currentStep === 1"></billing-address>
-  <payment-methods ng-if="currentStep === 2"></payment-methods>
-  <checkout-success ng-if="currentStep === 3"></checkout-success>
+  <plan-picker ng-show="currentStep === 0"></plan-picker>
+  <billing-address ng-show="currentStep === 1"></billing-address>
+  <payment-methods ng-show="currentStep === 2"></payment-methods>
+  <checkout-success ng-show="currentStep === 3"></checkout-success>
 
   <div class="row mt-5 pt-5 border-top purchase-footer">
     <div class="col-md-4 mb-5">

--- a/web/partials/purchase/checkout-billing-address.html
+++ b/web/partials/purchase/checkout-billing-address.html
@@ -46,7 +46,7 @@
     </form>
 
   </div>
-  <purchase-summary></purchase-summary>
+  <purchase-summary id="checkout-estimate-summary"></purchase-summary>
 </div>
 
 <div id="errorBox" class="madero-style alert alert-danger u_margin-md-top" role="alert" ng-show="billingAddress.validationError">

--- a/web/partials/purchase/checkout-payment-methods.html
+++ b/web/partials/purchase/checkout-payment-methods.html
@@ -184,8 +184,10 @@
 
 <div class="button-row text-right mt-5">
   <button id="backButton" type="button" aria-label="Go back to Billing Address" class="btn btn-default btn-toolbar pull-left" ng-click="setPreviousStep()" translate>common.back</button>
-  <button id="payButton" type="submit" class="btn btn-primary btn-toolbar-wide" form="form.paymentMethodsForm" ng-click="completePayment(cardNumber)" tabindex="1" aria-label="Complete Payment">
-    <span id="payLabel" ng-if="purchase.paymentMethods.paymentMethod === 'card'">Pay ${{purchase.estimate.total | number:2}} Now</span>
-    <span id="invoiceLabel" ng-if="purchase.paymentMethods.paymentMethod === 'invoice'">Invoice Me ${{purchase.estimate.total | number:2}} Now</span>
+  <button id="payButton" type="submit" class="btn btn-primary btn-toolbar-wide" form="form.paymentMethodsForm" ng-click="completeCardPayment(cardNumber)" tabindex="1" aria-label="Complete Payment" ng-if="purchase.paymentMethods.paymentMethod === 'card'">
+    <span id="payLabel">Pay ${{purchase.estimate.total | number:2}} Now</span>
+  </button>
+  <button id="invoiceButton" type="submit" class="btn btn-primary btn-toolbar-wide" form="form.paymentMethodsForm" ng-click="completePayment()" tabindex="1" aria-label="Complete Payment" ng-if="purchase.paymentMethods.paymentMethod === 'invoice'">
+    <span id="invoiceLabel">Invoice Me ${{purchase.estimate.total | number:2}} Now</span>
   </button>
 </div>

--- a/web/partials/purchase/checkout-payment-methods.html
+++ b/web/partials/purchase/checkout-payment-methods.html
@@ -19,7 +19,7 @@
         </div>
       </div>
 
-      <div id="credit-card-form" ng-if="paymentMethods.paymentMethod === 'card'">
+      <div id="credit-card-form" ng-show="paymentMethods.paymentMethod === 'card'">
         <!-- Alpha Release - Select New Card by default -->
         <div class="row" ng-if="false">
           <div class="col-md-12">
@@ -33,7 +33,7 @@
         </div>
 
         <!-- NEW CREDIT CARD -->
-        <div id="new-credit-card-form" ng-if="paymentMethods.selectedCard.isNew">
+        <div id="new-credit-card-form" ng-show="paymentMethods.selectedCard.isNew">
           <div class="row">
             <div class="col-md-12">
               <div class="form-group" ng-class="{ 'has-error': (form.paymentMethodsForm.cardholderName.$dirty || form.paymentMethodsForm.$submitted) && form.paymentMethodsForm.cardholderName.$invalid }">
@@ -140,7 +140,7 @@
       </div>
 
       <!-- //GENERATE INVOICE FORM -->
-      <div id="generateInvoice" ng-if="paymentMethods.paymentMethod === 'invoice'">
+      <div id="generateInvoice" ng-show="paymentMethods.paymentMethod === 'invoice'">
         <p>Please enter a purchase order number if applicable. Your invoice will be sent to 
           <b>{{contactEmail}}</b> with net 30 day terms. Invoice is payable by check, wire transfer, or credit card.</p>
 

--- a/web/partials/purchase/checkout-payment-methods.html
+++ b/web/partials/purchase/checkout-payment-methods.html
@@ -171,7 +171,7 @@
     </form>
 
   </div>
-  <purchase-summary></purchase-summary>
+  <purchase-summary id="checkout-purchase-summary"></purchase-summary>
 </div>
 
 <div id="errorBox" class="madero-style alert alert-danger u_margin-md-top" role="alert" ng-show="paymentMethods.tokenError">

--- a/web/partials/purchase/checkout-purchase-summary.html
+++ b/web/partials/purchase/checkout-purchase-summary.html
@@ -1,5 +1,5 @@
 <!-- Step 5 -->
-<div id="checkout-purchase-summary" class="purchase-summary">
+<div class="purchase-summary">
   <h4 class="u_margin-md-bottom mt-0">Subscription Details</h4>
 
   <div id="errorBox" class="madero-style alert alert-danger u_margin-md-top" role="alert" ng-show="purchase.estimate.estimateError">

--- a/web/scripts/purchase/controllers/ctr-purchase.js
+++ b/web/scripts/purchase/controllers/ctr-purchase.js
@@ -86,6 +86,12 @@ angular.module('risevision.apps.purchase')
           .then($scope.completePayment);
       };
 
+      var _refreshEstimate = function() {
+        if ($scope.currentStep === 1 || $scope.currentStep === 2) {
+          purchaseFactory.getEstimate();
+        }
+      };
+
       $scope.setNextStep = function () {
         // Note: Ensure to check if the form is valid before calling
         if (($scope.finalStep && $scope.currentStep < 1) || $scope.currentStep === 1) {
@@ -96,6 +102,7 @@ angular.module('risevision.apps.purchase')
           $scope.currentStep++;
         }
 
+        _refreshEstimate();
       };
 
       $scope.setPreviousStep = function () {
@@ -108,6 +115,8 @@ angular.module('risevision.apps.purchase')
         purchaseFactory.purchase.checkoutError = null;
 
         $scope.currentStep = index;
+
+        _refreshEstimate();
       };
 
       $scope.close = function () {

--- a/web/scripts/purchase/controllers/ctr-purchase.js
+++ b/web/scripts/purchase/controllers/ctr-purchase.js
@@ -87,10 +87,7 @@ angular.module('risevision.apps.purchase')
       };
 
       $scope.setNextStep = function () {
-        if (!_isFormValid()) {
-          return;
-        }
-
+        // Note: Ensure to check if the form is valid before calling
         if (($scope.finalStep && $scope.currentStep < 1) || $scope.currentStep === 1) {
           $scope.currentStep = 2;
 
@@ -104,17 +101,11 @@ angular.module('risevision.apps.purchase')
       $scope.setPreviousStep = function () {
         if ($scope.currentStep > 0) {
           $scope.currentStep--;
-        } else {
-          $state.go('apps.plans.home');
         }
       };
 
       $scope.setCurrentStep = function (index) {
         purchaseFactory.purchase.checkoutError = null;
-
-        if (index === -1) {
-          $state.go('apps.plans.home');
-        }
 
         $scope.currentStep = index;
       };

--- a/web/scripts/purchase/controllers/ctr-purchase.js
+++ b/web/scripts/purchase/controllers/ctr-purchase.js
@@ -67,19 +67,23 @@ angular.module('risevision.apps.purchase')
           });
       };
 
-      $scope.completePayment = function (element) {
+      $scope.completePayment = function () {
+        return purchaseFactory.completePayment()
+          .then(function () {
+            if (!purchaseFactory.purchase.checkoutError) {
+              $scope.setNextStep();
+            }
+          });
+      };
+
+      $scope.completeCardPayment = function (element) {
         if (!_isFormValid()) {
           return;
         }
 
         purchaseFactory.validatePaymentMethod(element)
           .then(purchaseFactory.preparePaymentIntent)
-          .then(purchaseFactory.completePayment)
-          .then(function () {
-            if (!purchaseFactory.purchase.checkoutError) {
-              $scope.setNextStep();
-            }
-          });
+          .then($scope.completePayment);
       };
 
       $scope.setNextStep = function () {

--- a/web/scripts/purchase/directives/dtv-payment-methods.js
+++ b/web/scripts/purchase/directives/dtv-payment-methods.js
@@ -45,31 +45,27 @@ angular.module('risevision.apps.purchase')
 
           $scope.purchase = purchaseFactory.purchase;
 
-          $scope.$watch('paymentMethods.paymentMethod', function() {
-            if ($scope.paymentMethods.paymentMethod === 'card') {
-              stripeService.initializeStripeElements(stripeElements, elementOptions)
-                .then(function (elements) {
-                  elements.forEach(function (el, idx) {
-                    $scope[stripeElements[idx]] = el;
-                    el.mount(stripeElementSelectors[idx]);
+          stripeService.initializeStripeElements(stripeElements, elementOptions)
+            .then(function (elements) {
+              elements.forEach(function (el, idx) {
+                $scope[stripeElements[idx]] = el;
+                el.mount(stripeElementSelectors[idx]);
 
-                    el.on('blur', function() {
-                      $scope.$digest();
-                    });
-
-                    el.on('change', function(event) {
-                      var element = document.querySelector(stripeElementSelectors[idx]);
-
-                      if (element) {                        
-                        element.classList.add('dirty');
-                      }
-
-                      $scope.$digest();
-                    });
-                  });
+                el.on('blur', function() {
+                  $scope.$digest();
                 });
-            }
-          });
+
+                el.on('change', function(event) {
+                  var element = document.querySelector(stripeElementSelectors[idx]);
+
+                  if (element) {                        
+                    element.classList.add('dirty');
+                  }
+
+                  $scope.$digest();
+                });
+              });
+            });
 
           $scope.getCardDescription = function (card) {
             return '***-' + card.last4 + ', ' + card.cardType + (card.isDefault ? ' (default)' : '');

--- a/web/scripts/purchase/directives/dtv-purchase-summary.js
+++ b/web/scripts/purchase/directives/dtv-purchase-summary.js
@@ -11,8 +11,6 @@ angular.module('risevision.apps.purchase')
           $scope.selectedCompany = userState.getCopyOfSelectedCompany();
           $scope.isSubcompanySelected = userState.isSubcompanySelected();
 
-          purchaseFactory.getEstimate();
-
           $scope.getAdditionalDisplaysPrice = function () {
             var plan = $scope.purchase.plan;
             if (plan.isMonthly) {


### PR DESCRIPTION
## Description
Use ng-show to prevent stripe elements from resetting

Remove watch code

[stage-2]

## Motivation and Context
Fix issue where Credit Card field values are being reset on navigation between purchase steps.

## How Has This Been Tested?
Tested changes locally. Tests pass.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No