### PR TITLE
Remove concurrent requests on bulk actions

### DIFF
--- a/test/unit/components/scrolling-list/services/svc-batch-operations.tests.js
+++ b/test/unit/components/scrolling-list/services/svc-batch-operations.tests.js
@@ -45,7 +45,18 @@ describe("service: BatchOperations:", function() {
 
   it("should init the service objects",function(){
     expect(batchOperations.activeOperation).to.not.be.ok;
-    expect(batchOperations.queueLimit).to.be.greaterThan(0);
+    expect(batchOperations.queueLimit).to.equal(3);
+    expect(batchOperations.progress).to.equal(0);
+    expect(batchOperations.totalItemCount).to.equal(0);
+    expect(batchOperations.completedItemCount).to.equal(0);
+  });
+
+  it("should init with default values",function(){
+    batchOperations = new BatchOperations({});
+    
+    expect(batchOperations.queueLimit).to.equal(1);
+
+    expect(batchOperations.activeOperation).to.not.be.ok;
     expect(batchOperations.progress).to.equal(0);
     expect(batchOperations.totalItemCount).to.equal(0);
     expect(batchOperations.completedItemCount).to.equal(0);

--- a/web/scripts/components/scrolling-list/services/svc-batch-operations.js
+++ b/web/scripts/components/scrolling-list/services/svc-batch-operations.js
@@ -8,7 +8,7 @@ angular.module('risevision.common.components.scrolling-list')
           return {};
         }
 
-        operations.queueLimit = operations.queueLimit || 5;
+        operations.queueLimit = operations.queueLimit || 1;
 
         var queue;
 


### PR DESCRIPTION
## Description
Bulk operations no longer make requests in parallel to avoid ConcurrentModificationException.

## Motivation and Context
Due to a combination  of  parallel requests and the fact that datastore uses optimistic locking, some batch requests were failing with ConcurrentModificationException

Fix for https://github.com/Rise-Vision/core/issues/848 and potentially https://github.com/Rise-Vision/core/issues/849 


## How Has This Been Tested?
Validated locally and on [stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
