### PR TITLE
Autofocus bulk delete confirmation input

### DIFF
--- a/web/partials/components/scrolling-list/bulk-delete-confirmation-modal.html
+++ b/web/partials/components/scrolling-list/bulk-delete-confirmation-modal.html
@@ -22,7 +22,7 @@
 
     <div class="align-left u_margin-md-top">
       <p class="mb-2"><strong>Type "{{expectedText}}" to confirm deletion:</strong></p>
-      <input class="w-100 form-control" type="text" ng-model="inputText"></input>
+      <input class="w-100 form-control" type="text" ng-model="inputText" autofocus></input>
     </div>
   </div>
 


### PR DESCRIPTION
## Description
Autofocus bulk delete confirmation input

[stage-15]

## Motivation and Context
Make it easier for user to access the input.

## How Has This Been Tested?
Tested on both desktop and mobile.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No