### PR TITLE
Show custom 409 error message from Core

### DIFF
--- a/test/unit/components/scrolling-list/services/svc-batch-operations.tests.js
+++ b/test/unit/components/scrolling-list/services/svc-batch-operations.tests.js
@@ -62,6 +62,24 @@ describe("service: BatchOperations:", function() {
     expect(batchOperations.completedItemCount).to.equal(0);
   });
 
+  it("should reset old values",function(){
+    batchOperations = new BatchOperations({
+      hasErrors: true,
+      error: 'error',
+      activeOperation: 'test',
+      progress: 50,
+      totalItemCount: 5,
+      completedItemCount: 2
+    });
+
+    expect(batchOperations.hasErrors).to.not.be.ok;
+    expect(batchOperations.error).to.not.be.ok;
+    expect(batchOperations.activeOperation).to.not.be.ok;
+    expect(batchOperations.progress).to.equal(0);
+    expect(batchOperations.totalItemCount).to.equal(0);
+    expect(batchOperations.completedItemCount).to.equal(0);
+  });
+
   describe('batch:', function() {
     it('should return a promise', function() {
       expect(batchOperations.batch().then).to.be.a('function');

--- a/test/unit/components/scrolling-list/services/svc-batch-operations.tests.js
+++ b/test/unit/components/scrolling-list/services/svc-batch-operations.tests.js
@@ -205,9 +205,29 @@ describe("service: BatchOperations:", function() {
 
     it('should reject if an operation fails', function(done) {
       method.returns(Q.resolve());
-      method.onCall(1).returns(Q.reject());
+      method.onCall(1).returns(Q.reject('reason1'));
 
-      batchOperations.batch(items, method, 'operationName').catch(function() {
+      batchOperations.batch(items, method, 'operationName').catch(function(reason) {
+        expect(reason).to.equal('reason1');
+
+        expect(batchOperations.hasErrors).to.be.true;
+        expect(batchOperations.progress).to.equal(100);
+        expect(batchOperations.totalItemCount).to.equal(8);
+        expect(batchOperations.completedItemCount).to.equal(8);
+
+        expect(batchOperationsTracker).to.have.been.calledWith('Batch Operation Failed', 'operationName', items, {failureReason: ''});
+        done();
+      });
+    });
+
+    it('should reject with the first failure', function(done) {
+      method.returns(Q.resolve());
+      method.onCall(1).returns(Q.reject('reason1'));
+      method.onCall(2).returns(Q.reject('reason2'));
+
+      batchOperations.batch(items, method, 'operationName').catch(function(reason) {
+        expect(reason).to.equal('reason1');
+
         expect(batchOperations.hasErrors).to.be.true;
         expect(batchOperations.progress).to.equal(100);
         expect(batchOperations.totalItemCount).to.equal(8);

--- a/test/unit/components/scrolling-list/services/svc-scrolling-list-service.tests.js
+++ b/test/unit/components/scrolling-list/services/svc-scrolling-list-service.tests.js
@@ -695,6 +695,53 @@ describe("service: ScrollingListService:", function() {
         }, 10);
       });
 
+      describe('showActionError:', function() {
+        it('should overwrite api error', function(done) {
+          var deferred = Q.defer();
+          listOperations.operations[1].showActionError = sinon.stub().returns(true);
+
+          scrollingListService.batchOperations.batch.returns(Q.reject('batchError'));
+
+          listOperations.operations[1].onClick();
+
+          scrollingListService.errorMessage = 'existingMessage';
+          scrollingListService.apiError = 'existingError';
+
+          setTimeout(function() {
+            processErrorCode.should.have.been.calledWith('Items', 'license', 'batchError');
+
+            listOperations.operations[1].showActionError.should.have.been.called;
+
+            expect(scrollingListService.errorMessage).to.equal('existingMessage');
+            expect(scrollingListService.apiError).to.equal('error');
+
+            done();
+          }, 10);
+        });
+
+        it('should keep api error', function(done) {
+          var deferred = Q.defer();
+          listOperations.operations[1].showActionError = sinon.stub().returns(false);
+
+          scrollingListService.batchOperations.batch.returns(Q.reject('batchError'));
+
+          listOperations.operations[1].onClick();
+
+          scrollingListService.errorMessage = 'existingMessage';
+          scrollingListService.apiError = 'existingError';
+
+          setTimeout(function() {
+            listOperations.operations[1].showActionError.should.have.been.called;
+
+            expect(scrollingListService.errorMessage).to.equal('existingMessage');
+            expect(scrollingListService.apiError).to.equal('existingError');
+
+            done();
+          }, 10);
+        });
+
+      });
+
     });
 
     describe('refresh:', function() {

--- a/test/unit/editor/controllers/ctr-presentation-list.tests.js
+++ b/test/unit/editor/controllers/ctr-presentation-list.tests.js
@@ -96,6 +96,18 @@ describe('controller: Presentation List', function() {
 
         editorFactory.deletePresentationByObject.should.have.been.calledWith('presentationObject', true);
       });
+
+      describe('showActionError:', function() {
+        it('should show for 409 errors', function() {
+          expect($scope.listOperations.operations[0].showActionError({status: 409})).to.be.true;
+        });
+
+        it('should not show for other errors', function() {
+          expect($scope.listOperations.operations[0].showActionError()).to.be.false;
+          expect($scope.listOperations.operations[0].showActionError({status: 400})).to.be.false;
+        });
+      });
+
     });
 
   });

--- a/web/scripts/components/scrolling-list/services/svc-batch-operations.js
+++ b/web/scripts/components/scrolling-list/services/svc-batch-operations.js
@@ -46,8 +46,9 @@ angular.module('risevision.common.components.scrolling-list')
 
           var _executeOperation = function (item, args) {
             method(item, args)
-              .catch(function (e) {
+              .catch(function (err) {
                 operations.hasErrors = true;
+                operations.error = operations.error || err;
               })
               .finally(function () {
                 _.remove(queue, function (listItem) {
@@ -98,7 +99,7 @@ angular.module('risevision.common.components.scrolling-list')
               batchOperationsTracker('Batch Operation Failed', operation, items, {
                 failureReason: err || ''
               });
-              return $q.reject(err);
+              return $q.reject(err || operations.error);
             });
         };
 

--- a/web/scripts/components/scrolling-list/services/svc-batch-operations.js
+++ b/web/scripts/components/scrolling-list/services/svc-batch-operations.js
@@ -15,6 +15,7 @@ angular.module('risevision.common.components.scrolling-list')
         var _reset = function () {
           queue = [];
           operations.hasErrors = false;
+          operations.error = null;
           operations.activeOperation = null;
           operations.progress = 0;
           operations.totalItemCount = 0;

--- a/web/scripts/components/scrolling-list/services/svc-scrolling-list-service.js
+++ b/web/scripts/components/scrolling-list/services/svc-scrolling-list-service.js
@@ -205,6 +205,12 @@ angular.module('risevision.common.components.scrolling-list')
                 // reload list
                 factory.doSearch();
               }
+            }).catch(function(err) {
+              if (operation.showActionError && operation.showActionError(err)) {
+                factory.apiError = processErrorCode(factory.search.name, operation.name.toLowerCase(), err);
+              }
+
+              throw err;
             });
           };
         };

--- a/web/scripts/editor/controllers/ctr-presentation-list.js
+++ b/web/scripts/editor/controllers/ctr-presentation-list.js
@@ -23,6 +23,12 @@ angular.module('risevision.editor.controllers')
           actionCall: function(presentation) {
             return editorFactory.deletePresentationByObject(presentation, true);
           },
+          showActionError: function(err) {
+            if (err && err.status === 409) {
+              return true;
+            }
+            return false;
+          },
           requireRole: 'cp'
         }]
       };


### PR DESCRIPTION
## Description
Show custom 409 error message from Core

On Presentation deletion, if there is a conflict
show the custom message returned from the Core

Catch and save first error in batch
Throw first error in batch
Catch batch error and process if available
If processing returns true log formatted message

[stage-2]

## Motivation and Context
Fix for #2207 

## How Has This Been Tested?
Tested changes locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No