### PR TITLE
Check scroll event target before loading list

### DIFF
--- a/test/unit/components/scrolling-list/directives/dtv-scrolling-list.tests.js
+++ b/test/unit/components/scrolling-list/directives/dtv-scrolling-list.tests.js
@@ -1,0 +1,93 @@
+'use strict';
+describe('directive: scrolling-list', function() {
+  var $scope,
+    element,
+    loadList,
+    sandbox = sinon.sandbox.create();
+
+    beforeEach(module('risevision.common.components.scrolling-list'));
+
+  beforeEach(inject(function($compile, $rootScope, $injector){
+    $rootScope.loadList = loadList = sandbox.stub();
+
+    element = $compile('<div scrolling-list="loadList()"></div>')($rootScope.$new());
+
+    $scope = element.scope();
+    $scope.$digest();
+  }));
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it('should initialize', function() {
+    expect($scope).to.be.ok;
+    expect($scope.handleScroll).to.be.a('function');
+  });
+
+  it('should compile', function() {
+    expect(element[0].outerHTML).to.equal('<div class="ng-scope" rv-scroll-event="handleScroll($event, isEndEvent)"></div>');
+  });
+
+  describe('handleScroll:', function() {
+
+    it('should load list if at the bottom', function() {
+      sandbox.stub(element[0], 'contains').returns(true);
+
+      $scope.handleScroll({
+        target: {
+          scrollTop: 10,
+          scrollHeight: 0,
+          clientHeight: 0
+        }
+      }, true);
+
+      loadList.should.have.been.called;
+    });
+
+    it('should not load list if the container is not scrolled within 20px', function() {
+      sandbox.stub(element[0], 'contains').returns(true);
+
+      $scope.handleScroll({
+        target: {
+          scrollTop: 10,
+          scrollHeight: 50,
+          clientHeight: 0
+        }
+      }, true);
+
+      loadList.should.not.have.been.called;
+    });
+
+    it('should not load list for non end event', function() {
+      sandbox.stub(element[0], 'contains').returns(true);
+
+      $scope.handleScroll({
+        target: {
+          scrollTop: 10,
+          scrollHeight: 0,
+          clientHeight: 0
+        }
+      }, false);
+
+      loadList.should.not.have.been.called;
+    });
+
+    it('should not load list if event.target is not within the container', function() {
+      sandbox.stub(element[0], 'contains').returns(false);
+
+      $scope.handleScroll({
+        target: {
+          scrollTop: 10,
+          scrollHeight: 0,
+          clientHeight: 0
+        }
+      }, true);
+
+      loadList.should.not.have.been.called;
+    });
+
+
+  });
+
+});

--- a/web/scripts/components/scrolling-list/directives/dtv-scrolling-list.js
+++ b/web/scripts/components/scrolling-list/directives/dtv-scrolling-list.js
@@ -14,8 +14,10 @@
             var fn = $parse(attr.scrollingList);
 
             scope.handleScroll = function (event, isEndEvent) {
+              var elContainsTarget = element[0].contains(event.target);
+
               // $log.debug(event.target.scrollTop + ' / ' + event.target.scrollHeight + ' / ' + isEndEvent);
-              if (isEndEvent) {
+              if (elContainsTarget && isEndEvent) {
                 if (event.target.scrollTop &&
                   (event.target.scrollHeight - event.target.clientHeight -
                     event.target.scrollTop) < 20) {


### PR DESCRIPTION
## Description
Check scroll event target before loading list

Fixes issue where events from multiple scrolling-lists
overlap and cause reload

[stage-15]

## Motivation and Context
Fix issue with multiple lists.

## How Has This Been Tested?
Tested with local version where there are two scrolling lists on the billing page. Added unit test coverage.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.