### PR TITLE
Use nextPageToken instead of cursor for store lists

### DIFF
--- a/test/unit/billing/services/svc-billing.tests.js
+++ b/test/unit/billing/services/svc-billing.tests.js
@@ -30,20 +30,22 @@ describe('service: billing:', function() {
               }
             }
           },
-          invoice: {
-            listUnpaid: function() {
-              if (!failedResponse) {
-                return Q.resolve({
-                  result: {
-                    nextPageToken: 1,
-                    items: [{ invoiceId: 'inv1' }]
-                  }
-                });
+          integrations: {
+            invoice: {
+              list: function() {
+                if (!failedResponse) {
+                  return Q.resolve({
+                    result: {
+                      nextPageToken: 1,
+                      items: [{ invoiceId: 'inv1' }]
+                    }
+                  });
+                }
+                else {
+                  return Q.reject('API Failed');
+                }
               }
-              else {
-                return Q.reject('API Failed');
-              }
-            }
+            }  
           }
         });
       };
@@ -59,7 +61,7 @@ describe('service: billing:', function() {
   it('should exist',function() {
     expect(billing).to.be.ok;
     expect(billing.getSubscriptions).to.be.a.function;
-    expect(billing.getUnpaidInvoices).to.be.a.function;
+    expect(billing.getInvoices).to.be.a.function;
   });
 
   describe('getSubscriptions:', function() {
@@ -89,11 +91,11 @@ describe('service: billing:', function() {
     });
   });
 
-  describe('getUnpaidInvoices:', function() {
+  describe('getInvoices:', function() {
     it('should return a list of invoices', function(done) {
       failedResponse = false;
 
-      billing.getUnpaidInvoices({})
+      billing.getInvoices({})
       .then(function(result) {
         expect(result).to.be.ok;
         expect(result.items).to.be.ok;
@@ -105,7 +107,7 @@ describe('service: billing:', function() {
     it('should handle failure to get list correctly', function(done) {
       failedResponse = true;
 
-      billing.getUnpaidInvoices({})
+      billing.getInvoices({})
       .then(function(invoices) {
         done(invoices);
       })

--- a/test/unit/billing/services/svc-chargebee-factory-spec.js
+++ b/test/unit/billing/services/svc-chargebee-factory-spec.js
@@ -4,7 +4,7 @@ describe("Services: ChargebeeFactory", function() {
   var sandbox = sinon.sandbox.create();
   var clock, $rootScope, $window, $loading, userState, storeService, plansFactory, currentPlanFactory, chargebeePortal;
 
-  beforeEach(module("risevision.store.services"));
+  beforeEach(module("risevision.apps.billing.services"));
 
   beforeEach(module(function ($provide) {
     $provide.value("CHARGEBEE_TEST_SITE", "risevision-test");
@@ -75,7 +75,6 @@ describe("Services: ChargebeeFactory", function() {
           return {
             ACCOUNT_DETAILS: "ACCOUNT_DETAILS",
             ADDRESS: "ADDRESS",
-            BILLING_HISTORY: "BILLING_HISTORY",
             PAYMENT_SOURCES: "PAYMENT_SOURCES",
             SUBSCRIPTION_DETAILS: "SUBSCRIPTION_DETAILS",
             EDIT_SUBSCRIPTION: "EDIT_SUBSCRIPTION"
@@ -265,17 +264,6 @@ describe("Services: ChargebeeFactory", function() {
       });
     });
 
-    it("should open Address section", function(done) {
-      chargebeeFactoryInstance.openBillingHistory("companyId1");
-
-      setTimeout(function () {
-        expect(chargebeePortal.open).to.have.been.calledOnce;
-        expect(chargebeePortal.open.getCall(0).args[1].sectionType).to.equal(chargebeeSections.BILLING_HISTORY);
-        expect(plansFactory.apiError).to.not.be.ok;
-        done();
-      });
-    });
-
     it("should open Payment Sources section", function(done) {
       chargebeeFactoryInstance.openPaymentSources("companyId1");
 
@@ -345,16 +333,6 @@ describe("Services: ChargebeeFactory", function() {
 
       it("should open Store Account instead of Customer Portal Address", function(done) {
         chargebeeFactoryInstance.openAddress("companyId1");
-
-        setTimeout(function () {
-          expect(chargebeePortal.open).to.not.have.been.called;
-          expect(plansFactory.showPlansModal).to.have.been.calledOnce;
-          done();
-        });
-      });
-
-      it("should open Store Account instead of Customer Billing History", function(done) {
-        chargebeeFactoryInstance.openBillingHistory("companyId1");
 
         setTimeout(function () {
           expect(chargebeePortal.open).to.not.have.been.called;

--- a/test/unit/components/scrolling-list/services/svc-scrolling-list-service.tests.js
+++ b/test/unit/components/scrolling-list/services/svc-scrolling-list-service.tests.js
@@ -139,6 +139,38 @@ describe("service: ScrollingListService:", function() {
         },10);
       });
 
+      it("should update cursor",function(done){
+        scrollingListService.search.selectAll = true;
+
+        result = {
+          items: [21],
+          cursor: 'updatedCursor'
+        };
+        scrollingListService.load();
+
+        setTimeout(function(){
+          expect(scrollingListService.items.cursor).to.equal('updatedCursor');
+
+          done();
+        },10);
+      });
+
+      it("should use nextPageToken if cursor is not available",function(done){
+        scrollingListService.search.selectAll = true;
+
+        result = {
+          items: [21],
+          nextPageToken: 'nextPageToken'
+        };
+        scrollingListService.load();
+
+        setTimeout(function(){
+          expect(scrollingListService.items.cursor).to.equal('nextPageToken');
+
+          done();
+        },10);
+      });
+
       it("should not re-load if there are no more items",function(done){
         result = {
           items: [41]

--- a/web/index.html
+++ b/web/index.html
@@ -145,7 +145,6 @@
   <script src="scripts/common-header/filters/ftr-supress-zero.js"></script>
 
   <script src="scripts/common-header/services/svc-account.js"></script>
-  <script src="scripts/common-header/services/svc-chargebee-factory.js"></script>
   <script src="scripts/common-header/services/svc-company-icp.js"></script>
   <script src="scripts/common-header/services/svc-company-settings-factory.js"></script>
   <script src="scripts/common-header/services/svc-cookie-tester.js"></script>
@@ -317,6 +316,7 @@
   <!-- billing -->
   <script src="scripts/billing/app.js"></script>
   <script src="scripts/billing/controllers/ctr-billing.js"></script>
+  <script src="scripts/billing/services/svc-chargebee-factory.js"></script>
   <script src="scripts/billing/services/svc-billing.js"></script>
 
   <!-- plans -->

--- a/web/scripts/billing/controllers/ctr-billing.js
+++ b/web/scripts/billing/controllers/ctr-billing.js
@@ -7,17 +7,15 @@ angular.module('risevision.apps.billing.controllers')
     function ($rootScope, $scope, $loading, $timeout, ScrollingListService, userState,
       currentPlanFactory, ChargebeeFactory, billing, PLANS_LIST, companySettingsFactory) {
 
-      $scope.search = {
-        count: $scope.listLimit,
-        sortBy: 'status',
-        reverse: false,
-        name: 'Subscriptions'
-      };
-
       $scope.company = userState.getCopyOfSelectedCompany();
       $scope.currentPlan = currentPlanFactory.currentPlan;
       $scope.chargebeeFactory = new ChargebeeFactory();
-      $scope.subscriptions = new ScrollingListService(billing.getSubscriptions, $scope.search);
+
+      $scope.subscriptions = new ScrollingListService(billing.getSubscriptions, {
+        sortBy: 'status',
+        reverse: false,
+        name: 'Subscriptions'
+      });
       $scope.invoices = new ScrollingListService(billing.getInvoices, {
         name: 'Invoices'
       });
@@ -33,6 +31,14 @@ angular.module('risevision.apps.billing.controllers')
           $loading.stop('billing-loader');
         }
       });
+
+      var _reloadSubscriptions = function () {
+        $loading.start('billing-loader');
+
+        $timeout(function () {
+          $scope.subscriptions.doSearch();
+        }, 10000);
+      };
 
       $rootScope.$on('chargebee.subscriptionChanged', _reloadSubscriptions);
       $rootScope.$on('chargebee.subscriptionCancelled', _reloadSubscriptions);
@@ -88,14 +94,6 @@ angular.module('risevision.apps.billing.controllers')
 
       $scope.isSuspended = function (subscription) {
         return subscription.status === 'Suspended';
-      };
-
-      var _reloadSubscriptions = function() {
-        $loading.start('billing-loader');
-
-        $timeout(function () {
-          $scope.subscriptions.doSearch();
-        }, 10000);
       };
 
       var _getPeriod = function(subscription) {

--- a/web/scripts/billing/services/svc-chargebee-factory.js
+++ b/web/scripts/billing/services/svc-chargebee-factory.js
@@ -1,7 +1,7 @@
 'use strict';
 /*jshint camelcase: false */
 
-angular.module('risevision.store.services')
+angular.module('risevision.apps.billing.services')
   .factory('getChargebeeInstance', ['$q', '$window', '$loading', 'storeService', 'userState',
     'CHARGEBEE_TEST_SITE', 'CHARGEBEE_PROD_SITE',
     function ($q, $window, $loading, storeService, userState, CHARGEBEE_TEST_SITE, CHARGEBEE_PROD_SITE) {

--- a/web/scripts/components/scrolling-list/services/svc-scrolling-list-service.js
+++ b/web/scripts/components/scrolling-list/services/svc-scrolling-list-service.js
@@ -40,7 +40,7 @@ angular.module('risevision.common.components.scrolling-list')
 
             listService(factory.search, factory.items.cursor)
               .then(function (result) {
-                factory.items.add(result.items ? result.items : [], result.cursor);
+                factory.items.add(result.items ? result.items : [], result.cursor || result.nextPageToken);
 
                 factory.search.selectAll = false;
               })

--- a/web/storage-selector.html
+++ b/web/storage-selector.html
@@ -85,7 +85,6 @@
   <script src="scripts/common-header/filters/ftr-supress-zero.js"></script>
   
   <script src="scripts/common-header/services/svc-account.js"></script>
-  <script src="scripts/common-header/services/svc-chargebee-factory.js"></script>
   <script src="scripts/common-header/services/svc-company-icp.js"></script>
   <script src="scripts/common-header/services/svc-company-settings-factory.js"></script>
   <script src="scripts/common-header/services/svc-cookie-tester.js"></script>


### PR DESCRIPTION
## Description
Use nextPageToken instead of cursor for store lists

Update unit tests
Move file to billing folder

[stage-19]

## Motivation and Context
Fix scrolling list retrieving more results from Store APIs. Fix unit tests.

## How Has This Been Tested?
Tested that invoices list returns more results on scroll (use Rise Vision testing company). Tests pass.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No