### PR TITLE
Create separate credit-card-form directive

### DIFF
--- a/test/unit/purchase/directives/dtv-credit-card-form-spec.js
+++ b/test/unit/purchase/directives/dtv-credit-card-form-spec.js
@@ -1,0 +1,138 @@
+"use strict";
+
+describe("directive: credit card form", function() {
+  beforeEach(module("risevision.apps.purchase"));
+
+  beforeEach(module(function ($provide) {
+    var _generateElement = function(id) {
+      return {
+        id: id,
+        mount: sinon.stub(),
+        on: sinon.stub()
+      };
+    }; 
+
+    $provide.value("creditCardFactory", {
+      initElements: sinon.stub()
+    });
+
+  }));
+
+  var $scope, element, creditCardFactory;
+
+  beforeEach(inject(function($compile, $rootScope, $templateCache, $injector){
+    creditCardFactory = $injector.get('creditCardFactory');
+
+    $templateCache.put("partials/purchase/credit-card-form.html", "<p>mock</p>");
+    $rootScope.form = {
+      creditCardForm: {}
+    };
+    $rootScope.paymentMethods = {
+      stripeElements: {}
+    };
+
+    element = $compile("<credit-card-form form-object=\"form.creditCardForm\" payment-methods-object=\"paymentMethods\"></credit-card-form>")($rootScope);
+
+    $scope = element.isolateScope();
+  }));
+
+  it("should replace the element with the appropriate content", function() {
+    expect(element.html()).to.equal("<p>mock</p>");
+  });
+
+  it("should initialize scope", function() {
+    expect($scope).to.be.an("object");
+
+    expect($scope.paymentMethods).to.be.an('object');
+    expect($scope.formObject).to.be.an('object');
+
+    expect($scope.getCardDescription).to.be.a("function");
+    expect($scope.stripeElementError).to.be.a("function");
+  });
+
+  it('initElements', function() {
+    creditCardFactory.initElements.should.have.been.called;
+  });
+
+  it("getCardDescription: ", function() {
+    var card = {
+      last4: "2345",
+      cardType: "Visa",
+      isDefault: false
+    };
+
+    expect($scope.getCardDescription(card)).to.equal("***-2345, Visa");
+
+    card.isDefault = true;
+
+    expect($scope.getCardDescription(card)).to.equal("***-2345, Visa (default)");
+  });
+
+  describe('stripeElementError:', function() {
+    var stripeElement;
+
+    beforeEach(function() {
+      stripeElement = angular.element('<div id="stripe-element"/>').appendTo('body');
+    });
+
+    afterEach(function() {
+      stripeElement.remove();
+    });
+
+    it('should return false if element is not found', function() {
+      expect($scope.stripeElementError('blank')).to.be.false;
+    });
+
+    it('should return false for blank element', function() {
+      expect($scope.stripeElementError('stripe-element')).to.not.be.ok;
+    });
+
+    describe('form is submitted', function() {
+      beforeEach(function() {
+        $scope.formObject.$submitted = true;
+      });
+
+      it('should return false if there are no validation errors', function() {
+        expect($scope.stripeElementError('stripe-element')).to.not.be.ok;
+      });
+
+      it('should return true if the field is empty', function() {
+        stripeElement[0].classList.add('StripeElement--empty');
+
+        expect($scope.stripeElementError('stripe-element')).to.be.true;
+      });
+
+      it('should return true if the field is invalid', function() {
+        stripeElement[0].classList.add('StripeElement--invalid');
+
+        expect($scope.stripeElementError('stripe-element')).to.be.true;
+      });
+
+    });
+
+    describe('element is dirty', function() {
+      beforeEach(function() {
+        stripeElement[0].classList.add('dirty');
+      });
+
+      it('should return false if there are no validation errors', function() {
+        expect($scope.stripeElementError('stripe-element')).to.not.be.ok;
+      });
+
+      it('should return true if the field is empty', function() {
+        stripeElement[0].classList.add('StripeElement--empty');
+
+        expect($scope.stripeElementError('stripe-element')).to.be.true;
+      });
+
+      it('should return true if the field is invalid', function() {
+        stripeElement[0].classList.add('StripeElement--invalid');
+
+        expect($scope.stripeElementError('stripe-element')).to.be.true;
+      });
+
+    });
+
+  });
+
+});

--- a/test/unit/purchase/directives/dtv-payment-methods-spec.js
+++ b/test/unit/purchase/directives/dtv-payment-methods-spec.js
@@ -12,26 +12,12 @@ describe("directive: payment methods", function() {
         }
       }
     });
-
-    var _generateElement = function(id) {
-      return {
-        id: id,
-        mount: sinon.stub(),
-        on: sinon.stub()
-      };
-    }; 
-
-    $provide.value("stripeService", {
-      initializeStripeElements: sinon.stub().returns(Q.resolve([_generateElement(1), _generateElement(2), _generateElement(3)]))
-    });
-
+    $provide.value("creditCardFactory", "creditCardFactory");
   }));
 
-  var $scope, element, stripeService;
+  var $scope, element;
 
   beforeEach(inject(function($compile, $rootScope, $templateCache, $injector){
-    stripeService = $injector.get('stripeService');
-
     $templateCache.put("partials/purchase/checkout-payment-methods.html", "<p>mock</p>");
     $scope = $rootScope.$new();
 
@@ -47,153 +33,8 @@ describe("directive: payment methods", function() {
 
     expect($scope.paymentMethods).to.equal("paymentMethods");
     expect($scope.contactEmail).to.equal("contactEmail");
-
-    expect($scope.getCardDescription).to.be.a("function");
-    expect($scope.stripeElementError).to.be.a("function");
-  });
-
-  describe('initializeStripeElements:', function() {
-    beforeEach(function(done) {
-      setTimeout(function() {
-        done();
-      }, 10);
-    });
-    it('should initialize', function() {
-      stripeService.initializeStripeElements.should.have.been.calledWith([
-        'cardNumber',
-        'cardExpiry',
-        'cardCvc'
-      ], sinon.match.object);
-    });
-
-    it('should initialize elements and add them to the scope', function() {
-      expect($scope['cardNumber']).to.be.an('object');
-      expect($scope['cardExpiry']).to.be.an('object');
-      expect($scope['cardCvc']).to.be.an('object');
-    });
-
-    it('should initialize handlers', function() {
-      $scope['cardNumber'].mount.should.have.been.calledWith('#new-card-number');
-
-      $scope['cardNumber'].on.should.have.been.calledTwice;
-      $scope['cardNumber'].on.should.have.been.calledWith('blur', sinon.match.func);
-      $scope['cardNumber'].on.should.have.been.calledWith('change', sinon.match.func);
-    });
-
-    it('should $digest on blur', function() {
-      sinon.spy($scope, '$digest');
-
-      $scope['cardNumber'].on.getCall(0).args[1]();
-
-      $scope.$digest.should.have.been.called;
-    });
-
-    it('should add dirty class and $digest on change', function() {
-      var cardElement = angular.element('<div id="new-card-number"/>').appendTo('body');
-
-      sinon.spy($scope, '$digest');
-
-      $scope['cardNumber'].on.getCall(1).args[1]();
-
-      expect(cardElement[0].className).to.contain('dirty');
-      $scope.$digest.should.have.been.called;
-
-      element.remove();
-    });
-
-    it('should handle failure to get element', function() {
-      sinon.spy($scope, '$digest');
-
-      $scope['cardNumber'].on.getCall(1).args[1]();
-
-      $scope.$digest.should.have.been.called;
-    });
-
-  });
-
-  it("getCardDescription: ", function() {
-    var card = {
-      last4: "2345",
-      cardType: "Visa",
-      isDefault: false
-    };
-
-    expect($scope.getCardDescription(card)).to.equal("***-2345, Visa");
-
-    card.isDefault = true;
-
-    expect($scope.getCardDescription(card)).to.equal("***-2345, Visa (default)");
-  });
-
-  describe('stripeElementError:', function() {
-    var stripeElement;
-
-    beforeEach(function() {
-      $scope.form = {
-        paymentMethodsForm: {}
-      };
-
-      stripeElement = angular.element('<div id="stripe-element"/>').appendTo('body');
-    });
-
-    afterEach(function() {
-      stripeElement.remove();
-    });
-
-    it('should return false if element is not found', function() {
-      expect($scope.stripeElementError('blank')).to.be.false;
-    });
-
-    it('should return false for blank element', function() {
-      expect($scope.stripeElementError('stripe-element')).to.not.be.ok;
-    });
-
-    describe('form is submitted', function() {
-      beforeEach(function() {
-        $scope.form.paymentMethodsForm.$submitted = true;
-      });
-
-      it('should return false if there are no validation errors', function() {
-        expect($scope.stripeElementError('stripe-element')).to.not.be.ok;
-      });
-
-      it('should return true if the field is empty', function() {
-        stripeElement[0].classList.add('StripeElement--empty');
-
-        expect($scope.stripeElementError('stripe-element')).to.be.true;
-      });
-
-      it('should return true if the field is invalid', function() {
-        stripeElement[0].classList.add('StripeElement--invalid');
-
-        expect($scope.stripeElementError('stripe-element')).to.be.true;
-      });
-
-    });
-
-    describe('element is dirty', function() {
-      beforeEach(function() {
-        stripeElement[0].classList.add('dirty');
-      });
-
-      it('should return false if there are no validation errors', function() {
-        expect($scope.stripeElementError('stripe-element')).to.not.be.ok;
-      });
-
-      it('should return true if the field is empty', function() {
-        stripeElement[0].classList.add('StripeElement--empty');
-
-        expect($scope.stripeElementError('stripe-element')).to.be.true;
-      });
-
-      it('should return true if the field is invalid', function() {
-        stripeElement[0].classList.add('StripeElement--invalid');
-
-        expect($scope.stripeElementError('stripe-element')).to.be.true;
-      });
-
-    });
-
+    expect($scope.purchase).to.be.ok;
+    expect($scope.creditCardFactory).to.equal("creditCardFactory");
   });
 
 });

--- a/test/unit/purchase/services/svc-credit-card-factory-spec.js
+++ b/test/unit/purchase/services/svc-credit-card-factory-spec.js
@@ -1,0 +1,97 @@
+/*jshint expr:true */
+"use strict";
+
+describe("Services: credit card factory", function() {
+  beforeEach(module("risevision.apps.purchase"));
+  beforeEach(module(function ($provide) {
+    var _generateElement = function(id) {
+      return {
+        id: id,
+        mount: sinon.stub(),
+        on: sinon.stub()
+      };
+    };
+
+    $provide.value("stripeService", {
+      initializeStripeElements: sinon.stub().returns(Q.resolve([_generateElement(1), _generateElement(2), _generateElement(3)]))
+    });
+
+  }));
+
+  var $rootScope, creditCardFactory, stripeService;
+
+  beforeEach(function() {
+    inject(function($injector) {
+      $rootScope = $injector.get('$rootScope');
+      stripeService = $injector.get("stripeService");
+      creditCardFactory = $injector.get("creditCardFactory");
+    });
+  });
+
+  it("should exist", function() {
+    expect(creditCardFactory).to.be.ok;
+    expect(creditCardFactory.initElements).to.be.a("function");
+  });
+
+  describe("initElements: ", function() {
+    beforeEach(function(done) {
+      creditCardFactory.initElements();
+      setTimeout(function() {
+        done();
+      }, 10);
+    });
+
+    it('should initialize', function() {
+      stripeService.initializeStripeElements.should.have.been.calledWith([
+        'cardNumber',
+        'cardExpiry',
+        'cardCvc'
+      ], sinon.match.object);
+    });
+
+    it('should initialize elements and add them to the scope', function() {
+      expect(creditCardFactory.stripeElements['cardNumber']).to.be.an('object');
+      expect(creditCardFactory.stripeElements['cardExpiry']).to.be.an('object');
+      expect(creditCardFactory.stripeElements['cardCvc']).to.be.an('object');
+    });
+
+    it('should initialize handlers', function() {
+      creditCardFactory.stripeElements['cardNumber'].mount.should.have.been.calledWith('#new-card-number');
+
+      creditCardFactory.stripeElements['cardNumber'].on.should.have.been.calledTwice;
+      creditCardFactory.stripeElements['cardNumber'].on.should.have.been.calledWith('blur', sinon.match.func);
+      creditCardFactory.stripeElements['cardNumber'].on.should.have.been.calledWith('change', sinon.match.func);
+    });
+
+    it('should $digest on blur', function() {
+      sinon.spy($rootScope, '$digest');
+
+      creditCardFactory.stripeElements['cardNumber'].on.getCall(0).args[1]();
+
+      $rootScope.$digest.should.have.been.called;
+    });
+
+    it('should add dirty class and $digest on change', function() {
+      var cardElement = angular.element('<div id="new-card-number"/>').appendTo('body');
+
+      sinon.spy($rootScope, '$digest');
+
+      creditCardFactory.stripeElements['cardNumber'].on.getCall(1).args[1]();
+
+      expect(cardElement[0].className).to.contain('dirty');
+      $rootScope.$digest.should.have.been.called;
+
+      cardElement.remove();
+    });
+
+    it('should handle failure to get element', function() {
+      sinon.spy($rootScope, '$digest');
+
+      creditCardFactory.stripeElements['cardNumber'].on.getCall(1).args[1]();
+
+      $rootScope.$digest.should.have.been.called;
+    });
+
+  });
+
+});

--- a/web/index.html
+++ b/web/index.html
@@ -334,6 +334,7 @@
   <script src="scripts/purchase/directives/dtv-billing-address.js"></script>
   <script src="scripts/purchase/directives/dtv-checkout-success.js"></script>
   <script src="scripts/purchase/directives/dtv-payment-methods.js"></script>
+  <script src="scripts/purchase/directives/dtv-credit-card-form.js"></script>
   <script src="scripts/purchase/directives/dtv-plan-picker.js"></script>
   <script src="scripts/purchase/directives/dtv-province-validator.js"></script>
   <script src="scripts/purchase/directives/dtv-purchase-summary.js"></script>
@@ -347,6 +348,7 @@
   <script src="scripts/purchase/services/svc-address.js"></script>
   <script src="scripts/purchase/services/svc-contact.js"></script>
   <script src="scripts/purchase/services/svc-purchase-factory.js"></script>
+  <script src="scripts/purchase/services/svc-credit-card-factory.js"></script>
   <script src="scripts/purchase/services/svc-stripe-loader.js"></script>
   <script src="scripts/purchase/services/svc-stripe.js"></script>
 

--- a/web/partials/purchase/checkout-payment-methods.html
+++ b/web/partials/purchase/checkout-payment-methods.html
@@ -19,125 +19,7 @@
         </div>
       </div>
 
-      <div id="credit-card-form" ng-show="paymentMethods.paymentMethod === 'card'">
-        <!-- Alpha Release - Select New Card by default -->
-        <div class="row" ng-if="false">
-          <div class="col-md-12">
-            <div class="form-group">
-              <label for="credit-card-select" class="hidden">Add New Credit Card</label>
-              <select id="credit-card-select" class="form-control selectpicker" ng-model="paymentMethods.selectedCard" ng-options="c as getCardDescription(c) for c in paymentMethods.existingCreditCards track by c.id">
-                <option value="">Add New Credit Card</option>
-              </select>
-            </div>
-          </div>
-        </div>
-
-        <!-- NEW CREDIT CARD -->
-        <div id="new-credit-card-form" ng-show="paymentMethods.selectedCard.isNew">
-          <div class="row">
-            <div class="col-md-12">
-              <div class="form-group" ng-class="{ 'has-error': (form.paymentMethodsForm.cardholderName.$dirty || form.paymentMethodsForm.$submitted) && form.paymentMethodsForm.cardholderName.$invalid }">
-                <label for="new-card-name" class="control-label">Cardholder Name: *</label>
-                <input id="new-card-name" aria-required="true" type="text" class="form-control" name="cardholderName" data-stripe="name" ng-model="paymentMethods.newCreditCard.name" autocomplete="cc-name" required>
-                <p class="text-danger" ng-show="(form.paymentMethodsForm.cardholderName.$dirty || form.paymentMethodsForm.$submitted) && form.paymentMethodsForm.cardholderName.$invalid">
-                  Choose a Cardholder Name.
-                </p>
-              </div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-md-12">
-              <div class="form-group" ng-class="{ 'has-error': stripeElementError('new-card-number') }">
-                <label for="new-card-number" class="control-label">Card Number: *</label>
-                <div class="form-control" id="new-card-number"></div>
-                <p class="text-danger" ng-show="stripeElementError('new-card-number')">
-                  Choose a Card Number.
-                </p>
-              </div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-md-4">
-              <div class="form-group" ng-class="{ 'has-error': stripeElementError('new-card-expiry') }">
-                <label for="new-card-expiry" class="control-label">Expiration Date: *</label>
-                <div class="form-control" id="new-card-expiry"></div>
-                <p class="text-danger" ng-show="stripeElementError('new-card-expiry')">
-                  Choose an Expiration Date Month and Year.
-                </p>
-              </div>
-            </div>
-            <div class="col-md-4">
-              <div class="form-group" ng-class="{ 'has-error': stripeElementError('new-card-cvc') }">
-                <label for="new-card-cvc" class="control-label">Security Code: *</label>
-                <div class="form-control" id="new-card-cvc"></div>
-                <p class="text-danger" ng-show="stripeElementError('new-card-cvc')">
-                  Choose a Security Code.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <div class="row">
-            <div class="col-md-12">
-              <div class="form-group">
-                <label for="toggleMatchBillingAddress" class="control-label mb-0">Cardholder Billing Address: *</label>
-                <div class="flex-row">
-                  <madero-checkbox id="toggleMatchBillingAddress" ng-model="paymentMethods.newCreditCard.useBillingAddress"></madero-checkbox>
-                  <span class="mr-3">Use Company Billing Address</span>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- NEW CC ADDRESS -->
-          <div id="new-card-address">
-
-            <address-form form-object="form.paymentMethodsForm" address-object="paymentMethods.newCreditCard.address" hide-company-name="true" ng-if="!paymentMethods.newCreditCard.useBillingAddress"></address-form>
-
-          </div>
-          <!--  END NEW CC ADDRESS -->
-        </div>
-        <!-- END NEW CC -->
-
-        <!-- EXISTING CREDIT CARD -->
-        <div id="existing-credit-card-form" ng-if="!paymentMethods.selectedCard.isNew">
-          <div id="errorBox" class="alert alert-danger" role="alert" ng-show="paymentMethods.selectedCard.validationErrors.length">
-            <strong>Card Validation Error</strong> {{paymentMethods.selectedCard.validationErrors[0]}}
-          </div>
-
-          <div class="row">
-            <div class="col-md-12">
-              <div class="form-group">
-                <label for="existing-card-name" class="control-label">Cardholder Name</label>
-                <input id="existing-card-name" type="text" class="form-control" placeholder="{{paymentMethods.selectedCard.name}}" disabled="disabled">
-              </div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-md-12">
-              <div class="form-group">
-                <label for="existing-card-number" class="control-label">Card Number</label>
-                <input id="existing-card-number" type="text" class="form-control" placeholder="{{paymentMethods.selectedCard.last4 | cardLastFour}}" disabled="disabled" />
-              </div>
-            </div>
-          </div>
-          <div class="row form-group">
-            <div class="col-md-4">
-              <div class="form-group">
-                <label for="existing-card-expiry-month" class="control-label">Expiry Month</label>
-                <input id="existing-card-expiry-month" type="text" class="form-control masked"  placeholder="{{paymentMethods.selectedCard.expMonth | paddedMonth}}" disabled="disabled" />
-              </div>
-            </div>
-            <div class="col-md-4">
-              <div class="form-group">
-                <label for="existing-card-expiry-year" class="control-label">Expiry Year</label>
-                <input id="existing-card-expiry-year" type="text" class="form-control masked"  placeholder="{{paymentMethods.selectedCard.expYear}}" disabled="disabled"/>
-              </div>
-            </div>          
-          </div>
-        </div>
-        <!-- END EXISTING CC -->
-      </div>
+      <credit-card-form form-object="form.paymentMethodsForm" payment-methods-object="paymentMethods" ng-show="paymentMethods.paymentMethod === 'card'"></credit-card-form>
 
       <!-- //GENERATE INVOICE FORM -->
       <div id="generateInvoice" ng-show="paymentMethods.paymentMethod === 'invoice'">
@@ -184,7 +66,7 @@
 
 <div class="button-row text-right mt-5">
   <button id="backButton" type="button" aria-label="Go back to Billing Address" class="btn btn-default btn-toolbar pull-left" ng-click="setPreviousStep()" translate>common.back</button>
-  <button id="payButton" type="submit" class="btn btn-primary btn-toolbar-wide" form="form.paymentMethodsForm" ng-click="completeCardPayment(cardNumber)" tabindex="1" aria-label="Complete Payment" ng-if="purchase.paymentMethods.paymentMethod === 'card'">
+  <button id="payButton" type="submit" class="btn btn-primary btn-toolbar-wide" form="form.paymentMethodsForm" ng-click="completeCardPayment(creditCardFactory.stripeElements.cardNumber)" tabindex="1" aria-label="Complete Payment" ng-if="purchase.paymentMethods.paymentMethod === 'card'">
     <span id="payLabel">Pay ${{purchase.estimate.total | number:2}} Now</span>
   </button>
   <button id="invoiceButton" type="submit" class="btn btn-primary btn-toolbar-wide" form="form.paymentMethodsForm" ng-click="completePayment()" tabindex="1" aria-label="Complete Payment" ng-if="purchase.paymentMethods.paymentMethod === 'invoice'">

--- a/web/partials/purchase/credit-card-form.html
+++ b/web/partials/purchase/credit-card-form.html
@@ -1,0 +1,120 @@
+<div id="credit-card-form">
+  <!-- Alpha Release - Select New Card by default -->
+  <div class="row" ng-if="false">
+    <div class="col-md-12">
+      <div class="form-group">
+        <label for="credit-card-select" class="hidden">Add New Credit Card</label>
+        <select id="credit-card-select" class="form-control selectpicker" ng-model="paymentMethods.selectedCard" ng-options="c as getCardDescription(c) for c in paymentMethods.existingCreditCards track by c.id">
+          <option value="">Add New Credit Card</option>
+        </select>
+      </div>
+    </div>
+  </div>
+
+  <!-- NEW CREDIT CARD -->
+  <div id="new-credit-card-form" ng-show="paymentMethods.selectedCard.isNew">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="form-group" ng-class="{ 'has-error': (formObject.cardholderName.$dirty || formObject.$submitted) && formObject.cardholderName.$invalid }">
+          <label for="new-card-name" class="control-label">Cardholder Name: *</label>
+          <input id="new-card-name" aria-required="true" type="text" class="form-control" name="cardholderName" data-stripe="name" ng-model="paymentMethods.newCreditCard.name" autocomplete="cc-name" required>
+          <p class="text-danger" ng-show="(formObject.cardholderName.$dirty || formObject.$submitted) && formObject.cardholderName.$invalid">
+            Choose a Cardholder Name.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12">
+        <div class="form-group" ng-class="{ 'has-error': stripeElementError('new-card-number') }">
+          <label for="new-card-number" class="control-label">Card Number: *</label>
+          <div class="form-control" id="new-card-number"></div>
+          <p class="text-danger" ng-show="stripeElementError('new-card-number')">
+            Choose a Card Number.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-4">
+        <div class="form-group" ng-class="{ 'has-error': stripeElementError('new-card-expiry') }">
+          <label for="new-card-expiry" class="control-label">Expiration Date: *</label>
+          <div class="form-control" id="new-card-expiry"></div>
+          <p class="text-danger" ng-show="stripeElementError('new-card-expiry')">
+            Choose an Expiration Date Month and Year.
+          </p>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="form-group" ng-class="{ 'has-error': stripeElementError('new-card-cvc') }">
+          <label for="new-card-cvc" class="control-label">Security Code: *</label>
+          <div class="form-control" id="new-card-cvc"></div>
+          <p class="text-danger" ng-show="stripeElementError('new-card-cvc')">
+            Choose a Security Code.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-12">
+        <div class="form-group">
+          <label for="toggleMatchBillingAddress" class="control-label mb-0">Cardholder Billing Address: *</label>
+          <div class="flex-row">
+            <madero-checkbox id="toggleMatchBillingAddress" ng-model="paymentMethods.newCreditCard.useBillingAddress"></madero-checkbox>
+            <span class="mr-3">Use Company Billing Address</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- NEW CC ADDRESS -->
+    <div id="new-card-address">
+
+      <address-form form-object="formObject" address-object="paymentMethods.newCreditCard.address" hide-company-name="true" ng-if="!paymentMethods.newCreditCard.useBillingAddress"></address-form>
+
+    </div>
+    <!--  END NEW CC ADDRESS -->
+  </div>
+  <!-- END NEW CC -->
+
+  <!-- EXISTING CREDIT CARD -->
+  <div id="existing-credit-card-form" ng-if="!paymentMethods.selectedCard.isNew">
+    <div id="errorBox" class="alert alert-danger" role="alert" ng-show="paymentMethods.selectedCard.validationErrors.length">
+      <strong>Card Validation Error</strong> {{paymentMethods.selectedCard.validationErrors[0]}}
+    </div>
+
+    <div class="row">
+      <div class="col-md-12">
+        <div class="form-group">
+          <label for="existing-card-name" class="control-label">Cardholder Name</label>
+          <input id="existing-card-name" type="text" class="form-control" placeholder="{{paymentMethods.selectedCard.name}}" disabled="disabled">
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12">
+        <div class="form-group">
+          <label for="existing-card-number" class="control-label">Card Number</label>
+          <input id="existing-card-number" type="text" class="form-control" placeholder="{{paymentMethods.selectedCard.last4 | cardLastFour}}" disabled="disabled" />
+        </div>
+      </div>
+    </div>
+    <div class="row form-group">
+      <div class="col-md-4">
+        <div class="form-group">
+          <label for="existing-card-expiry-month" class="control-label">Expiry Month</label>
+          <input id="existing-card-expiry-month" type="text" class="form-control masked"  placeholder="{{paymentMethods.selectedCard.expMonth | paddedMonth}}" disabled="disabled" />
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="form-group">
+          <label for="existing-card-expiry-year" class="control-label">Expiry Year</label>
+          <input id="existing-card-expiry-year" type="text" class="form-control masked"  placeholder="{{paymentMethods.selectedCard.expYear}}" disabled="disabled"/>
+        </div>
+      </div>          
+    </div>
+  </div>
+  <!-- END EXISTING CC -->
+  
+</div>

--- a/web/scripts/purchase/directives/dtv-credit-card-form.js
+++ b/web/scripts/purchase/directives/dtv-credit-card-form.js
@@ -1,0 +1,34 @@
+'use strict';
+
+angular.module('risevision.apps.purchase')
+  .directive('creditCardForm', ['$templateCache', 'creditCardFactory',
+    function ($templateCache, creditCardFactory) {
+      return {
+        restrict: 'E',
+        scope: {
+          paymentMethods: '=paymentMethodsObject',
+          formObject: '='
+        },
+        template: $templateCache.get('partials/purchase/credit-card-form.html'),
+        link: function ($scope) {
+          creditCardFactory.initElements();
+
+          $scope.getCardDescription = function (card) {
+            return '***-' + card.last4 + ', ' + card.cardType + (card.isDefault ? ' (default)' : '');
+          };
+
+          $scope.stripeElementError = function (elementId) {
+            var element = document.getElementById(elementId);
+
+            if (!element) {
+              return false;
+            } else if ($scope.formObject.$submitted || element.className.indexOf('dirty') !== -1) {
+              return element.className.indexOf('StripeElement--invalid') !== -1 ||
+                element.className.indexOf('StripeElement--empty') !== -1;
+            }
+          };
+
+        }
+      };
+    }
+  ]);

--- a/web/scripts/purchase/directives/dtv-payment-methods.js
+++ b/web/scripts/purchase/directives/dtv-payment-methods.js
@@ -1,87 +1,17 @@
 'use strict';
 
 angular.module('risevision.apps.purchase')
-  .directive('paymentMethods', ['$templateCache', 'purchaseFactory', 'stripeService',
-    function ($templateCache, purchaseFactory, stripeService) {
+  .directive('paymentMethods', ['$templateCache', 'purchaseFactory', 'creditCardFactory',
+    function ($templateCache, purchaseFactory, creditCardFactory) {
       return {
         restrict: 'E',
         template: $templateCache.get('partials/purchase/checkout-payment-methods.html'),
         link: function ($scope) {
-          var elementOptions = {
-            style: {
-              base: {
-                backgroundColor: '#FFF',
-                color: '#020620',
-                fontFamily: 'Helvetica,Arial,sans-serif',
-                fontSize: '14px',
-                fontSmoothing: 'antialiased',
-                fontWeight: 400,
-                iconColor: '#020620',
-                '::placeholder': {
-                  color: '#777',
-                },
-              },
-              invalid: {
-                iconColor: '#020620',
-                color: '#020620',
-              }
-            },
-          };
-
-          var stripeElements = [
-            'cardNumber',
-            'cardExpiry',
-            'cardCvc'
-          ];
-
-          var stripeElementSelectors = [
-            '#new-card-number',
-            '#new-card-expiry',
-            '#new-card-cvc'
-          ];
-
           $scope.paymentMethods = purchaseFactory.purchase.paymentMethods;
           $scope.contactEmail = purchaseFactory.purchase.contact.email;
 
           $scope.purchase = purchaseFactory.purchase;
-
-          stripeService.initializeStripeElements(stripeElements, elementOptions)
-            .then(function (elements) {
-              elements.forEach(function (el, idx) {
-                $scope[stripeElements[idx]] = el;
-                el.mount(stripeElementSelectors[idx]);
-
-                el.on('blur', function () {
-                  $scope.$digest();
-                });
-
-                el.on('change', function (event) {
-                  var element = document.querySelector(stripeElementSelectors[idx]);
-
-                  if (element) {
-                    element.classList.add('dirty');
-                  }
-
-                  $scope.$digest();
-                });
-              });
-            });
-
-          $scope.getCardDescription = function (card) {
-            return '***-' + card.last4 + ', ' + card.cardType + (card.isDefault ? ' (default)' : '');
-          };
-
-          $scope.stripeElementError = function (elementId) {
-            var element = document.getElementById(elementId);
-
-            if (!element) {
-              return false;
-            } else if ($scope.form.paymentMethodsForm.$submitted || element.className.indexOf('dirty') !== -1) {
-              return element.className.indexOf('StripeElement--invalid') !== -1 ||
-                element.className.indexOf('StripeElement--empty') !== -1;
-            }
-          };
-
+          $scope.creditCardFactory = creditCardFactory;
         }
       };
     }

--- a/web/scripts/purchase/services/svc-credit-card-factory.js
+++ b/web/scripts/purchase/services/svc-credit-card-factory.js
@@ -1,0 +1,73 @@
+(function (angular) {
+
+  'use strict';
+
+  angular.module('risevision.apps.purchase')
+    .factory('creditCardFactory', ['$rootScope', 'stripeService',
+      function ($rootScope, stripeService) {
+        var factory = {
+          stripeElements: {}
+        };
+
+        var elementOptions = {
+          style: {
+            base: {
+              backgroundColor: '#FFF',
+              color: '#020620',
+              fontFamily: 'Helvetica,Arial,sans-serif',
+              fontSize: '14px',
+              fontSmoothing: 'antialiased',
+              fontWeight: 400,
+              iconColor: '#020620',
+              '::placeholder': {
+                color: '#777',
+              },
+            },
+            invalid: {
+              iconColor: '#020620',
+              color: '#020620',
+            }
+          },
+        };
+
+        var stripeElements = [
+          'cardNumber',
+          'cardExpiry',
+          'cardCvc'
+        ];
+
+        var stripeElementSelectors = [
+          '#new-card-number',
+          '#new-card-expiry',
+          '#new-card-cvc'
+        ];
+
+        factory.initElements = function() {
+          stripeService.initializeStripeElements(stripeElements, elementOptions)
+            .then(function (elements) {
+              elements.forEach(function (el, idx) {
+                factory.stripeElements[stripeElements[idx]] = el;
+                el.mount(stripeElementSelectors[idx]);
+
+                el.on('blur', function () {
+                  $rootScope.$digest();
+                });
+
+                el.on('change', function (event) {
+                  var element = document.querySelector(stripeElementSelectors[idx]);
+
+                  if (element) {
+                    element.classList.add('dirty');
+                  }
+
+                  $rootScope.$digest();
+                });
+              });
+            });  
+        };
+
+        return factory;
+      }
+    ]);
+
+})(angular);


### PR DESCRIPTION
## Description
Create separate credit-card-form directive

Directive will be re-used for paying invoices

Created separate factory for the stripe elements
Factory needed to prevent scope issues with the
element references

[stage-18]

## Motivation and Context
In preparation for allowing users to pay an invoice with their CC.

## How Has This Been Tested?
Tested changes locally with the current purchase flow and various scenarios. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No