### PR TITLE
Load legacy preview over HTTPS

### DIFF
--- a/test/e2e/editor/cases/shared-templates.js
+++ b/test/e2e/editor/cases/shared-templates.js
@@ -74,7 +74,7 @@ var SharedTemplatesScenarios = function() {
         oldWindowHandle = handles[0];
         newWindowHandle = handles[1];
         browser.switchTo().window(newWindowHandle).then(function () {
-          expect(browser.driver.getCurrentUrl()).to.eventually.contain('http://viewer-test.risevision.com/?type=presentation&id=ebbb1b89-166e-41fb-9adb-d0052132b0df');
+          expect(browser.driver.getCurrentUrl()).to.eventually.contain('https://viewer-test.risevision.com/?type=presentation&id=ebbb1b89-166e-41fb-9adb-d0052132b0df');
 
           browser.driver.close();
           browser.switchTo().window(oldWindowHandle);

--- a/web/scripts/config/beta.js
+++ b/web/scripts/config/beta.js
@@ -23,7 +23,7 @@
     .value('STORE_ENDPOINT_URL',
       'https://store-dot-rvaserver2.appspot.com/_ah/api')
     .value('RVA_URL', 'http://rva.risevision.com')
-    .value('VIEWER_URL', 'http://preview.risevision.com')
+    .value('VIEWER_URL', 'https://preview.risevision.com')
     .value('SHARED_SCHEDULE_URL', 'https://preview.risevision.com/?type=sharedschedule&id=SCHEDULE_ID')
     .value('ALERTS_WS_URL',
       'https://rvaserver2.appspot.com/alerts/cap')

--- a/web/scripts/config/dev.js
+++ b/web/scripts/config/dev.js
@@ -31,7 +31,7 @@
       'https://store-dot-rvacore-test.appspot.com/_ah/api') // override default Store server value
     .value('STORE_SERVER_URL', 'https://store-dot-rvacore-test.appspot.com/')
     .value('RVA_URL', 'http://rva-test.appspot.com')
-    .value('VIEWER_URL', 'http://viewer-test.risevision.com')
+    .value('VIEWER_URL', 'https://viewer-test.risevision.com')
     .value('SHARED_SCHEDULE_URL', 'https://viewer-test.risevision.com/?type=sharedschedule&id=SCHEDULE_ID')
     .value('ALERTS_WS_URL',
       'https://rvacore-test.appspot.com/alerts/cap')

--- a/web/scripts/config/prod.js
+++ b/web/scripts/config/prod.js
@@ -23,7 +23,7 @@
     .value('STORE_ENDPOINT_URL',
       'https://store-dot-rvaserver2.appspot.com/_ah/api')
     .value('RVA_URL', 'http://rva.risevision.com')
-    .value('VIEWER_URL', 'http://preview.risevision.com')
+    .value('VIEWER_URL', 'https://preview.risevision.com')
     .value('SHARED_SCHEDULE_URL', 'https://preview.risevision.com/?type=sharedschedule&id=SCHEDULE_ID')
     .value('ALERTS_WS_URL',
       'https://rvaserver2.appspot.com/alerts/cap')

--- a/web/scripts/config/stage.js
+++ b/web/scripts/config/stage.js
@@ -30,7 +30,7 @@
       'https://store-dot-rvacore-test.appspot.com/_ah/api') // override default Store server value
     .value('STORE_SERVER_URL', 'https://store-dot-rvacore-test.appspot.com/')
     .value('RVA_URL', 'http://rva-test.appspot.com')
-    .value('VIEWER_URL', 'http://viewer-test.risevision.com')
+    .value('VIEWER_URL', 'https://viewer-test.risevision.com')
     .value('SHARED_SCHEDULE_URL', 'https://viewer-test.risevision.com/?type=sharedschedule&id=SCHEDULE_ID')
     .value('ALERTS_WS_URL',
       'https://rvacore-test.appspot.com/alerts/cap')

--- a/web/scripts/config/test.js
+++ b/web/scripts/config/test.js
@@ -31,7 +31,7 @@
       'https://store-dot-rvacore-test.appspot.com/_ah/api') // override default Store server value
     .value('STORE_SERVER_URL', 'https://store-dot-rvacore-test.appspot.com/')
     .value('RVA_URL', 'http://rva-test.appspot.com')
-    .value('VIEWER_URL', 'http://viewer-test.risevision.com')
+    .value('VIEWER_URL', 'https://viewer-test.risevision.com')
     .value('SHARED_SCHEDULE_URL', 'https://viewer-test.risevision.com/?type=sharedschedule&id=SCHEDULE_ID')
     .value('ALERTS_WS_URL',
       'https://rvacore-test.appspot.com/alerts/cap')


### PR DESCRIPTION
## Description
Load legacy preview over HTTPS

## Motivation and Context
We are moving all content to HTTPS in order to implement caching using service workers

## How Has This Been Tested?
Tested visually on stage-3

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
