### PR TITLE
Close Share Schedule & Selector modals when clicking outside

### DIFF
--- a/test/e2e/schedules/pages/scheduleAddPage.js
+++ b/test/e2e/schedules/pages/scheduleAddPage.js
@@ -21,7 +21,7 @@ var ScheduleAddPage = function() {
 
   var playlistItems = element.all(by.repeater('playlistItem in playlistItems'));
 
-  var shareScheduleButton = element(by.id('tooltipButton'));
+  var shareScheduleButton = element(by.id('share-schedule-button'));
 
   var saveButton = element(by.id('saveButton'));
   var cancelButton = element(by.id('cancelButton'));

--- a/test/unit/common/services/svc-outside-click-handler.tests.js
+++ b/test/unit/common/services/svc-outside-click-handler.tests.js
@@ -1,0 +1,72 @@
+'use strict';
+
+describe('service: outside click handler:', function() {
+  beforeEach(module('risevision.apps.services'));
+
+  var outsideClickHandler, $document, $timeout;
+  beforeEach(function() {
+    inject(function($injector) {
+      outsideClickHandler = $injector.get('outsideClickHandler');
+      $document = $injector.get('$document');
+      $timeout = $injector.get('$timeout');
+
+      sinon.spy($document,'bind');
+      sinon.spy($document,'unbind');
+    });
+  });
+
+  it('should exist', function() {
+    expect(outsideClickHandler).to.be.ok;
+    expect(outsideClickHandler.bind).to.be.a('function');
+    expect(outsideClickHandler.unbind).to.be.a('function');
+  });
+
+  describe('bind', function() {
+    it('should bind to click and touch start', function() {
+      var callback = sinon.stub();
+      var bindId = 'bindId';
+      outsideClickHandler.bind(bindId, 'body', callback);
+
+      $document.bind.should.have.been.calledWith('click.'+bindId+' touchstart.'+bindId, sinon.match.func);
+    });
+
+    it('should call callback when clicking outside', function() {
+      var callback = sinon.stub();
+      outsideClickHandler.bind('bindId', 'body', callback);
+
+      //click outside
+      $document.trigger('click');
+
+      $timeout.flush();
+
+      callback.should.have.been.called;
+    });
+
+    it('should not call callback when clicking inside', function() {
+      var parentElement = angular.element('<div id="parent"><div id="child"></div></div>');
+      parentElement.appendTo(document.body);
+
+      var callback = sinon.stub();
+      outsideClickHandler.bind('bindId', 'html', callback);
+
+      //click inside element
+      var event = new CustomEvent('click');
+      var target = angular.element('#child');
+      target.trigger('click');
+      
+      $timeout.flush();
+
+      callback.should.not.have.been.called;
+    });
+  });
+
+  describe('unbind', function() {
+    it('should unbind from click and touch start', function() {
+      var callback = sinon.stub();
+      var bindId = 'bindId';
+      outsideClickHandler.unbind(bindId);
+
+      $document.unbind.should.have.been.calledWith('click.'+bindId+' touchstart.'+bindId);
+    });
+  });
+});

--- a/test/unit/schedules/directives/dtv-schedule-selector.tests.js
+++ b/test/unit/schedules/directives/dtv-schedule-selector.tests.js
@@ -23,7 +23,7 @@ describe('directive: schedule-selector', function() {
   }));
 
   beforeEach(inject(function($compile, $templateCache, $injector){
-    $templateCache.put('partials/schedules/schedule-selector.html', '<div id="tooltipButton"></div>');
+    $templateCache.put('partials/schedules/schedule-selector.html', '<div id="share-schedule-button"></div>');
     $rootScope = $injector.get('$rootScope');
     $timeout = $injector.get('$timeout');
     $loading = $injector.get('$loading');
@@ -36,7 +36,7 @@ describe('directive: schedule-selector', function() {
 
     $scope = $rootScope.$new();
 
-    element = $compile('<schedule-selector show-tooltip="showTooltip"></schedule-selector>')($scope);
+    element = $compile('<schedule-selector show-tooltip="share-schedule-button"></schedule-selector>')($scope);
 
     $rootScope.$digest();
     $scope = element.isolateScope();   

--- a/test/unit/schedules/directives/dtv-share-schedule-button.tests.js
+++ b/test/unit/schedules/directives/dtv-share-schedule-button.tests.js
@@ -1,6 +1,6 @@
 'use strict';
 describe('directive: share-schedule-button', function() {
-  var $scope, $rootScope, element, $timeout, innerElementStub, currentPlanFactory, plansFactory,
+  var $scope, $rootScope, element, $timeout, innerElementStub, currentPlanFactory, plansFactory, outsideClickHandler,
     sandbox = sinon.sandbox.create();
 
 
@@ -16,6 +16,12 @@ describe('directive: share-schedule-button', function() {
         showUnlockThisFeatureModal: sinon.stub()
       };
     });
+    $provide.service('outsideClickHandler', function() {
+      return {
+        bind: sinon.stub(),
+        unbind: sinon.stub()
+      };
+    });
   }));
 
   beforeEach(inject(function($compile, $templateCache, $injector){
@@ -24,6 +30,7 @@ describe('directive: share-schedule-button', function() {
     $timeout = $injector.get('$timeout');
     currentPlanFactory = $injector.get('currentPlanFactory');
     plansFactory = $injector.get('plansFactory');
+    outsideClickHandler = $injector.get('outsideClickHandler');
 
     innerElementStub = {
       trigger: sandbox.stub(),
@@ -61,14 +68,15 @@ describe('directive: share-schedule-button', function() {
   });
 
   describe('toggleTooltip:', function() {
-    it('should open tooltip', function() {
+    it('should open tooltip and register outsideClickHandler', function() {
       $scope.toggleTooltip();
       $timeout.flush();
 
       innerElementStub.trigger.should.have.been.calledWith('show');
+      outsideClickHandler.bind.should.have.been.calledWith('share-schedule', '#share-schedule-button, #share-schedule-popover', $scope.toggleTooltip);
     });
 
-    it('should close tooltip if open', function() {
+    it('should close tooltip if open and unregister outsideClickHandler', function() {
       //open
       $scope.toggleTooltip();
       $timeout.flush();
@@ -79,6 +87,7 @@ describe('directive: share-schedule-button', function() {
       $timeout.flush();
 
       innerElementStub.trigger.should.have.been.calledWith('hide');
+      outsideClickHandler.unbind.should.have.been.called;
     });
 
     it('should show Unlock This Feature modal if user is not subscribed to a plan', function() {

--- a/test/unit/schedules/directives/dtv-share-schedule-button.tests.js
+++ b/test/unit/schedules/directives/dtv-share-schedule-button.tests.js
@@ -19,7 +19,7 @@ describe('directive: share-schedule-button', function() {
   }));
 
   beforeEach(inject(function($compile, $templateCache, $injector){
-    $templateCache.put('partials/schedules/share-schedule-button.html', '<div id="tooltipButton"></div><div id="actionSheetButton"></div>');
+    $templateCache.put('partials/schedules/share-schedule-button.html', '<div id="share-schedule-button"></div><div id="actionSheetButton"></div>');
     $rootScope = $injector.get('$rootScope');
     $timeout = $injector.get('$timeout');
     currentPlanFactory = $injector.get('currentPlanFactory');
@@ -57,7 +57,7 @@ describe('directive: share-schedule-button', function() {
   });
 
   it('should compile', function() {
-    expect(element[0].outerHTML).to.equal('<share-schedule-button schedule="selectedSchedule" class="ng-scope ng-isolate-scope"><div id="tooltipButton"></div><div id="actionSheetButton"></div></share-schedule-button>');
+    expect(element[0].outerHTML).to.equal('<share-schedule-button schedule="selectedSchedule" class="ng-scope ng-isolate-scope"><div id="share-schedule-button"></div><div id="actionSheetButton"></div></share-schedule-button>');
   });
 
   describe('toggleTooltip:', function() {

--- a/test/unit/template-editor/components/directives/dtv-component-schedules.tests.js
+++ b/test/unit/template-editor/components/directives/dtv-component-schedules.tests.js
@@ -64,7 +64,6 @@ describe('directive: templateComponentSchedules', function() {
     expect(directive).to.be.ok;
     expect(directive.type).to.equal('rise-schedules');
     expect(directive.show).to.be.a('function');
-    expect(directive.onBackHandler).to.be.a('function');
   });
 
   it('directive.show: ', function() {
@@ -73,16 +72,6 @@ describe('directive: templateComponentSchedules', function() {
     directive.show();
 
     $scope.setPanelTitle.should.have.been.calledWith('Schedules');
-  });
-
-  it('directive.onBackHandler: ', function() {
-    var directive = $scope.registerDirective.getCall(0).args[0];
-
-    $scope.showTooltip = true;
-
-    directive.onBackHandler();
-
-    expect($scope.showTooltip).to.be.false;
   });
 
   describe('watch loadingSchedules:', function() {

--- a/web/index.html
+++ b/web/index.html
@@ -312,6 +312,7 @@
   <script src="scripts/common/services/svc-gadgets-api.js"></script>
   <script src="scripts/common/services/svc-resource-loader.js"></script>
   <script src="scripts/common/services/svc-company-assets-factory.js"></script>
+  <script src="scripts/common/services/svc-outside-click-handler.js"></script>
 
   <!-- billing -->
   <script src="scripts/billing/app.js"></script>

--- a/web/partials/schedules/share-schedule-button.html
+++ b/web/partials/schedules/share-schedule-button.html
@@ -1,4 +1,4 @@
-<button id="tooltipButton" type="button" class="btn {{buttonClass}} hidden-xs" 
+<button id="share-schedule-button" type="button" class="btn {{buttonClass}} hidden-xs" 
   tooltip-placement="bottom"
   tooltip-class="madero-style tooltip-share-options"
   tooltip-trigger="show"

--- a/web/partials/schedules/share-schedule-popover.html
+++ b/web/partials/schedules/share-schedule-popover.html
@@ -1,4 +1,4 @@
-<div id="shareSchedulePopover" ng-controller="SharedSchedulePopoverController" class="share-schedule-popover">
+<div id="share-schedule-popover" ng-controller="SharedSchedulePopoverController" class="share-schedule-popover">
   <div class="row">
     <div class="col-xs-12">
       <button type="button" class="close" ng-click="dismiss()" aria-hidden="true">

--- a/web/partials/template-editor/components/component-schedules.html
+++ b/web/partials/template-editor/components/component-schedules.html
@@ -2,7 +2,7 @@
   <div class="attribute-editor-row">
     <label class="text-sm mb-3">Which schedule(s) should this presentation show on?</label>
 
-    <schedule-selector show-tooltip="showTooltip"></schedule-selector>
+    <schedule-selector></schedule-selector>
 
   </div>
 </div>

--- a/web/scripts/common/services/svc-outside-click-handler.js
+++ b/web/scripts/common/services/svc-outside-click-handler.js
@@ -1,0 +1,31 @@
+'use strict';
+
+angular.module('risevision.apps.services')
+  .factory('outsideClickHandler', ['$document', '$timeout',
+    function ($document, $timeout) {
+      var factory = {};
+
+      factory.bind = function(bindId, elementsWhitelist, callback) {
+        $document.bind('click.' + bindId + ' touchstart.' + bindId, 
+          function(event) {
+            var elements = angular.element(elementsWhitelist);
+
+            for(var i=0; i<elements.length; i++) {
+              if (elements[i].contains(event.target)) {
+                return;
+              }
+            }
+            
+            $timeout(function () {
+              callback();
+            });
+        });
+      };
+
+      factory.unbind = function(bindId) {
+        $document.unbind('click.' + bindId + ' touchstart.' + bindId);
+      };
+
+      return factory;
+    }
+  ]);

--- a/web/scripts/schedules/directives/dtv-preview-selector.js
+++ b/web/scripts/schedules/directives/dtv-preview-selector.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.schedules.directives')
-  .directive('previewSelector', ['$timeout', '$loading', 'ScrollingListService', 'schedule', '$document',
-    function ($timeout, $loading, ScrollingListService, schedule, $document) {
+  .directive('previewSelector', ['$timeout', '$loading', 'ScrollingListService', 'schedule', 'outsideClickHandler',
+    function ($timeout, $loading, ScrollingListService, schedule, outsideClickHandler) {
       return {
         restrict: 'E',
         templateUrl: 'partials/schedules/preview-selector.html',
@@ -36,31 +36,18 @@ angular.module('risevision.schedules.directives')
             }
           });
 
-          var _closeTooltip = function (event) {
-            var tooltipContent = angular.element('#preview-selector-tooltip');
-            if (tooltipContent && tooltipContent[0] && tooltipContent[0].contains(event.target) ||
-              tooltipElement && tooltipElement[0] && tooltipElement[0].contains(event.target)) {
-              return;
-            }
-            $timeout(function () {
-              $scope.toggleTooltip();
-            });
-          };
-
           $scope.$watch('showTooltip', function () {
             if ($scope.showTooltip) {
               $scope.schedules = new ScrollingListService(schedule.list, $scope.search);
               selected = $scope.ngModel;
 
               $timeout(function () {
-                $document.bind('click', _closeTooltip);
-                $document.bind('touchstart', _closeTooltip);
+                outsideClickHandler.bind('preview-selector', '#preview-selector, #preview-selector-tooltip', $scope.toggleTooltip);
                 tooltipElement.trigger('show');
               });
             } else {
               $timeout(function () {
-                $document.unbind('click', _closeTooltip);
-                $document.unbind('touchstart', _closeTooltip);
+                outsideClickHandler.unbind('preview-selector');                
                 tooltipElement.trigger('hide');
               });
             }

--- a/web/scripts/schedules/directives/dtv-schedule-selector.js
+++ b/web/scripts/schedules/directives/dtv-schedule-selector.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.schedules.directives')
-  .directive('scheduleSelector', ['scheduleSelectorFactory', '$timeout', '$loading',
-    function (scheduleSelectorFactory, $timeout, $loading) {
+  .directive('scheduleSelector', ['scheduleSelectorFactory', '$timeout', '$loading', 'outsideClickHandler',
+    function (scheduleSelectorFactory, $timeout, $loading, outsideClickHandler) {
       return {
         restrict: 'E',
         templateUrl: 'partials/schedules/schedule-selector.html',
@@ -32,12 +32,14 @@ angular.module('risevision.schedules.directives')
           $scope.$watch('showTooltip', function () {
             if ($scope.showTooltip) {
               $timeout(function () {
+                outsideClickHandler.bind('schedule-selector', '#schedule-selector, #schedule-selector-tooltip', $scope.toggleTooltip);
                 tooltipElement.trigger('show');
 
                 $scope.factory.load();
               });
             } else {
               $timeout(function () {
+                outsideClickHandler.unbind('schedule-selector');
                 tooltipElement.trigger('hide');
               });
             }

--- a/web/scripts/schedules/directives/dtv-share-schedule-button.js
+++ b/web/scripts/schedules/directives/dtv-share-schedule-button.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.schedules.directives')
-  .directive('shareScheduleButton', ['$timeout', 'currentPlanFactory', 'plansFactory', '$window',
-    function ($timeout, currentPlanFactory, plansFactory, $window) {
+  .directive('shareScheduleButton', ['$timeout', 'currentPlanFactory', 'plansFactory', '$window', 'outsideClickHandler',
+    function ($timeout, currentPlanFactory, plansFactory, $window, outsideClickHandler) {
       return {
         restrict: 'E',
         templateUrl: 'partials/schedules/share-schedule-button.html',
@@ -12,7 +12,7 @@ angular.module('risevision.schedules.directives')
         },
         link: function ($scope, element) {
           var isTooltipOpen = false;
-          var tooltipButton = angular.element(element[0].querySelector('#tooltipButton'));
+          var tooltipButton = angular.element(element[0].querySelector('#share-schedule-button'));
 
           var isActionSheetOpen = false;
           var actionSheetButton = angular.element(element[0].querySelector('#actionSheetButton'));
@@ -21,6 +21,7 @@ angular.module('risevision.schedules.directives')
             $timeout(function () {
               if (isTooltipOpen) {
                 isTooltipOpen = false;
+                outsideClickHandler.unbind('share-schedule');
                 tooltipButton.trigger('hide');
               }
 
@@ -37,9 +38,11 @@ angular.module('risevision.schedules.directives')
             $timeout(function () {
               if (isTooltipOpen) {
                 isTooltipOpen = false;
+                outsideClickHandler.unbind('share-schedule');
                 tooltipButton.trigger('hide');
               } else {
                 isTooltipOpen = true;
+                outsideClickHandler.bind('share-schedule', '#share-schedule-button, #share-schedule-popover', $scope.toggleTooltip);
                 tooltipButton.trigger('show');
               }
             });

--- a/web/scripts/template-editor/components/directives/dtv-component-schedules.js
+++ b/web/scripts/template-editor/components/directives/dtv-component-schedules.js
@@ -23,9 +23,6 @@ angular.module('risevision.template-editor.directives')
             element: element,
             show: function () {
               $scope.setPanelTitle('Schedules');
-            },
-            onBackHandler: function () {
-              $scope.showTooltip = false;
             }
           });
 


### PR DESCRIPTION
## Description
Close Share Schedule & Selector modals when clicking outside.

Used a new factory `outsideClickHandler` to handle the logic
Removed onBackHandler on schedule-component as no longer needed given the modal is automatically dismissed now

## Motivation and Context
Fix for https://github.com/Rise-Vision/rise-vision-apps/issues/2229

## How Has This Been Tested?
Validated all impacted modals locally and on [stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
