### PR TITLE
Separate paymentMethods code from purchaseFactory

### DIFF
--- a/test/unit/purchase/directives/dtv-credit-card-form-spec.js
+++ b/test/unit/purchase/directives/dtv-credit-card-form-spec.js
@@ -13,7 +13,7 @@ describe("directive: credit card form", function() {
     }; 
 
     $provide.value("creditCardFactory", {
-      initElements: sinon.stub()
+      initStripeElements: sinon.stub()
     });
 
   }));
@@ -27,11 +27,8 @@ describe("directive: credit card form", function() {
     $rootScope.form = {
       creditCardForm: {}
     };
-    $rootScope.paymentMethods = {
-      stripeElements: {}
-    };
 
-    element = $compile("<credit-card-form form-object=\"form.creditCardForm\" payment-methods-object=\"paymentMethods\"></credit-card-form>")($rootScope);
+    element = $compile("<credit-card-form form-object=\"form.creditCardForm\"></credit-card-form>")($rootScope);
 
     $scope = element.isolateScope();
   }));
@@ -43,15 +40,15 @@ describe("directive: credit card form", function() {
   it("should initialize scope", function() {
     expect($scope).to.be.an("object");
 
-    expect($scope.paymentMethods).to.be.an('object');
+    expect($scope.factory).to.be.an('object');
     expect($scope.formObject).to.be.an('object');
 
     expect($scope.getCardDescription).to.be.a("function");
     expect($scope.stripeElementError).to.be.a("function");
   });
 
-  it('initElements', function() {
-    creditCardFactory.initElements.should.have.been.called;
+  it('initStripeElements', function() {
+    creditCardFactory.initStripeElements.should.have.been.called;
   });
 
   it("getCardDescription: ", function() {

--- a/test/unit/purchase/directives/dtv-payment-methods-spec.js
+++ b/test/unit/purchase/directives/dtv-payment-methods-spec.js
@@ -6,13 +6,14 @@ describe("directive: payment methods", function() {
   beforeEach(module(function ($provide) {
     $provide.value("purchaseFactory", {
       purchase: {
-        paymentMethods: "paymentMethods",
         contact: {
           email: "contactEmail"
         }
       }
     });
-    $provide.value("creditCardFactory", "creditCardFactory");
+    $provide.value("creditCardFactory", {
+      paymentMethods: "paymentMethods"
+    });
   }));
 
   var $scope, element;
@@ -34,7 +35,6 @@ describe("directive: payment methods", function() {
     expect($scope.paymentMethods).to.equal("paymentMethods");
     expect($scope.contactEmail).to.equal("contactEmail");
     expect($scope.purchase).to.be.ok;
-    expect($scope.creditCardFactory).to.equal("creditCardFactory");
   });
 
 });

--- a/web/partials/purchase/checkout-payment-methods.html
+++ b/web/partials/purchase/checkout-payment-methods.html
@@ -19,7 +19,7 @@
         </div>
       </div>
 
-      <credit-card-form form-object="form.paymentMethodsForm" payment-methods-object="paymentMethods" ng-show="paymentMethods.paymentMethod === 'card'"></credit-card-form>
+      <credit-card-form form-object="form.paymentMethodsForm" ng-show="paymentMethods.paymentMethod === 'card'"></credit-card-form>
 
       <!-- //GENERATE INVOICE FORM -->
       <div id="generateInvoice" ng-show="paymentMethods.paymentMethod === 'invoice'">
@@ -66,10 +66,10 @@
 
 <div class="button-row text-right mt-5">
   <button id="backButton" type="button" aria-label="Go back to Billing Address" class="btn btn-default btn-toolbar pull-left" ng-click="setPreviousStep()" translate>common.back</button>
-  <button id="payButton" type="submit" class="btn btn-primary btn-toolbar-wide" form="form.paymentMethodsForm" ng-click="completeCardPayment(creditCardFactory.stripeElements.cardNumber)" tabindex="1" aria-label="Complete Payment" ng-if="purchase.paymentMethods.paymentMethod === 'card'">
+  <button id="payButton" type="submit" class="btn btn-primary btn-toolbar-wide" form="form.paymentMethodsForm" ng-click="completeCardPayment()" tabindex="1" aria-label="Complete Payment" ng-if="paymentMethods.paymentMethod === 'card'">
     <span id="payLabel">Pay ${{purchase.estimate.total | number:2}} Now</span>
   </button>
-  <button id="invoiceButton" type="submit" class="btn btn-primary btn-toolbar-wide" form="form.paymentMethodsForm" ng-click="completePayment()" tabindex="1" aria-label="Complete Payment" ng-if="purchase.paymentMethods.paymentMethod === 'invoice'">
+  <button id="invoiceButton" type="submit" class="btn btn-primary btn-toolbar-wide" form="form.paymentMethodsForm" ng-click="completePayment()" tabindex="1" aria-label="Complete Payment" ng-if="paymentMethods.paymentMethod === 'invoice'">
     <span id="invoiceLabel">Invoice Me ${{purchase.estimate.total | number:2}} Now</span>
   </button>
 </div>

--- a/web/partials/purchase/credit-card-form.html
+++ b/web/partials/purchase/credit-card-form.html
@@ -4,7 +4,7 @@
     <div class="col-md-12">
       <div class="form-group">
         <label for="credit-card-select" class="hidden">Add New Credit Card</label>
-        <select id="credit-card-select" class="form-control selectpicker" ng-model="paymentMethods.selectedCard" ng-options="c as getCardDescription(c) for c in paymentMethods.existingCreditCards track by c.id">
+        <select id="credit-card-select" class="form-control selectpicker" ng-model="factory.paymentMethods.selectedCard" ng-options="c as getCardDescription(c) for c in factory.paymentMethods.existingCreditCards track by c.id">
           <option value="">Add New Credit Card</option>
         </select>
       </div>
@@ -12,12 +12,12 @@
   </div>
 
   <!-- NEW CREDIT CARD -->
-  <div id="new-credit-card-form" ng-show="paymentMethods.selectedCard.isNew">
+  <div id="new-credit-card-form" ng-show="factory.paymentMethods.selectedCard.isNew">
     <div class="row">
       <div class="col-md-12">
         <div class="form-group" ng-class="{ 'has-error': (formObject.cardholderName.$dirty || formObject.$submitted) && formObject.cardholderName.$invalid }">
           <label for="new-card-name" class="control-label">Cardholder Name: *</label>
-          <input id="new-card-name" aria-required="true" type="text" class="form-control" name="cardholderName" data-stripe="name" ng-model="paymentMethods.newCreditCard.name" autocomplete="cc-name" required>
+          <input id="new-card-name" aria-required="true" type="text" class="form-control" name="cardholderName" data-stripe="name" ng-model="factory.paymentMethods.newCreditCard.name" autocomplete="cc-name" required>
           <p class="text-danger" ng-show="(formObject.cardholderName.$dirty || formObject.$submitted) && formObject.cardholderName.$invalid">
             Choose a Cardholder Name.
           </p>
@@ -61,7 +61,7 @@
         <div class="form-group">
           <label for="toggleMatchBillingAddress" class="control-label mb-0">Cardholder Billing Address: *</label>
           <div class="flex-row">
-            <madero-checkbox id="toggleMatchBillingAddress" ng-model="paymentMethods.newCreditCard.useBillingAddress"></madero-checkbox>
+            <madero-checkbox id="toggleMatchBillingAddress" ng-model="factory.paymentMethods.newCreditCard.useBillingAddress"></madero-checkbox>
             <span class="mr-3">Use Company Billing Address</span>
           </div>
         </div>
@@ -71,7 +71,7 @@
     <!-- NEW CC ADDRESS -->
     <div id="new-card-address">
 
-      <address-form form-object="formObject" address-object="paymentMethods.newCreditCard.address" hide-company-name="true" ng-if="!paymentMethods.newCreditCard.useBillingAddress"></address-form>
+      <address-form form-object="formObject" address-object="factory.paymentMethods.newCreditCard.address" hide-company-name="true" ng-if="!factory.paymentMethods.newCreditCard.useBillingAddress"></address-form>
 
     </div>
     <!--  END NEW CC ADDRESS -->
@@ -79,16 +79,16 @@
   <!-- END NEW CC -->
 
   <!-- EXISTING CREDIT CARD -->
-  <div id="existing-credit-card-form" ng-if="!paymentMethods.selectedCard.isNew">
-    <div id="errorBox" class="alert alert-danger" role="alert" ng-show="paymentMethods.selectedCard.validationErrors.length">
-      <strong>Card Validation Error</strong> {{paymentMethods.selectedCard.validationErrors[0]}}
+  <div id="existing-credit-card-form" ng-if="!factory.paymentMethods.selectedCard.isNew">
+    <div id="errorBox" class="alert alert-danger" role="alert" ng-show="factory.paymentMethods.selectedCard.validationErrors.length">
+      <strong>Card Validation Error</strong> {{factory.paymentMethods.selectedCard.validationErrors[0]}}
     </div>
 
     <div class="row">
       <div class="col-md-12">
         <div class="form-group">
           <label for="existing-card-name" class="control-label">Cardholder Name</label>
-          <input id="existing-card-name" type="text" class="form-control" placeholder="{{paymentMethods.selectedCard.name}}" disabled="disabled">
+          <input id="existing-card-name" type="text" class="form-control" placeholder="{{factory.paymentMethods.selectedCard.name}}" disabled="disabled">
         </div>
       </div>
     </div>
@@ -96,7 +96,7 @@
       <div class="col-md-12">
         <div class="form-group">
           <label for="existing-card-number" class="control-label">Card Number</label>
-          <input id="existing-card-number" type="text" class="form-control" placeholder="{{paymentMethods.selectedCard.last4 | cardLastFour}}" disabled="disabled" />
+          <input id="existing-card-number" type="text" class="form-control" placeholder="{{factory.paymentMethods.selectedCard.last4 | cardLastFour}}" disabled="disabled" />
         </div>
       </div>
     </div>
@@ -104,13 +104,13 @@
       <div class="col-md-4">
         <div class="form-group">
           <label for="existing-card-expiry-month" class="control-label">Expiry Month</label>
-          <input id="existing-card-expiry-month" type="text" class="form-control masked"  placeholder="{{paymentMethods.selectedCard.expMonth | paddedMonth}}" disabled="disabled" />
+          <input id="existing-card-expiry-month" type="text" class="form-control masked"  placeholder="{{factory.paymentMethods.selectedCard.expMonth | paddedMonth}}" disabled="disabled" />
         </div>
       </div>
       <div class="col-md-4">
         <div class="form-group">
           <label for="existing-card-expiry-year" class="control-label">Expiry Year</label>
-          <input id="existing-card-expiry-year" type="text" class="form-control masked"  placeholder="{{paymentMethods.selectedCard.expYear}}" disabled="disabled"/>
+          <input id="existing-card-expiry-year" type="text" class="form-control masked"  placeholder="{{factory.paymentMethods.selectedCard.expYear}}" disabled="disabled"/>
         </div>
       </div>          
     </div>

--- a/web/scripts/purchase/directives/dtv-credit-card-form.js
+++ b/web/scripts/purchase/directives/dtv-credit-card-form.js
@@ -6,12 +6,13 @@ angular.module('risevision.apps.purchase')
       return {
         restrict: 'E',
         scope: {
-          paymentMethods: '=paymentMethodsObject',
           formObject: '='
         },
         template: $templateCache.get('partials/purchase/credit-card-form.html'),
         link: function ($scope) {
-          creditCardFactory.initElements();
+          creditCardFactory.initStripeElements();
+
+          $scope.factory = creditCardFactory;
 
           $scope.getCardDescription = function (card) {
             return '***-' + card.last4 + ', ' + card.cardType + (card.isDefault ? ' (default)' : '');

--- a/web/scripts/purchase/directives/dtv-payment-methods.js
+++ b/web/scripts/purchase/directives/dtv-payment-methods.js
@@ -7,11 +7,10 @@ angular.module('risevision.apps.purchase')
         restrict: 'E',
         template: $templateCache.get('partials/purchase/checkout-payment-methods.html'),
         link: function ($scope) {
-          $scope.paymentMethods = purchaseFactory.purchase.paymentMethods;
+          $scope.paymentMethods = creditCardFactory.paymentMethods;
           $scope.contactEmail = purchaseFactory.purchase.contact.email;
 
           $scope.purchase = purchaseFactory.purchase;
-          $scope.creditCardFactory = creditCardFactory;
         }
       };
     }

--- a/web/scripts/purchase/services/svc-credit-card-factory.js
+++ b/web/scripts/purchase/services/svc-credit-card-factory.js
@@ -1,10 +1,13 @@
 (function (angular) {
 
   'use strict';
+  
+  /*jshint camelcase: false */
 
   angular.module('risevision.apps.purchase')
-    .factory('creditCardFactory', ['$rootScope', 'stripeService',
-      function ($rootScope, stripeService) {
+    .factory('creditCardFactory', ['$rootScope', '$q', 'stripeService', 'userState',
+      'addressService',
+      function ($rootScope, $q, stripeService, userState, addressService) {
         var factory = {
           stripeElements: {}
         };
@@ -42,7 +45,7 @@
           '#new-card-cvc'
         ];
 
-        factory.initElements = function() {
+        factory.initStripeElements = function() {
           stripeService.initializeStripeElements(stripeElements, elementOptions)
             .then(function (elements) {
               elements.forEach(function (el, idx) {
@@ -64,6 +67,76 @@
                 });
               });
             });  
+        };
+
+        factory.initPaymentMethods = function() {
+          factory.paymentMethods = {
+            existingCreditCards: [],
+            newCreditCard: {
+              isNew: true,
+              address: {},
+              useBillingAddress: true,
+              billingAddress: addressService.copyAddress(userState.getCopyOfSelectedCompany())
+            }
+          };
+
+          // Alpha Release - Select New Card by default
+          factory.paymentMethods.selectedCard = factory.paymentMethods.newCreditCard;
+        };
+
+        factory.validatePaymentMethod = function () {
+          factory.paymentMethods.tokenError = null;
+
+          if (!factory.paymentMethods.selectedCard.isNew) {
+            return $q.resolve();
+          } else {
+            var element = factory.stripeElements.cardNumber;
+            var address = factory.paymentMethods.newCreditCard && factory.paymentMethods.newCreditCard.address;
+            if (factory.paymentMethods.newCreditCard && factory.paymentMethods.newCreditCard.useBillingAddress) {
+              address = factory.paymentMethods.newCreditCard.billingAddress;
+            }
+
+            var details = {
+              billing_details: {
+                name: factory.paymentMethods.newCreditCard && factory.paymentMethods.newCreditCard.name,
+                address: address ? {
+                  city: address.city,
+                  country: address.country,
+                  postal_code: address.postalCode,
+                  state: address.province
+                } : {}
+              }
+            };
+
+            return stripeService.createPaymentMethod('card', element, details)
+              .then(function (response) {
+                if (response.error) {
+                  factory.paymentMethods.tokenError = response.error.message;
+
+                  return $q.reject(response.error);
+                } else {
+                  factory.paymentMethods.paymentMethodResponse = response;
+
+                  return $q.resolve();
+                }
+              });
+          }
+        };
+
+        factory.authenticate3ds = function (intentSecret) {
+          return stripeService.authenticate3ds(intentSecret)
+            .then(function (result) {
+              if (result.error) {
+                factory.paymentMethods.tokenError = result.error;
+                return $q.reject(result.error);
+              }
+            })
+            .catch(function (error) {
+              console.log(error);
+              factory.paymentMethods.tokenError =
+                'Something went wrong, please retry or contact support@risevision.com';
+              return $q.reject(error);
+            });
         };
 
         return factory;


### PR DESCRIPTION
## Description
Separate paymentMethods code from purchaseFactory

Move to creditCardFactory; Update references

Move credit card related functions
createPaymentMethod and validate3ds via Stripe

[stage-18]

## Motivation and Context
Allow paymentMethods code to be shared with Invoice Payment flow.

## How Has This Been Tested?
Tested changes locally. Updated unit tests.

Tested Purchase Success, Credit Card validation failure, Credit Card payment intent failure, 3ds flow.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
