### PR TITLE
Fix/display status comparison for last activity date

### DIFF
--- a/web/scripts/displays/services/svc-display.js
+++ b/web/scripts/displays/services/svc-display.js
@@ -60,7 +60,8 @@
                 var result = resp.result;
 
                 angular.forEach(result.items, function (item) {
-                  item.lastActivityDate = item.onlineStatus === 'online' ? Date.now() : (item
+
+                  item.lastActivityDate = item.onlineStatus === 'online' ? new Date() : (item
                     .lastActivityDate ? new Date(item.lastActivityDate) : '');
                 });
 
@@ -91,7 +92,7 @@
 
                 var item = resp.result.item;
                 if (item) {
-                  item.lastActivityDate = item.onlineStatus === 'online' ? Date.now() : (item.lastActivityDate ?
+                  item.lastActivityDate = item.onlineStatus === 'online' ? new Date() : (item.lastActivityDate ?
                     new Date(item.lastActivityDate) : '');
 
                   $rootScope.$broadcast('displaysLoaded', [item]);

--- a/web/scripts/displays/services/svc-display.js
+++ b/web/scripts/displays/services/svc-display.js
@@ -60,7 +60,6 @@
                 var result = resp.result;
 
                 angular.forEach(result.items, function (item) {
-
                   item.lastActivityDate = item.onlineStatus === 'online' ? new Date() : (item
                     .lastActivityDate ? new Date(item.lastActivityDate) : '');
                 });

--- a/web/scripts/displays/services/svc-display.js
+++ b/web/scripts/displays/services/svc-display.js
@@ -60,7 +60,7 @@
                 var result = resp.result;
 
                 angular.forEach(result.items, function (item) {
-                  item.lastActivityDate = item.onlineStatus === true ? Date.now() : (item
+                  item.lastActivityDate = item.onlineStatus === 'online' ? Date.now() : (item
                     .lastActivityDate ? new Date(item.lastActivityDate) : '');
                 });
 
@@ -91,7 +91,7 @@
 
                 var item = resp.result.item;
                 if (item) {
-                  item.lastActivityDate = item.onlineStatus === true ? Date.now() : (item.lastActivityDate ?
+                  item.lastActivityDate = item.onlineStatus === 'online' ? Date.now() : (item.lastActivityDate ?
                     new Date(item.lastActivityDate) : '');
 
                   $rootScope.$broadcast('displaysLoaded', [item]);


### PR DESCRIPTION
## Description
There was already code to display current date for online displays, but the comparison, and the assigned value were both wrong.

[stage-9]

## Motivation and Context
Online displays should show current date for last connection value.

## How Has This Been Tested?
Added unit tests for this on both list and get displays methods.
I tested it also manually on stage-9.

## Release Plan:
To be released on Monday

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify support
