### PR TITLE
Allow unauthenticated invoice page and payment

### DIFF
--- a/test/unit/billing/app.tests.js
+++ b/test/unit/billing/app.tests.js
@@ -89,21 +89,33 @@ describe('app:', function() {
 
   });
 
+  describe('state apps.billing.unpaid:',function(){
+
+    it('should register state',function(){
+      var state = $state.get('apps.billing.unpaid');
+      expect(state).to.be.ok;
+      expect(state.url).to.equal('/billing/unpaid?:token');
+      expect(state.controller).to.equal('UnpaidInvoicesCtrl');
+    });
+
+  });
+
   describe('state apps.billing.invoice:',function(){
 
     it('should register state',function(){
       var state = $state.get('apps.billing.invoice');
       expect(state).to.be.ok;
-      expect(state.url).to.equal('/invoice/:invoiceId');
+      expect(state.url).to.equal('/billing/invoice/:invoiceId?:token');
       expect(state.controller).to.equal('InvoiceCtrl');
     });
 
     it('should open Edit Invoice', function(done) {
       $stateParams.invoiceId = 'invoiceId';
-      $state.get('apps.billing.invoice').resolve.invoiceInfo[3](canAccessApps, billingFactory, $stateParams);
+      $stateParams.cid = 'companyId';
+      $stateParams.token = 'token';
+      $state.get('apps.billing.invoice').resolve.invoiceInfo[2](billingFactory, $stateParams);
       setTimeout(function() {
-        canAccessApps.should.have.been.called.once;
-        billingFactory.getInvoice.should.have.been.calledWith('invoiceId');
+        billingFactory.getInvoice.should.have.been.calledWith('invoiceId', 'companyId', 'token');
 
         done();
       }, 10);

--- a/test/unit/billing/controllers/ctr-unpaid-invoices.tests.js
+++ b/test/unit/billing/controllers/ctr-unpaid-invoices.tests.js
@@ -1,0 +1,78 @@
+'use strict';
+
+describe('controller: UnpaidInvoicesCtrl', function () {
+  var sandbox = sinon.sandbox.create();
+  var $scope, $loading, $stateParams, ScrollingListService, listServiceInstance;
+
+  beforeEach(module('risevision.apps.billing.controllers'));
+
+  beforeEach(module(function ($provide) {
+    $provide.service('$loading', function () {
+      return {
+        start: sandbox.stub(),
+        stop: sandbox.stub()
+      };
+    });
+    $provide.service('ScrollingListService', function () {
+      return sinon.stub().returns(listServiceInstance);
+    });
+    $provide.service('billing', function () {
+      return {
+        getUnpaidInvoices: 'getUnpaidInvoices'
+      };
+    });
+    $provide.value('billingFactory', {
+    });
+    $provide.value('$stateParams', {
+      cid: 'companyId',
+      token: 'token'
+    });
+  }));
+
+  beforeEach(inject(function($injector, $rootScope, $controller) {
+    $scope = $rootScope.$new();
+    $loading = $injector.get('$loading');
+    ScrollingListService = $injector.get('ScrollingListService');
+
+    $controller('UnpaidInvoicesCtrl', {
+      $scope: $scope
+    });
+    $scope.$digest();
+  }));
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it('should exist',function () {
+    expect($scope).to.be.ok;
+    expect($scope.billingFactory).to.be.ok;
+
+    expect($scope.unpaidInvoices).to.be.ok;
+  });
+  
+  it('should init list service', function() {
+    ScrollingListService.should.have.been.calledWith('getUnpaidInvoices', {
+      name: 'Unpaid Invoices',
+      companyId: 'companyId',
+      token: 'token'
+    });
+  });
+
+  describe('$loading: ', function() {
+    it('should stop spinner', function() {
+      $loading.stop.should.have.been.calledWith('unpaid-invoice-loader');
+    });
+
+    it('should start spinner', function(done) {
+      $scope.unpaidInvoices.loadingItems = true;
+      $scope.$digest();
+      setTimeout(function() {
+        $loading.start.should.have.been.calledWith('unpaid-invoice-loader');
+
+        done();
+      }, 10);
+    });
+  });
+
+});

--- a/test/unit/billing/services/svc-billing.tests.js
+++ b/test/unit/billing/services/svc-billing.tests.js
@@ -1,6 +1,6 @@
 'use strict';
 describe('service: billing:', function() {
-  var billing, failedResponse;
+  var billing, storeApi, failedResponse;
 
   beforeEach(module('risevision.apps.billing.services'));
   beforeEach(module(function ($provide) {
@@ -14,7 +14,7 @@ describe('service: billing:', function() {
     });
     $provide.service('storeAPILoader',function () {
       return function() {
-        return Q.resolve({
+        return Q.resolve(storeApi = {
           subscription: {
             listUser: function() {
               if (!failedResponse) {
@@ -45,7 +45,20 @@ describe('service: billing:', function() {
                   return Q.reject('API Failed');
                 }
               },
-              get: function() {
+              listUnpaid: sinon.spy(function() {
+                if (!failedResponse) {
+                  return Q.resolve({
+                    result: {
+                      nextPageToken: 1,
+                      items: [{ invoiceId: 'inv1' }]
+                    }
+                  });
+                }
+                else {
+                  return Q.reject('API Failed');
+                }
+              }),
+              get: sinon.spy(function() {
                 if (!failedResponse) {
                   return Q.resolve({
                     result: 'invoice'
@@ -54,8 +67,8 @@ describe('service: billing:', function() {
                 else {
                   return Q.reject('API Failed');
                 }
-              },
-              getPdf: function() {
+              }),
+              getPdf: sinon.spy(function() {
                 if (!failedResponse) {
                   return Q.resolve({
                     result: 'invoicePdf'
@@ -64,7 +77,7 @@ describe('service: billing:', function() {
                 else {
                   return Q.reject('API Failed');
                 }
-              }
+              })
             }  
           }
         });
@@ -82,6 +95,7 @@ describe('service: billing:', function() {
     expect(billing).to.be.ok;
     expect(billing.getSubscriptions).to.be.a.function;
     expect(billing.getInvoices).to.be.a.function;
+    expect(billing.getUnpaidInvoices).to.be.a.function;
     expect(billing.getInvoice).to.be.a.function;
     expect(billing.getInvoicePdf).to.be.a.function;
   });
@@ -140,12 +154,58 @@ describe('service: billing:', function() {
     });
   });
 
+  describe('getUnpaidInvoices:', function() {
+    it('should return a list of invoices', function(done) {
+      failedResponse = false;
+
+      billing.getUnpaidInvoices({
+        companyId: 'companyId',
+        token: 'token',
+        count: 'count'
+      }, 'cursor')
+      .then(function(result) {
+        storeApi.integrations.invoice.listUnpaid.should.have.been.called;
+        storeApi.integrations.invoice.listUnpaid.should.have.been.calledWith({
+          companyId: 'companyId',
+          token: 'token',
+          count: 'count',
+          cursor: 'cursor'
+        });
+
+        expect(result).to.be.ok;
+        expect(result.items).to.be.ok;
+        expect(result.items.length).to.equal(1);
+        done();
+      });
+    });
+
+    it('should handle failure to get list correctly', function(done) {
+      failedResponse = true;
+
+      billing.getUnpaidInvoices({})
+      .then(function(invoices) {
+        done(invoices);
+      })
+      .then(null, function(error) {
+        expect(error).to.deep.equal('API Failed');
+        done();
+      });
+    });
+  });
+
   describe('getInvoice:', function() {
     it('should return an invoice', function(done) {
       failedResponse = false;
 
-      billing.getInvoice('invoiceId')
+      billing.getInvoice('invoiceId', 'companyId', 'token')
       .then(function(result) {
+        storeApi.integrations.invoice.get.should.have.been.called;
+        storeApi.integrations.invoice.get.should.have.been.calledWith({
+          invoiceId: 'invoiceId',
+          companyId: 'companyId',
+          token: 'token'
+        });
+
         expect(result).to.be.ok;
         expect(result).to.equal('invoice');
         done();
@@ -170,8 +230,15 @@ describe('service: billing:', function() {
     it('should return the invoice pdf', function(done) {
       failedResponse = false;
 
-      billing.getInvoicePdf('invoiceId')
+      billing.getInvoicePdf('invoiceId', 'companyId', 'token')
       .then(function(result) {
+        storeApi.integrations.invoice.getPdf.should.have.been.called;
+        storeApi.integrations.invoice.getPdf.should.have.been.calledWith({
+          invoiceId: 'invoiceId',
+          companyId: 'companyId',
+          token: 'token'
+        });
+
         expect(result).to.be.ok;
         expect(result).to.equal('invoicePdf');
         done();

--- a/test/unit/common-header/services/svc-store-service-spec.js
+++ b/test/unit/common-header/services/svc-store-service-spec.js
@@ -419,13 +419,14 @@ describe("Services: storeService", function() {
     });
 
     it("should pass the parameters and call the api", function(done) {
-      storeService.preparePayment("paymentMethodId", "invoiceId", "companyId")
+      storeService.preparePayment("paymentMethodId", "invoiceId", "companyId", "token")
       .then(function() {
         storeApi.payment.prepare.should.have.been.called;
         storeApi.payment.prepare.should.have.been.calledWith({
           paymentMethodId: "paymentMethodId",
           invoiceId: "invoiceId",
-          companyId: "companyId"
+          companyId: "companyId",
+          token: "token"
         });
         done();
       })
@@ -509,13 +510,14 @@ describe("Services: storeService", function() {
     });
 
     it("should pass the parameters and call the api", function(done) {
-      storeService.collectPayment("paymentIntentId", "invoiceId", "companyId")
+      storeService.collectPayment("paymentIntentId", "invoiceId", "companyId", "token")
       .then(function() {
         storeApi.payment.collect.should.have.been.called;
         storeApi.payment.collect.should.have.been.calledWith({
           paymentIntentId: "paymentIntentId",
           invoiceId: "invoiceId",
-          companyId: "companyId"
+          companyId: "companyId",
+          token: "token"
         });
         done();
       })

--- a/test/unit/common/controllers/ctr-app.tests.js
+++ b/test/unit/common/controllers/ctr-app.tests.js
@@ -29,7 +29,7 @@ describe('controller: app', function() {
 
   it('should exist',function(){
     expect($scope).to.be.ok;
-    expect($scope.hideCommonHeader).to.be.false;
+    expect($scope.hideCommonHeader).to.be.true;
     expect($scope.navOptions).to.be.ok;
     expect($scope.navSelected).to.be.ok;
   });
@@ -40,13 +40,30 @@ describe('controller: app', function() {
     expect($scope.navSelected).to.equal('apps.display.alerts');
   });
 
-  it('should hide CH on login page',function(){
-    $state.current.name = 'common.auth.unauthorized';
-    rootScope.$broadcast('$stateChangeSuccess');
-    expect($scope.hideCommonHeader).to.be.true;
-    
-    $state.current.name = 'apps.home';
-    rootScope.$broadcast('$stateChangeSuccess');
-    expect($scope.hideCommonHeader).to.be.false;
+  describe('hideCommonHeader', function() {
+    it('should hide CH on login page',function(){
+      $state.current.name = 'common.auth.unauthorized';
+      rootScope.$broadcast('$stateChangeSuccess');
+      expect($scope.hideCommonHeader).to.be.true;
+    });
+
+    it('should hide CH on invoice page',function(){
+      $state.current.name = 'apps.billing.invoice';
+      rootScope.$broadcast('$stateChangeSuccess');
+      expect($scope.hideCommonHeader).to.be.true;
+    });
+
+    it('should hide CH on unpaid invoices page',function(){
+      $state.current.name = 'apps.billing.unpaid';
+      rootScope.$broadcast('$stateChangeSuccess');
+      expect($scope.hideCommonHeader).to.be.true;
+    });
+
+    it('should show CH otherwise',function(){
+      $state.current.name = 'apps.home';
+      rootScope.$broadcast('$stateChangeSuccess');
+      expect($scope.hideCommonHeader).to.be.false;
+    });
   });
+
 });

--- a/web/index.html
+++ b/web/index.html
@@ -321,6 +321,7 @@
   <script src="scripts/billing/services/svc-billing-factory.js"></script>
 
   <script src="scripts/billing/controllers/ctr-billing.js"></script>
+  <script src="scripts/billing/controllers/ctr-unpaid-invoices.js"></script>
   <script src="scripts/billing/controllers/ctr-invoice.js"></script>
 
   <!-- plans -->

--- a/web/partials/billing/app-billing.html
+++ b/web/partials/billing/app-billing.html
@@ -129,7 +129,7 @@
               </a>
             </td>
             <td class="table-body__cell py-0">
-              <a class="btn btn-default btn-pay-now" ng-if="item.invoice.status !== 'paid'" ui-sref="apps.billing.invoice({invoiceId: item.invoice.id})">Pay Now</a>
+              <a class="btn btn-default btn-pay-now" ng-if="item.invoice.status !== 'paid'" ui-sref="apps.billing.invoice({invoiceId: item.invoice.id, token: billingFactory.getToken()})" target="_blank">Pay Now</a>
             </td>
           </tr>
 

--- a/web/partials/billing/invoice.html
+++ b/web/partials/billing/invoice.html
@@ -1,189 +1,195 @@
 <div class="madero-style">
 
-  <div class="button-row text-right mt-5">
-    <button id="shareButton" type="button" class="btn btn-default btn-toolbar mr-2">
-      Share
-    </button>
-    <button id="downloadButton" type="button" class="btn btn-default btn-toolbar mr-2" ng-click="billingFactory.downloadInvoice(billingFactory.invoice.id)">
-      Download
-    </button>
-    <button id="payNowButton" type="button" class="btn btn-primary btn-toolbar" ng-click="showPaymentForm = true" ng-disabled="showPaymentForm" ng-hide="billingFactory.invoice.status === 'paid'">
-      Pay Now
-    </button>
+  <div class="row my-5">
+    <div class="col-xs-12 col-sm-2 pb-5 pb-md-0">
+      <div class="rise-logo"><img src="https://s3.amazonaws.com/Rise-Images/Website/rise-logo.svg"></div>
+    </div>
+
+    <div class="col-xs-12 col-sm-10">
+      <div class="button-row text-right my-0">
+        <button id="shareButton" type="button" class="btn btn-default btn-toolbar mr-2">
+          Share
+        </button>
+        <button id="downloadButton" type="button" class="btn btn-default btn-toolbar mr-2" ng-click="billingFactory.downloadInvoice(billingFactory.invoice.id)">
+          Download
+        </button>
+        <button id="payNowButton" type="button" class="btn btn-primary btn-toolbar" ng-click="showPaymentForm = true" ng-disabled="showPaymentForm" ng-hide="billingFactory.invoice.status === 'paid'">
+          Pay Now
+        </button>
+      </div>
+    </div>
   </div>
 
-  <div rv-spinner rv-spinner-key="invoice-loader" rv-spinner-start-active="1">
+  <div rv-spinner rv-spinner-key="invoice-loader" rv-spinner-start-active="1"></div>
 
-    <div id="errorBox" ng-show="billingFactory.apiError" class="madero-style alert alert-danger" role="alert">
-      <strong>{{billingFactory.apiError}}</strong>
-    </div>
+  <div id="errorBox" ng-show="billingFactory.apiError" class="madero-style alert alert-danger" role="alert">
+    <strong>{{billingFactory.apiError}}</strong>
+  </div>
 
-    <div class="border-container u_margin-md-top u_margin-md-bottom" ng-show="showPaymentForm && billingFactory.invoice.status !== 'paid'">
-      <div class="panel-body">
+  <div class="border-container u_margin-md-top u_margin-md-bottom" ng-show="showPaymentForm && billingFactory.invoice.status !== 'paid'">
+    <div class="panel-body">
 
-        <form id="form.paymentMethodsForm" role="form" name="form.paymentMethodsForm" novalidate>
+      <form id="form.paymentMethodsForm" role="form" name="form.paymentMethodsForm" novalidate>
 
-          <credit-card-form form-object="form.paymentMethodsForm"></credit-card-form>
+        <credit-card-form form-object="form.paymentMethodsForm"></credit-card-form>
 
-        </form>
+      </form>
 
-        <div class="text-right mt-5">
-          <button id="cancelButton" type="button" aria-label="Cancel" class="btn btn-default btn-toolbar pull-left" ng-click="showPaymentForm = false" translate>Cancel</button>
-          <button id="payButton" type="submit" class="btn btn-primary btn-toolbar-wide" form="form.paymentMethodsForm" ng-click="completeCardPayment()" tabindex="1" aria-label="Complete Payment">
-            <span id="payLabel">Pay ${{billingFactory.invoice.amount_due / 100 | number:2}} Now</span>
-          </button>
-        </div>
-
+      <div class="text-right mt-5">
+        <button id="cancelButton" type="button" aria-label="Cancel" class="btn btn-default btn-toolbar pull-left" ng-click="showPaymentForm = false">Cancel</button>
+        <button id="payButton" type="submit" class="btn btn-primary btn-toolbar-wide" form="form.paymentMethodsForm" ng-click="completeCardPayment()" tabindex="1" aria-label="Complete Payment">
+          <span id="payLabel">Pay ${{billingFactory.invoice.amount_due / 100 | number:2}} Now</span>
+        </button>
       </div>
+
     </div>
+  </div>
 
-    <div class="border-container u_margin-md-top u_margin-md-bottom">
-      <div class="panel-body">
-        <div class="pb-5 mb-5 border-bottom">
-          <div class="row">
-            <div class="col-sm-12 col-md-6 pb-4 pb-lg-0">
-              <div class="app-header mb-3">
-                <!-- App Title -->
-                <h1 class="app-header-title">Invoice #{{billingFactory.invoice.id}}</h1>
-              </div>
-              <label>Billed To:</label><br>
-              <span ng-show="billingFactory.invoice.billing_address.first_name || billingFactory.invoice.billing_address.last_name">
-                {{billingFactory.invoice.billing_address.first_name}} {{billingFactory.invoice.billing_address.last_name}}<br>
-              </span>
-              {{billingFactory.invoice.billing_address.company}}<br>
-              {{billingFactory.invoice.billing_address.line1}}<br> 
-              <span ng-show="billingFactory.invoice.billing_address.line2">
-                {{billingFactory.invoice.billing_address.line2}}
-                <br>
-              </span>
-              {{billingFactory.invoice.billing_address.city}}, <span ng-show="billingFactory.invoice.billing_address.state">{{billingFactory.invoice.billing_address.state}},</span> {{billingFactory.invoice.billing_address.zip}}<br> 
-              {{billingFactory.invoice.billing_address.country | countryName}}<br>
-              <span ng-show="billingFactory.invoice.billing_address.email">
-                {{billingFactory.invoice.billing_address.email}}<br>
-              </span>
-              <span ng-show="billingFactory.invoice.billing_address.phone">
-                {{billingFactory.invoice.billing_address.phone}}<br>
-              </span>
+  <div class="border-container u_margin-md-top u_margin-md-bottom">
+    <div class="panel-body">
+      <div class="pb-5 mb-5 border-bottom">
+        <div class="row">
+          <div class="col-sm-12 col-md-6 pb-4 pb-lg-0">
+            <div class="app-header mb-3">
+              <!-- App Title -->
+              <h1 class="app-header-title">Invoice #{{billingFactory.invoice.id}}</h1>
+            </div>
+            <label>Billed To:</label><br>
+            <span ng-show="billingFactory.invoice.billing_address.first_name || billingFactory.invoice.billing_address.last_name">
+              {{billingFactory.invoice.billing_address.first_name}} {{billingFactory.invoice.billing_address.last_name}}<br>
+            </span>
+            {{billingFactory.invoice.billing_address.company}}<br>
+            {{billingFactory.invoice.billing_address.line1}}<br> 
+            <span ng-show="billingFactory.invoice.billing_address.line2">
+              {{billingFactory.invoice.billing_address.line2}}
+              <br>
+            </span>
+            {{billingFactory.invoice.billing_address.city}}, <span ng-show="billingFactory.invoice.billing_address.state">{{billingFactory.invoice.billing_address.state}},</span> {{billingFactory.invoice.billing_address.zip}}<br> 
+            {{billingFactory.invoice.billing_address.country | countryName}}<br>
+            <span ng-show="billingFactory.invoice.billing_address.email">
+              {{billingFactory.invoice.billing_address.email}}<br>
+            </span>
+            <span ng-show="billingFactory.invoice.billing_address.phone">
+              {{billingFactory.invoice.billing_address.phone}}<br>
+            </span>
+          </div>
+
+          <div class="col-sm-12 col-md-6">
+            <div class="app-header mb-3" ng-show="billingFactory.invoice.status === 'paid'">
+              <!-- App Title -->
+              <h1 class="app-header-title text-success">Paid</h1>
             </div>
 
-            <div class="col-sm-12 col-md-6">
-              <div class="app-header mb-3" ng-show="billingFactory.invoice.status === 'paid'">
-                <!-- App Title -->
-                <h1 class="app-header-title text-success">Paid</h1>
+            <div class="row">
+              <div class="col-md-4">
+                <label class="mb-0">Invoice Date:</label>
               </div>
-
-              <div class="row">
-                <div class="col-md-4">
-                  <label class="mb-0">Invoice Date:</label>
-                </div>
-                <div class="col-md-8" ng-show="billingFactory.invoice.date">
-                  {{billingFactory.invoice.date * 1000 | date:'d-MMM-yyyy'}}
-                </div>
+              <div class="col-md-8" ng-show="billingFactory.invoice.date">
+                {{billingFactory.invoice.date * 1000 | date:'d-MMM-yyyy'}}
               </div>
-              <div class="row">
-                <div class="col-md-4">
-                  <label class="mb-0">Invoice Amount:</label>
-                </div>
-                <div class="col-md-8" ng-show="billingFactory.invoice">
-                  ${{billingFactory.invoice.total / 100 | number:2}} {{billingFactory.invoice.currency_code}}
-                </div>
-              </div>
-              <div class="row">
-                <div class="col-md-4">
-                  <label class="mb-0">Customer ID:</label>
-                </div>
-                <div class="col-md-8">
-                  {{billingFactory.invoice.customer_id}}
-                </div>
-              </div>
-              <div class="row">
-                <div class="col-md-4">
-                  <label class="mb-0">Payment Terms:</label>
-                </div>
-                <div class="col-md-8">
-                  <span ng-show="billingFactory.invoice.net_term_days > 0">
-                    Net {{billingFactory.invoice.net_term_days}}
-                  </span>
-                  <span ng-show="billingFactory.invoice.net_term_days === 0">
-                    Due Upon Receipt
-                  </span>
-                </div>
-              </div>
-              <div class="row">
-                <div class="col-md-4">
-                  <label class="mb-0">Due Date:</label>
-                </div>
-                <div class="col-md-8" ng-show="billingFactory.invoice.due_date">
-                  {{billingFactory.invoice.due_date * 1000 | date:'d-MMM-yyyy'}}
-                </div>
-              </div>
-              <div class="row">
-                <div class="col-md-4">
-                  <label class="mb-0">Billing Period:</label>
-                </div>
-                <div class="col-md-8" ng-show="billingFactory.invoice.line_items[0]">
-                  {{billingFactory.invoice.line_items[0].date_from * 1000 | date:'d-MMM-yyyy'}} — {{billingFactory.invoice.line_items[0].date_to * 1000 | date:'d-MMM-yyyy'}}
-                </div>
-              </div>
-              <div class="row">
-                <div class="col-md-4">
-                  <label class="mb-0">Next Billing Date:</label>
-                </div>
-                <div class="col-md-8" ng-show="billingFactory.invoice.line_items[0]">
-                  {{billingFactory.invoice.line_items[0].date_to * 1000 | date:'d-MMM-yyyy'}}
-                </div>
-              </div>
-              <div class="row" ng-show="billingFactory.invoice.po_number">
-                <div class="col-md-4">
-                  <label class="mb-0">PO:</label>
-                </div>
-                <div class="col-md-8">
-                  {{billingFactory.invoice.po_number}}
-                </div>
-              </div>
-
             </div>
-          </div>
-        </div>
-
-        <div class="pb-5 mb-5 border-bottom" ng-show="billingFactory.invoice.line_items">
-          <div class="text-right" ng-repeat="line_item in billingFactory.invoice.line_items">
-            <label class="mb-0 pull-left">{{line_item.description}}</label>
-            ${{line_item.amount / 100 | number:2}}
-          </div>
-        </div>
-
-        <div ng-show="billingFactory.invoice">
-          <div class="row">
-            <div class="col-md-offset-8 col-md-4">
-              <div class="text-right">
-                <label class="mb-0 pull-left">Total:</label>
-                <label class="mb-0">
-                  ${{billingFactory.invoice.total / 100 | number:2}}
-                </label>
+            <div class="row">
+              <div class="col-md-4">
+                <label class="mb-0">Invoice Amount:</label>
               </div>
-              <div class="text-right mt-3" ng-show="billingFactory.invoice.amount_paid">
-                <label class="mb-0 pull-left">Payment:</label>
-                <label class="mb-0">
-                  ${{billingFactory.invoice.amount_paid / 100 | number:2}}
-                </label>
+              <div class="col-md-8" ng-show="billingFactory.invoice">
+                ${{billingFactory.invoice.total / 100 | number:2}} {{billingFactory.invoice.currency_code}}
               </div>
-              <div class="text-right mt-3">
-                <h4>
-                  <span class="pull-left">Amount Due:</span>
-                  ${{billingFactory.invoice.amount_due / 100 | number:2}}
-                </h4>
-              </div>
-
             </div>
+            <div class="row">
+              <div class="col-md-4">
+                <label class="mb-0">Customer ID:</label>
+              </div>
+              <div class="col-md-8">
+                {{billingFactory.invoice.customer_id}}
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-4">
+                <label class="mb-0">Payment Terms:</label>
+              </div>
+              <div class="col-md-8">
+                <span ng-show="billingFactory.invoice.net_term_days > 0">
+                  Net {{billingFactory.invoice.net_term_days}}
+                </span>
+                <span ng-show="billingFactory.invoice.net_term_days === 0">
+                  Due Upon Receipt
+                </span>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-4">
+                <label class="mb-0">Due Date:</label>
+              </div>
+              <div class="col-md-8" ng-show="billingFactory.invoice.due_date">
+                {{billingFactory.invoice.due_date * 1000 | date:'d-MMM-yyyy'}}
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-4">
+                <label class="mb-0">Billing Period:</label>
+              </div>
+              <div class="col-md-8" ng-show="billingFactory.invoice.line_items[0]">
+                {{billingFactory.invoice.line_items[0].date_from * 1000 | date:'d-MMM-yyyy'}} — {{billingFactory.invoice.line_items[0].date_to * 1000 | date:'d-MMM-yyyy'}}
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-4">
+                <label class="mb-0">Next Billing Date:</label>
+              </div>
+              <div class="col-md-8" ng-show="billingFactory.invoice.line_items[0]">
+                {{billingFactory.invoice.line_items[0].date_to * 1000 | date:'d-MMM-yyyy'}}
+              </div>
+            </div>
+            <div class="row" ng-show="billingFactory.invoice.po_number">
+              <div class="col-md-4">
+                <label class="mb-0">PO:</label>
+              </div>
+              <div class="col-md-8">
+                {{billingFactory.invoice.po_number}}
+              </div>
+            </div>
+
           </div>
         </div>
-
       </div>
+
+      <div class="pb-5 mb-5 border-bottom" ng-show="billingFactory.invoice.line_items">
+        <div class="text-right" ng-repeat="line_item in billingFactory.invoice.line_items">
+          <label class="mb-0 pull-left">{{line_item.description}}</label>
+          ${{line_item.amount / 100 | number:2}}
+        </div>
+      </div>
+
+      <div ng-show="billingFactory.invoice">
+        <div class="row">
+          <div class="col-md-offset-8 col-md-4">
+            <div class="text-right">
+              <label class="mb-0 pull-left">Total:</label>
+              <label class="mb-0">
+                ${{billingFactory.invoice.total / 100 | number:2}}
+              </label>
+            </div>
+            <div class="text-right mt-3" ng-show="billingFactory.invoice.amount_paid">
+              <label class="mb-0 pull-left">Payment:</label>
+              <label class="mb-0">
+                ${{billingFactory.invoice.amount_paid / 100 | number:2}}
+              </label>
+            </div>
+            <div class="text-right mt-3">
+              <h4>
+                <span class="pull-left">Amount Due:</span>
+                ${{billingFactory.invoice.amount_due / 100 | number:2}}
+              </h4>
+            </div>
+
+          </div>
+        </div>
+      </div>
+
     </div>
+  </div>
 
-    <div ng-include="'partials/purchase/purchase-footer.html'"></div>
+  <div ng-include="'partials/purchase/purchase-footer.html'"></div>
 
-
-  </div><!--container-->
-</div><!--appLauncherContainer-->
+</div><!--container-->

--- a/web/partials/billing/unpaid-invoices.html
+++ b/web/partials/billing/unpaid-invoices.html
@@ -1,0 +1,79 @@
+<div class="madero-style">
+  <div class="row my-5">
+    <div class="col-xs-12 col-sm-2 pb-5 pb-md-0">
+      <div class="rise-logo"><img src="https://s3.amazonaws.com/Rise-Images/Website/rise-logo.svg"></div>
+    </div>
+
+    <div class="col-xs-12 col-sm-10">
+      <div class="button-row text-right my-0">
+        <button id="shareButton" type="button" class="btn btn-default btn-toolbar mr-2">
+          Share
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div class="mb-4">
+    <h4>Unpaid Invoices</h4>
+  </div>
+
+  <div rv-spinner rv-spinner-key="unpaid-invoice-loader" rv-spinner-start-active="1"></div>
+  <div id="errorBox" ng-show="unpaidInvoices.apiError" class="madero-style alert alert-danger" role="alert">
+    <p><strong>{{unpaidInvoices.errorMessage}}</strong></p>
+    {{unpaidInvoices.apiError}}
+  </div>
+
+  <div id="errorBox" ng-show="billingFactory.apiError" class="madero-style alert alert-danger" role="alert">
+    <strong>{{billingFactory.apiError}}</strong>
+  </div>
+
+  <div class="scrollable-list horizontal-scroll border-container u_margin-md-top u_margin-md-bottom" scrolling-list="unpaidInvoices.load()">
+
+    <table id="unpaidInvoicesListTable" class="table">
+      <thead class="table-header">
+        <tr class="table-header__row">
+          <th class="table-header__cell col-xs-1">Status</th>
+          <th class="table-header__cell col-xs-1">Date</th>
+          <th class="table-header__cell col-xs-2">Description</th>
+          <th class="table-header__cell col-xs-5">Amount</th>
+          <th class="table-header__cell col-xs-2">Invoice</th>
+          <th class="table-header__cell col-xs-1">&nbsp;</th>
+        </tr>
+      </thead>
+      <tbody class="table-body">
+        <tr class="table-body__row" ng-repeat="item in unpaidInvoices.items.list">
+          <td class="table-body__cell">
+            <streamline-icon class="status unpaid" name="exclamation" width="5" height="15" ng-show="item.invoice.status !== 'paid'"></streamline-icon>
+            <streamline-icon class="status paid" name="checkmark" width="17" height="14" ng-show="item.invoice.status === 'paid'"></streamline-icon>
+          </td>
+          <td class="table-body__cell">{{item.invoice.date * 1000 | date:'d-MMM-yyyy'}}</td>
+          <td class="table-body__cell font-weight-bold">
+            Invoice #{{item.invoice.id}}
+          </td>
+          <td class="table-body__cell">
+            ${{item.invoice.total / 100 | number:2}}
+          </td>
+          <td class="table-body__cell">
+            <a class="madero-link u_clickable" ng-click="billingFactory.downloadInvoice(item.invoice.id)">
+              <img src="../images/icon-download.svg" width="20" height="20">
+            </a>
+          </td>
+          <td class="table-body__cell py-0">
+            <a class="btn btn-default btn-pay-now" ng-if="item.invoice.status !== 'paid'" ui-sref="apps.billing.invoice({invoiceId: item.invoice.id, token: billingFactory.getToken()})" target="_blank">Pay Now</a>
+          </td>
+        </tr>
+
+        <tr ng-show="unpaidInvoices.items.list.length === 0 && unpaidInvoices.items.list.length === 0">
+          <td colspan="6" class="text-center"><span translate>You do not have any unpaidInvoices yet.</span></td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+
+  <div class="u_margin-lg text-center">
+    <label>Need help with something?</label>
+    <p><a class="madero-link" href="https://help.risevision.com/hc/en-us/articles/360041149991-Payment-instructions-and-common-questions-" target="_blank">Common Billing & Payment Questions</a></p>
+  </div>
+
+</div><!--container-->

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -182,8 +182,7 @@ angular.module('risevision.apps', [
             reload: true
           });
         } else if ($state.current.name === 'apps.purchase.plans' ||
-          $state.current.name === 'apps.purchase.home' ||
-          $state.current.name === 'apps.billing.invoice') {
+          $state.current.name === 'apps.purchase.home') {
           $state.go('apps.home');
         }
       });

--- a/web/scripts/billing/app.js
+++ b/web/scripts/billing/app.js
@@ -34,16 +34,14 @@ angular.module('risevision.apps')
         })
 
         .state('apps.billing.invoice', {
-          url: '/invoice/:invoiceId',
+          url: '/invoice/:invoiceId/:token',
           templateUrl: 'partials/billing/invoice.html',
           controller: 'InvoiceCtrl',
           resolve: {
-            invoiceInfo: ['canAccessApps', 'billingFactory', '$stateParams',
-              function (canAccessApps, billingFactory, $stateParams) {
-                return canAccessApps().then(function () {
-                  //load the invoice based on the url param
-                  billingFactory.getInvoice($stateParams.invoiceId);
-                });
+            invoiceInfo: ['billingFactory', '$stateParams',
+              function (billingFactory, $stateParams) {
+                //load the invoice based on the url param
+                billingFactory.getInvoice($stateParams.invoiceId, $stateParams.cid, $stateParams.token);
               }
             ]
           }

--- a/web/scripts/billing/app.js
+++ b/web/scripts/billing/app.js
@@ -33,14 +33,20 @@ angular.module('risevision.apps')
           }
         })
 
+        .state('apps.billing.unpaid', {
+          url: '/billing/unpaid?:token',
+          templateUrl: 'partials/billing/unpaid-invoices.html',
+          controller: 'UnpaidInvoicesCtrl'
+        })
+
         .state('apps.billing.invoice', {
-          url: '/invoice/:invoiceId/:token',
+          url: '/billing/invoice/:invoiceId?:token',
           templateUrl: 'partials/billing/invoice.html',
           controller: 'InvoiceCtrl',
           resolve: {
             invoiceInfo: ['billingFactory', '$stateParams',
               function (billingFactory, $stateParams) {
-                //load the invoice based on the url param
+                // pass $stateParams to service as values could be blank before state is loaded
                 billingFactory.getInvoice($stateParams.invoiceId, $stateParams.cid, $stateParams.token);
               }
             ]

--- a/web/scripts/billing/controllers/ctr-unpaid-invoices.js
+++ b/web/scripts/billing/controllers/ctr-unpaid-invoices.js
@@ -1,0 +1,25 @@
+'use strict';
+
+angular.module('risevision.apps.billing.controllers')
+  .controller('UnpaidInvoicesCtrl', ['$scope', '$loading', '$stateParams', 
+    'billing', 'billingFactory', 'ScrollingListService',
+    function ($scope, $loading, $stateParams, billing, billingFactory, ScrollingListService) {
+
+      $scope.billingFactory = billingFactory;
+
+      $scope.unpaidInvoices = new ScrollingListService(billing.getUnpaidInvoices, {
+        companyId: $stateParams.cid,
+        token: $stateParams.token,
+        name: 'Unpaid Invoices'
+      });
+
+      $scope.$watch('unpaidInvoices.loadingItems', function (newValue) {
+        if (newValue) {
+          $loading.start('unpaid-invoice-loader');
+        } else {
+          $loading.stop('unpaid-invoice-loader');
+        }
+      });
+
+    }
+  ]);

--- a/web/scripts/billing/services/svc-billing-factory.js
+++ b/web/scripts/billing/services/svc-billing-factory.js
@@ -33,10 +33,10 @@ angular.module('risevision.apps.billing.services')
         var company = userState.getCopyOfSelectedCompany();
         var authKey = company && company.authKey;
 
-        if (authKey && authKey.length > 6) {
+        if (authKey) {
           return authKey.substr(authKey.length - 6);
         } else {
-          return authKey || null;
+          return null;
         }
       };
 

--- a/web/scripts/billing/services/svc-billing-factory.js
+++ b/web/scripts/billing/services/svc-billing-factory.js
@@ -34,7 +34,7 @@ angular.module('risevision.apps.billing.services')
         var authKey = company && company.authKey;
 
         if (authKey && authKey.length > 6) {
-          return authKey.substr(authKey.length - 6)
+          return authKey.substr(authKey.length - 6);
         } else {
           return authKey || null;
         }

--- a/web/scripts/billing/services/svc-billing-factory.js
+++ b/web/scripts/billing/services/svc-billing-factory.js
@@ -3,9 +3,10 @@
 /*jshint camelcase: false */
 
 angular.module('risevision.apps.billing.services')
-  .service('billingFactory', ['$q', '$log', '$window', 'billing', 'storeService', 'creditCardFactory',
-    'userState', 'processErrorCode',
-    function ($q, $log, $window, billing, storeService, creditCardFactory, userState, processErrorCode) {
+  .service('billingFactory', ['$q', '$log', '$window', '$stateParams', 'billing',
+    'storeService', 'creditCardFactory', 'userState', 'processErrorCode',
+    function ($q, $log, $window, $stateParams, billing, storeService, creditCardFactory,
+      userState, processErrorCode) {
       var factory = {};
 
       var _clearMessages = function () {
@@ -20,13 +21,32 @@ angular.module('risevision.apps.billing.services')
         creditCardFactory.initPaymentMethods();
       };
 
-      factory.getInvoice = function (invoiceId) {
+      var _getCompanyId = function() {
+        return $stateParams.cid || userState.getSelectedCompanyId();
+      };
+
+      factory.getToken = function () {
+        if ($stateParams.token) {
+          return $stateParams.token;
+        }
+
+        var company = userState.getCopyOfSelectedCompany();
+        var authKey = company && company.authKey;
+
+        if (authKey && authKey.length > 6) {
+          return authKey.substr(authKey.length - 6)
+        } else {
+          return authKey || null;
+        }
+      };
+
+      factory.getInvoice = function (invoiceId, companyId, token) {
         factory.init();
 
         factory.invoice = null;
         factory.loading = true;
 
-        return billing.getInvoice(invoiceId)
+        return billing.getInvoice(invoiceId, companyId, token)
           .then(function (resp) {
             factory.invoice = resp.item;
           })
@@ -43,7 +63,7 @@ angular.module('risevision.apps.billing.services')
           creditCardFactory.paymentMethods.paymentMethodResponse.paymentMethod.id : null;
 
         return storeService.preparePayment(paymentMethodId, factory.invoice.id, 
-          userState.getSelectedCompanyId())
+          _getCompanyId(), factory.getToken())
           .then(function (response) {
             if (response.error) {
               return $q.reject(response.error);
@@ -63,7 +83,7 @@ angular.module('risevision.apps.billing.services')
           creditCardFactory.paymentMethods.intentResponse.intentId : null;
 
         return storeService.collectPayment(paymentIntentId, factory.invoice.id, 
-          userState.getSelectedCompanyId())
+          _getCompanyId(), factory.getToken())
           .then(function () {
             factory.invoice.status = 'paid';
             factory.invoice.amount_paid = factory.invoice.total;
@@ -110,7 +130,7 @@ angular.module('risevision.apps.billing.services')
 
         factory.loading = true;
 
-        billing.getInvoicePdf(invoiceId)
+        billing.getInvoicePdf(invoiceId, _getCompanyId(), factory.getToken())
           .then(function (resp) {
             if (resp && resp.result) {
               // Trigger download

--- a/web/scripts/billing/services/svc-billing.js
+++ b/web/scripts/billing/services/svc-billing.js
@@ -56,11 +56,12 @@ angular.module('risevision.apps.billing.services')
 
           return deferred.promise;
         },
-        getInvoice: function (invoiceId) {
+        getInvoice: function (invoiceId, companyId, token) {
           var deferred = $q.defer();
           var params = {
-            'companyId': userState.getSelectedCompanyId(),
-            'invoiceId': invoiceId
+            'companyId': companyId,
+            'invoiceId': invoiceId,
+            'token': token
           };
 
           $log.debug('Store integrations.invoice.get called with', params);
@@ -80,11 +81,12 @@ angular.module('risevision.apps.billing.services')
 
           return deferred.promise;
         },
-        getInvoicePdf: function (invoiceId) {
+        getInvoicePdf: function (invoiceId, companyId, token) {
           var deferred = $q.defer();
           var params = {
-            'companyId': userState.getSelectedCompanyId(),
-            'invoiceId': invoiceId
+            'companyId': companyId,
+            'invoiceId': invoiceId,
+            'token': token
           };
 
           $log.debug('Store integrations.invoice.getPdf called with', params);

--- a/web/scripts/billing/services/svc-billing.js
+++ b/web/scripts/billing/services/svc-billing.js
@@ -56,6 +56,32 @@ angular.module('risevision.apps.billing.services')
 
           return deferred.promise;
         },
+        getUnpaidInvoices: function (search, cursor) {
+          var deferred = $q.defer();
+          var params = {
+            'companyId': search.companyId,
+            'token': search.token,
+            'cursor': cursor,
+            'count': search.count
+          };
+
+          $log.debug('Store integrations.invoice.listUnpaid called with', params);
+
+          storeAPILoader().then(function (storeApi) {
+              return storeApi.integrations.invoice.listUnpaid(params);
+            })
+            .then(function (resp) {
+              $log.debug('integrations.invoice.listUnpaid resp', resp);
+
+              deferred.resolve(resp.result);
+            })
+            .then(null, function (e) {
+              console.error('Failed to get company\'s unpaid invoices.', e);
+              deferred.reject(e);
+            });
+
+          return deferred.promise;
+        },
         getInvoice: function (invoiceId, companyId, token) {
           var deferred = $q.defer();
           var params = {

--- a/web/scripts/common-header/services/svc-store-service.js
+++ b/web/scripts/common-header/services/svc-store-service.js
@@ -125,13 +125,14 @@
               });
             return deferred.promise;
           },
-          preparePayment: function (paymentMethodId, invoiceId, companyId) {
+          preparePayment: function (paymentMethodId, invoiceId, companyId, token) {
             var deferred = $q.defer();
             storeAPILoader().then(function (storeAPI) {
                 var obj = {
                   paymentMethodId: paymentMethodId,
                   invoiceId: invoiceId,
-                  companyId: companyId
+                  companyId: companyId,
+                  token: token
                 };
                 return storeAPI.payment.prepare(obj);
               })
@@ -150,13 +151,14 @@
               });
             return deferred.promise;
           },
-          collectPayment: function (paymentIntentId, invoiceId, companyId) {
+          collectPayment: function (paymentIntentId, invoiceId, companyId, token) {
             var deferred = $q.defer();
             storeAPILoader().then(function (storeAPI) {
                 var obj = {
                   paymentIntentId: paymentIntentId,
                   invoiceId: invoiceId,
-                  companyId: companyId
+                  companyId: companyId,
+                  token: token
                 };
                 return storeAPI.payment.collect(obj);
               })

--- a/web/scripts/common/controllers/ctr-app.js
+++ b/web/scripts/common/controllers/ctr-app.js
@@ -41,12 +41,13 @@ angular.module('risevision.apps.controllers')
         states: ['apps.storage.home']
       }];
       $scope.navSelected = 'apps.editor.home';
-      $scope.hideCommonHeader = false;
+      $scope.hideCommonHeader = true;
 
       $rootScope.$on('$stateChangeSuccess', function () {
         $scope.navSelected = $state.current.name;
         $scope.hideCommonHeader =
-          $state.current.name.indexOf('common.auth') !== -1;
+          $state.current.name.indexOf('common.auth') !== -1 ||
+          $state.current.name.indexOf('apps.billing.invoice') !== -1;
       });
     }
   ]); //ctr

--- a/web/scripts/common/controllers/ctr-app.js
+++ b/web/scripts/common/controllers/ctr-app.js
@@ -47,7 +47,8 @@ angular.module('risevision.apps.controllers')
         $scope.navSelected = $state.current.name;
         $scope.hideCommonHeader =
           $state.current.name.indexOf('common.auth') !== -1 ||
-          $state.current.name.indexOf('apps.billing.invoice') !== -1;
+          $state.current.name.indexOf('apps.billing.invoice') !== -1 ||
+          $state.current.name.indexOf('apps.billing.unpaid') !== -1;
       });
     }
   ]); //ctr

--- a/web/scss/sections/apps.scss
+++ b/web/scss/sections/apps.scss
@@ -48,6 +48,12 @@
     }
 }
 
+.rise-logo {
+  img {
+    width: 150px;
+  }
+}
+
 // Login page
 .app-login {
 	padding-top: 60px;
@@ -72,10 +78,6 @@
 
 	.rise-logo {
     margin-bottom: 40px;
-
-		img {
-			width: 150px;
-		}
 	}
 
   .feature-sideways-panels {


### PR DESCRIPTION
## Description
Allow unauthenticated invoice page and payment

Remove authentication check from invoice page
Hide common header

Open invoice page with token parameter in a new tab
Forward token to api requests along with cid

[stage-19]

## Motivation and Context
Billing Frictions epic

## How Has This Been Tested?
Tested changes locally with the updated store-server version. Will update unit tests and add the logo in a subsequent PR.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No