### PR TITLE
Fix/issue 2241 help button failsafe

### DIFF
--- a/test/unit/common-header/services/svc-help-widget-factory-spec.js
+++ b/test/unit/common-header/services/svc-help-widget-factory-spec.js
@@ -80,37 +80,6 @@ describe("Services: helpWidgetFactory", function() {
       $window.document.createElement.should.not.have.been.called;
       $window._elev.on.should.not.have.been.called;
     });
-
-    it("should not open failback help screen if help script was loaded", function(done) {
-      factory.initializeWidget();
-      $window._elev.on.should.have.been.calledWith('load');
-
-      var loadCallback = $window._elev.on.getCall(0).args[1];
-      expect(loadCallback).to.be.a("function");
-      loadCallback($window._elev)
-
-      $window._elev.setSettings.should.have.been.calledWith({hideLauncher: true});
-
-      $timeout.flush(2000);
-      setTimeout(function() {
-        $window.open.should.not.have.been.called;
-
-        done();
-      }, 10);
-    });
-
-    it("should open failback help screen if help script was not loaded", function(done) {
-      factory.initializeWidget();
-      $window._elev.on.should.have.been.calledWith('load');
-      $window._elev.setSettings.should.not.have.been.called;
-
-      $timeout.flush(2000);
-      setTimeout(function() {
-        $window.open.should.have.been.calledWith('https://help.risevision.com/', '_blank');
-
-        done();
-      }, 10);
-    });
   });
 
   describe("showWidgetButton:", function() {
@@ -131,6 +100,61 @@ describe("Services: helpWidgetFactory", function() {
     it("should open help widget", function() {
       factory.showHelpWidget();
       $window._elev.openHome.should.have.been.called;
+    });
+  });
+
+  describe("showHelpWidget:helpFallback", function() {
+    var element;
+
+    beforeEach(function() {
+      element = $window.document.createElement('script');
+      element.innerText = "ToBeChanged";
+
+      sandbox.stub($window.document,"createElement", function() {
+        return element;
+      });
+    });
+
+    afterEach(function() {
+      $window.document.createElement.restore();
+    });
+
+    it("should not open failback help screen if help script was loaded", function(done) {
+      factory.initializeWidget();
+      $window._elev.on.should.have.been.calledWith('load');
+
+      var loadCallback = $window._elev.on.getCall(0).args[1];
+      expect(loadCallback).to.be.a("function");
+
+      factory.showHelpWidget();
+      $window._elev.openHome.should.have.been.called;
+
+      // simulating that the script loads and the load callback is called
+      loadCallback($window._elev)
+      $window._elev.setSettings.should.have.been.calledWith({hideLauncher: true});
+
+      $timeout.flush(2000);
+      setTimeout(function() {
+        $window.open.should.not.have.been.called;
+
+        done();
+      }, 10);
+    });
+
+    it("should open failback help screen if help script was not loaded", function(done) {
+      factory.initializeWidget();
+      $window._elev.on.should.have.been.calledWith('load');
+      $window._elev.setSettings.should.not.have.been.called;
+
+      factory.showHelpWidget();
+      $window._elev.openHome.should.have.been.called;
+
+      $timeout.flush(2000);
+      setTimeout(function() {
+        $window.open.should.have.been.calledWith('https://help.risevision.com/', '_blank');
+
+        done();
+      }, 10);
     });
   });
 });

--- a/test/unit/common-header/services/svc-help-widget-factory-spec.js
+++ b/test/unit/common-header/services/svc-help-widget-factory-spec.js
@@ -2,7 +2,7 @@
 
 describe("Services: helpWidgetFactory", function() {
   var sandbox = sinon.sandbox.create();
-  var $timeout, $window, factory;
+  var $window, factory;
 
   beforeEach(module("risevision.common.support"));
 
@@ -19,7 +19,6 @@ describe("Services: helpWidgetFactory", function() {
 
   beforeEach(function() {
     inject(function($injector, _$rootScope_) {
-      $timeout = $injector.get("$timeout");
       $window = $injector.get("$window");
       factory = $injector.get("helpWidgetFactory");
 
@@ -96,7 +95,7 @@ describe("Services: helpWidgetFactory", function() {
     });
   });
 
-  describe("showHelpWidget:helpFallback", function() {
+  describe("showHelpWidget:", function() {
     var element;
 
     beforeEach(function() {
@@ -112,7 +111,7 @@ describe("Services: helpWidgetFactory", function() {
       $window.document.createElement.restore();
     });
 
-    it("should open help widget and not open failback help screen if help script was loaded", function(done) {
+    it("should open help widget and not open failback help screen if help script was loaded", function() {
       factory.initializeWidget();
       $window._elev.on.should.have.been.calledWith('load');
 
@@ -125,29 +124,17 @@ describe("Services: helpWidgetFactory", function() {
 
       factory.showHelpWidget();
       $window._elev.openHome.should.have.been.called;
-
-      $timeout.flush(2000);
-      setTimeout(function() {
-        $window.open.should.not.have.been.called;
-
-        done();
-      }, 10);
+      $window.open.should.not.have.been.called;
     });
 
-    it("should not open help widget and open failback help screen if help script was not loaded", function(done) {
+    it("should not open help widget and open failback help screen if help script was not loaded", function() {
       factory.initializeWidget();
       $window._elev.on.should.have.been.calledWith('load');
       $window._elev.setSettings.should.not.have.been.called;
 
       factory.showHelpWidget();
       $window._elev.openHome.should.not.have.been.called;
-
-      $timeout.flush(2000);
-      setTimeout(function() {
-        $window.open.should.have.been.calledWith('https://help.risevision.com/', '_blank');
-
-        done();
-      }, 10);
+      $window.open.should.have.been.calledWith('https://help.risevision.com/', '_blank');
     });
   });
 });

--- a/test/unit/common-header/services/svc-help-widget-factory-spec.js
+++ b/test/unit/common-header/services/svc-help-widget-factory-spec.js
@@ -96,13 +96,6 @@ describe("Services: helpWidgetFactory", function() {
     });
   });
 
-  describe("showHelpWidget:", function() {
-    it("should open help widget", function() {
-      factory.showHelpWidget();
-      $window._elev.openHome.should.have.been.called;
-    });
-  });
-
   describe("showHelpWidget:helpFallback", function() {
     var element;
 
@@ -119,19 +112,19 @@ describe("Services: helpWidgetFactory", function() {
       $window.document.createElement.restore();
     });
 
-    it("should not open failback help screen if help script was loaded", function(done) {
+    it("should open help widget and not open failback help screen if help script was loaded", function(done) {
       factory.initializeWidget();
       $window._elev.on.should.have.been.calledWith('load');
 
       var loadCallback = $window._elev.on.getCall(0).args[1];
       expect(loadCallback).to.be.a("function");
 
-      factory.showHelpWidget();
-      $window._elev.openHome.should.have.been.called;
-
       // simulating that the script loads and the load callback is called
       loadCallback($window._elev)
       $window._elev.setSettings.should.have.been.calledWith({hideLauncher: true});
+
+      factory.showHelpWidget();
+      $window._elev.openHome.should.have.been.called;
 
       $timeout.flush(2000);
       setTimeout(function() {
@@ -141,13 +134,13 @@ describe("Services: helpWidgetFactory", function() {
       }, 10);
     });
 
-    it("should open failback help screen if help script was not loaded", function(done) {
+    it("should not open help widget and open failback help screen if help script was not loaded", function(done) {
       factory.initializeWidget();
       $window._elev.on.should.have.been.calledWith('load');
       $window._elev.setSettings.should.not.have.been.called;
 
       factory.showHelpWidget();
-      $window._elev.openHome.should.have.been.called;
+      $window._elev.openHome.should.not.have.been.called;
 
       $timeout.flush(2000);
       setTimeout(function() {

--- a/web/scripts/common-header/services/svc-help-widget-factory.js
+++ b/web/scripts/common-header/services/svc-help-widget-factory.js
@@ -4,12 +4,15 @@
   'use strict';
 
   angular.module('risevision.common.support', [])
+    .value('HELP_URL', 'https://help.risevision.com/')
     .value('HELP_WIDGET_SCRIPT',
       '!function(e,l,v,i,o,n){e[i]||(e[i]={}),e[i].account_id=n;var g,h;g=l.createElement(v),g.type="text/javascript",g.async=1,g.src=o+n,h=l.getElementsByTagName(v)[0],h.parentNode.insertBefore(g,h);e[i].q=[];e[i].on=function(z,y){e[i].q.push([z,y])}}(window,document,"script","_elev","https://cdn.elev.io/sdk/bootloader/v4/elevio-bootloader.js?cid=","5f2331387a97f");'
     )
-    .factory('helpWidgetFactory', ['$window', 'HELP_WIDGET_SCRIPT',
-      function ($window, HELP_WIDGET_SCRIPT) {
+    .factory('helpWidgetFactory', ['$timeout', '$window', 'HELP_URL', 'HELP_WIDGET_SCRIPT',
+      function ($timeout, $window, HELP_URL, HELP_WIDGET_SCRIPT) {
         var loaded = false;
+        var widgetScriptLoaded = false;
+        var failsafeCheckDelay = 2000;
 
         function initializeWidget() {
           if (!loaded) {
@@ -18,11 +21,18 @@
 
             $window.document.body.appendChild(scriptElem);
             $window._elev.on('load', function (_elev) {
+              widgetScriptLoaded = true;
               _elev.setSettings({
                 hideLauncher: true
               });
             });
             loaded = true;
+
+            $timeout(function() {
+              if( !widgetScriptLoaded ) {
+                $window.open(HELP_URL, '_blank');
+              }
+            }, failsafeCheckDelay);
           }
         }
 

--- a/web/scripts/common-header/services/svc-help-widget-factory.js
+++ b/web/scripts/common-header/services/svc-help-widget-factory.js
@@ -47,7 +47,7 @@
         }
 
         function showHelpWidget() {
-          if ($window._elev) {
+          if ($window._elev && widgetScriptLoaded) {
             $window._elev.openHome();
           }
 

--- a/web/scripts/common-header/services/svc-help-widget-factory.js
+++ b/web/scripts/common-header/services/svc-help-widget-factory.js
@@ -27,12 +27,6 @@
               });
             });
             loaded = true;
-
-            $timeout(function() {
-              if( !widgetScriptLoaded ) {
-                $window.open(HELP_URL, '_blank');
-              }
-            }, failsafeCheckDelay);
           }
         }
 
@@ -56,6 +50,12 @@
           if ($window._elev) {
             $window._elev.openHome();
           }
+
+          $timeout(function() {
+            if( !widgetScriptLoaded ) {
+              $window.open(HELP_URL, '_blank');
+            }
+          }, failsafeCheckDelay);
         }
 
         return {

--- a/web/scripts/common-header/services/svc-help-widget-factory.js
+++ b/web/scripts/common-header/services/svc-help-widget-factory.js
@@ -8,11 +8,10 @@
     .value('HELP_WIDGET_SCRIPT',
       '!function(e,l,v,i,o,n){e[i]||(e[i]={}),e[i].account_id=n;var g,h;g=l.createElement(v),g.type="text/javascript",g.async=1,g.src=o+n,h=l.getElementsByTagName(v)[0],h.parentNode.insertBefore(g,h);e[i].q=[];e[i].on=function(z,y){e[i].q.push([z,y])}}(window,document,"script","_elev","https://cdn.elev.io/sdk/bootloader/v4/elevio-bootloader.js?cid=","5f2331387a97f");'
     )
-    .factory('helpWidgetFactory', ['$timeout', '$window', 'HELP_URL', 'HELP_WIDGET_SCRIPT',
-      function ($timeout, $window, HELP_URL, HELP_WIDGET_SCRIPT) {
+    .factory('helpWidgetFactory', ['$window', 'HELP_URL', 'HELP_WIDGET_SCRIPT',
+      function ($window, HELP_URL, HELP_WIDGET_SCRIPT) {
         var loaded = false;
         var widgetScriptLoaded = false;
-        var failsafeCheckDelay = 2000;
 
         function initializeWidget() {
           if (!loaded) {
@@ -49,13 +48,9 @@
         function showHelpWidget() {
           if ($window._elev && widgetScriptLoaded) {
             $window._elev.openHome();
+          } else {
+            $window.open(HELP_URL, '_blank');
           }
-
-          $timeout(function() {
-            if( !widgetScriptLoaded ) {
-              $window.open(HELP_URL, '_blank');
-            }
-          }, failsafeCheckDelay);
         }
 
         return {


### PR DESCRIPTION
## Description
Open help.risevision.com in a new browser tab, if the elev script doesn't load.

I added a 2 second wait to account for a user that immediately clicks the button while the page is still loading; but I can change ( or eliminate ) that delay if considered necessary.

## Motivation and Context
Issue 2241

## How Has This Been Tested?
Created unit tests as part of this PR, and tested manually.

As we don't have control on the third party code, I created a test branch that always opens the help browser tab: https://apps-stage-9.risevision.com/editor

This particular scenario can be manually tested in stage-9

## Release Plan:
To be released on Monday.
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to update documentation
