### PR TITLE
Feature/prompt to license display

### DIFF
--- a/test/unit/displays/controllers/ctr-display-add.tests.js
+++ b/test/unit/displays/controllers/ctr-display-add.tests.js
@@ -2,6 +2,7 @@
 
 describe('controller: display add', function() {
   var displayId = '1234';
+  var isProAvailable = true;
   var sandbox = sinon.sandbox.create();
 
   beforeEach(module('risevision.displays.services'));
@@ -36,7 +37,7 @@ describe('controller: display add', function() {
     $provide.factory('playerLicenseFactory', function() {
       return {
         isProAvailable: function() {
-          return true;
+          return isProAvailable;
         }
       };
     });
@@ -95,9 +96,23 @@ describe('controller: display add', function() {
     });
   });
 
-  describe('license:', function() {
-    it('should not show license modal if there are licenses available', function() {
+  describe('license:available:', function() {
+    before( function() {
+      isProAvailable = true;
+    });
+
+    it('should not show license modal if licenses are available', function() {
       plansFactory.confirmAndPurchase.should.not.have.been.called;
+    });
+  });
+
+  describe('license:unavailable:', function() {
+    before( function() {
+      isProAvailable = false;
+    });
+
+    it('should show license modal if no licenses are available', function() {
+      plansFactory.confirmAndPurchase.should.have.been.called;
     });
   });
 

--- a/test/unit/displays/controllers/ctr-display-add.tests.js
+++ b/test/unit/displays/controllers/ctr-display-add.tests.js
@@ -13,6 +13,10 @@ describe('controller: display add', function() {
         addDisplay: sinon.spy()
       };
     });
+    $provide.service('plansFactory', function() {
+      return {
+      };
+    });
     $provide.service('scheduleFactory', function() {
       return {
         getAllDisplaysSchedule: function() {

--- a/test/unit/displays/controllers/ctr-display-add.tests.js
+++ b/test/unit/displays/controllers/ctr-display-add.tests.js
@@ -15,6 +15,7 @@ describe('controller: display add', function() {
     });
     $provide.service('plansFactory', function() {
       return {
+        confirmAndPurchase: sandbox.stub()
       };
     });
     $provide.service('scheduleFactory', function() {
@@ -33,14 +34,19 @@ describe('controller: display add', function() {
       };
     });
     $provide.factory('playerLicenseFactory', function() {
-      return {};
+      return {
+        isProAvailable: function() {
+          return true;
+        }
+      };
     });
 
   }));
-  var $scope, $loading, displayFactory, scheduleFactory;
+  var $scope, $loading, displayFactory, plansFactory, scheduleFactory;
   beforeEach(function(){
     inject(function($injector, $controller){
       displayFactory = $injector.get('displayFactory');
+      plansFactory = $injector.get('plansFactory');
       scheduleFactory = $injector.get('scheduleFactory');
       $loading = $injector.get('$loading');
 
@@ -86,6 +92,12 @@ describe('controller: display add', function() {
 
         done();
       }, 10);
+    });
+  });
+
+  describe('license:', function() {
+    it('should not show license modal if there are licenses available', function() {
+      plansFactory.confirmAndPurchase.should.not.have.been.called;
     });
   });
 

--- a/web/scripts/displays/controllers/ctr-display-add.js
+++ b/web/scripts/displays/controllers/ctr-display-add.js
@@ -33,5 +33,8 @@ angular.module('risevision.displays.controllers')
         displayFactory.addDisplay($scope.selectedSchedule);
       };
 
+      if(!playerLicenseFactory.isProAvailable(displayFactory.display)) {
+        plansFactory.confirmAndPurchase();
+      }
     }
   ]);

--- a/web/scripts/displays/controllers/ctr-display-add.js
+++ b/web/scripts/displays/controllers/ctr-display-add.js
@@ -1,9 +1,10 @@
 'use strict';
 
 angular.module('risevision.displays.controllers')
-  .controller('displayAdd', ['$scope', '$log', '$loading', 'displayFactory', 'playerLicenseFactory',
-    'scheduleFactory',
-    function ($scope, $log, $loading, displayFactory, playerLicenseFactory, scheduleFactory) {
+  .controller('displayAdd', ['$scope', '$log', '$loading', 'displayFactory', 'plansFactory',
+    'playerLicenseFactory', 'scheduleFactory',
+    function ($scope, $log, $loading, displayFactory, plansFactory, playerLicenseFactory,
+      scheduleFactory) {
       $scope.factory = displayFactory;
       $scope.playerLicenseFactory = playerLicenseFactory;
       $scope.selectedSchedule = null;


### PR DESCRIPTION
## Description
Show license modal when add display page is opened and there are no displays available.

[stage-9]

## Motivation and Context
As requested.

## How Has This Been Tested?
Unit tests were added, and it can be tested in stage-9 by selecting a company with no available licenses and opening the add display page.

## Release Plan:
No release before Monday

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
