### PR TITLE
Revert rewrite widgets S3 URLs [stage-8]

### DIFF
--- a/test/unit/editor/services/svc-widget-utils.tests.js
+++ b/test/unit/editor/services/svc-widget-utils.tests.js
@@ -22,7 +22,7 @@ describe('service: widgetUtils:', function() {
     expect(widgetUtils.getWidgetId).to.be.a('function');
     expect(widgetUtils.getProfessionalWidgets).to.be.a('function');
   });
-  
+
   it('isRenderingAllowed: ', function() {
     expect(widgetUtils.isRenderingAllowed(WIDGETS_INFO.WEB_PAGE.ids.PROD)).to.be.true;
     expect(widgetUtils.isRenderingAllowed(WIDGETS_INFO.VIDEO.ids.PROD)).to.be.false;
@@ -31,8 +31,8 @@ describe('service: widgetUtils:', function() {
 
   it('isWebpageWidget: ', function() {
     expect(widgetUtils.isWebpageWidget(WIDGETS_INFO.WEB_PAGE.ids.PROD)).to.be.true;
-    expect(widgetUtils.isWebpageWidget(WIDGETS_INFO.VIDEO.ids.PROD)).to.be.false;    
-    expect(widgetUtils.isWebpageWidget('1234')).to.be.false;    
+    expect(widgetUtils.isWebpageWidget(WIDGETS_INFO.VIDEO.ids.PROD)).to.be.false;
+    expect(widgetUtils.isWebpageWidget('1234')).to.be.false;
   });
 
   it('getInAppSettings: ', function() {
@@ -43,10 +43,10 @@ describe('service: widgetUtils:', function() {
     expect(widgetUtils.getInAppSettings(WIDGETS_INFO.IMAGE.ids.PROD)).to.be.null;
     expect(widgetUtils.getInAppSettings('1234')).to.be.null;
   });
-  
+
   it('getIconClass: ', function() {
     item.objectReference = WIDGETS_INFO.VIDEO.ids.PROD;
-    expect(widgetUtils.getIconClass(item)).to.equal('ph-item-icon ph-video-item');    
+    expect(widgetUtils.getIconClass(item)).to.equal('ph-item-icon ph-video-item');
     item.objectReference = WIDGETS_INFO.WEB_PAGE.ids.PROD;
     expect(widgetUtils.getIconClass(item)).to.equal('ph-item-icon');
     item.objectReference = '1234';
@@ -55,10 +55,10 @@ describe('service: widgetUtils:', function() {
     item.type = 'presentation';
     expect(widgetUtils.getIconClass(item)).to.equal('ph-item-icon ph-embedded-item');
   });
-  
+
   it('getSvgIcon: ', function() {
     item.objectReference = WIDGETS_INFO.VIDEO.ids.PROD;
-    expect(widgetUtils.getSvgIcon(item)).to.equal('riseWidgetVideo');    
+    expect(widgetUtils.getSvgIcon(item)).to.equal('riseWidgetVideo');
     item.objectReference = WIDGETS_INFO.WEB_PAGE.ids.PROD;
     expect(widgetUtils.getSvgIcon(item)).to.equal('riseWidgetMore');
     item.objectReference = '1234';
@@ -71,7 +71,7 @@ describe('service: widgetUtils:', function() {
   it('getWidgetId: ', function() {
     expect(widgetUtils.getWidgetId('video')).to.equal(WIDGETS_INFO.VIDEO.ids.TEST);
     expect(widgetUtils.getWidgetId('web_page')).to.equal(WIDGETS_INFO.WEB_PAGE.ids.TEST);
-    expect(widgetUtils.getWidgetId()).to.not.be.ok;    
+    expect(widgetUtils.getWidgetId()).to.not.be.ok;
     expect(widgetUtils.getWidgetId('1234')).to.not.be.ok;
   });
 
@@ -87,14 +87,14 @@ describe('service: widgetUtils:', function() {
   describe('getProfessionalWidgets: ', function() {
     it('should have expected properties', function() {
       var widgets = widgetUtils.getProfessionalWidgets();
-      
+
       widgets.forEach(function(widget) {
         expect(widget.name).to.be.a('string');
         expect(widget.imageUrl).to.be.a('string');
         expect(widget.imageAlt).to.be.a('string');
         expect(widget.gadgetType).to.be.a('string');
         expect(widget.id).to.be.a('string');
-      });      
+      });
     });
 
     it('should contain all Pro widgets', function() {
@@ -106,32 +106,6 @@ describe('service: widgetUtils:', function() {
       expect(widgets[1].name).to.contain('Embedded');
       expect(widgets[1].env).to.be.undefined;
     });
-  });
-
-  describe('rewriteS3Urls: ', function() {
-    it('should rewrite S3 urls', function() {
-      var urlHttp  = "http://s3.amazonaws.com/widget-image/0.1.1/dist/widget.html";
-      var urlHttps = "https://s3.amazonaws.com/widget-image/0.1.1/dist/widget.html";
-      var expected = "https://widgets.risevision.com/widget-image/0.1.1/dist/widget.html";
-
-      expect(widgetUtils.rewriteS3Urls(urlHttp)).to.be.equal(expected);
-      expect(widgetUtils.rewriteS3Urls(urlHttps)).to.be.equal(expected);
-    });
-
-    it('should rewrite url with parameters', function() {
-      var url      = "http://s3.amazonaws.com/widget-image/0.1.1/dist/widget.html?p1=v1&p2=v2";
-      var expected = "https://widgets.risevision.com/widget-image/0.1.1/dist/widget.html?p1=v1&p2=v2";
-
-      expect(widgetUtils.rewriteS3Urls(url)).to.be.equal(expected);
-    });
-
-    it('should rewrite 3rd party urls', function() {
-      var url      = "http://scottsdigitalsignage.com/widget/vimeo-widget/demo/index.html";
-      var expected = "https://widgets.risevision.com/widget-vimeo/demo/index.html";
-
-      expect(widgetUtils.rewriteS3Urls(url)).to.be.equal(expected);
-    });
-
   });
 
 });

--- a/web/scripts/editor/services/svc-widget-renderer.js
+++ b/web/scripts/editor/services/svc-widget-renderer.js
@@ -77,9 +77,8 @@ angular.module('risevision.editor.services')
 
       var _createIframe = function (placeholder, element) {
         var renderId = placeholder.id;
-        var widgetUrl = widgetUtils.rewriteS3Urls(placeholder.items[0].objectData);
-        widgetUrl = widgetUrl +
-          (widgetUrl.indexOf('?') > -1 ? '&' : '?') +
+        var widgetUrl = placeholder.items[0].objectData +
+          (placeholder.items[0].objectData.indexOf('?') > -1 ? '&' : '?') +
           'up_id=' + renderId +
           '&up_companyId=' + userState.getSelectedCompanyId() +
           '&up_rsW=' + placeholder.width +

--- a/web/scripts/editor/services/svc-widget-utils.js
+++ b/web/scripts/editor/services/svc-widget-utils.js
@@ -215,50 +215,6 @@ angular.module('risevision.editor.services')
         });
       };
 
-      factory.rewriteS3Urls = function (url) {
-        var search = [
-          new RegExp('https?://s3.amazonaws.com/widget-', 'g'),
-          new RegExp('https?://data-feed.digichief.com/risevision/weather/WeatherWidget.html', 'gi'),
-          new RegExp('https?://account.testinseconds.com/WeatherWidget/widget.html', 'gi'),
-          new RegExp('https://account.testinseconds.com/TextMarquee/widget.html', 'gi'),
-          new RegExp('https://account.testinseconds.com/TrafficMapWidget/widget.html', 'gi'),
-          new RegExp('http://www.scottsdigitalsignage.com/widget/youtube-widget/demo/index.html', 'gi'),
-          new RegExp('https://data-feed.digichief.com/risevision/NewsRadar/NewsRadarWidget.html', 'gi'),
-          new RegExp('https://account.testinseconds.com/ImageGalleryWidget/widget.html', 'gi'),
-          new RegExp('http://data-feed.digichief.com/risevision/News/NewsWidget.html', 'gi'),
-          new RegExp('https://rep.smartplayds.com/plugin/facebook-widget/widget.html', 'gi'),
-          new RegExp('https://account.testinseconds.com/CountUpWidget/widget.html', 'gi'),
-          new RegExp('https://account.testinseconds.com/CountdownWidget/widget.html', 'gi'),
-          new RegExp('http://data-feed.digichief.com/risevision/Sports/SportsWidget.html', 'gi'),
-          new RegExp('http://scottsdigitalsignage.com/widget/vimeo-widget/demo/index.html', 'gi')
-        ];
-
-        var replace = [
-          'https://widgets.risevision.com/widget-',
-          'https://widgets.risevision.com/widget-digichief-weather/WeatherWidget.html',
-          'https://widgets.risevision.com/widget-computer-aid-weather/widget.html',
-          'https://widgets.risevision.com/widget-computer-aid-marquee/widget.html',
-          'https://widgets.risevision.com/widget-computer-aid-traffic/widget.html',
-          'https://widgets.risevision.com/widget-youtube/demo/index.html',
-          'https://widgets.risevision.com/widget-newsradar/NewsRadarWidget.html',
-          'https://widgets.risevision.com/widget-computer-aid-gallery/widget.html',
-          'https://widgets.risevision.com/widget-news/NewsWidget.html',
-          'https://widgets.risevision.com/widget-facebook/widget.html',
-          'https://widgets.risevision.com/widget-computer-aid-count-up/widget.html',
-          'https://widgets.risevision.com/widget-computer-aid-count-down/widget.html',
-          'https://widgets.risevision.com/widget-sports/SportsWidget.html',
-          'https://widgets.risevision.com/widget-vimeo/demo/index.html'
-        ];
-
-        if (url) {
-          angular.forEach(search, function (regex, i) {
-            url = url.replace(regex, replace[i]);
-          });
-        }
-
-        return url;
-      };
-
       return factory;
     }
   ]);


### PR DESCRIPTION
## Description
Revert changes made to rewrite widgets s3 urls to widgets.risevision.com

## Motivation and Context
A bug was introduced in Chrome OS Player from rewriting widget urls to be loaded over HTTPS protocol. A fix will be applied to Viewer, in the meantime we need to stop the propagation of these rewrites to prevent any more potential storage bandwidth increase from users making changes to presentations containing Video widgets. 

## How Has This Been Tested?
Tested on stage 8 - https://apps-stage-8.risevision.com/editor/workspace/37c2a73d-3cee-4f63-aadc-3aeee6ccabd7?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
