### PR TITLE
Add handler for outside clicks to share url popover

### DIFF
--- a/test/unit/billing/directives/dtv-share-url-button.tests.js
+++ b/test/unit/billing/directives/dtv-share-url-button.tests.js
@@ -1,12 +1,22 @@
 'use strict';
 describe('directive: share-url-button', function() {
-  var $scope, element, $timeout;
+  var $scope, element, $timeout, outsideClickHandler;
 
   beforeEach(module('risevision.apps.billing.directives'));
 
+  beforeEach(module(function ($provide) {
+    $provide.service('outsideClickHandler', function() {
+      return {
+        bind: sinon.stub(),
+        unbind: sinon.stub()
+      };
+    });
+  }));
+
   beforeEach(inject(function($compile, $rootScope, $templateCache, $injector){
-    $templateCache.put('partials/billing/share-url-button.html', '<button id="tooltipButton"></button>');
+    $templateCache.put('partials/billing/share-url-button.html', '<button id="share-schedule-button"></button>');
     $timeout = $injector.get('$timeout');
+    outsideClickHandler = $injector.get('outsideClickHandler');
 
     $scope = $rootScope.$new();
 
@@ -28,12 +38,14 @@ describe('directive: share-url-button', function() {
   });
 
   it('should compile', function() {
-    expect(element[0].outerHTML).to.equal('<button id="tooltipButton" class="ng-isolate-scope"></button>');
+    expect(element[0].outerHTML).to.equal('<button id="share-schedule-button" class="ng-isolate-scope"></button>');
   });
 
   describe('toggleTooltip:', function() {
     it('should open tooltip', function(done) {
       element.on('show', function() {
+        outsideClickHandler.bind.should.have.been.calledWith('share-url-button', '#share-url-button, #share-url-popover', $scope.toggleTooltip);
+
         done();
       });
 
@@ -47,6 +59,8 @@ describe('directive: share-url-button', function() {
       $timeout.flush();
 
       element.on('hide', function() {
+        outsideClickHandler.unbind.should.have.been.called;
+
         done();
       });
 
@@ -62,6 +76,8 @@ describe('directive: share-url-button', function() {
       $timeout.flush();
 
       element.on('hide', function() {
+        outsideClickHandler.unbind.should.have.been.called;
+
         done();
       });
 

--- a/web/partials/billing/share-url-button.html
+++ b/web/partials/billing/share-url-button.html
@@ -1,4 +1,4 @@
-<button id="tooltipButton" type="button"
+<button id="share-url-button" type="button"
   tooltip-placement="bottom"
   tooltip-class="madero-style tooltip-share-options"
   tooltip-trigger="show"

--- a/web/partials/billing/share-url-popover.html
+++ b/web/partials/billing/share-url-popover.html
@@ -1,4 +1,4 @@
-<div id="shareUrl" ng-controller="ShareUrlController" class="share-url-popover">
+<div id="share-url-popover" ng-controller="ShareUrlController">
   <span class="text-sm font-weight-bold">Share</span>
   <button type="button" class="close" ng-click="dismiss()" aria-hidden="true">
     <streamline-icon name="close" width="10" height="10"></streamline-icon>

--- a/web/scripts/billing/directives/dtv-share-url-button.js
+++ b/web/scripts/billing/directives/dtv-share-url-button.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('risevision.apps.billing.directives')
-  .directive('shareUrlButton', ['$timeout',
-    function ($timeout) {
+  .directive('shareUrlButton', ['$timeout', 'outsideClickHandler',
+    function ($timeout, outsideClickHandler) {
       return {
         restrict: 'E',
         templateUrl: 'partials/billing/share-url-button.html',
@@ -14,6 +14,7 @@ angular.module('risevision.apps.billing.directives')
           $scope.dismiss = function () {
             $timeout(function () {
               isTooltipOpen = false;
+              outsideClickHandler.unbind('share-url-button');
               element.trigger('hide');
             });
           };
@@ -22,9 +23,11 @@ angular.module('risevision.apps.billing.directives')
             $timeout(function () {
               if (isTooltipOpen) {
                 isTooltipOpen = false;
+                outsideClickHandler.unbind('share-url-button');
                 element.trigger('hide');
               } else {
                 isTooltipOpen = true;
+                outsideClickHandler.bind('share-url-button', '#share-url-button, #share-url-popover', $scope.toggleTooltip);
                 element.trigger('show');
               }
             });


### PR DESCRIPTION
## Description
Add handler for outside clicks to share url popover

[stage-16]

## Motivation and Context
Fix issue where modal is not closing.

## How Has This Been Tested?
Tested changes locally; updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No