### PR TITLE
Correct CSS selector for schedule-selector-tooltip

### DIFF
--- a/web/partials/schedules/schedule-selector-tooltip.html
+++ b/web/partials/schedules/schedule-selector-tooltip.html
@@ -1,4 +1,4 @@
-<span class="schedule-selector-tooltip">
+<span id="schedule-selector-tooltip">
   <div class="row">
     <div class="col-xs-12">
       <search-filter filter-config="filterConfig" search="factory.search" do-search="factory.unselectedSchedules.doSearch" icon-set="madero"></search-filter>


### PR DESCRIPTION
## Description
`outsideClickHandler` was expecting `id='schedule-selector-tooltip'` instead of `class`. Probably missed committing this file on previous PR https://github.com/Rise-Vision/rise-vision-apps/pull/2236.

## Motivation and Context
Fix for #2259

## How Has This Been Tested?
Locally and on [stage-1]


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
