### PR TITLE
Reinstate rewriting Widgets S3 URLs [stage-8]

### DIFF
--- a/test/unit/editor/services/svc-widget-utils.tests.js
+++ b/test/unit/editor/services/svc-widget-utils.tests.js
@@ -108,4 +108,30 @@ describe('service: widgetUtils:', function() {
     });
   });
 
+  describe('rewriteS3Urls: ', function() {
+    it('should rewrite S3 urls', function() {
+      var urlHttp  = "http://s3.amazonaws.com/widget-image/0.1.1/dist/widget.html";
+      var urlHttps = "https://s3.amazonaws.com/widget-image/0.1.1/dist/widget.html";
+      var expected = "https://widgets.risevision.com/widget-image/0.1.1/dist/widget.html";
+
+      expect(widgetUtils.rewriteS3Urls(urlHttp)).to.be.equal(expected);
+      expect(widgetUtils.rewriteS3Urls(urlHttps)).to.be.equal(expected);
+    });
+
+    it('should rewrite url with parameters', function() {
+      var url      = "http://s3.amazonaws.com/widget-image/0.1.1/dist/widget.html?p1=v1&p2=v2";
+      var expected = "https://widgets.risevision.com/widget-image/0.1.1/dist/widget.html?p1=v1&p2=v2";
+
+      expect(widgetUtils.rewriteS3Urls(url)).to.be.equal(expected);
+    });
+
+    it('should rewrite 3rd party urls', function() {
+      var url      = "http://scottsdigitalsignage.com/widget/vimeo-widget/demo/index.html";
+      var expected = "https://widgets.risevision.com/widget-vimeo/demo/index.html";
+
+      expect(widgetUtils.rewriteS3Urls(url)).to.be.equal(expected);
+    });
+
+  });
+
 });

--- a/web/scripts/editor/services/svc-widget-renderer.js
+++ b/web/scripts/editor/services/svc-widget-renderer.js
@@ -77,8 +77,9 @@ angular.module('risevision.editor.services')
 
       var _createIframe = function (placeholder, element) {
         var renderId = placeholder.id;
-        var widgetUrl = placeholder.items[0].objectData +
-          (placeholder.items[0].objectData.indexOf('?') > -1 ? '&' : '?') +
+        var widgetUrl = widgetUtils.rewriteS3Urls(placeholder.items[0].objectData);
+        widgetUrl = widgetUrl +
+          (widgetUrl.indexOf('?') > -1 ? '&' : '?') +
           'up_id=' + renderId +
           '&up_companyId=' + userState.getSelectedCompanyId() +
           '&up_rsW=' + placeholder.width +

--- a/web/scripts/editor/services/svc-widget-utils.js
+++ b/web/scripts/editor/services/svc-widget-utils.js
@@ -215,6 +215,50 @@ angular.module('risevision.editor.services')
         });
       };
 
+      factory.rewriteS3Urls = function (url) {
+        var search = [
+          new RegExp('https?://s3.amazonaws.com/widget-', 'g'),
+          new RegExp('https?://data-feed.digichief.com/risevision/weather/WeatherWidget.html', 'gi'),
+          new RegExp('https?://account.testinseconds.com/WeatherWidget/widget.html', 'gi'),
+          new RegExp('https://account.testinseconds.com/TextMarquee/widget.html', 'gi'),
+          new RegExp('https://account.testinseconds.com/TrafficMapWidget/widget.html', 'gi'),
+          new RegExp('http://www.scottsdigitalsignage.com/widget/youtube-widget/demo/index.html', 'gi'),
+          new RegExp('https://data-feed.digichief.com/risevision/NewsRadar/NewsRadarWidget.html', 'gi'),
+          new RegExp('https://account.testinseconds.com/ImageGalleryWidget/widget.html', 'gi'),
+          new RegExp('http://data-feed.digichief.com/risevision/News/NewsWidget.html', 'gi'),
+          new RegExp('https://rep.smartplayds.com/plugin/facebook-widget/widget.html', 'gi'),
+          new RegExp('https://account.testinseconds.com/CountUpWidget/widget.html', 'gi'),
+          new RegExp('https://account.testinseconds.com/CountdownWidget/widget.html', 'gi'),
+          new RegExp('http://data-feed.digichief.com/risevision/Sports/SportsWidget.html', 'gi'),
+          new RegExp('http://scottsdigitalsignage.com/widget/vimeo-widget/demo/index.html', 'gi')
+        ];
+
+        var replace = [
+          'https://widgets.risevision.com/widget-',
+          'https://widgets.risevision.com/widget-digichief-weather/WeatherWidget.html',
+          'https://widgets.risevision.com/widget-computer-aid-weather/widget.html',
+          'https://widgets.risevision.com/widget-computer-aid-marquee/widget.html',
+          'https://widgets.risevision.com/widget-computer-aid-traffic/widget.html',
+          'https://widgets.risevision.com/widget-youtube/demo/index.html',
+          'https://widgets.risevision.com/widget-newsradar/NewsRadarWidget.html',
+          'https://widgets.risevision.com/widget-computer-aid-gallery/widget.html',
+          'https://widgets.risevision.com/widget-news/NewsWidget.html',
+          'https://widgets.risevision.com/widget-facebook/widget.html',
+          'https://widgets.risevision.com/widget-computer-aid-count-up/widget.html',
+          'https://widgets.risevision.com/widget-computer-aid-count-down/widget.html',
+          'https://widgets.risevision.com/widget-sports/SportsWidget.html',
+          'https://widgets.risevision.com/widget-vimeo/demo/index.html'
+        ];
+
+        if (url) {
+          angular.forEach(search, function (regex, i) {
+            url = url.replace(regex, replace[i]);
+          });
+        }
+
+        return url;
+      };
+
       return factory;
     }
   ]);


### PR DESCRIPTION
## Description
Reinstate rewriting Widgets S3 URLs in editor preview. The rewrite rules are copied from [Viewer](https://github.com/Rise-Vision/viewer/blob/b0054261046307151c0b2bf6f83ce4190e730d37/src-js/Viewer/Data/ViewerDataInfo.js#L114).

## Motivation and Context
We are working on eliminating use of Amazon S3 for widgets. Latest versions of Widgets are no longer deployed to S3. See this [Trello card](https://trello.com/c/OOV9y0sv/7833-eliminate-use-of-amazon-s3-for-widgets-stop-propagation-of-s3-usage-3) for more details.

These changes were previously reverted in PR #2250 due to a defect which has now been fixed in Viewer https://github.com/Rise-Vision/viewer/pull/470

## How Has This Been Tested?
- Added unit tests
- Tested in Editor on stage-8

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
