### PR TITLE
Add taxes, discounts and credits to the invoice

### DIFF
--- a/web/partials/billing/invoice.html
+++ b/web/partials/billing/invoice.html
@@ -181,6 +181,28 @@
       <div ng-show="billingFactory.invoice">
         <div class="row">
           <div class="col-md-offset-8 col-md-4">
+            <div class="pb-3 mb-3 border-bottom" ng-hide="billingFactory.invoice.sub_total === billingFactory.invoice.total">
+              <div class="text-right">
+                <span class="pull-left">Sub Total:</span>
+                <span>
+                  ${{billingFactory.invoice.sub_total / 100 | number:2}}
+                </span>
+              </div>
+              <div class="text-right mt-3" ng-repeat="discount in billingFactory.invoice.discounts">
+                <span class="pull-left">{{discount.description}}:</span>
+                <span>
+                  -${{discount.amount / 100 | number:2}}
+                </span>
+              </div>
+              <div class="text-right mt-3" ng-repeat="tax in billingFactory.invoice.taxes">
+                <span class="pull-left">{{tax.description}}:</span>
+                <span>
+                  ${{tax.amount / 100 | number:2}}
+                </span>
+              </div>
+
+            </div>
+
             <div class="text-right">
               <label class="mb-0 pull-left">Total:</label>
               <label class="mb-0">
@@ -188,12 +210,19 @@
               </label>
             </div>
             <div class="text-right mt-3" ng-show="billingFactory.invoice.amount_paid">
-              <label class="mb-0 pull-left">Payment:</label>
-              <label class="mb-0">
-                ${{billingFactory.invoice.amount_paid / 100 | number:2}}
-              </label>
+              <span class="mb-0 pull-left">Payment:</span>
+              <span class="mb-0">
+                -${{billingFactory.invoice.amount_paid / 100 | number:2}}
+              </span>
             </div>
-            <div class="text-right mt-3">
+            <div class="text-right mt-3" ng-show="billingFactory.invoice.credits_applied">
+              <span class="mb-0 pull-left">Credits:</span>
+              <span class="mb-0">
+                -${{billingFactory.invoice.credits_applied / 100 | number:2}}
+              </span>
+            </div>
+
+            <div class="text-right mt-3 border-top">
               <h4>
                 <span class="pull-left">Amount Due:</span>
                 ${{billingFactory.invoice.amount_due / 100 | number:2}}


### PR DESCRIPTION
## Description
Add taxes, discounts and credits to the invoice

Add dividers even if it's not in the mockups.
-ve signs for discounts and payments.

[stage-2]

## Motivation and Context
Billing Frictions epic.

## How Has This Been Tested?
Tested changes locally.

Plain:
https://apps-stage-2.risevision.com/billing/invoice/6792?token=estKey&cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

Education & credits:
https://apps-stage-2.risevision.com/billing/invoice/8498?token=estKey&cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

Taxes:
https://apps-stage-2.risevision.com/billing/invoice/8551?token=KbFoV9&cid=17899fe3-db05-4ecd-ade4-a7106fe53784

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
