### PR TITLE
Use client side search for store products

### DIFF
--- a/test/unit/editor/controllers/ctr-store-products-modal.tests.js
+++ b/test/unit/editor/controllers/ctr-store-products-modal.tests.js
@@ -131,6 +131,8 @@ describe('controller: Store Products Modal', function() {
     expect($scope.search).to.be.ok;
     expect($scope.search).to.have.property('category');
     expect($scope.search.count).to.equal(1000);
+    // mocks search function for client side search
+    expect($scope.search.doSearch).to.be.a('function');
   });
 
   describe('isEducationCustomer:',function(){   

--- a/web/partials/editor/store-products-modal.html
+++ b/web/partials/editor/store-products-modal.html
@@ -8,12 +8,12 @@
   <div class="modal-body u_padding-lg" stop-event="touchend">
     
     <div class="u_margin-md-bottom" ng-if="!categoryFilters">
-      <search-filter filter-config="filterConfig" search="search" do-search="factory.doSearch"></search-filter>
+      <search-filter filter-config="filterConfig" search="search" do-search="search.doSearch"></search-filter>
     </div>
 
     <div class="row" ng-if="categoryFilters">
       <div class="col-md-8 u_margin-sm-bottom">
-        <search-filter filter-config="filterConfig" search="search" do-search="factory.doSearch"></search-filter>
+        <search-filter filter-config="filterConfig" search="search" do-search="search.doSearch"></search-filter>
       </div>
       <div class="col-md-4 u_margin-md-bottom aligner">
         <label for="filter-templates" class="u_remove-bottom u_nowrap u_margin-right">Filter Templates:</label>
@@ -44,7 +44,7 @@
 
               <ng-include ng-if="!isEducationCustomer" src="'partials/editor/blank-presentation.html'"></ng-include>
 
-              <ng-repeat ng-repeat="product in factory.items.list | filter: getTemplatesFilter()">
+              <ng-repeat ng-repeat="product in factory.items.list | filter:search.query | filter: getTemplatesFilter()">
                 <div id="storeProduct" class="col-sm-6 col-md-4 col-lg-3" ng-click="select(product)">
                   <div class="product-grid_item panel panel-default">
 

--- a/web/scripts/editor/controllers/ctr-store-products-modal.js
+++ b/web/scripts/editor/controllers/ctr-store-products-modal.js
@@ -12,7 +12,8 @@ angular.module('risevision.editor.controllers')
 
       $scope.search = {
         category: category,
-        count: defaultCount
+        count: defaultCount,
+        doSearch: function() {}
       };
 
       $scope.factory = new ScrollingListService(productsFactory.loadProducts,


### PR DESCRIPTION
## Description
Use client side search for store products

Disable server side search by mocking function
Add search string as filter
Applies to both Templates and Widgets search

[stage-19]

## Motivation and Context
Fix for #2265 

## How Has This Been Tested?
Tested changes locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No