### PR TITLE
Chore/build user manager silent

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -239,7 +239,11 @@ gulp.task("html-selector", function () {
   return buildHtml("./web/storage-selector.html");
 });
 
-gulp.task("html", ["lint", "html-index", "html-selector"]);
+gulp.task("html-user-manager-silent", function () {
+  return buildHtml("./web/user-manager-silent.html");
+});
+
+gulp.task("html", ["lint", "html-index", "html-selector", "html-user-manager-silent"]);
 
 gulp.task("jpgcompressor", function() {
   return gulp.src("node_modules/compressorjs/dist/compressor.min.js")
@@ -346,7 +350,7 @@ gulp.task("test:e2e:core", ["test:webdriver_update"],factory.testE2EAngular({
   stageEnv: process.env.STAGE_ENV || os.userInfo().username || 'local',
   twitterUser: process.env.TWITTER_USER,
   twitterPass: process.env.TWITTER_PASS,
-  testFiles: function(){ 
+  testFiles: function(){
     try{
       return JSON.parse(fs.readFileSync('/tmp/testFiles.txt').toString())
     } catch (e) {
@@ -354,7 +358,7 @@ gulp.task("test:e2e:core", ["test:webdriver_update"],factory.testE2EAngular({
     }
   }()
 }));
-gulp.task("test:e2e", function (cb) { 
+gulp.task("test:e2e", function (cb) {
   runSequence(["build-pieces", "config-e2e"], "server", "test:e2e:core", "server-close", cb);
 });
 

--- a/web/user-manager-silent.html
+++ b/web/user-manager-silent.html
@@ -6,8 +6,13 @@
 </head>
 
 <body>
+    <!-- dependencies -->
+    <!-- build:js js/user-manager-silent.min.js -->
+
     <script src="bower_components/oidc-client/dist/oidc-client.js"></script>
     <script src='scripts/user-manager-silent.js'></script>
+
+    <!-- endbuild -->
 </body>
 
 </html>


### PR DESCRIPTION
## Description
Minifies user-manager-silent.html dependencies, and moves into dist

## Motivation and Context
So it's accessible from built files.

## How Has This Been Tested?
Running 'gulp build' moves the HTML file into dist, pointing to the minified dependencies:

![minified](https://user-images.githubusercontent.com/33162690/101659394-9ee82f80-3a0b-11eb-8d7c-93fdd49f25e5.jpg)

## Release Plan:
Now just planning to merge into development's branch

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
