### PR TITLE
Separate logic for forceAuth and redirect

### DIFF
--- a/web/scripts/components/gapi-loader/svc-gapi.js
+++ b/web/scripts/components/gapi-loader/svc-gapi.js
@@ -19,9 +19,6 @@ var handleClientJSLoad = function () {
 angular.module('risevision.common.gapi', [
     'risevision.common.components.util'
   ])
-  .value('CLIENT_ID', '614513768474.apps.googleusercontent.com')
-  .value('OAUTH2_SCOPES', 'profile')
-
   .factory('gapiLoader', ['$q', '$window',
     function ($q, $window) {
       var deferred = $q.defer();

--- a/web/scripts/components/userstate/app.js
+++ b/web/scripts/components/userstate/app.js
@@ -55,7 +55,7 @@
 
                 openidConnect.signinRedirectCallback()
                   .then(function(user) {
-                    userAuthFactory.authenticate(false);
+                    userAuthFactory.authenticate(true);
 
                     window.location.hash = '';
                   });

--- a/web/scripts/components/userstate/controllers/ctr-login.js
+++ b/web/scripts/components/userstate/controllers/ctr-login.js
@@ -2,10 +2,10 @@
 
 angular.module('risevision.common.components.userstate')
   .controller('LoginCtrl', ['$scope', '$filter', '$loading', '$stateParams',
-    '$state', '$exceptionHandler', 'userAuthFactory', 'customAuthFactory', 'uiFlowManager',
-    'urlStateService', 'userState', 'getError', 'FORCE_GOOGLE_AUTH',
+    '$state', '$exceptionHandler', 'userAuthFactory', 'customAuthFactory', 'googleAuthFactory',
+    'uiFlowManager', 'urlStateService', 'userState', 'getError', 'FORCE_GOOGLE_AUTH',
     function ($scope, $filter, $loading, $stateParams, $state, $exceptionHandler, userAuthFactory,
-      customAuthFactory, uiFlowManager, urlStateService, userState, getError,
+      customAuthFactory, googleAuthFactory, uiFlowManager, urlStateService, userState, getError,
       FORCE_GOOGLE_AUTH) {
       $scope.forms = {};
       $scope.credentials = {};
@@ -38,7 +38,7 @@ angular.module('risevision.common.components.userstate')
 
       $scope.googleLogin = function (endStatus) {
         $loading.startGlobal('auth-buttons-login');
-        userAuthFactory.authenticate(true)
+        googleAuthFactory.authenticate(true)
           .finally(function () {
             $loading.stopGlobal('auth-buttons-login');
             uiFlowManager.invalidateStatus(endStatus);

--- a/web/scripts/components/userstate/services/svc-google-auth-factory.js
+++ b/web/scripts/components/userstate/services/svc-google-auth-factory.js
@@ -10,7 +10,7 @@
       function ($rootScope, $q, $log, $window, $stateParams, gapiLoader,
         uiFlowManager, userState, urlStateService, openidConnect) {
 
-        var setToken = function (user) {
+        var _setToken = function (user) {
           return gapiLoader().then(function (gApi) {
             var token = {
               access_token: user.id_token,
@@ -57,7 +57,7 @@
               }
             })
             .then(function(user) {
-              setToken(user);
+              _setToken(user);
 
               if (userState._state.redirectState) {
                 urlStateService.redirectToState(userState._state.redirectState);
@@ -117,7 +117,6 @@
               return forceAuthenticate();
             }
           },
-          setToken: setToken,
           signOut: signOut
         };
 

--- a/web/scripts/components/userstate/services/svc-user-auth-factory.js
+++ b/web/scripts/components/userstate/services/svc-user-auth-factory.js
@@ -213,7 +213,7 @@
                 _resetUserState();
               }
 
-              authenticationPromise = googleAuthFactory.authenticate(forceAuth);
+              authenticationPromise = googleAuthFactory.authenticate();
             }
 
             authenticationPromise

--- a/web/scripts/user-manager-silent.js
+++ b/web/scripts/user-manager-silent.js
@@ -1,3 +1,12 @@
-window.Oidc.Log.logger = console;
-window.Oidc.Log.level = window.Oidc.Log.INFO;
-new window.Oidc.UserManager().signinSilentCallback();
+'use strict';
+
+(function (Oidc, console) {
+  if (!Oidc) {
+    return;
+  }
+
+  Oidc.Log.logger = console;
+  Oidc.Log.level = Oidc.Log.INFO;
+  new Oidc.UserManager().signinSilentCallback();
+
+})(window.Oidc, console);


### PR DESCRIPTION
## Description
Separate logic for forceAuth and redirect

Trigger Google Login redirect from factory directly
Use forceAuth to clear auth promise only

Clean up client id code
Override oidc signinSilent to provide login_hint
Enable automaticSilentRenew, and remove id token
Set response_type token to receive token expiry

[stage-19]

## Motivation and Context
Fixes for the Google Authentication flow

## How Has This Been Tested?
Tested the various scenarios locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No