### PR TITLE
Test display activation right after adding the display

### DIFF
--- a/test/e2e/displays/cases/displayadd.js
+++ b/test/e2e/displays/cases/displayadd.js
@@ -1,10 +1,13 @@
 'use strict';
 var expect = require('rv-common-e2e').expect;
+var url = require('url');
+var https = require('https');
 var HomePage = require('./../../common/pages/homepage.js');
 var SignInPage = require('./../../common/pages/signInPage.js');
 var CommonHeaderPage = require('./../../common-header/pages/commonHeaderPage.js');
 var DisplaysListPage = require('./../pages/displaysListPage.js');
 var DisplayManagePage = require('./../pages/displayManagePage.js');
+var DownloadPlayerModalPage = require('./../pages/downloadPlayerModalPage.js');
 var helper = require('rv-common-e2e').helper;
 
 var DisplayAddScenarios = function() {
@@ -16,6 +19,7 @@ var DisplayAddScenarios = function() {
     var signInPage;
     var commonHeaderPage;
     var displaysListPage;
+    var downloadPlayerModalPage;
     var displayManagePage;
 
     before(function () {
@@ -23,6 +27,7 @@ var DisplayAddScenarios = function() {
       signInPage = new SignInPage();
       displaysListPage = new DisplaysListPage();
       displayManagePage = new DisplayManagePage();
+      downloadPlayerModalPage = new DownloadPlayerModalPage();
       commonHeaderPage = new CommonHeaderPage();
 
       homepage.getDisplays();
@@ -73,6 +78,71 @@ var DisplayAddScenarios = function() {
       helper.wait(displayManagePage.getDeleteButton(), 'Display Delete Button');
 
       expect(displayManagePage.getDeleteButton().isPresent()).to.eventually.be.true;
+    });
+
+    describe('display activation', function() {
+      it('should show the Display instructions', function() {
+        helper.wait(displayManagePage.getDisplayInstructionsPanel(), 'Display Instructions Panel');
+        expect(displayManagePage.getDisplayInstructionsPanel().isDisplayed()).to.eventually.be.true;
+
+        expect(displayManagePage.getPurchasePlayerButton().isDisplayed()).to.eventually.be.true;
+        expect(displayManagePage.getInstallPlayerButton().isDisplayed()).to.eventually.be.true;
+      });
+
+      it('should show Download options',function() {
+        helper.clickWhenClickable(displayManagePage.getInstallPlayerButton(), 'Install Player Button');
+
+        helper.wait(downloadPlayerModalPage.getDownloadPlayerModal(), 'Download Player Modal');
+        
+        expect(downloadPlayerModalPage.getDownloadPlayerModal().isDisplayed()).to.eventually.be.true;
+
+        expect(downloadPlayerModalPage.getTitle().getText()).to.eventually.equal('Install Rise Player');
+        
+        expect(downloadPlayerModalPage.getDownloadWindows32Link().isDisplayed()).to.eventually.be.true;
+      });
+
+      it('should provide HTTPS download links to prevent browsers block',function() {
+        expect(downloadPlayerModalPage.getDownloadWindows32Link().getAttribute('href')).to.eventually.match(/^https:/);
+        expect(downloadPlayerModalPage.getDownloadWindows64Link().getAttribute('href')).to.eventually.match(/^https:/);
+
+        expect(downloadPlayerModalPage.getDownloadUbuntu32Link().getAttribute('href')).to.eventually.match(/^https:/);
+        expect(downloadPlayerModalPage.getDownloadUbuntu64Link().getAttribute('href')).to.eventually.match(/^https:/);
+
+        expect(downloadPlayerModalPage.getDownloadRaspberryLink().getAttribute('href')).to.eventually.match(/^https:/);
+      });
+
+      it('should provide working download links',function() {
+        downloadPlayerModalPage.getDownloadWindows32Link().getAttribute('href').then(function(href) {
+          var httpHeadRequest = function() {
+            var defer = protractor.promise.defer();
+            const options = {
+              hostname: url.parse(href).hostname,
+              port: 443,
+              path: url.parse(href).path,
+              method: 'HEAD',
+            }
+            https.request(options, function(response) {
+              defer.fulfill(response.statusCode);
+            }).on('error', function(e) {
+              defer.reject('Request failed: ' + e.message);
+            }).end();
+            return defer.promise;
+          };
+
+          protractor.promise.controlFlow().execute(httpHeadRequest).then(function (statusCode) {
+              expect(statusCode).to.equal(200);
+          });
+        });
+
+      });
+
+      it('should close modal',function() {
+        helper.clickWhenClickable(downloadPlayerModalPage.getDismissButton(), 'Dismiss Button');
+
+        helper.waitDisappear(downloadPlayerModalPage.getDownloadPlayerModal(), 'Download Player Modal');
+        expect(downloadPlayerModalPage.getDownloadPlayerModal().isPresent()).to.eventually.be.false;
+      });
+
     });
 
   });

--- a/test/e2e/displays/cases/displaymanage.js
+++ b/test/e2e/displays/cases/displaymanage.js
@@ -1,6 +1,4 @@
 'use strict';
-var https = require('https');
-var url = require('url');
 var expect = require('rv-common-e2e').expect;
 var HomePage = require('./../../common/pages/homepage.js');
 var SignInPage = require('./../../common/pages/signInPage.js');
@@ -137,71 +135,6 @@ var DisplayManageScenarios = function() {
           done();
         });
       });
-    });
-
-    describe('display activation', function() {
-      it('should show the Display instructions', function() {
-        helper.wait(displayManagePage.getDisplayInstructionsPanel(), 'Display Instructions Panel');
-        expect(displayManagePage.getDisplayInstructionsPanel().isDisplayed()).to.eventually.be.true;
-
-        expect(displayManagePage.getPurchasePlayerButton().isDisplayed()).to.eventually.be.true;
-        expect(displayManagePage.getInstallPlayerButton().isDisplayed()).to.eventually.be.true;
-      });
-
-      it('should show Download options',function() {
-        helper.clickWhenClickable(displayManagePage.getInstallPlayerButton(), 'Install Player Button');
-
-        helper.wait(downloadPlayerModalPage.getDownloadPlayerModal(), 'Download Player Modal');
-        
-        expect(downloadPlayerModalPage.getDownloadPlayerModal().isDisplayed()).to.eventually.be.true;
-
-        expect(downloadPlayerModalPage.getTitle().getText()).to.eventually.equal('Install Rise Player');
-        
-        expect(downloadPlayerModalPage.getDownloadWindows32Link().isDisplayed()).to.eventually.be.true;
-      });
-
-      it('should provide HTTPS download links to prevent browsers block',function() {
-        expect(downloadPlayerModalPage.getDownloadWindows32Link().getAttribute('href')).to.eventually.match(/^https:/);
-        expect(downloadPlayerModalPage.getDownloadWindows64Link().getAttribute('href')).to.eventually.match(/^https:/);
-
-        expect(downloadPlayerModalPage.getDownloadUbuntu32Link().getAttribute('href')).to.eventually.match(/^https:/);
-        expect(downloadPlayerModalPage.getDownloadUbuntu64Link().getAttribute('href')).to.eventually.match(/^https:/);
-
-        expect(downloadPlayerModalPage.getDownloadRaspberryLink().getAttribute('href')).to.eventually.match(/^https:/);
-      });
-
-      it('should provide working download links',function() {
-        downloadPlayerModalPage.getDownloadWindows32Link().getAttribute('href').then(function(href) {
-          var httpHeadRequest = function() {
-            var defer = protractor.promise.defer();
-            const options = {
-              hostname: url.parse(href).hostname,
-              port: 443,
-              path: url.parse(href).path,
-              method: 'HEAD',
-            }
-            https.request(options, function(response) {
-              defer.fulfill(response.statusCode);
-            }).on('error', function(e) {
-              defer.reject('Request failed: ' + e.message);
-            }).end();
-            return defer.promise;
-          };
-
-          protractor.promise.controlFlow().execute(httpHeadRequest).then(function (statusCode) {
-              expect(statusCode).to.equal(200);
-          });
-        });
-
-      });
-
-      it('should close modal',function() {
-        helper.clickWhenClickable(downloadPlayerModalPage.getDismissButton(), 'Dismiss Button');
-
-        helper.waitDisappear(downloadPlayerModalPage.getDownloadPlayerModal(), 'Download Player Modal');
-        expect(downloadPlayerModalPage.getDownloadPlayerModal().isPresent()).to.eventually.be.false;
-      });
-
     });
 
     describe('display actions', function() {


### PR DESCRIPTION
## Description
Test display activation right after adding the display to temporarily overcome e2e failure.

## Motivation and Context
Display activation E2E tests started to fail.
A new display is being reported as offline instead of not_activated after Restart bulk action is performed. Still pending investigation.

## How Has This Been Tested?
E2E tests pass. [stage-1]


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
