### PR TITLE
Temporarily disable tracking expired token

### DIFF
--- a/test/unit/components/userstate/services/svc-openid-connect.tests.js
+++ b/test/unit/components/userstate/services/svc-openid-connect.tests.js
@@ -55,7 +55,7 @@ describe("Services: openidConnect", function() {
         expect(openidClient.events.addUserLoaded).to.have.been.called;
         expect(openidClient.events.addUserUnloaded).to.have.been.called;
         expect(openidClient.events.addAccessTokenExpiring).to.have.been.called;
-        expect(openidClient.events.addAccessTokenExpired).to.have.been.called;
+        // expect(openidClient.events.addAccessTokenExpired).to.have.been.called;
         expect(openidClient.events.addSilentRenewError).to.have.been.called;
         expect(openidClient.events.addUserSignedOut).to.have.been.called;
 
@@ -137,7 +137,7 @@ describe("Services: openidConnect", function() {
       }, 10);
     });
 
-    it("should call tracker for token expired event", function(done) {
+    xit("should call tracker for token expired event", function(done) {
       setTimeout(function() {
         var tokenExpiredHandler =
           openidClient.events.addAccessTokenExpired.getCall(0).args[0]

--- a/web/scripts/components/userstate/services/svc-openid-connect.js
+++ b/web/scripts/components/userstate/services/svc-openid-connect.js
@@ -86,9 +86,10 @@
             client.events.addAccessTokenExpiring(function() {
               trackOpenidEvent('access token expiring');
             });
-            client.events.addAccessTokenExpired(function() {
-              trackOpenidEvent('access token expired');
-            });
+            // Temporarily removed to avoid sending too many events
+            // client.events.addAccessTokenExpired(function() {
+            //   trackOpenidEvent('access token expired');
+            // });
             client.events.addSilentRenewError(function(error) {
               trackOpenidEvent('silent renew error', {errorMessage: error.message});
             });


### PR DESCRIPTION
## Description
Temporarily disable tracking expired token event

## Motivation and Context
Event was being logged every second, causing too many calls to Segment 

## How Has This Been Tested?
Event was not triggered [stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
