### PR TITLE
Skip company reset based on route flag

### DIFF
--- a/test/unit/billing/app.tests.js
+++ b/test/unit/billing/app.tests.js
@@ -60,6 +60,7 @@ describe('app:', function() {
       expect(state).to.be.ok;
       expect(state.url).to.equal('/billing?edit');
       expect(state.controller).to.be.ok;
+      expect(state.forceAuth).to.not.be.false;
     });
 
     it('should open Edit Subscription if edit param is provided', function(done) {
@@ -96,6 +97,7 @@ describe('app:', function() {
       expect(state).to.be.ok;
       expect(state.url).to.equal('/billing/unpaid?:token');
       expect(state.controller).to.equal('UnpaidInvoicesCtrl');
+      expect(state.forceAuth).to.be.false;
     });
 
   });
@@ -107,6 +109,7 @@ describe('app:', function() {
       expect(state).to.be.ok;
       expect(state.url).to.equal('/billing/invoice/:invoiceId?:token');
       expect(state.controller).to.equal('InvoiceCtrl');
+      expect(state.forceAuth).to.be.false;
     });
 
     it('should open Edit Invoice', function(done) {

--- a/web/scripts/billing/app.js
+++ b/web/scripts/billing/app.js
@@ -36,7 +36,8 @@ angular.module('risevision.apps')
         .state('apps.billing.unpaid', {
           url: '/billing/unpaid?:token',
           templateUrl: 'partials/billing/unpaid-invoices.html',
-          controller: 'UnpaidInvoicesCtrl'
+          controller: 'UnpaidInvoicesCtrl',
+          forceAuth: false
         })
 
         .state('apps.billing.invoice', {
@@ -50,7 +51,8 @@ angular.module('risevision.apps')
                 billingFactory.getInvoice($stateParams.invoiceId, $stateParams.cid, $stateParams.token);
               }
             ]
-          }
+          },
+          forceAuth: false
         });
     }
   ]);

--- a/web/scripts/components/userstate/services/svc-companystate.js
+++ b/web/scripts/components/userstate/services/svc-companystate.js
@@ -3,9 +3,9 @@
   'use strict';
 
   angular.module('risevision.common.components.userstate')
-    .factory('companyState', ['$location', 'getCompany', 'objectHelper',
+    .factory('companyState', ['$location', '$state', 'getCompany', 'objectHelper',
       '$rootScope', '$log', '$q',
-      function ($location, getCompany, objectHelper, $rootScope, $log, $q) {
+      function ($location, $state, getCompany, objectHelper, $rootScope, $log, $q) {
         var pendingSelectedCompany;
 
         var _state = {
@@ -39,7 +39,9 @@
               return _switchCompany(selectedCompanyId);
             })
             .then(null, function () {
-              _companyState.resetCompany();
+              if ($state.current.forceAuth !== false) {                
+                _companyState.resetCompany();
+              }
             })
             .finally(function () {
               pendingSelectedCompany = null;
@@ -116,8 +118,7 @@
           resetCompany: function () {
             objectHelper.clearAndCopy(_state.userCompany, _state.selectedCompany);
 
-            $rootScope.$broadcast(
-              'risevision.company.selectedCompanyChanged');
+            $rootScope.$broadcast('risevision.company.selectedCompanyChanged');
           },
           resetCompanyState: _resetCompanyState,
           getUserCompanyId: function () {


### PR DESCRIPTION
## Description
Skip company reset based on route flag

[stage-2]

## Motivation and Context
Fix for #2297 

## How Has This Been Tested?
Tested changes locally with an authenticated user in an incorrect company. Tested other scenarios for authenticated and unauthenticated users. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No