### PR TITLE
Fix situation where the credit card address is undefined

### DIFF
--- a/test/unit/billing/services/svc-billing-factory.tests.js
+++ b/test/unit/billing/services/svc-billing-factory.tests.js
@@ -32,7 +32,6 @@ describe('service: billingFactory:', function() {
     $provide.service('creditCardFactory',function() {
       return {
         initPaymentMethods: sinon.stub(),
-        loadCreditCards: sinon.stub(),
         getPaymentMethodId: sinon.stub().returns('paymentMethodId'),
         validatePaymentMethod: sinon.stub().returns(Q.resolve()),
         authenticate3ds: sinon.stub().returns(Q.resolve({item: 'invoice'})),
@@ -100,8 +99,7 @@ describe('service: billingFactory:', function() {
     expect(billingFactory.loading).to.be.false;
     expect(billingFactory.apiError).to.not.be.ok;
 
-    creditCardFactory.initPaymentMethods.should.have.been.called;
-    creditCardFactory.loadCreditCards.should.have.been.called;
+    creditCardFactory.initPaymentMethods.should.have.been.calledWith(true);
   });
 
   describe('getToken:', function() {

--- a/test/unit/purchase/services/svc-purchase-factory-spec.js
+++ b/test/unit/purchase/services/svc-purchase-factory-spec.js
@@ -169,14 +169,17 @@ describe("Services: purchase factory", function() {
       }, 10);
     });
 
-    it("should initialize invoice due date 30 days from now", function() {
+    it("should initialize invoice due date 30 days from now", function(done) {
       var newDate = new Date();
 
       purchaseFactory.init();
 
-      expect(creditCardFactory.paymentMethods.invoiceDate).to.be.ok;
-      expect(creditCardFactory.paymentMethods.invoiceDate).to.be.a("date");
-      expect(creditCardFactory.paymentMethods.invoiceDate - newDate).to.equal(30 * 24 * 60 * 60 * 1000);
+      setTimeout(function() {
+        expect(creditCardFactory.paymentMethods.invoiceDate).to.be.ok;
+        expect(creditCardFactory.paymentMethods.invoiceDate).to.be.a("date");
+        expect(creditCardFactory.paymentMethods.invoiceDate - newDate).to.equal(30 * 24 * 60 * 60 * 1000);
+        done();
+      }, 10);
     });
   });
 

--- a/test/unit/purchase/services/svc-purchase-factory-spec.js
+++ b/test/unit/purchase/services/svc-purchase-factory-spec.js
@@ -78,7 +78,7 @@ describe("Services: purchase factory", function() {
     });
 
     $provide.value("creditCardFactory", {
-      initPaymentMethods: sinon.stub(),
+      initPaymentMethods: sinon.stub().returns(Q.resolve()),
       validatePaymentMethod: sinon.stub().returns(Q.resolve({})),
       paymentMethods: {
         newCreditCard: {}
@@ -96,7 +96,7 @@ describe("Services: purchase factory", function() {
 
   }));
 
-  var $rootScope, $modal, $state, $timeout, clock, purchaseFactory, creditCardFactory, userState, storeService, purchaseFlowTracker, validate, RPP_ADDON_ID;
+  var $rootScope, $modal, $state, $timeout, purchaseFactory, creditCardFactory, userState, storeService, purchaseFlowTracker, validate, RPP_ADDON_ID;
 
   beforeEach(function() {
     inject(function($injector) {
@@ -125,13 +125,6 @@ describe("Services: purchase factory", function() {
   });
 
   describe("init: ", function() {
-    beforeEach(function() {
-      clock = sinon.useFakeTimers();
-    });
-
-    afterEach(function () {
-      clock.restore();
-    });
 
     it("should initialize default volume plan, attach addresses and clean contact info", function() {
       purchaseFactory.init();
@@ -160,16 +153,20 @@ describe("Services: purchase factory", function() {
       expect(purchaseFactory.purchase.estimate).to.deep.equal({});
     });
 
-    it("should initialize payment methods", function() {
+    it("should initialize payment methods", function(done) {
       purchaseFactory.init();
       
-      creditCardFactory.initPaymentMethods.should.have.been.called;
+      creditCardFactory.initPaymentMethods.should.have.been.calledWith(false);
 
-      expect(purchaseFactory.purchase).to.be.ok;
-      expect(creditCardFactory.paymentMethods).to.be.ok;
-      expect(creditCardFactory.paymentMethods.paymentMethod).to.equal("card");
+      setTimeout(function() {
+        expect(purchaseFactory.purchase).to.be.ok;
+        expect(creditCardFactory.paymentMethods).to.be.ok;
+        expect(creditCardFactory.paymentMethods.paymentMethod).to.equal("card");
+        
+        expect(creditCardFactory.paymentMethods.newCreditCard.billingAddress).to.equal(purchaseFactory.purchase.billingAddress);
 
-      expect(creditCardFactory.paymentMethods.newCreditCard.billingAddress).to.equal(purchaseFactory.purchase.billingAddress);
+        done();
+      }, 10);
     });
 
     it("should initialize invoice due date 30 days from now", function() {

--- a/web/partials/purchase/credit-card-form.html
+++ b/web/partials/purchase/credit-card-form.html
@@ -60,7 +60,7 @@
       <div class="col-md-12">
         <div class="form-group">
           <label for="toggleMatchBillingAddress" class="control-label mb-0">Cardholder Billing Address: *</label>
-          <div class="flex-row">
+          <div class="flex-row" ng-if="factory.paymentMethods.newCreditCard.billingAddress">
             <madero-checkbox id="toggleMatchBillingAddress" ng-model="factory.paymentMethods.newCreditCard.useBillingAddress"></madero-checkbox>
             <span class="mr-3">Use Company Billing Address</span>
           </div>

--- a/web/scripts/billing/services/svc-billing-factory.js
+++ b/web/scripts/billing/services/svc-billing-factory.js
@@ -18,8 +18,7 @@ angular.module('risevision.apps.billing.services')
       factory.init = function() {
         _clearMessages();
 
-        creditCardFactory.initPaymentMethods();
-        creditCardFactory.loadCreditCards();
+        creditCardFactory.initPaymentMethods(true);
       };
 
       var _getCompanyId = function() {

--- a/web/scripts/purchase/services/svc-credit-card-factory.js
+++ b/web/scripts/purchase/services/svc-credit-card-factory.js
@@ -73,35 +73,42 @@
           factory.paymentMethods.selectedCard = factory.paymentMethods.newCreditCard;
         };
 
-        factory.initPaymentMethods = function() {
+        var _loadCreditCards = function() {
+          billing.getCreditCards({
+            count: 40
+          })
+          .then(function(result) {
+            factory.paymentMethods.existingCreditCards = result.items;
+            
+            if (result.items[0]) {
+              factory.paymentMethods.selectedCard = result.items[0];
+            }
+          });
+        };
+
+        factory.initPaymentMethods = function(loadExistingCards) {
           factory.paymentMethods = {
             existingCreditCards: [],
             newCreditCard: {
               isNew: true,
               address: {},
-              useBillingAddress: true,
-              billingAddress: addressService.copyAddress(userState.getCopyOfSelectedCompany())
+              useBillingAddress: false
             }
           };
 
           // Select New Card by default
           factory.selectNewCreditCard();
-        };
 
-        factory.loadCreditCards = function() {
-          userAuthFactory.authenticate()
+          return userAuthFactory.authenticate()
             .then(function () {
-              if (userState.isRiseVisionUser()) {
-                billing.getCreditCards({
-                  count: 40
-                })
-                .then(function(result) {
-                  factory.paymentMethods.existingCreditCards = result.items;
-                  
-                  if (result.items[0]) {
-                    factory.paymentMethods.selectedCard = result.items[0];
-                  }
-                });
+              var company = userState.getCopyOfSelectedCompany();
+              if (company.id) {
+                factory.paymentMethods.newCreditCard.useBillingAddress = true;
+                factory.paymentMethods.newCreditCard.billingAddress = addressService.copyAddress(company);
+
+                if (loadExistingCards) {
+                  _loadCreditCards();
+                }
               }
             });
         };

--- a/web/scripts/purchase/services/svc-purchase-factory.js
+++ b/web/scripts/purchase/services/svc-purchase-factory.js
@@ -46,14 +46,16 @@
           factory.purchase.taxExemption = {};
           factory.purchase.estimate = {};
 
-          creditCardFactory.initPaymentMethods();
-
-          creditCardFactory.paymentMethods.paymentMethod = 'card';
-          creditCardFactory.paymentMethods.newCreditCard.billingAddress = factory.purchase.billingAddress;
-
           var invoiceDate = new Date();
           invoiceDate.setDate(invoiceDate.getDate() + 30);
           creditCardFactory.paymentMethods.invoiceDate = invoiceDate;
+
+          creditCardFactory.initPaymentMethods(false)
+            .finally(function() {
+              creditCardFactory.paymentMethods.paymentMethod = 'card';
+              creditCardFactory.paymentMethods.newCreditCard.billingAddress = factory.purchase.billingAddress;              
+            });
+
         };
 
         factory.updatePlan = function (displays, isMonthly, total) {

--- a/web/scripts/purchase/services/svc-purchase-factory.js
+++ b/web/scripts/purchase/services/svc-purchase-factory.js
@@ -46,14 +46,14 @@
           factory.purchase.taxExemption = {};
           factory.purchase.estimate = {};
 
-          var invoiceDate = new Date();
-          invoiceDate.setDate(invoiceDate.getDate() + 30);
-          creditCardFactory.paymentMethods.invoiceDate = invoiceDate;
-
           creditCardFactory.initPaymentMethods(false)
             .finally(function() {
               creditCardFactory.paymentMethods.paymentMethod = 'card';
-              creditCardFactory.paymentMethods.newCreditCard.billingAddress = factory.purchase.billingAddress;              
+              creditCardFactory.paymentMethods.newCreditCard.billingAddress = factory.purchase.billingAddress;
+              
+              var invoiceDate = new Date();
+              invoiceDate.setDate(invoiceDate.getDate() + 30);
+              creditCardFactory.paymentMethods.invoiceDate = invoiceDate;
             });
 
         };


### PR DESCRIPTION
## Description
Fix situation where the credit card address is undefined

When loading the invoice page the company
is not yet loaded, so the address is not defined

Fixed by allowing a promise to define when the
address is updated

Also, if no address is found, force user to enter
one

[stage-19]

## Motivation and Context
Fix issue as described above.

## How Has This Been Tested?
Tested changes locally with various scenarios. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No