### PR TITLE
Check selected company id before retrieving cards

### DIFF
--- a/test/unit/billing/services/svc-billing-factory.tests.js
+++ b/test/unit/billing/services/svc-billing-factory.tests.js
@@ -32,7 +32,6 @@ describe('service: billingFactory:', function() {
     $provide.service('creditCardFactory',function() {
       return {
         initPaymentMethods: sinon.stub(),
-        loadCreditCards: sinon.stub(),
         getPaymentMethodId: sinon.stub().returns('paymentMethodId'),
         validatePaymentMethod: sinon.stub().returns(Q.resolve()),
         authenticate3ds: sinon.stub().returns(Q.resolve({item: 'invoice'})),
@@ -100,8 +99,7 @@ describe('service: billingFactory:', function() {
     expect(billingFactory.loading).to.be.false;
     expect(billingFactory.apiError).to.not.be.ok;
 
-    creditCardFactory.initPaymentMethods.should.have.been.called;
-    creditCardFactory.loadCreditCards.should.have.been.called;
+    creditCardFactory.initPaymentMethods.should.have.been.calledWith(true);
   });
 
   describe('getToken:', function() {

--- a/test/unit/purchase/services/svc-credit-card-factory-spec.js
+++ b/test/unit/purchase/services/svc-credit-card-factory-spec.js
@@ -24,8 +24,7 @@ describe("Services: credit card factory", function() {
       getCopyOfSelectedCompany: sinon.stub().returns({
         id: "id",
         street: "billingStreet",
-      }),
-      getSelectedCompanyId: sinon.stub().returns("id")
+      })
     });
 
     $provide.value('userAuthFactory', {
@@ -60,7 +59,6 @@ describe("Services: credit card factory", function() {
 
     expect(creditCardFactory.selectNewCreditCard).to.be.a("function");
     expect(creditCardFactory.initPaymentMethods).to.be.a("function");
-    expect(creditCardFactory.loadCreditCards).to.be.a('function');
 
     expect(creditCardFactory.validatePaymentMethod).to.be.a("function");
     expect(creditCardFactory.getPaymentMethodId).to.be.a("function");
@@ -139,91 +137,138 @@ describe("Services: credit card factory", function() {
     expect(creditCardFactory.paymentMethods.selectedCard).to.equal('newCard');
   });
 
-  it("initPaymentMethods:", function() {
-    creditCardFactory.initPaymentMethods();
-    
-    expect(creditCardFactory).to.be.ok;
-    expect(creditCardFactory.paymentMethods).to.be.ok;
-    expect(creditCardFactory.paymentMethods.existingCreditCards).to.deep.equal([]);
+  describe("initPaymentMethods:", function() {
+    it("should init factory object", function() {
+      creditCardFactory.initPaymentMethods(false);
+      
+      expect(creditCardFactory).to.be.ok;
+      expect(creditCardFactory.paymentMethods).to.be.ok;
+      expect(creditCardFactory.paymentMethods.existingCreditCards).to.deep.equal([]);
 
-    expect(creditCardFactory.paymentMethods.newCreditCard).to.deep.equal({
-      isNew: true,
-      address: {},
-      useBillingAddress: true,
-      billingAddress: {
-        id: "id",
-        name: undefined,
-        street: "billingStreet",
-        unit: undefined,
-        city: undefined,
-        country: undefined,
-        postalCode: undefined,
-        province: undefined
-      }
-    });
+      expect(creditCardFactory.paymentMethods.newCreditCard).to.deep.equal({
+        isNew: true,
+        address: {},
+        useBillingAddress: false
+      });
 
-    expect(creditCardFactory.paymentMethods.selectedCard).to.equal(creditCardFactory.paymentMethods.newCreditCard);
-  });
-
-  describe('loadCreditCards:', function() {
-    beforeEach(function() {
-      creditCardFactory.paymentMethods = {};
+      expect(creditCardFactory.paymentMethods.selectedCard).to.equal(creditCardFactory.paymentMethods.newCreditCard);
     });
 
     it('should authenticate user', function() {
-      creditCardFactory.loadCreditCards();
+      creditCardFactory.initPaymentMethods(false);
 
       userAuthFactory.authenticate.should.have.been.called;
     });
 
-    it('should handle failure to authenticate', function(done) {
+    it('should use company address', function(done) {
+      creditCardFactory.initPaymentMethods(true)
+        .then(function() {
+          expect(creditCardFactory.paymentMethods.newCreditCard).to.deep.equal({
+            isNew: true,
+            address: {},
+            useBillingAddress: true,
+            billingAddress: {
+              id: "id",
+              name: undefined,
+              street: "billingStreet",
+              unit: undefined,
+              city: undefined,
+              country: undefined,
+              postalCode: undefined,
+              province: undefined
+            }
+          });
+
+          done();
+        });
+    });
+
+    it('should not update address on authentication failure', function(done) {
       userAuthFactory.authenticate.returns(Q.reject());
 
-      creditCardFactory.loadCreditCards();
+      creditCardFactory.initPaymentMethods(false)
+        .catch(function() {
+          expect(creditCardFactory.paymentMethods.newCreditCard).to.deep.equal({
+            isNew: true,
+            address: {},
+            useBillingAddress: false
+          });
 
-      setTimeout(function() {
-        billing.getCreditCards.should.not.have.been.called;
-
-        done();
-      });
-    });
-
-    it('should not retrieve cards if user is not registered', function(done) {
-      userState.getSelectedCompanyId.returns(null);
-
-      creditCardFactory.loadCreditCards();
-
-      setTimeout(function() {
-        billing.getCreditCards.should.not.have.been.called;
-
-        done();
-      });
-    });
-
-    it('should retrieve cards and update list if successful', function(done) {
-      creditCardFactory.loadCreditCards();
-
-      setTimeout(function() {
-        billing.getCreditCards.should.have.been.calledWith({
-          count: 40
+          done();
         });
-
-        expect(creditCardFactory.paymentMethods.existingCreditCards).to.be.an('array');
-
-        done();
-      });
     });
 
-    it('should set selected card to the first item if available', function(done) {
-      billing.getCreditCards.returns(Q.resolve({items: ['card1']}))
+    it('should not update address if selected company is invalid', function(done) {
+      userState.getCopyOfSelectedCompany.returns({});
 
-      creditCardFactory.loadCreditCards();
+      creditCardFactory.initPaymentMethods(false)
+        .then(function() {
+          expect(creditCardFactory.paymentMethods.newCreditCard).to.deep.equal({
+            isNew: true,
+            address: {},
+            useBillingAddress: false
+          });
 
-      setTimeout(function() {
-        expect(creditCardFactory.paymentMethods.selectedCard).to.equal('card1');
+          done();
+        });
+    });
 
-        done();
+    it('should not load cards', function(done) {
+      creditCardFactory.initPaymentMethods(false)
+        .then(function() {
+          billing.getCreditCards.should.not.have.been.called;
+
+          done();
+        });
+    });
+
+    describe('_loadCreditCards:', function() {
+      it('should handle failure to authenticate', function(done) {
+        userAuthFactory.authenticate.returns(Q.reject());
+
+        creditCardFactory.initPaymentMethods(true)
+          .catch(function() {
+            billing.getCreditCards.should.not.have.been.called;
+
+            done();
+          });
       });
+
+      it('should not retrieve cards selected company is invalid', function(done) {
+        userState.getCopyOfSelectedCompany.returns({});
+
+        creditCardFactory.initPaymentMethods(true)
+          .then(function() {
+            billing.getCreditCards.should.not.have.been.called;
+
+            done();
+          });
+      });
+
+      it('should retrieve cards and update list if successful', function(done) {
+        creditCardFactory.initPaymentMethods(true)
+          .then(function() {
+            billing.getCreditCards.should.have.been.calledWith({
+              count: 40
+            });
+
+            expect(creditCardFactory.paymentMethods.existingCreditCards).to.be.an('array');
+
+            done();
+          });
+      });
+
+      it('should set selected card to the first item if available', function(done) {
+        billing.getCreditCards.returns(Q.resolve({items: ['card1']}))
+
+        creditCardFactory.initPaymentMethods(true)
+          .then(function() {
+            expect(creditCardFactory.paymentMethods.selectedCard).to.equal('card1');
+
+            done();
+          });
+      });
+
     });
 
   });

--- a/test/unit/purchase/services/svc-credit-card-factory-spec.js
+++ b/test/unit/purchase/services/svc-credit-card-factory-spec.js
@@ -25,7 +25,7 @@ describe("Services: credit card factory", function() {
         id: "id",
         street: "billingStreet",
       }),
-      isRiseVisionUser: sinon.stub().returns(true)
+      getSelectedCompanyId: sinon.stub().returns("id")
     });
 
     $provide.value('userAuthFactory', {
@@ -189,7 +189,7 @@ describe("Services: credit card factory", function() {
     });
 
     it('should not retrieve cards if user is not registered', function(done) {
-      userState.isRiseVisionUser.returns(false);
+      userState.getSelectedCompanyId.returns(null);
 
       creditCardFactory.loadCreditCards();
 

--- a/test/unit/purchase/services/svc-purchase-factory-spec.js
+++ b/test/unit/purchase/services/svc-purchase-factory-spec.js
@@ -78,7 +78,7 @@ describe("Services: purchase factory", function() {
     });
 
     $provide.value("creditCardFactory", {
-      initPaymentMethods: sinon.stub(),
+      initPaymentMethods: sinon.stub().returns(Q.resolve()),
       validatePaymentMethod: sinon.stub().returns(Q.resolve({})),
       paymentMethods: {
         newCreditCard: {}
@@ -96,7 +96,7 @@ describe("Services: purchase factory", function() {
 
   }));
 
-  var $rootScope, $modal, $state, $timeout, clock, purchaseFactory, creditCardFactory, userState, storeService, purchaseFlowTracker, validate, RPP_ADDON_ID;
+  var $rootScope, $modal, $state, $timeout, purchaseFactory, creditCardFactory, userState, storeService, purchaseFlowTracker, validate, RPP_ADDON_ID;
 
   beforeEach(function() {
     inject(function($injector) {
@@ -125,13 +125,6 @@ describe("Services: purchase factory", function() {
   });
 
   describe("init: ", function() {
-    beforeEach(function() {
-      clock = sinon.useFakeTimers();
-    });
-
-    afterEach(function () {
-      clock.restore();
-    });
 
     it("should initialize default volume plan, attach addresses and clean contact info", function() {
       purchaseFactory.init();
@@ -160,26 +153,33 @@ describe("Services: purchase factory", function() {
       expect(purchaseFactory.purchase.estimate).to.deep.equal({});
     });
 
-    it("should initialize payment methods", function() {
+    it("should initialize payment methods", function(done) {
       purchaseFactory.init();
       
-      creditCardFactory.initPaymentMethods.should.have.been.called;
+      creditCardFactory.initPaymentMethods.should.have.been.calledWith(false);
 
-      expect(purchaseFactory.purchase).to.be.ok;
-      expect(creditCardFactory.paymentMethods).to.be.ok;
-      expect(creditCardFactory.paymentMethods.paymentMethod).to.equal("card");
+      setTimeout(function() {
+        expect(purchaseFactory.purchase).to.be.ok;
+        expect(creditCardFactory.paymentMethods).to.be.ok;
+        expect(creditCardFactory.paymentMethods.paymentMethod).to.equal("card");
+        
+        expect(creditCardFactory.paymentMethods.newCreditCard.billingAddress).to.equal(purchaseFactory.purchase.billingAddress);
 
-      expect(creditCardFactory.paymentMethods.newCreditCard.billingAddress).to.equal(purchaseFactory.purchase.billingAddress);
+        done();
+      }, 10);
     });
 
-    it("should initialize invoice due date 30 days from now", function() {
+    it("should initialize invoice due date 30 days from now", function(done) {
       var newDate = new Date();
 
       purchaseFactory.init();
 
-      expect(creditCardFactory.paymentMethods.invoiceDate).to.be.ok;
-      expect(creditCardFactory.paymentMethods.invoiceDate).to.be.a("date");
-      expect(creditCardFactory.paymentMethods.invoiceDate - newDate).to.equal(30 * 24 * 60 * 60 * 1000);
+      setTimeout(function() {
+        expect(creditCardFactory.paymentMethods.invoiceDate).to.be.ok;
+        expect(creditCardFactory.paymentMethods.invoiceDate).to.be.a("date");
+        expect(creditCardFactory.paymentMethods.invoiceDate - newDate).to.equal(30 * 24 * 60 * 60 * 1000);
+        done();
+      }, 10);
     });
   });
 

--- a/web/partials/purchase/credit-card-form.html
+++ b/web/partials/purchase/credit-card-form.html
@@ -60,7 +60,7 @@
       <div class="col-md-12">
         <div class="form-group">
           <label for="toggleMatchBillingAddress" class="control-label mb-0">Cardholder Billing Address: *</label>
-          <div class="flex-row">
+          <div class="flex-row" ng-if="factory.paymentMethods.newCreditCard.billingAddress">
             <madero-checkbox id="toggleMatchBillingAddress" ng-model="factory.paymentMethods.newCreditCard.useBillingAddress"></madero-checkbox>
             <span class="mr-3">Use Company Billing Address</span>
           </div>

--- a/web/scripts/billing/services/svc-billing-factory.js
+++ b/web/scripts/billing/services/svc-billing-factory.js
@@ -18,8 +18,7 @@ angular.module('risevision.apps.billing.services')
       factory.init = function() {
         _clearMessages();
 
-        creditCardFactory.initPaymentMethods();
-        creditCardFactory.loadCreditCards();
+        creditCardFactory.initPaymentMethods(true);
       };
 
       var _getCompanyId = function() {

--- a/web/scripts/purchase/services/svc-credit-card-factory.js
+++ b/web/scripts/purchase/services/svc-credit-card-factory.js
@@ -91,7 +91,7 @@
         factory.loadCreditCards = function() {
           userAuthFactory.authenticate()
             .then(function () {
-              if (userState.isRiseVisionUser()) {
+              if (userState.getSelectedCompanyId()) {
                 billing.getCreditCards({
                   count: 40
                 })

--- a/web/scripts/purchase/services/svc-credit-card-factory.js
+++ b/web/scripts/purchase/services/svc-credit-card-factory.js
@@ -73,35 +73,42 @@
           factory.paymentMethods.selectedCard = factory.paymentMethods.newCreditCard;
         };
 
-        factory.initPaymentMethods = function() {
+        var _loadCreditCards = function() {
+          billing.getCreditCards({
+            count: 40
+          })
+          .then(function(result) {
+            factory.paymentMethods.existingCreditCards = result.items;
+            
+            if (result.items[0]) {
+              factory.paymentMethods.selectedCard = result.items[0];
+            }
+          });
+        };
+
+        factory.initPaymentMethods = function(loadExistingCards) {
           factory.paymentMethods = {
             existingCreditCards: [],
             newCreditCard: {
               isNew: true,
               address: {},
-              useBillingAddress: true,
-              billingAddress: addressService.copyAddress(userState.getCopyOfSelectedCompany())
+              useBillingAddress: false
             }
           };
 
           // Select New Card by default
           factory.selectNewCreditCard();
-        };
 
-        factory.loadCreditCards = function() {
-          userAuthFactory.authenticate()
+          return userAuthFactory.authenticate()
             .then(function () {
-              if (userState.getSelectedCompanyId()) {
-                billing.getCreditCards({
-                  count: 40
-                })
-                .then(function(result) {
-                  factory.paymentMethods.existingCreditCards = result.items;
-                  
-                  if (result.items[0]) {
-                    factory.paymentMethods.selectedCard = result.items[0];
-                  }
-                });
+              var company = userState.getCopyOfSelectedCompany();
+              if (company.id) {
+                factory.paymentMethods.newCreditCard.useBillingAddress = true;
+                factory.paymentMethods.newCreditCard.billingAddress = addressService.copyAddress(company);
+
+                if (loadExistingCards) {
+                  _loadCreditCards();
+                }
               }
             });
         };

--- a/web/scripts/purchase/services/svc-purchase-factory.js
+++ b/web/scripts/purchase/services/svc-purchase-factory.js
@@ -46,14 +46,16 @@
           factory.purchase.taxExemption = {};
           factory.purchase.estimate = {};
 
-          creditCardFactory.initPaymentMethods();
+          creditCardFactory.initPaymentMethods(false)
+            .finally(function() {
+              creditCardFactory.paymentMethods.paymentMethod = 'card';
+              creditCardFactory.paymentMethods.newCreditCard.billingAddress = factory.purchase.billingAddress;
+              
+              var invoiceDate = new Date();
+              invoiceDate.setDate(invoiceDate.getDate() + 30);
+              creditCardFactory.paymentMethods.invoiceDate = invoiceDate;
+            });
 
-          creditCardFactory.paymentMethods.paymentMethod = 'card';
-          creditCardFactory.paymentMethods.newCreditCard.billingAddress = factory.purchase.billingAddress;
-
-          var invoiceDate = new Date();
-          invoiceDate.setDate(invoiceDate.getDate() + 30);
-          creditCardFactory.paymentMethods.invoiceDate = invoiceDate;
         };
 
         factory.updatePlan = function (displays, isMonthly, total) {


### PR DESCRIPTION
Checking for the user is not sufficient

[stage-2]

## Description
Check for the company id. If the company fails to load, but the User is registered, the id will be null and cause an error retrieving the CC list from the Store server. The user is not actually affected by this failure, however this is preventing a potential alert.

## Motivation and Context
Fix potential alert for the store-server

## How Has This Been Tested?
Tested changes locally to ensure the error no longer occurs.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No