### PR TITLE
Load credit cards from user company

### DIFF
--- a/test/unit/components/userstate/services/svc-companystate.tests.js
+++ b/test/unit/components/userstate/services/svc-companystate.tests.js
@@ -266,8 +266,9 @@ describe("Services: company state", function() {
 
         expect(apiCount).to.equal(2);
         expect(companyState.getUserCompanyId()).to.equal("RV_parent_id");
-        expect(companyState.getSelectedCompanyId()).to.not.be.ok;
-        expect(companyState.isSubcompanySelected()).to.be.true;
+        expect(companyState.getSelectedCompanyId()).to.equal("RV_parent_id");
+        expect(companyState.getSelectedCompanyName()).to.equal("Parent Company");
+        expect(companyState.isSubcompanySelected()).to.be.false;
         
         done();
       },10);

--- a/web/scripts/components/userstate/services/svc-companystate.js
+++ b/web/scripts/components/userstate/services/svc-companystate.js
@@ -41,6 +41,8 @@
             .then(null, function () {
               if ($state.current.forceAuth !== false) {                
                 _companyState.resetCompany();
+              } else {
+                objectHelper.clearAndCopy(_state.userCompany, _state.selectedCompany);
               }
             })
             .finally(function () {


### PR DESCRIPTION
## Description
Load credit cards from user company

If selected company fails to load
Show User company creditc cards

[stage-18]

## Motivation and Context
Keep functionality as is expected until situation is reviewed.

## How Has This Been Tested?
Tested changes locally to ensure credit cards are still loaded for the user's company. Updated relevant unit test.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No