### PR TITLE
Use inherited scope instead of parent scope

### DIFF
--- a/web/scripts/components/scrolling-list/directives/dtv-scrolling-list.js
+++ b/web/scripts/components/scrolling-list/directives/dtv-scrolling-list.js
@@ -10,6 +10,7 @@
           replace: false,
           terminal: true,
           priority: 1000,
+          scope: true,
           link: function link(scope, element, attr) {
             var fn = $parse(attr.scrollingList);
 


### PR DESCRIPTION
## Description
Use inherited scope instead of parent scope

Fixes issues with multiple lists on the same page

[stage-17]

## Motivation and Context
Fix for the issue that https://github.com/Rise-Vision/rise-vision-apps/pull/2217 was trying to fix.

Apparently the problem stemmed from the scope function from the first directive getting overwritten by the scope function in the second.

## How Has This Been Tested?
Tested changes locally with the Rise Vision Test Company. On the Billing page both Invoices and Subscriptions lists should load on scroll. Currently, only the invoices list loads on scroll.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No