### PR TITLE
Fix/edit subscription link

### DIFF
--- a/test/unit/billing/controllers/ctr-billing.tests.js
+++ b/test/unit/billing/controllers/ctr-billing.tests.js
@@ -117,18 +117,11 @@ describe('controller: BillingCtrl', function () {
   });
 
   describe('edit subscriptions', function () {
-    it('should show Chargebee subscription details for a Subscription with parentId == null', function () {
+    it('should show Chargebee subscription details', function () {
       $scope.editSubscription({ id: 'subs1' });
       expect($scope.chargebeeFactory.openSubscriptionDetails).to.be.calledOnce;
       expect($scope.chargebeeFactory.openSubscriptionDetails.getCall(0).args[0]).to.equal('testId');
       expect($scope.chargebeeFactory.openSubscriptionDetails.getCall(0).args[1]).to.equal('subs1');
-    });
-
-    it('should show Chargebee parent subscription details for a Subscription with parentId != null', function () {
-      $scope.editSubscription({ id: 'subs1', parentId: 'parentId' });
-      expect($scope.chargebeeFactory.openSubscriptionDetails).to.be.calledOnce;
-      expect($scope.chargebeeFactory.openSubscriptionDetails.getCall(0).args[0]).to.equal('testId');
-      expect($scope.chargebeeFactory.openSubscriptionDetails.getCall(0).args[1]).to.equal('parentId');
     });
   });
 

--- a/test/unit/billing/controllers/ctr-billing.tests.js
+++ b/test/unit/billing/controllers/ctr-billing.tests.js
@@ -16,7 +16,7 @@ describe('controller: BillingCtrl', function () {
       return {
         openCompanySettings: sandbox.stub()
       };
-    });   
+    });
     $provide.service('ScrollingListService', function () {
       return sinon.stub().returns(listServiceInstance);
     });
@@ -81,7 +81,7 @@ describe('controller: BillingCtrl', function () {
     expect($scope.subscriptions).to.be.ok;
     expect($scope.invoices).to.be.ok;
   });
-  
+
   it('should init list service', function() {
     ScrollingListService.should.have.been.calledTwice;
     ScrollingListService.should.have.been.calledWith('getSubscriptions', {
@@ -118,14 +118,14 @@ describe('controller: BillingCtrl', function () {
 
   describe('edit subscriptions', function () {
     it('should show Chargebee subscription details for a Subscription with parentId == null', function () {
-      $scope.editSubscription({ subscriptionId: 'subs1' });
+      $scope.editSubscription({ id: 'subs1' });
       expect($scope.chargebeeFactory.openSubscriptionDetails).to.be.calledOnce;
       expect($scope.chargebeeFactory.openSubscriptionDetails.getCall(0).args[0]).to.equal('testId');
       expect($scope.chargebeeFactory.openSubscriptionDetails.getCall(0).args[1]).to.equal('subs1');
     });
 
     it('should show Chargebee parent subscription details for a Subscription with parentId != null', function () {
-      $scope.editSubscription({ subscriptionId: 'subs1', parentId: 'parentId' });
+      $scope.editSubscription({ id: 'subs1', parentId: 'parentId' });
       expect($scope.chargebeeFactory.openSubscriptionDetails).to.be.calledOnce;
       expect($scope.chargebeeFactory.openSubscriptionDetails.getCall(0).args[0]).to.equal('testId');
       expect($scope.chargebeeFactory.openSubscriptionDetails.getCall(0).args[1]).to.equal('parentId');

--- a/web/scripts/billing/controllers/ctr-billing.js
+++ b/web/scripts/billing/controllers/ctr-billing.js
@@ -53,7 +53,7 @@ angular.module('risevision.apps.billing.controllers')
       };
 
       $scope.editSubscription = function (subscription) {
-        var subscriptionId = subscription.id;
+        var subscriptionId = subscription.parentId || subscription.id;
 
         $scope.chargebeeFactory.openSubscriptionDetails(userState.getSelectedCompanyId(), subscriptionId);
       };

--- a/web/scripts/billing/controllers/ctr-billing.js
+++ b/web/scripts/billing/controllers/ctr-billing.js
@@ -53,7 +53,7 @@ angular.module('risevision.apps.billing.controllers')
       };
 
       $scope.editSubscription = function (subscription) {
-        var subscriptionId = subscription.parentId || subscription.id;
+        var subscriptionId = subscription.id;
 
         $scope.chargebeeFactory.openSubscriptionDetails(userState.getSelectedCompanyId(), subscriptionId);
       };

--- a/web/scripts/billing/controllers/ctr-billing.js
+++ b/web/scripts/billing/controllers/ctr-billing.js
@@ -7,7 +7,7 @@ angular.module('risevision.apps.billing.controllers')
     'ScrollingListService', 'userState', 'currentPlanFactory', 'ChargebeeFactory', 'billing',
     'billingFactory', 'PLANS_LIST', 'companySettingsFactory',
     function ($rootScope, $scope, $loading, $timeout, ScrollingListService, userState,
-      currentPlanFactory, ChargebeeFactory, billing, billingFactory, PLANS_LIST, 
+      currentPlanFactory, ChargebeeFactory, billing, billingFactory, PLANS_LIST,
       companySettingsFactory) {
 
       $scope.company = userState.getCopyOfSelectedCompany();
@@ -53,7 +53,7 @@ angular.module('risevision.apps.billing.controllers')
       };
 
       $scope.editSubscription = function (subscription) {
-        var subscriptionId = subscription.parentId || subscription.subscriptionId;
+        var subscriptionId = subscription.id;
 
         $scope.chargebeeFactory.openSubscriptionDetails(userState.getSelectedCompanyId(), subscriptionId);
       };
@@ -85,12 +85,12 @@ angular.module('risevision.apps.billing.controllers')
         var prefix = subscription.plan_quantity > 1 ? subscription.plan_quantity + ' x ' : '';
         var plan = _getPlan(subscription);
         var name = plan ? plan.name : subscription.plan_id;
-        
+
         // Show `1` plan_quantity for Per Display subscriptions
         if (plan && _isVolumePlan(plan) && subscription.plan_quantity > 0) {
           prefix = subscription.plan_quantity + ' x ';
         }
-        
+
         var period = _getPeriod(subscription);
 
         if (_isVolumePlan(plan)) {
@@ -98,7 +98,7 @@ angular.module('risevision.apps.billing.controllers')
         } else {
           name = name + ' Plan ' + period;
         }
-        
+
         return prefix + name;
       };
 


### PR DESCRIPTION
## Description
Fixes edit subscription link action.

[stage-8]

## Motivation and Context
Edit subscription link in the development branch is failing because the property to get the subscription id has changed. If clicked, it gives the following error:

![error](https://user-images.githubusercontent.com/33162690/103101322-ac411480-45dc-11eb-81b9-88fde9f8f2d0.png)

## How Has This Been Tested?
Tested is working on stage-8 -

![fixed](https://user-images.githubusercontent.com/33162690/103101343-bb27c700-45dc-11eb-8550-fbc67c47347f.png)

## Release Plan:
To be released to development parent branch.

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
