### PR TITLE
List active subscription managed by parent

### DIFF
--- a/test/e2e/billing/cases/account-billing.js
+++ b/test/e2e/billing/cases/account-billing.js
@@ -78,6 +78,20 @@
           expect(accountBillingPage.getPaidInvoiceIcon().isPresent()).to.eventually.be.true;
         });
 
+        describe("Subscriptions managed by parent", function() {
+          it("should load subcompany", function() {
+            commonHeaderPage.selectSubscribedSubCompany();
+
+            helper.waitDisappear(accountBillingPage.getLoader(), "Account & Billing Page");
+          });
+
+          it('should list the subscription managed by the parent company', function () {
+            expect(accountBillingPage.getFirstSubscriptionName().isPresent()).to.eventually.be.true;
+            expect(accountBillingPage.getFirstSubscriptionName().getText()).to.eventually.contain('Subscription managed by');
+          });
+
+        });
+
       });
 
     });

--- a/test/e2e/billing/pages/accountBillingPage.js
+++ b/test/e2e/billing/pages/accountBillingPage.js
@@ -12,6 +12,7 @@
     var subscriptionsTableHeaderRenewalDate = element(by.css('#subscriptionsListTable tr th:nth-child(3)'));
     var subscriptionsTableHeaderRenewalAmount = element(by.css('#subscriptionsListTable tr th:nth-child(4)'));
     var firstSubscriptionLink = element(by.css('#subscriptionsListTable tbody tr:first-child td a'));
+    var firstSubscriptionName = element(by.css('#subscriptionsListTable tbody tr:first-child td'));
     var paidInvoiceIcon = element(by.css('#invoicesListTable td .paid'));
     var payNowButton = element(by.css('#invoicesListTable td .btn-pay-now'));
 
@@ -49,6 +50,10 @@
 
     this.getFirstSubscriptionLink = function() {
       return firstSubscriptionLink;
+    };
+
+    this.getFirstSubscriptionName = function() {
+      return firstSubscriptionName;
     };
 
     this.getPaidInvoiceIcon = function() {

--- a/web/partials/billing/app-billing.html
+++ b/web/partials/billing/app-billing.html
@@ -58,7 +58,26 @@
           </tr>
         </thead>
         <tbody class="table-body">
-          <tr class="table-body__row" ng-repeat="item in subscriptions.items.list" ng-if="item.subscription.current_term_end">
+          <tr class="table-body__row" ng-if="currentPlan.isPurchasedByParent">
+            <td class="table-body__cell font-weight-bold">
+              Subscription managed by {{currentPlan.parentPlanCompanyName || "the Parent Company"}}
+            </td>
+            <td class="table-body__cell">
+              <span class="u_capitalize text-success">
+                Active
+              </span>
+            </td>
+            <td class="table-body__cell">
+              -
+            </td>
+            <td class="table-body__cell">
+              -
+            </td>
+            <td class="table-body__cell">
+            </td>
+          </tr>
+
+          <tr class="table-body__row" ng-repeat="item in (filteredSubscriptions = (subscriptions.items.list | filter: { subscription: { current_term_end: '!!' }}))">
             <td class="table-body__cell font-weight-bold">
               <a class="madero-link u_clickable" ng-click="editSubscription(item.subscription)" ng-if="item.subscription.customer_id === company.id">{{getSubscriptionDesc(item.subscription)}}</a>
               <span ng-if="item.subscription.customer_id !== company.id">{{getSubscriptionDesc(item.subscription)}}</span>
@@ -77,13 +96,10 @@
             <td class="table-body__cell">
               <span ng-if="item.subscription.customer_id !== item.subscription.cf_ship_to_company">{{item.subscription.shipping_address.company}}</span>
             </td>
-            <td class="table-body__cell">
-              <span ng-if="item.subscription.customer_id !== company.id">Managed by Parent</span>
-            </td>
           </tr>
 
-          <tr ng-show="subscriptions.items.list.length === 0">
-            <td colspan="6" class="text-center"><span translate>You haven't Subscribed to any Products yet.</span></td>
+          <tr ng-show="filteredSubscriptions.length === 0 && !currentPlan.isPurchasedByParent">
+            <td colspan="5" class="text-center"><span translate>You haven't Subscribed to any Products yet.</span></td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
## Description
List active subscription managed by parent in the subcompany's billing page

## Motivation and Context
To keep current behaviour of listing parent's subscription from subcompany's billing page

## How Has This Been Tested?
Locally and on stage-1.
Sample company: https://apps-stage-1.risevision.com/billing?cid=ddb3a39b-5dc2-4200-8142-5692b38b32e5
Sample company along with cancelled: https://apps-stage-1.risevision.com/billing?cid=9bd35f40-c3c6-4ea9-96c8-fdfd895c41e0

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
