### PR TITLE
Add name mapping for financial subscriptions

### DIFF
--- a/test/unit/billing/controllers/ctr-billing.tests.js
+++ b/test/unit/billing/controllers/ctr-billing.tests.js
@@ -195,14 +195,14 @@ describe('controller: BillingCtrl', function () {
           plan_quantity: 1,
           billing_period: 1,
           billing_period_unit: 'year',
-        })).to.equal('pppc Plan Yearly');
+        })).to.equal('pppc');
 
         expect($scope.getSubscriptionDesc({
           plan_id: 'pppc',
           plan_quantity: 3,
           billing_period: 1,
           billing_period_unit: 'year',
-        })).to.equal('3 x pppc Plan Yearly');
+        })).to.equal('pppc');
       });
 
       it('should format volume plan names', function () {

--- a/web/scripts/billing/controllers/ctr-billing.js
+++ b/web/scripts/billing/controllers/ctr-billing.js
@@ -69,7 +69,7 @@ angular.module('risevision.apps.billing.controllers')
       };
 
       var _isVolumePlan = function (plan) {
-        return plan && plan.type.indexOf('volume') !== -1;
+        return plan && plan.type && plan.type.indexOf('volume') !== -1;
       };
 
       var _getPeriod = function(subscription) {

--- a/web/scripts/billing/controllers/ctr-billing.js
+++ b/web/scripts/billing/controllers/ctr-billing.js
@@ -84,22 +84,26 @@ angular.module('risevision.apps.billing.controllers')
       $scope.getSubscriptionDesc = function (subscription) {
         var prefix = subscription.plan_quantity > 1 ? subscription.plan_quantity + ' x ' : '';
         var plan = _getPlan(subscription);
-        var name = plan ? plan.name : subscription.plan_id;
+        if (plan) {
+          var name = plan.name;
 
-        // Show `1` plan_quantity for Per Display subscriptions
-        if (plan && _isVolumePlan(plan) && subscription.plan_quantity > 0) {
-          prefix = subscription.plan_quantity + ' x ';
-        }
+          // Show `1` plan_quantity for Per Display subscriptions
+          if (plan && _isVolumePlan(plan) && subscription.plan_quantity > 0) {
+            prefix = subscription.plan_quantity + ' x ';
+          }
 
-        var period = _getPeriod(subscription);
+          var period = _getPeriod(subscription);
 
-        if (_isVolumePlan(plan)) {
-          name = name + ' ' + period + ' Plan';
+          if (_isVolumePlan(plan)) {
+            name = name + ' ' + period + ' Plan';
+          } else {
+            name = name + ' Plan ' + period;
+          }
+
+          return prefix + name;
         } else {
-          name = name + ' Plan ' + period;
+          return subscription.plan_id;
         }
-
-        return prefix + name;
       };
 
       $scope.isActive = function (subscription) {

--- a/web/scripts/components/plans/services/svc-plans-factory.js
+++ b/web/scripts/components/plans/services/svc-plans-factory.js
@@ -158,6 +158,15 @@
       productId: '303',
       productCode: 'd521f5bfbc1eef109481eebb79831e11c7804ad8',
       proLicenseCount: 0
+    }, {
+      name: 'Basic Financial MarketWall',
+      productCode: '0dbb19f8394612730c2673b092d811e46413b132'
+    }, {
+      name: 'Premium Financial MarketWall',
+      productCode: '0c583c663655c246c3e7b3c1be0ec05a442211aa'
+    }, {
+      name: 'Financial Data License',
+      productCode: '356ab5e0541a41e96e4ef0b45ecac9f72af454ac'
     }])
     .factory('plansFactory', ['$modal', 'userState', 'PLANS_LIST', 'analyticsFactory',
       '$state', 'confirmModal',


### PR DESCRIPTION
## Description
Add name mapping for financial subscriptions
Fallback to plan id if mapping is not present (for Ticker), without prefixes as not relevant and billing term is already part of the ticker subscription id (e.g. `led-ticker-license-annual-cad`)

## Motivation and Context
Financial and LED Ticker subscriptions didn't have a human readable name in the subscriptions list.
Now it will show the correct names for Financial subscriptions and the plan id for Ticker subscriptions (e.g. `led-ticker-license-annual-cad`)

## How Has This Been Tested?
Locally and on [stage-1]
Sample: https://apps-stage-1.risevision.com/billing?cid=4b5870e7-c7c3-40bf-9290-ef3e668f3a95

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
