### PR TITLE
handle error reject as other functions [stage-9]

### DIFF
--- a/web/scripts/common-header/services/svc-store-service.js
+++ b/web/scripts/common-header/services/svc-store-service.js
@@ -274,9 +274,10 @@
                 $log.debug('integrations.subscription.estimate resp', resp);
                 deferred.resolve(resp.result);
               })
-              .then(null, function (e) {
-                console.error('Failed to retrieve subscription estimate.', e);
-                deferred.reject(e);
+              .then(null, function (resp) {
+                console.error('Failed to retrieve subscription estimate.', resp);
+
+                deferred.reject(resp && resp.result && resp.result.error);
               });
             return deferred.promise;
           },
@@ -298,9 +299,10 @@
                 $log.debug('integrations.subscription.update resp', resp);
                 deferred.resolve(resp.result);
               })
-              .then(null, function (e) {
-                console.error('Failed to retrieve subscription update.', e);
-                deferred.reject(e);
+              .then(null, function (resp) {
+                console.error('Failed to retrieve subscription update.', resp);
+
+                deferred.reject(resp && resp.result && resp.result.error);
               });
             return deferred.promise;
           }


### PR DESCRIPTION
## Description
Update estimationSubscriptionUpdate and updateSubscription functions to return error rejections as other functions in the same class do, so error messages are properly shown in the page.

[stage-9]

## Motivation and Context
Specific error messages were not shown.

## How Has This Been Tested?
Tested locally and in stage-9. An invalid coupon now shows the expected error message:
![coupon-error](https://user-images.githubusercontent.com/33162690/103686610-b22be380-4f54-11eb-83f8-62f8cc5c8312.png)

## Release Plan:
To be merged to purchase-licenses branch.

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
-
