### PR TITLE
Check for education discount instead of customer profile

### DIFF
--- a/web/scripts/purchase/services/svc-purchase-licenses-factory.js
+++ b/web/scripts/purchase/services/svc-purchase-licenses-factory.js
@@ -137,13 +137,17 @@
         };
 
         var _updatePerDisplayPrice = function () {
-          var isEducation = userState.isEducationCustomer();
+          if (!factory.estimate.next_invoice_estimate) {
+            return;
+          }
 
           var currentDisplayCount = currentPlanFactory.currentPlan.playerProTotalLicenseCount;
           var displayCount = factory.purchase.displayCount + currentDisplayCount;
 
           var lineItem = factory.estimate.next_invoice_estimate.line_items[0];
           var isMonthly = lineItem.entity_id.endsWith('m');
+
+          var isEducation = factory.estimate.next_invoice_estimate.line_item_discounts.indexOf('EDUCATION') >= 0;
 
           factory.currentPricePerDisplay = pricingFactory.getPricePerDisplay(isMonthly, currentDisplayCount, isEducation);
           factory.newPricePerDisplay = pricingFactory.getPricePerDisplay(isMonthly, displayCount, isEducation);

--- a/web/scripts/purchase/services/svc-purchase-licenses-factory.js
+++ b/web/scripts/purchase/services/svc-purchase-licenses-factory.js
@@ -147,7 +147,10 @@
           var lineItem = factory.estimate.next_invoice_estimate.line_items[0];
           var isMonthly = lineItem.entity_id.endsWith('m');
 
-          var isEducation = factory.estimate.next_invoice_estimate.line_item_discounts.indexOf('EDUCATION') >= 0;
+          var educationDiscount = _.find(factory.estimate.next_invoice_estimate.line_item_discounts, {
+            coupon_id: 'EDUCATION'
+          });
+          var isEducation = !!educationDiscount;
 
           factory.currentPricePerDisplay = pricingFactory.getPricePerDisplay(isMonthly, currentDisplayCount, isEducation);
           factory.newPricePerDisplay = pricingFactory.getPricePerDisplay(isMonthly, displayCount, isEducation);


### PR DESCRIPTION
## Description
Check for education discount instead of customer profile

[stage-18]

## Motivation and Context
There are other industries that could have the discount. Using the company setting is not reliable.

## How Has This Been Tested?
Tested changes locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No