### PR TITLE
Add displayCount to route and pass it when selecting multiple displays

### DIFF
--- a/test/unit/app.tests.js
+++ b/test/unit/app.tests.js
@@ -11,12 +11,6 @@ describe('app:', function() {
         return sinon.stub().returns(Q.resolve("auth"));
       });
 
-      $provide.service('plansFactory',function(){
-        return {
-          showPurchaseOptions: sinon.stub()
-        };
-      });
-
       $provide.service('$modal', function() {
         return {
           open: sinon.stub().returns({result: Q.resolve()})
@@ -92,7 +86,6 @@ describe('app:', function() {
       setTimeout(function() {
         canAccessApps.should.have.been.called;
 
-        expect(plansFactory.showPurchaseOptions).to.not.have.been.called;
         $modal.open.should.have.been.calledWith({
           templateUrl: 'partials/common-header/user-settings-modal.html',
           controller: 'AddUserModalCtrl',

--- a/test/unit/billing/services/svc-chargebee-factory-spec.js
+++ b/test/unit/billing/services/svc-chargebee-factory-spec.js
@@ -35,7 +35,7 @@ describe("Services: ChargebeeFactory", function() {
     });
     $provide.service("plansFactory", function() {
       return {
-        showPlansModal: sinon.stub(),
+        showPurchaseOptions: sinon.stub(),
         isPlansModalOpen: false
       };
     });
@@ -204,7 +204,7 @@ describe("Services: ChargebeeFactory", function() {
       setTimeout(function () {
         expect($window.Chargebee.init.getCall(0).args[0].site).to.equal("risevision-test");
         expect(chargebeePortal.open).to.have.been.calledOnce;
-        expect(plansFactory.showPlansModal).to.not.have.been.called;
+        expect(plansFactory.showPurchaseOptions).to.not.have.been.called;
         expect(plansFactory.apiError).to.not.be.ok;
         done();
       });
@@ -219,7 +219,7 @@ describe("Services: ChargebeeFactory", function() {
       setTimeout(function () {
         expect($window.Chargebee.init.getCall(0).args[0].site).to.equal("risevision");
         expect(chargebeePortal.open).to.have.been.calledOnce;
-        expect(plansFactory.showPlansModal).to.not.have.been.called;
+        expect(plansFactory.showPurchaseOptions).to.not.have.been.called;
         expect(plansFactory.apiError).to.not.be.ok;
         done();
       });
@@ -236,7 +236,7 @@ describe("Services: ChargebeeFactory", function() {
 
       setTimeout(function () {
         expect(chargebeePortal.open).to.not.have.been.called;
-        expect(plansFactory.showPlansModal).to.not.have.been.called;
+        expect(plansFactory.showPurchaseOptions).to.not.have.been.called;
         expect(plansFactory.apiError).to.be.not.null;
         done();
       });
@@ -315,7 +315,7 @@ describe("Services: ChargebeeFactory", function() {
 
         setTimeout(function () {
           expect(chargebeePortal.open).to.not.have.been.called;
-          expect(plansFactory.showPlansModal).to.have.been.calledOnce;
+          expect(plansFactory.showPurchaseOptions).to.have.been.calledOnce;
 
           done();
         });
@@ -326,7 +326,7 @@ describe("Services: ChargebeeFactory", function() {
 
         setTimeout(function () {
           expect(chargebeePortal.open).to.not.have.been.called;
-          expect(plansFactory.showPlansModal).to.have.been.calledOnce;
+          expect(plansFactory.showPurchaseOptions).to.have.been.calledOnce;
           done();
         });
       });
@@ -336,7 +336,7 @@ describe("Services: ChargebeeFactory", function() {
 
         setTimeout(function () {
           expect(chargebeePortal.open).to.not.have.been.called;
-          expect(plansFactory.showPlansModal).to.have.been.calledOnce;
+          expect(plansFactory.showPurchaseOptions).to.have.been.calledOnce;
           done();
         });
       });
@@ -346,7 +346,7 @@ describe("Services: ChargebeeFactory", function() {
 
         setTimeout(function () {
           expect(chargebeePortal.open).to.not.have.been.called;
-          expect(plansFactory.showPlansModal).to.have.been.calledOnce;
+          expect(plansFactory.showPurchaseOptions).to.have.been.calledOnce;
           done();
         });
       });
@@ -356,7 +356,7 @@ describe("Services: ChargebeeFactory", function() {
 
         setTimeout(function () {
           expect(chargebeePortal.open).to.not.have.been.called;
-          expect(plansFactory.showPlansModal).to.have.been.calledOnce;
+          expect(plansFactory.showPurchaseOptions).to.have.been.calledOnce;
           done();
         });
       });
@@ -366,7 +366,7 @@ describe("Services: ChargebeeFactory", function() {
 
         setTimeout(function () {
           expect(chargebeePortal.open).to.not.have.been.called;
-          expect(plansFactory.showPlansModal).to.have.been.calledOnce;
+          expect(plansFactory.showPurchaseOptions).to.have.been.calledOnce;
           done();
         });
       });
@@ -379,7 +379,7 @@ describe("Services: ChargebeeFactory", function() {
 
           setTimeout(function () {
             expect(chargebeePortal.open).to.not.have.been.called;
-            expect(plansFactory.showPlansModal).to.not.have.been.called;
+            expect(plansFactory.showPurchaseOptions).to.not.have.been.called;
             expect(chargebeeFactoryInstance.apiError).to.equal(403);
 
             done();

--- a/test/unit/common-header/controllers/ctr-plan-banner-spec.js
+++ b/test/unit/common-header/controllers/ctr-plan-banner-spec.js
@@ -27,7 +27,7 @@ describe("controller: plan banner", function() {
     });
     $provide.factory("plansFactory", function() {
       return {
-        showPlansModal: sinon.stub()
+        showPurchaseOptions: sinon.stub()
       };
     });
   }));

--- a/test/unit/components/plans/services/svc-plans-factory-spec.js
+++ b/test/unit/components/plans/services/svc-plans-factory-spec.js
@@ -62,15 +62,8 @@ describe("Services: plans factory", function() {
 
   it("should exist", function() {
     expect(plansFactory).to.be.ok;
-    expect(plansFactory.showPlansModal).to.be.a('function');
     expect(plansFactory.showPurchaseOptions).to.be.a('function');
     expect(plansFactory.initVolumePlanTrial).to.be.a('function');
-  });
-
-  it("showPlansModal: ", function() {
-    plansFactory.showPlansModal();
-
-    $state.go.should.have.been.calledWith('apps.purchase.home');
   });
 
   it("showPurchaseOptions: ", function() {

--- a/test/unit/components/plans/services/svc-plans-factory-spec.js
+++ b/test/unit/components/plans/services/svc-plans-factory-spec.js
@@ -67,16 +67,18 @@ describe("Services: plans factory", function() {
   });
 
   it("showPurchaseOptions: ", function() {
-    plansFactory.showPurchaseOptions();
+    plansFactory.showPurchaseOptions('displayCount');
 
-    $state.go.should.have.been.calledWith('apps.purchase.home');
+    $state.go.should.have.been.calledWith('apps.purchase.home', {
+      displayCount: 'displayCount'
+    });
   });
 
   describe("confirmAndPurchase:", function(){
     it("should show confirmation message and proceed to purchase on confirmation", function(done) {
       sinon.spy(plansFactory, "showPurchaseOptions");
 
-      plansFactory.confirmAndPurchase();
+      plansFactory.confirmAndPurchase('displayCount');
 
       setTimeout(function() {        
         expect(confirmModalStub).to.have.been.calledWith(
@@ -85,7 +87,7 @@ describe("Services: plans factory", function() {
           'Yes', 'No', 'madero-style centered-modal',
           'partials/components/confirm-modal/madero-confirm-modal.html', 'sm'
         );
-        expect(plansFactory.showPurchaseOptions).to.have.been.called;
+        expect(plansFactory.showPurchaseOptions).to.have.been.calledWith('displayCount');
 
         done();
       },10);

--- a/test/unit/displays/services/svc-display-factory.tests.js
+++ b/test/unit/displays/services/svc-display-factory.tests.js
@@ -87,7 +87,7 @@ describe('service: displayFactory:', function() {
     });
     $provide.factory('plansFactory', function() {
       return {
-        showPlansModal: sinon.spy()
+        showPurchaseOptions: sinon.spy()
       };
     });
     $provide.factory('scheduleFactory', function() {

--- a/test/unit/displays/services/svc-display-list-operations.tests.js
+++ b/test/unit/displays/services/svc-display-list-operations.tests.js
@@ -214,7 +214,7 @@ describe('service: DisplayListOperations:', function() {
 
         licenseOperation.beforeBatchAction(selected)
           .catch(function() {
-            plansFactory.confirmAndPurchase.should.have.been.called;
+            plansFactory.confirmAndPurchase.should.have.been.calledWith(1);
 
             done();
           });        
@@ -338,7 +338,7 @@ describe('service: DisplayListOperations:', function() {
               '2 of your selected displays are not licensed and to perform this action they need to be. You have 1 available license and you need to subscribe for 1 more to license these displays.',
               'Subscribe', 'Cancel', 'madero-style centered-modal','partials/components/confirm-modal/madero-confirm-modal.html','sm');
 
-            plansFactory.showPurchaseOptions.should.have.been.called;
+            plansFactory.showPurchaseOptions.should.have.been.calledWith(1);
 
             done();
           },10);

--- a/test/unit/displays/services/svc-player-license-factory.tests.js
+++ b/test/unit/displays/services/svc-player-license-factory.tests.js
@@ -458,7 +458,7 @@ describe('Services: playerLicenseFactory', function() {
 
       playerLicenseFactory.confirmAndLicense(['displayId']).catch(function() {
         confirmModal.should.have.been.called;
-        plansFactory.confirmAndPurchase.should.have.been.called;
+        plansFactory.confirmAndPurchase.should.have.been.calledWith(1);
 
         done();
       });

--- a/test/unit/editor/controllers/ctr-playlist-item-modal.tests.js
+++ b/test/unit/editor/controllers/ctr-playlist-item-modal.tests.js
@@ -65,7 +65,7 @@ describe('controller: playlist item modal', function() {
 
     $provide.service('plansFactory', function() {
       return {
-        showPlansModal: sinon.stub()
+        showPurchaseOptions: sinon.stub()
       };
     });
 

--- a/test/unit/editor/services/svc-presentation-utils.tests.js
+++ b/test/unit/editor/services/svc-presentation-utils.tests.js
@@ -13,7 +13,7 @@ describe('service: presentationUtils:', function() {
 
     $provide.service('plansFactory', function() {
       return plansFactory = {
-        showPlansModal: sinon.stub()
+        showPurchaseOptions: sinon.stub()
       }
     })
   }));

--- a/test/unit/purchase/app.tests.js
+++ b/test/unit/purchase/app.tests.js
@@ -75,7 +75,21 @@ describe('app:', function() {
       canAccessApps.should.have.been.called;
 
       setTimeout(function(){
-        expect($state.go).to.have.been.calledWith('apps.purchase.licenses');
+        expect($state.go).to.have.been.calledWith('apps.purchase.licenses', {displayCount: 1});
+
+        expect(messageBoxStub).to.not.have.been.called;
+        done();
+      },10);
+    });
+
+    it('should pass displayCount parameter value', function(done) {
+      $state.go('apps.purchase.home', {displayCount: 'displayCount'});
+      $rootScope.$digest();
+
+      canAccessApps.should.have.been.called;
+
+      setTimeout(function(){
+        expect($state.go).to.have.been.calledWith('apps.purchase.licenses', {displayCount: 'displayCount'});
 
         expect(messageBoxStub).to.not.have.been.called;
         done();

--- a/test/unit/storage/services/svc-file-selector-factory.tests.js
+++ b/test/unit/storage/services/svc-file-selector-factory.tests.js
@@ -10,7 +10,7 @@ describe('service: FileSelectorFactory (aka FilesFactory):', function() {
     });
     $provide.factory("plansFactory", function() {
       return {
-        showPlansModal: sinon.stub()
+        showPurchaseOptions: sinon.stub()
       };
     });
   }));

--- a/test/unit/storage/services/svc-files-factory.tests.js
+++ b/test/unit/storage/services/svc-files-factory.tests.js
@@ -32,7 +32,7 @@ describe('service: FilesFactory:', function() {
 
     $provide.factory("plansFactory", function() {
       return {
-        showPlansModal: sinon.stub()
+        showPurchaseOptions: sinon.stub()
       };
     });
 

--- a/web/scripts/billing/services/svc-chargebee-factory.js
+++ b/web/scripts/billing/services/svc-chargebee-factory.js
@@ -81,7 +81,7 @@ angular.module('risevision.apps.billing.services')
         var _handleChargebeePortalError = function (err, companyId) {
           if (err.status === 404 && !currentPlanFactory.currentPlan.isPurchasedByParent && !plansFactory
             .isPlansModalOpen) {
-            plansFactory.showPlansModal();
+            plansFactory.showPurchaseOptions();
           } else if (err.status === 404 && currentPlanFactory.currentPlan.isPurchasedByParent) {
             // Throw no access error
             factory.apiError = 403;

--- a/web/scripts/common-header/controllers/ctr-plan-banner.js
+++ b/web/scripts/common-header/controllers/ctr-plan-banner.js
@@ -7,7 +7,7 @@ angular.module('risevision.common.header')
     function ($scope, $rootScope, userState, plansFactory, currentPlanFactory,
       STORE_URL, ACCOUNT_PATH) {
       $scope.plan = {};
-      $scope.showPlans = plansFactory.showPlansModal;
+      $scope.showPlans = plansFactory.showPurchaseOptions;
       $scope.storeAccountUrl = STORE_URL + ACCOUNT_PATH;
 
       $rootScope.$on('risevision.plan.loaded', function () {

--- a/web/scripts/components/plans/services/svc-plans-factory.js
+++ b/web/scripts/components/plans/services/svc-plans-factory.js
@@ -173,12 +173,8 @@
       function ($modal, userState, PLANS_LIST, analyticsFactory, $state, confirmModal) {
         var _factory = {};
 
-        _factory.showPlansModal = function () {
-          $state.go('apps.purchase.home');
-        };
-
         _factory.showPurchaseOptions = function () {
-          _factory.showPlansModal();
+          $state.go('apps.purchase.home');
         };
 
         _factory.confirmAndPurchase = function () {
@@ -207,7 +203,7 @@
               cancelButton: null
             }
           }).result.then(function () {
-            _factory.showPlansModal();
+            _factory.showPurchaseOptions();
           });
         };
 

--- a/web/scripts/components/plans/services/svc-plans-factory.js
+++ b/web/scripts/components/plans/services/svc-plans-factory.js
@@ -173,17 +173,19 @@
       function ($modal, userState, PLANS_LIST, analyticsFactory, $state, confirmModal) {
         var _factory = {};
 
-        _factory.showPurchaseOptions = function () {
-          $state.go('apps.purchase.home');
+        _factory.showPurchaseOptions = function (displayCount) {
+          $state.go('apps.purchase.home', {
+            displayCount: displayCount
+          });
         };
 
-        _factory.confirmAndPurchase = function () {
+        _factory.confirmAndPurchase = function (displayCount) {
           confirmModal('Almost there!',
               'There aren\'t available licenses to assign to the selected displays. Subscribe to additional licenses?',
               'Yes', 'No', 'madero-style centered-modal',
               'partials/components/confirm-modal/madero-confirm-modal.html', 'sm')
             .then(function () {
-              _factory.showPurchaseOptions();
+              _factory.showPurchaseOptions(displayCount);
             });
         };
 

--- a/web/scripts/displays/services/svc-display-list-operations.js
+++ b/web/scripts/displays/services/svc-display-list-operations.js
@@ -19,7 +19,7 @@ angular.module('risevision.displays.services')
               'sm');
             return $q.reject();
           } else if (playerLicenseFactory.getProAvailableLicenseCount() < selected.length) {
-            plansFactory.confirmAndPurchase();
+            plansFactory.confirmAndPurchase(selected.length - playerLicenseFactory.getProAvailableLicenseCount());
             return $q.reject();
           } else {
             return confirmModal(
@@ -77,7 +77,7 @@ angular.module('risevision.displays.services')
                 ' more to license ' + (notAuthorized.length > 1 ? 'these displays.' : 'this display.'),
                 'Subscribe', 'Cancel', 'madero-style centered-modal',
                 'partials/components/confirm-modal/madero-confirm-modal.html', 'sm').then(function () {
-                plansFactory.showPurchaseOptions();
+                plansFactory.showPurchaseOptions(notAuthorized.length - availableLicenses);
                 return $q.reject();
               });
             }

--- a/web/scripts/displays/services/svc-player-license-factory.js
+++ b/web/scripts/displays/services/svc-player-license-factory.js
@@ -73,7 +73,7 @@ angular.module('risevision.displays.services')
             if (factory.getProAvailableLicenseCount() >= displayIds.length) {
               return _licenseDisplays(displayIds);
             } else {
-              plansFactory.confirmAndPurchase();
+              plansFactory.confirmAndPurchase(displayIds.length - factory.getProAvailableLicenseCount());
               return $q.reject();
             }
           });

--- a/web/scripts/purchase/app.js
+++ b/web/scripts/purchase/app.js
@@ -9,7 +9,10 @@ angular.module('risevision.apps')
       $stateProvider
         .state('apps.purchase', {
           abstract: true,
-          template: '<div class="container purchase-app" ui-view></div>'
+          template: '<div class="container purchase-app" ui-view></div>',
+          params: {
+            displayCount: 1 
+          }
         })
 
         .state('apps.purchase.plans', {
@@ -28,12 +31,14 @@ angular.module('risevision.apps')
           }],
           controller: 'PurchaseCtrl',
           resolve: {
-            canAccessApps: ['$state', 'canAccessApps', 'currentPlanFactory',
-              function ($state, canAccessApps, currentPlanFactory) {
+            canAccessApps: ['$state', '$stateParams', 'canAccessApps', 'currentPlanFactory',
+              function ($state, $stateParams, canAccessApps, currentPlanFactory) {
                 return canAccessApps()
                   .then(function () {
                     if (currentPlanFactory.isSubscribed() && !currentPlanFactory.isParentPlan()) {
-                      $state.go('apps.purchase.licenses');
+                      $state.go('apps.purchase.licenses', {
+                        displayCount: $stateParams.displayCount
+                      });
                     }
                   });
               }

--- a/web/scripts/purchase/controllers/ctr-purchase-licenses.js
+++ b/web/scripts/purchase/controllers/ctr-purchase-licenses.js
@@ -2,9 +2,9 @@
 
 angular.module('risevision.apps.purchase')
 
-  .controller('PurchaseLicensesCtrl', ['$scope', '$state', '$loading', 'purchaseLicensesFactory',
+  .controller('PurchaseLicensesCtrl', ['$scope', '$loading', 'purchaseLicensesFactory',
     'helpWidgetFactory', '$location', 'redirectTo', 'currentPlanFactory',
-    function ($scope, $state, $loading, purchaseLicensesFactory, helpWidgetFactory, $location,
+    function ($scope, $loading, purchaseLicensesFactory, helpWidgetFactory, $location,
       redirectTo, currentPlanFactory) {
       $scope.helpWidgetFactory = helpWidgetFactory;
       $scope.factory = purchaseLicensesFactory;

--- a/web/scripts/purchase/services/svc-purchase-licenses-factory.js
+++ b/web/scripts/purchase/services/svc-purchase-licenses-factory.js
@@ -7,7 +7,7 @@
   angular.module('risevision.apps.purchase')
     .factory('purchaseLicensesFactory', ['$rootScope', '$q', '$log', '$timeout', '$stateParams',
       'userState', 'currentPlanFactory', 'storeService', 'addressService', 'creditCardFactory',
-      'purchaseFlowTracker', 'pricingFactory'
+      'purchaseFlowTracker', 'pricingFactory',
       function ($rootScope, $q, $log, $timeout, $stateParams, userState, currentPlanFactory, 
         storeService, addressService, creditCardFactory, purchaseFlowTracker, pricingFactory) {
         var factory = {};

--- a/web/scripts/purchase/services/svc-purchase-licenses-factory.js
+++ b/web/scripts/purchase/services/svc-purchase-licenses-factory.js
@@ -3,10 +3,11 @@
   'use strict';
 
   angular.module('risevision.apps.purchase')
-    .factory('purchaseLicensesFactory', ['$rootScope', '$q', '$log', '$timeout', 'userState',
-      'currentPlanFactory', 'storeService', 'addressService', 'creditCardFactory', 'purchaseFlowTracker',
-      function ($rootScope, $q, $log, $timeout, userState, currentPlanFactory, storeService, addressService,
-        creditCardFactory, purchaseFlowTracker) {
+    .factory('purchaseLicensesFactory', ['$rootScope', '$q', '$log', '$timeout', '$stateParams',
+      'userState', 'currentPlanFactory', 'storeService', 'addressService', 'creditCardFactory',
+      'purchaseFlowTracker',
+      function ($rootScope, $q, $log, $timeout, $stateParams, userState, currentPlanFactory, 
+        storeService, addressService, creditCardFactory, purchaseFlowTracker) {
         var factory = {};
         factory.userEmail = userState.getUserEmail();
 
@@ -15,7 +16,7 @@
 
           factory.purchase = {};
           factory.purchase.completed = false;
-          factory.purchase.displayCount = 1;
+          factory.purchase.displayCount = $stateParams.displayCount;
           factory.purchase.couponCode = '';
 
           factory.getEstimate();

--- a/web/scripts/storage/services/svc-files-factory.js
+++ b/web/scripts/storage/services/svc-files-factory.js
@@ -9,7 +9,7 @@ angular.module('risevision.storage.services')
         // filesFactory functionality ~~~~~~~~~~
 
         var factory = {
-          startTrial: plansFactory.showPlansModal,
+          startTrial: plansFactory.showPurchaseOptions,
           filesDetails: {
             files: [],
             code: 202


### PR DESCRIPTION
## Description
Add displayCount to route and pass it when selecting multiple displays

Deprecate showPlansModal and replace it with showPurchaseOptions

[stage-18]

## Motivation and Context
Billing Frictions epic.

## How Has This Been Tested?
Tested the various scenarios locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No