### PR TITLE
Create purchaseFooter directive that puts factory on scope

### DIFF
--- a/test/unit/billing/controllers/ctr-invoice.tests.js
+++ b/test/unit/billing/controllers/ctr-invoice.tests.js
@@ -19,9 +19,6 @@ describe('controller: InvoiceCtrl', function () {
       invoice: {}
     });
 
-    $provide.service('helpWidgetFactory', function () {
-      return {};
-    });
   }));
 
   beforeEach(inject(function($injector, $rootScope, $controller) {
@@ -47,7 +44,6 @@ describe('controller: InvoiceCtrl', function () {
     expect($scope).to.be.ok;
 
     expect($scope.billingFactory).to.be.ok;
-    expect($scope.helpWidgetFactory).to.be.ok;
 
     expect($scope.completeCardPayment).to.be.a('function');
     expect($scope.updatePoNumber).to.be.a('function');

--- a/test/unit/purchase/controllers/ctr-purchase-licenses-spec.js
+++ b/test/unit/purchase/controllers/ctr-purchase-licenses-spec.js
@@ -27,9 +27,6 @@ describe("controller: purchase-licenses", function() {
         purchase: {}
       };
     });
-    $provide.service("helpWidgetFactory", function() {
-      return {};
-    });
     $provide.service("$location", function() {
       return {
         path: sandbox.stub().returns("/purchase")
@@ -37,7 +34,7 @@ describe("controller: purchase-licenses", function() {
     });
   }));
 
-  var sandbox, $scope, $state, $loading, validate, purchaseLicensesFactory, helpWidgetFactory, $location, redirectTo;
+  var sandbox, $scope, $state, $loading, validate, purchaseLicensesFactory, $location, redirectTo;
 
   beforeEach(function() {
     validate = true;
@@ -48,7 +45,6 @@ describe("controller: purchase-licenses", function() {
       $state = $injector.get("$state");
       $loading = $injector.get("$loading");
       purchaseLicensesFactory = $injector.get("purchaseLicensesFactory");
-      helpWidgetFactory = $injector.get("helpWidgetFactory");
       $location = $injector.get("$location");
       redirectTo =  '/displays/list'
 
@@ -68,7 +64,6 @@ describe("controller: purchase-licenses", function() {
 
   it("should initialize",function() {
     expect($scope.factory).to.equal(purchaseLicensesFactory);
-    expect($scope.helpWidgetFactory).to.equal(helpWidgetFactory);
     expect($scope.currentPlan).to.be.ok;
 
     expect($scope.applyCouponCode).to.be.a("function");

--- a/test/unit/purchase/controllers/ctr-purchase-spec.js
+++ b/test/unit/purchase/controllers/ctr-purchase-spec.js
@@ -38,9 +38,6 @@ describe("controller: purchase", function() {
         init: sandbox.stub()
       };
     });
-    $provide.service("helpWidgetFactory", function() {
-      return {};
-    });
     $provide.service("$location", function() {
       return {
         path: sandbox.stub().returns("/purchase")
@@ -48,7 +45,7 @@ describe("controller: purchase", function() {
     });    
   }));
 
-  var sandbox, $scope, $state, $loading, validate, purchaseFactory, addressFactory, helpWidgetFactory, $location, redirectTo;
+  var sandbox, $scope, $state, $loading, validate, purchaseFactory, addressFactory, $location, redirectTo;
 
   beforeEach(function() {
     validate = true;
@@ -60,7 +57,6 @@ describe("controller: purchase", function() {
       $loading = $injector.get("$loading");
       addressFactory = $injector.get("addressFactory");
       purchaseFactory = $injector.get("purchaseFactory");
-      helpWidgetFactory = $injector.get("helpWidgetFactory");
       $location = $injector.get("$location");
       redirectTo =  '/displays/list'
 
@@ -81,7 +77,6 @@ describe("controller: purchase", function() {
   it("should initialize",function() {
     expect($scope.form).to.be.an("object");
     expect($scope.factory).to.equal(purchaseFactory);
-    expect($scope.helpWidgetFactory).to.equal(helpWidgetFactory);
 
     expect($scope.PURCHASE_STEPS).to.be.ok;
     expect($scope.currentStep).to.equal(0);

--- a/test/unit/purchase/directives/dtv-purchase-footer-spec.js
+++ b/test/unit/purchase/directives/dtv-purchase-footer-spec.js
@@ -1,0 +1,31 @@
+"use strict";
+
+describe("directive: purchase footer", function() {
+  beforeEach(module("risevision.apps.purchase"));
+  beforeEach(module(function ($provide) {
+    $provide.value("helpWidgetFactory", 'helpWidgetFactory');
+  }));
+
+  var $scope, element;
+
+  beforeEach(inject(function($compile, $rootScope, $templateCache){
+    $templateCache.put("partials/purchase/purchase-footer.html", "<p>mock</p>");
+
+    element = angular.element("<purchase-footer></purchase-footer>");
+    $compile(element)($rootScope);
+
+    $rootScope.$digest();
+    
+    $scope = element.isolateScope();
+  }));
+
+  it("should replace the element with the appropriate content", function() {
+    expect(element.html()).to.equal("<p>mock</p>");
+  });
+
+  it("should exist", function() {
+    expect($scope).to.be.ok;
+    expect($scope.helpWidgetFactory).to.equal('helpWidgetFactory');
+  });
+
+});

--- a/web/index.html
+++ b/web/index.html
@@ -353,6 +353,7 @@
   <script src="scripts/purchase/directives/dtv-plan-picker.js"></script>
   <script src="scripts/purchase/directives/dtv-province-validator.js"></script>
   <script src="scripts/purchase/directives/dtv-purchase-summary.js"></script>
+  <script src="scripts/purchase/directives/dtv-purchase-footer.js"></script>
   <script src="scripts/purchase/directives/dtv-tax-exemption.js"></script>
   <script src="scripts/purchase/directives/dtv-suggest-general-delivery.js"></script>
   <script src="scripts/purchase/directives/dtv-year-selector.js"></script>

--- a/web/partials/billing/invoice.html
+++ b/web/partials/billing/invoice.html
@@ -236,6 +236,6 @@
     </div>
   </div>
 
-  <div ng-include="'partials/purchase/purchase-footer.html'"></div>
+  <purchase-footer></purchase-footer>
 
 </div><!--container-->

--- a/web/partials/purchase/app-purchase.html
+++ b/web/partials/purchase/app-purchase.html
@@ -11,6 +11,8 @@
   <payment-methods ng-show="currentStep === 2"></payment-methods>
   <checkout-success ng-show="currentStep === 3"></checkout-success>
 
-  <div class="mt-5 border-top" ng-include="'partials/purchase/purchase-footer.html'"></div>
+  <div class="mt-5 border-top">
+    <purchase-footer></purchase-footer>
+  </div>
 
 </div>

--- a/web/partials/purchase/purchase-licenses.html
+++ b/web/partials/purchase/purchase-licenses.html
@@ -87,6 +87,8 @@
 
   <div ng-show="factory.purchase.completed" ng-include="'partials/purchase/purchase-licenses-success.html'"></div>
 
-  <div class="mt-5 border-top" ng-include="'partials/purchase/purchase-footer.html'"></div>
+  <div class="mt-5 border-top">
+    <purchase-footer></purchase-footer>
+  </div>
 
 </div>

--- a/web/scripts/billing/controllers/ctr-invoice.js
+++ b/web/scripts/billing/controllers/ctr-invoice.js
@@ -1,9 +1,8 @@
 'use strict';
 
 angular.module('risevision.apps.billing.controllers')
-  .controller('InvoiceCtrl', ['$scope', '$loading', 'billingFactory', 'helpWidgetFactory',
-    function ($scope, $loading, billingFactory, helpWidgetFactory) {
-      $scope.helpWidgetFactory = helpWidgetFactory;
+  .controller('InvoiceCtrl', ['$scope', '$loading', 'billingFactory',
+    function ($scope, $loading, billingFactory) {
       $scope.billingFactory = billingFactory;
 
       $scope.$watch('billingFactory.loading', function (newValue) {

--- a/web/scripts/purchase/controllers/ctr-purchase-licenses.js
+++ b/web/scripts/purchase/controllers/ctr-purchase-licenses.js
@@ -3,10 +3,9 @@
 angular.module('risevision.apps.purchase')
 
   .controller('PurchaseLicensesCtrl', ['$scope', '$state', '$loading', 'purchaseLicensesFactory',
-    'helpWidgetFactory', '$location', 'redirectTo', 'currentPlanFactory',
-    function ($scope, $state, $loading, purchaseLicensesFactory, helpWidgetFactory, $location,
+    '$location', 'redirectTo', 'currentPlanFactory',
+    function ($scope, $state, $loading, purchaseLicensesFactory, $location,
       redirectTo, currentPlanFactory) {
-      $scope.helpWidgetFactory = helpWidgetFactory;
       $scope.factory = purchaseLicensesFactory;
       $scope.currentPlan = currentPlanFactory.currentPlan;
 

--- a/web/scripts/purchase/controllers/ctr-purchase.js
+++ b/web/scripts/purchase/controllers/ctr-purchase.js
@@ -19,10 +19,9 @@ angular.module('risevision.apps.purchase')
   }])
 
   .controller('PurchaseCtrl', ['$scope', '$state', '$loading', 'purchaseFactory', 'addressFactory',
-    'PURCHASE_STEPS', 'helpWidgetFactory', '$location', 'redirectTo',
-    function ($scope, $state, $loading, purchaseFactory, addressFactory, PURCHASE_STEPS, helpWidgetFactory, $location,
+    'PURCHASE_STEPS', '$location', 'redirectTo',
+    function ($scope, $state, $loading, purchaseFactory, addressFactory, PURCHASE_STEPS, $location,
       redirectTo) {
-      $scope.helpWidgetFactory = helpWidgetFactory;
       $scope.form = {};
       $scope.factory = purchaseFactory;
 

--- a/web/scripts/purchase/directives/dtv-purchase-footer.js
+++ b/web/scripts/purchase/directives/dtv-purchase-footer.js
@@ -1,0 +1,15 @@
+'use strict';
+
+angular.module('risevision.apps.purchase')
+  .directive('purchaseFooter', ['$templateCache', 'helpWidgetFactory',
+    function ($templateCache, helpWidgetFactory) {
+      return {
+        restrict: 'E',
+        scope: {},
+        template: $templateCache.get('partials/purchase/purchase-footer.html'),
+        link: function ($scope) {
+          $scope.helpWidgetFactory = helpWidgetFactory;
+        }
+      };
+    }
+  ]);


### PR DESCRIPTION
## Description
Create purchaseFooter directive that puts factory on scope

Remove factory injections wherever the partial is used

[stage-15]

## Motivation and Context
Had a defect on this. Prevent code duplication and forgetting to add the factory to scope.

## How Has This Been Tested?
Tested changes locally. Updated tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No