### PR TITLE
Fix/prevent coupon apply if display count invalid

### DIFF
--- a/test/unit/purchase/controllers/ctr-purchase-licenses-spec.js
+++ b/test/unit/purchase/controllers/ctr-purchase-licenses-spec.js
@@ -100,8 +100,27 @@ describe("controller: purchase-licenses", function() {
       purchaseLicensesFactory.getEstimate.should.not.have.been.called;
     });
 
+    it("should not get estimate if form is not valid", function() {
+      $scope.couponCode = 'SAVE50';
+      $scope.purchaseLicensesForm = { $valid: false };
+      $scope.addCoupon = true;
+
+      $scope.applyCouponCode();
+
+      purchaseLicensesFactory.getEstimate.should.not.have.been.called;
+    });
+
+    it("should not get estimate if coupon code is not set", function() {
+      $scope.couponCode = '';
+      $scope.addCoupon = true;
+
+      $scope.applyCouponCode();
+
+      purchaseLicensesFactory.getEstimate.should.not.have.been.called;
+    });
+
     it("should get estimate and unset addCoupon flag if there's no API error", function(done) {
-      $scope.factory.purchase.couponCode = 'SAVE50';
+      $scope.couponCode = 'SAVE50';
       $scope.addCoupon = true;
 
       $scope.applyCouponCode();
@@ -109,6 +128,7 @@ describe("controller: purchase-licenses", function() {
       purchaseLicensesFactory.getEstimate.should.have.been.called;
 
       setTimeout(function() {
+        expect($scope.factory.purchase.couponCode).to.equal('SAVE50');
         expect($scope.addCoupon).to.be.false;
 
         done();
@@ -117,7 +137,7 @@ describe("controller: purchase-licenses", function() {
 
     it("should get estimate and not unset addCoupon flag if there's API error", function(done) {
       $scope.factory.apiError = true;
-      $scope.factory.purchase.couponCode = 'SAVE50';
+      $scope.couponCode = 'SAVE50';
       $scope.addCoupon = true;
 
       $scope.applyCouponCode();
@@ -125,6 +145,7 @@ describe("controller: purchase-licenses", function() {
       purchaseLicensesFactory.getEstimate.should.have.been.called;
 
       setTimeout(function() {
+        expect($scope.factory.purchase.couponCode).to.equal('SAVE50');
         expect($scope.addCoupon).to.be.true;
 
         done();

--- a/test/unit/purchase/controllers/ctr-purchase-licenses-spec.js
+++ b/test/unit/purchase/controllers/ctr-purchase-licenses-spec.js
@@ -156,23 +156,25 @@ describe("controller: purchase-licenses", function() {
   describe('clearCouponCode:', function() {
     it("should clear coupon code without estimating if there's no API error", function() {
       $scope.addCoupon = true;
-      $scope.factory.purchase.couponCode = 'SAVE50';
+      $scope.couponCode = 'SAVE50';
 
       $scope.clearCouponCode();
 
       expect($scope.addCoupon).to.be.false;
+      expect($scope.couponCode).to.be.null;
       expect($scope.factory.purchase.couponCode).to.be.null;
       purchaseLicensesFactory.getEstimate.should.not.have.been.called;
     });
 
     it("should clear coupon code and estimate if there's API error", function() {
       $scope.addCoupon = true;
-      $scope.factory.purchase.couponCode = 'SAVE50';
-        $scope.factory.apiError = true;
+      $scope.couponCode = 'SAVE50';
+      $scope.factory.apiError = true;
 
       $scope.clearCouponCode();
 
       expect($scope.addCoupon).to.be.false;
+      expect($scope.couponCode).to.be.null;
       expect($scope.factory.purchase.couponCode).to.be.null;
       purchaseLicensesFactory.getEstimate.should.have.been.called;
     });

--- a/web/partials/purchase/purchase-licenses.html
+++ b/web/partials/purchase/purchase-licenses.html
@@ -30,7 +30,7 @@
           <p class="mb-0">$-- per display license, per month.</p>
         </div>
 
-        <p class="mb-0" ng-show="!addCoupon && !factory.purchase.couponCode">
+        <p class="mb-0" ng-show="!addCoupon && !couponCode">
           &nbsp;
           <span class="pull-right">
             <a aria-label="Add Coupon Code" class="madero-link u_clickable" ng-click="addCoupon = true" tabindex="1">Add A Coupon Code</a>
@@ -44,7 +44,7 @@
                 <a aria-label="Cancel Coupon Code" class="madero-link u_clickable" ng-click="clearCouponCode()" tabindex="1">Cancel</a>
               </span>
               <div class="flex-row">
-                <input id="coupon-code" aria-required="false" type="text" class="form-control mr-3" name="couponCode" ng-model="factory.purchase.couponCode">
+                <input id="coupon-code" aria-required="false" type="text" class="form-control mr-3" name="couponCode" ng-model="couponCode">
                 <button id="apply-coupon-code" type="button" aria-label="Apply Coupon Code" class="btn btn-default" ng-click="applyCouponCode()">Apply</button>
               </div>
             </div>

--- a/web/scripts/purchase/controllers/ctr-purchase-licenses.js
+++ b/web/scripts/purchase/controllers/ctr-purchase-licenses.js
@@ -9,7 +9,7 @@ angular.module('risevision.apps.purchase')
       $scope.helpWidgetFactory = helpWidgetFactory;
       $scope.factory = purchaseLicensesFactory;
       $scope.currentPlan = currentPlanFactory.currentPlan;
-      $scope.couponCode = '';
+      $scope.couponCode = null;
 
       purchaseLicensesFactory.init();
 

--- a/web/scripts/purchase/controllers/ctr-purchase-licenses.js
+++ b/web/scripts/purchase/controllers/ctr-purchase-licenses.js
@@ -9,6 +9,7 @@ angular.module('risevision.apps.purchase')
       $scope.helpWidgetFactory = helpWidgetFactory;
       $scope.factory = purchaseLicensesFactory;
       $scope.currentPlan = currentPlanFactory.currentPlan;
+      $scope.couponCode = '';
 
       purchaseLicensesFactory.init();
 
@@ -26,7 +27,13 @@ angular.module('risevision.apps.purchase')
       };
 
       $scope.applyCouponCode = function () {
-        if ($scope.factory.purchase.couponCode) {
+        if (!_isFormValid()) {
+          return;
+        }
+
+        if ($scope.couponCode) {
+          $scope.factory.purchase.couponCode = $scope.couponCode;
+
           $scope.factory.getEstimate()
             .then(function () {
               if (!$scope.factory.apiError) {
@@ -37,6 +44,7 @@ angular.module('risevision.apps.purchase')
       };
 
       $scope.clearCouponCode = function () {
+        $scope.couponCode = null;
         $scope.factory.purchase.couponCode = null;
         $scope.addCoupon = false;
 


### PR DESCRIPTION
## Description
Prevents to apply a coupon if the display count is invalid.

[stage-8]

## Motivation and Context
Fixes a problem that happens in feature/purchase-licenses branch

This scenario should not happen:
- enter a coupon but don't apply
- set an invalid display count
- set a valid display count. The estimation is requested after a few seconds, but it incorrectly considers the coupon even if it's not applied because it's currently assigned to the purchase structure that performs the request.

This other scenario should not happen:
- set an invalid display count
- enter a coupon and apply. The estimation is requested even if there's an invalid display count. It should not happen. 

To solve both bad scenarios:
- The form valid flag is checked before applying the coupon ( as other functions do )
- The coupon code being edited is not saved to the factory purchase data structure until it's applied ( and the form is valid )

## How Has This Been Tested?
Tested locally and in stage-8.
Automated unit tests were created.

## Release Plan:
To be merged to feature/purchase-licenses branch

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
-
