### PR TITLE
Prevents E2E displays list loading race condition to delete displays

### DIFF
--- a/test/e2e/displays/cases/displaybulkdelete.js
+++ b/test/e2e/displays/cases/displaybulkdelete.js
@@ -57,6 +57,9 @@ var DisplayListScenarios = function() {
       });
 
       it('should show bulk actions bar when display is selected', function() {
+        //double check display name before deleting to prevent e2e issues
+        expect(displaysListPage.getFirstRowName().getText()).to.eventually.equal(displayName);
+
         expect(displaysListPage.getBulkActionsDropdown().isDisplayed()).to.eventually.be.false;
         helper.clickWhenClickable(displaysListPage.getFirstRowCheckbox());
         expect(displaysListPage.getBulkActionsDropdown().isDisplayed()).to.eventually.be.true;

--- a/test/e2e/displays/pages/displaysListPage.js
+++ b/test/e2e/displays/pages/displaysListPage.js
@@ -31,6 +31,8 @@ var DisplaysListPage = function() {
   var bulkActionsProgressBar = element(by.css('.multi-actions-progress-panel'));
 
   this.searchDisplay = function(displayName) {
+    helper.waitDisappear(displaysLoader, 'Displays loader');
+
     helper.wait(searchFilterField, 'Search Filter Field');
     searchFilterField.sendKeys(displayName);
     helper.wait(displaysLoader, 'Displays loader');
@@ -118,6 +120,10 @@ var DisplaysListPage = function() {
 
   this.getDisplaysLoader = function() {
     return displaysLoader;
+  };
+
+  this.getFirstRowName = function() {
+    return displayItems.first().element(by.css('.display-name'));
   };
 
   this.getFirstRowSchedule = function() {

--- a/web/partials/displays/displays-list.html
+++ b/web/partials/displays/displays-list.html
@@ -74,7 +74,7 @@
         </thead>
         <tbody class="table-body">
           <tr class="table-body__row" ng-class="{ 'bg-lighter-gray' : selectedCompayId !== display.companyId }" ng-repeat="display in displays.items.list">
-            <td class="table-body__cell">
+            <td class="table-body__cell display-name">
               <div class="flex-row">
                 <madero-checkbox ng-click="displays.select(display)" ng-value="display.selected"></madero-checkbox>
                 <a class="madero-link u_ellipsis-md" ui-sref="apps.displays.change({displayId: display.id, companyId: display.companyId})">


### PR DESCRIPTION
## Description
Waits for any pending display list loading to complete before starting a new search.
That issue caused all displays list result to be displayed and selected for bulk delete,  instead of the searched result.

Also, I added an expectation to confirm display name before selecting it, to double check before bulk deleting it. 

## Motivation and Context
E2E tests would eventually delete existing displays, causing other tests to fail that relied on displays being present in the company

## How Has This Been Tested?
Tests pass
[stage-20]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
