### PR TITLE
Apply coupons on Enter pressed instead of submitting form

### DIFF
--- a/web/partials/purchase/checkout-purchase-summary.html
+++ b/web/partials/purchase/checkout-purchase-summary.html
@@ -39,7 +39,7 @@
           <a aria-label="Cancel Coupon Code" class="madero-link u_clickable" ng-click="clearCouponCode()" tabindex="1">Cancel</a>
         </span>
         <div class="flex-row">
-          <input id="coupon-code" aria-required="false" type="text" class="form-control mr-3" name="couponCode" ng-model="purchase.couponCode">
+          <input id="coupon-code" aria-required="false" type="text" class="form-control mr-3" name="couponCode" ng-model="purchase.couponCode" ng-enter="applyCouponCode()">
           <button id="apply-coupon-code" type="button" aria-label="Apply Coupon Code" class="btn btn-default" ng-click="applyCouponCode()">Apply</button>
         </div>
       </div>

--- a/web/partials/purchase/purchase-licenses.html
+++ b/web/partials/purchase/purchase-licenses.html
@@ -47,7 +47,7 @@
                 <a aria-label="Cancel Coupon Code" class="madero-link u_clickable" ng-click="clearCouponCode()" tabindex="1">Cancel</a>
               </span>
               <div class="flex-row">
-                <input id="coupon-code" aria-required="false" type="text" class="form-control mr-3" name="couponCode" ng-model="couponCode">
+                <input id="coupon-code" aria-required="false" type="text" class="form-control mr-3" name="couponCode" ng-model="couponCode" ng-enter="applyCouponCode()">
                 <button id="apply-coupon-code" type="button" aria-label="Apply Coupon Code" class="btn btn-default" ng-click="applyCouponCode()">Apply</button>
               </div>
             </div>


### PR DESCRIPTION


## Description
Apply coupons on Enter pressed instead of submitting form

## Motivation and Context
Purchase License was being completed instead of coupon being submitted, potentially frustrating user and causing them to pay more.

## How Has This Been Tested?
Validated locally. [stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
