### PR TITLE
Fix subscription list e2e test

### DIFF
--- a/test/e2e/billing/cases/account-billing.js
+++ b/test/e2e/billing/cases/account-billing.js
@@ -65,9 +65,9 @@
           expect(accountBillingPage.getSubscriptionsTableHeaderRenewalAmount().getText()).to.eventually.equal('Renewal Amount');
         });
 
-        it('should show at least one subscription with its link', function () {
-          expect(accountBillingPage.getFirstSubscriptionLink().isPresent()).to.eventually.be.true;
-          expect(accountBillingPage.getFirstSubscriptionLink().getText()).to.eventually.equal('5 x Display Licenses Yearly Plan');
+        it('should show at least one subscription', function () {
+          expect(accountBillingPage.getFirstSubscriptionName().isPresent()).to.eventually.be.true;
+          expect(accountBillingPage.getFirstSubscriptionName().getText()).to.eventually.equal('5 x Display Licenses Yearly Plan');
         });
 
         it("shows invoices list table", function() {


### PR DESCRIPTION
## Description
Use subscription name to validate existence.

## Motivation and Context
Links are no longer shown for canceled subscriptions.

## How Has This Been Tested?
E2E tests pass.
[stage-1]


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
