### PR TITLE
Feature/estimate removal

### DIFF
--- a/test/e2e/registration/pages/addDisplayLicensesPage.js
+++ b/test/e2e/registration/pages/addDisplayLicensesPage.js
@@ -11,7 +11,7 @@ var AddDisplayLicensesPage = function() {
   var purchaseLicensesPanel = element(by.css('.purchase-licenses-centered-panel'));
   var backButton = element(by.id('backButton'));
   var payButton = element(by.id('payButton'));
-  var displayCountInput = element(by.css('input[name="displayCount"]'));
+  var displayCountInput = element(by.css('input[name="licensesToAdd"]'));
   var addCouponCodeLink = element(by.css('a[aria-label="Add Coupon Code"]'));
   var couponCodeInput = element(by.id('coupon-code'));
   var applyCouponCodeButton = element(by.id('apply-coupon-code'));

--- a/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
+++ b/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
@@ -433,7 +433,6 @@ describe("Services: purchase licenses factory", function() {
       storeService.updateSubscription.should.have.been.calledWith(1, 'subscriptionId', 'billToId', '');
     });
 
-    
     it("should track purchase", function(done) {
       purchaseLicensesFactory.completePayment();
       setTimeout(function() {
@@ -446,6 +445,40 @@ describe("Services: purchase licenses factory", function() {
 
         done();
       }, 10);
+    });
+
+    describe("getCreditTotal:", function() {
+      it("should get credit total 0 if there are no credit notes", function() {
+        var total = purchaseLicensesFactory.getCreditTotal();
+
+        expect(total).to.equal(0);
+      });
+
+      it("should get credit total for a single credit note", function() {
+        purchaseLicensesFactory.estimate = {
+          credit_note_estimates: [
+            { total: 1000 }
+          ]
+        };
+
+        var total = purchaseLicensesFactory.getCreditTotal();
+
+        expect(total).to.equal(10);
+      });
+
+      it("should get credit total for multiple credit notes", function() {
+        purchaseLicensesFactory.estimate = {
+          credit_note_estimates: [
+            { total: 1000 },
+            { total: 2000 },
+            { total: 3000 }
+          ]
+        };
+
+        var total = purchaseLicensesFactory.getCreditTotal();
+
+        expect(total).to.equal(60);
+      });
     });
   });
 

--- a/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
+++ b/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
@@ -85,9 +85,9 @@ describe("Services: purchase licenses factory", function() {
 
       expect(purchaseLicensesFactory.purchase).to.be.ok;
       expect(purchaseLicensesFactory.purchase.completed).to.be.false;
-      expect(purchaseLicensesFactory.purchase.displayCount).to.equal('displayCount');
+      expect(purchaseLicensesFactory.purchase.licensesToAdd).to.equal('displayCount');
+      expect(purchaseLicensesFactory.purchase.licensesToRemove).to.equal(0);
       expect(purchaseLicensesFactory.purchase.couponCode).to.equal('')
-      expect(purchaseLicensesFactory.purchase.action).to.equal('add')
 
       purchaseLicensesFactory.getEstimate.should.have.been.called;
     });
@@ -99,9 +99,9 @@ describe("Services: purchase licenses factory", function() {
       validate = true;
 
       purchaseLicensesFactory.purchase = {
-        displayCount: 5,
-        couponCode: 'couponCode',
-        action: 'add'
+        licensesToAdd: 5,
+        licensesToRemove: 0,
+        couponCode: 'couponCode'
       };
 
     });
@@ -264,9 +264,9 @@ describe("Services: purchase licenses factory", function() {
       validate = true;
 
       purchaseLicensesFactory.purchase = {
-        displayCount: 1,
-        couponCode: '',
-        action: 'remove'
+        licensesToAdd: 0,
+        licensesToRemove: 1,
+        couponCode: ''
       };
 
     });
@@ -304,9 +304,9 @@ describe("Services: purchase licenses factory", function() {
       validate = true;
 
       purchaseLicensesFactory.purchase = {
-        displayCount: 5,
-        couponCode: 'couponCode',
-        action: 'add'
+        licensesToAdd: 5,
+        licensesToRemove: 0,
+        couponCode: 'couponCode'
       };
 
     });
@@ -420,9 +420,9 @@ describe("Services: purchase licenses factory", function() {
       validate = true;
 
       purchaseLicensesFactory.purchase = {
-        displayCount: 1,
-        couponCode: '',
-        action: 'remove'
+        licensesToAdd: 0,
+        licensesToRemove: 1,
+        couponCode: ''
       };
     });
 

--- a/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
+++ b/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
@@ -415,4 +415,38 @@ describe("Services: purchase licenses factory", function() {
 
   });
 
+  describe("completePayment: remove:", function() {
+    beforeEach(function() {
+      validate = true;
+
+      purchaseLicensesFactory.purchase = {
+        displayCount: 1,
+        couponCode: '',
+        action: 'remove'
+      };
+    });
+
+    it("should call updateSubscription api and return a promise", function() {
+      expect(purchaseLicensesFactory.completePayment().then).to.be.a("function");
+
+      storeService.updateSubscription.should.have.been.called;
+      storeService.updateSubscription.should.have.been.calledWith(1, 'subscriptionId', 'billToId', '');
+    });
+
+    
+    it("should track purchase", function(done) {
+      purchaseLicensesFactory.completePayment();
+      setTimeout(function() {
+        analyticsFactory.track.should.have.been.calledWith('Subscription Updated', {
+          subscriptionId: 'subscriptionId',
+          changeInLicenses: -1,
+          totalLicenses: 1,
+          companyId: 'billToId'
+        });
+
+        done();
+      }, 10);
+    });
+  });
+
 });

--- a/web/partials/purchase/add-licenses-success.html
+++ b/web/partials/purchase/add-licenses-success.html
@@ -5,7 +5,7 @@
   </p>
   <p>
     <b>Details:</b><br />
-    You’ve added <b>{{factory.purchase.displayCount}} display license{{ factory.purchase.displayCount > 1 ? 's' : '' }}</b> to your subscription.<br/>
+    You’ve added <b>{{factory.purchase.licensesToAdd}} display license{{ factory.purchase.licensesToAdd > 1 ? 's' : '' }}</b> to your subscription.<br/>
     You will be charged <b>${{factory.estimate.invoice_estimate.amount_due/100 | number:2}}</b>.
   </p>
   <div class="button-row mt-5">

--- a/web/partials/purchase/add-licenses.html
+++ b/web/partials/purchase/add-licenses.html
@@ -15,16 +15,16 @@
       <div class="checkout-gray-panel">
         <h4 class="u_margin-md-bottom mt-0 mb-4">Subscription Details</h4>
 
-        <div class="left-right-aligner" ng-class="{'has-error': purchaseLicensesForm.displayCount.$invalid }">
-          <label for="displayCount" class="control-label">Number of display licenses you want to add:</label>
-          <input class="display-count-input mt-0 pull-right" type="number" name="displayCount" ng-model="factory.purchase.displayCount" min="1" ng-pattern="/^[0-9]+$/" required ng-change="getEstimate()" ng-model-options="{ debounce: 1000 }" autofocus />
+        <div class="left-right-aligner" ng-class="{'has-error': purchaseLicensesForm.licensesToAdd.$invalid }">
+          <label for="licensesToAdd" class="control-label">Number of display licenses you want to add:</label>
+          <input class="display-count-input mt-0 pull-right" type="number" name="licensesToAdd" ng-model="factory.purchase.licensesToAdd" min="1" ng-pattern="/^[0-9]+$/" required ng-change="getEstimate()" ng-model-options="{ debounce: 1000 }" autofocus />
         </div>
 
         <div class="border-bottom py-4 mb-4">
           <p class="left-right-aligner mb-0">
             <span class="font-weight-bold">Total number of display licenses for this subscription:</span>
             <span>
-              {{currentPlan.playerProTotalLicenseCount + factory.purchase.displayCount}}
+              {{currentPlan.playerProTotalLicenseCount + factory.purchase.licensesToAdd}}
             </span>
           </p>
           <p class="mb-0" ng-show="factory.currentPricePerDisplay && factory.currentPricePerDisplay === factory.newPricePerDisplay">${{factory.currentPricePerDisplay | number : 2}} per display license, per month.</p>

--- a/web/partials/purchase/remove-licenses.html
+++ b/web/partials/purchase/remove-licenses.html
@@ -31,24 +31,24 @@
 
         <div class="pt-4">
           <p id="prorated-amount-row" class="left-right-aligner mb-4" ng-if="factory.estimate.invoice_estimate">
-            <span class="font-weight-bold">Generated invoice, due now:</span>
+            <span class="font-weight-bold">Generated invoice:</span>
             <span>
               <span class="u_margin-right text-subtle">{{factory.estimate.invoice_estimate.currency_code}}</span>
-              <span class="purchase-total">${{factory.estimate.invoice_estimate.amount_due/100 | number:2}}</span>
+              <span class="purchase-total">${{factory.estimate.invoice_estimate.total/100 | number:2}}</span>
             </span>
           </p>
-          <p id="prorated-amount-row" class="left-right-aligner mb-4">
+          <p id="prorated-credit-row" class="left-right-aligner mb-4">
             <span class="font-weight-bold">Prorated credit added to your account:</span>
             <span>
               <span class="u_margin-right text-subtle">{{factory.estimate.credit_note_estimates[0].currency_code}}</span>
-              <span class="purchase-total">$--</span>
+              <span class="purchase-total">${{factory.getCreditTotal() | number:2}}</span>
             </span>
           </p>
           <p id="next-invoice-row" class="left-right-aligner mb-0">
             <span class="font-weight-bold">Next invoice on {{factory.estimate.subscription_estimate.next_billing_at * 1000 | date:'d-MMM-yyyy'}}:</span>
             <span>
               <span class="u_margin-right text-subtle">{{factory.estimate.next_invoice_estimate.currency_code}}</span>
-              <span class="purchase-total">${{factory.estimate.next_invoice_estimate.amount_due/100 | number:2}}</span>
+              <span class="purchase-total">${{factory.estimate.next_invoice_estimate.total/100 | number:2}}</span>
             </span>
           </p>
         </div>

--- a/web/partials/purchase/remove-licenses.html
+++ b/web/partials/purchase/remove-licenses.html
@@ -30,10 +30,17 @@
         </div>
 
         <div class="pt-4">
+          <p id="prorated-amount-row" class="left-right-aligner mb-4" ng-if="factory.estimate.invoice_estimate">
+            <span class="font-weight-bold">Generated invoice, due now:</span>
+            <span>
+              <span class="u_margin-right text-subtle">{{factory.estimate.invoice_estimate.currency_code}}</span>
+              <span class="purchase-total">${{factory.estimate.invoice_estimate.amount_due/100 | number:2}}</span>
+            </span>
+          </p>
           <p id="prorated-amount-row" class="left-right-aligner mb-4">
             <span class="font-weight-bold">Prorated credit added to your account:</span>
             <span>
-              <span class="u_margin-right text-subtle">{{factory.estimate.invoice_estimate.currency_code}}</span>
+              <span class="u_margin-right text-subtle">{{factory.estimate.credit_note_estimates[0].currency_code}}</span>
               <span class="purchase-total">$--</span>
             </span>
           </p>

--- a/web/partials/purchase/remove-licenses.html
+++ b/web/partials/purchase/remove-licenses.html
@@ -16,15 +16,15 @@
         <h4 class="u_margin-md-bottom mt-0 mb-4">Subscription Details</h4>
 
         <div class="left-right-aligner" ng-class="{'has-error': purchaseLicensesForm.$invalid }">
-          <label for="displayCount" class="control-label">Number of display licenses you want to remove:</label>
-          <input class="display-count-input mt-0 pull-right" type="number" name="displayCount" ng-model="factory.purchase.displayCount" min="1" max="{{currentPlan.playerProTotalLicenseCount-1}}" ng-pattern="/^[0-9]+$/" required ng-change="getEstimate()" ng-model-options="{ debounce: 1000 }" autofocus />
+          <label for="licensesToRemove" class="control-label">Number of display licenses you want to remove:</label>
+          <input class="display-count-input mt-0 pull-right" type="number" name="licensesToRemove" ng-model="factory.purchase.licensesToRemove" min="1" max="{{currentPlan.playerProTotalLicenseCount-1}}" ng-pattern="/^[0-9]+$/" required ng-change="getEstimate()" ng-model-options="{ debounce: 1000 }" autofocus />
         </div>
 
         <div class="border-bottom py-4 mb-4">
           <p class="left-right-aligner mb-0">
             <span class="font-weight-bold">Total number of display licenses for this subscription:</span>
             <span>
-              {{currentPlan.playerProTotalLicenseCount - factory.purchase.displayCount}}
+              {{currentPlan.playerProTotalLicenseCount - factory.purchase.licensesToRemove}}
             </span>
           </p>
         </div>

--- a/web/scripts/purchase/controllers/ctr-purchase-licenses.js
+++ b/web/scripts/purchase/controllers/ctr-purchase-licenses.js
@@ -10,7 +10,7 @@ angular.module('risevision.apps.purchase')
       $scope.currentPlan = currentPlanFactory.currentPlan;
       $scope.couponCode = null;
 
-      purchaseLicensesFactory.init();
+      purchaseLicensesFactory.init($stateParams.purchaseAction);
 
       $scope.$watch('factory.loading', function (loading) {
         if (loading) {

--- a/web/scripts/purchase/services/svc-purchase-licenses-factory.js
+++ b/web/scripts/purchase/services/svc-purchase-licenses-factory.js
@@ -22,18 +22,19 @@
         factory.init = function (purchaseAction) {
           _clearMessages();
 
+          var isRemove = purchaseAction === 'remove';
+
           factory.purchase = {};
           factory.purchase.completed = false;
-          factory.purchase.displayCount = $stateParams.displayCount;
+          factory.purchase.licensesToAdd = isRemove ? 0 : $stateParams.displayCount;
+          factory.purchase.licensesToRemove = isRemove ? $stateParams.displayCount : 0;
           factory.purchase.couponCode = '';
-          factory.purchase.action = purchaseAction;
 
           factory.getEstimate();
         };
 
         var _getChangeInLicenses = function() {
-          return factory.purchase.action === 'remove' ?
-            -factory.purchase.displayCount : factory.purchase.displayCount;
+          return factory.purchase.licensesToAdd - factory.purchase.licensesToRemove;
         };
 
         var _getTotalDisplayCount = function () {

--- a/web/scripts/purchase/services/svc-purchase-licenses-factory.js
+++ b/web/scripts/purchase/services/svc-purchase-licenses-factory.js
@@ -99,6 +99,18 @@
             });
         };
 
+        factory.getCreditTotal = function() {
+          if (!factory.estimate || !factory.estimate.credit_note_estimates) {
+            return 0;
+          }
+
+          var total = factory.estimate.credit_note_estimates.reduce(function(total, note) {
+            return total + note.total;
+          }, 0);
+
+          return total / 100;
+        };
+
         factory.completePayment = function () {
           _clearMessages();
 

--- a/web/scripts/purchase/services/svc-purchase-licenses-factory.js
+++ b/web/scripts/purchase/services/svc-purchase-licenses-factory.js
@@ -19,22 +19,34 @@
           factory.apiError = '';
         };
 
-        factory.init = function () {
+        factory.init = function (purchaseAction) {
           _clearMessages();
 
           factory.purchase = {};
           factory.purchase.completed = false;
           factory.purchase.displayCount = $stateParams.displayCount;
           factory.purchase.couponCode = '';
+          factory.purchase.action = purchaseAction;
 
           factory.getEstimate();
+        };
+
+        var _getChangeInLicenses = function() {
+          return factory.purchase.action === 'remove' ?
+            -factory.purchase.displayCount : factory.purchase.displayCount;
+        };
+
+        var _getTotalDisplayCount = function () {
+          var currentLicenses = currentPlanFactory.currentPlan.playerProTotalLicenseCount;
+
+          return currentLicenses + _getChangeInLicenses();
         };
 
         var _getTrackingProperties = function () {
           return {
             subscriptionId: currentPlanFactory.currentPlan.subscriptionId,
-            changeInLicenses: factory.purchase.displayCount,
-            totalLicenses: factory.purchase.displayCount + currentPlanFactory.currentPlan.playerProTotalLicenseCount,
+            changeInLicenses: _getChangeInLicenses(),
+            totalLicenses: _getTotalDisplayCount(),
             companyId: currentPlanFactory.currentPlan.billToId
           };
         };
@@ -45,7 +57,7 @@
           }
 
           var currentDisplayCount = currentPlanFactory.currentPlan.playerProTotalLicenseCount;
-          var displayCount = factory.purchase.displayCount + currentDisplayCount;
+          var displayCount = _getTotalDisplayCount();
 
           var lineItem = factory.estimate.next_invoice_estimate.line_items[0];
           var isMonthly = lineItem.entity_id.endsWith('m');
@@ -65,7 +77,7 @@
           factory.loading = true;
 
           var couponCode = factory.purchase.couponCode;
-          var displayCount = factory.purchase.displayCount + currentPlanFactory.currentPlan.playerProTotalLicenseCount;
+          var displayCount = _getTotalDisplayCount();
           var subscriptionId = currentPlanFactory.currentPlan.subscriptionId;
           var companyId = currentPlanFactory.currentPlan.billToId;
 
@@ -93,7 +105,7 @@
           factory.loading = true;
 
           var couponCode = factory.purchase.couponCode;
-          var displayCount = factory.purchase.displayCount + currentPlanFactory.currentPlan.playerProTotalLicenseCount;
+          var displayCount = _getTotalDisplayCount();
           var subscriptionId = currentPlanFactory.currentPlan.subscriptionId;
           var companyId = currentPlanFactory.currentPlan.billToId;
 


### PR DESCRIPTION
## Description
- Update purchase licenses factory to subtract displayCount when removing.
- Add function to add credit notes to single total.
- Show 3 totals in partial. 
- Estimate and update now working, but update success partial still doesn't exist ( next PR ).

[stage-9]

## Motivation and Context
Part of epic.

## How Has This Been Tested?
Locally and in stage-9.
Automated unit tests updated / created
To test 3 totals try to remove all displays minus one in some subscriptions.

![remove_form](https://user-images.githubusercontent.com/33162690/104507910-10884000-55ad-11eb-8388-60cadb63f635.png)

## Release Plan:
To be merged to parent branch

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
-
