### PR TITLE
Show plan name and licenses conditionally

### DIFF
--- a/test/unit/components/plans/services/svc-plans-spec.js
+++ b/test/unit/components/plans/services/svc-plans-spec.js
@@ -19,6 +19,7 @@ describe("Services: plans service", function() {
   it("should exist", function() {
     expect(plansService).to.be.ok;
     expect(plansService.getPlan).to.be.a('function');
+    expect(plansService.getPlanById).to.be.a('function');
     expect(plansService.getFreePlan).to.be.a('function');
     expect(plansService.getVolumePlan).to.be.a('function');
     expect(plansService.isVolumePlan).to.be.a('function');
@@ -31,6 +32,18 @@ describe("Services: plans service", function() {
 
     it('should handle failure to get plan', function() {
       expect(plansService.getPlan('productCode')).to.not.be.ok;
+    });
+  });
+
+  describe("getPlanById:", function() {
+    it('should get plan by planId', function() {
+      expect(plansService.getPlanById(PLANS_LIST[0].productCode + '-usd01m')).to.equal(PLANS_LIST[0]);
+    });
+
+    it('should handle failure to get plan', function() {
+      expect(plansService.getPlanById('productCode-usd01m')).to.not.be.ok;
+      expect(plansService.getPlanById('productCode')).to.not.be.ok;
+      expect(plansService.getPlanById()).to.not.be.ok;
     });
   });
 

--- a/web/partials/billing/subscription.html
+++ b/web/partials/billing/subscription.html
@@ -25,12 +25,13 @@
     <div class="col-md-4">
       <div class="border-container subscription-card">
         <div class="panel-body">
-          <label>Display Licenses</label>
-          <h1>{{subscriptionFactory.item.subscription.plan_quantity}}</h1>
-          <div ng-show="subscriptionFactory.item.subscription.status === 'active'">
-            <a id="editSubscription" class="btn btn-default btn-block" ng-click="editSubscription(subscriptionFactory.item.subscription)">Edit Subscription</a>
+          <label>{{getPlanName(subscriptionFactory.item.subscription)}}</label>
+          <h1 ng-show="isVolumePlan(subscriptionFactory.item.subscription)">{{subscriptionFactory.item.subscription.plan_quantity}}</h1>
 
-            <span ng-show="false">
+          <div ng-show="subscriptionFactory.item.subscription.status === 'active'">
+            <a id="editSubscription" class="btn btn-default btn-block mt-3" ng-click="editSubscription(subscriptionFactory.item.subscription)">Edit Subscription</a>
+
+            <span ng-show="false && isDisplayLicensePlan(subscriptionFactory.item.subscription)">
               <a id="addLicenses" class="btn btn-default btn-block" ui-sref="apps.billing.licenses({subscriptionId: subscriptionFactory.item.subscription.id})">Add Display Licenses</a>
               <a id="removeLicenses" class="btn btn-default btn-block mt-3" ui-sref="apps.billing.licenses.remove({subscriptionId: subscriptionFactory.item.subscription.id})">Remove Display Licenses</a>
               <a id="manageLicenses" class="btn btn-default btn-block mt-3" ui-sref="apps.billing.licenses.manage({subscriptionId: subscriptionFactory.item.subscription.id})" ng-if="false">Manage Network Licenses</a>

--- a/web/scripts/billing/controllers/ctr-subscription.js
+++ b/web/scripts/billing/controllers/ctr-subscription.js
@@ -1,10 +1,12 @@
 'use strict';
 
+/*jshint camelcase: false */
+
 angular.module('risevision.apps.billing.controllers')
   .controller('SubscriptionCtrl', ['$scope', '$rootScope', '$loading', 'subscriptionFactory',
-  'userState', 'creditCardFactory', 'companySettingsFactory', 'ChargebeeFactory',
+  'userState', 'creditCardFactory', 'companySettingsFactory', 'ChargebeeFactory', 'plansService',
     function ($scope, $rootScope, $loading, subscriptionFactory, userState, creditCardFactory,
-      companySettingsFactory, ChargebeeFactory) {
+      companySettingsFactory, ChargebeeFactory, plansService) {
       $scope.subscriptionFactory = subscriptionFactory;
       $scope.creditCardFactory = creditCardFactory;
       $scope.companySettingsFactory = companySettingsFactory;
@@ -19,12 +21,43 @@ angular.module('risevision.apps.billing.controllers')
         }
       });
 
+      $rootScope.$on('chargebee.subscriptionChanged', subscriptionFactory.reloadSubscription);
+      $rootScope.$on('chargebee.subscriptionCancelled', subscriptionFactory.reloadSubscription);
+
       $scope.isInvoiced = function() {
         return subscriptionFactory.item && !subscriptionFactory.item.card;
       };
 
-      $rootScope.$on('chargebee.subscriptionChanged', subscriptionFactory.reloadSubscription);
-      $rootScope.$on('chargebee.subscriptionCancelled', subscriptionFactory.reloadSubscription);
+      $scope.isDisplayLicensePlan = function (subscription) {
+        if (!subscription) {
+          return false;
+        }
+
+        var plan = plansService.getPlanById(subscription.plan_id);
+        var volumePlan = plansService.getVolumePlan();
+
+        return plan && plan.productCode === volumePlan.productCode;
+      };
+
+      $scope.isVolumePlan = function (subscription) {
+        if (!subscription) {
+          return false;
+        }
+
+        var plan = plansService.getPlanById(subscription.plan_id);
+
+        return plansService.isVolumePlan(plan);
+      };
+
+      $scope.getPlanName = function (subscription) {
+        if (!subscription) {
+          return '';
+        }
+
+        var plan = plansService.getPlanById(subscription.plan_id);
+
+        return plan && (plan.name + ' Plan') || subscription.plan_id;
+      };
 
       $scope.editSubscription = function (subscription) {
         var subscriptionId = subscription.id;

--- a/web/scripts/billing/filters/ftr-subscription-description.js
+++ b/web/scripts/billing/filters/ftr-subscription-description.js
@@ -3,22 +3,8 @@
 /*jshint camelcase: false */
 
 angular.module('risevision.apps.billing.filters')
-  .filter('subscriptionDescription', ['PLANS_LIST', 
-    function (PLANS_LIST) {
-      var _getPlan = function (subscription) {
-        var productCode = subscription.plan_id && subscription.plan_id.split('-')[0];
-
-        var plan = _.find(PLANS_LIST, function (plan) {
-          return plan.productCode === productCode;
-        });
-
-        return plan;
-      };
-
-      var _isVolumePlan = function (plan) {
-        return plan && plan.type && plan.type.indexOf('volume') !== -1;
-      };
-
+  .filter('subscriptionDescription', ['plansService',
+    function (plansService) {
       var _getPeriod = function(subscription) {
         if (subscription.billing_period > 1) {
           return (subscription.billing_period + ' ' + (subscription.billing_period_unit === 'month' ?
@@ -34,18 +20,18 @@ angular.module('risevision.apps.billing.filters')
         }
 
         var prefix = subscription.plan_quantity > 1 ? subscription.plan_quantity + ' x ' : '';
-        var plan = _getPlan(subscription);
+        var plan = plansService.getPlanById(subscription.plan_id);
         if (plan) {
           var name = plan.name;
 
           // Show `1` plan_quantity for Per Display subscriptions
-          if (plan && _isVolumePlan(plan) && subscription.plan_quantity > 0) {
+          if (plan && plansService.isVolumePlan(plan) && subscription.plan_quantity > 0) {
             prefix = subscription.plan_quantity + ' x ';
           }
 
           var period = _getPeriod(subscription);
 
-          if (_isVolumePlan(plan)) {
+          if (plansService.isVolumePlan(plan)) {
             name = name + ' ' + period + ' Plan';
           } else {
             name = name + ' Plan ' + period;

--- a/web/scripts/billing/services/svc-subscription-factory.js
+++ b/web/scripts/billing/services/svc-subscription-factory.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/*jshint camelcase: false */
-
 angular.module('risevision.apps.billing.services')
   .service('subscriptionFactory', ['$q', '$log', 'billing', 'creditCardFactory',
   'processErrorCode', 'analyticsFactory',

--- a/web/scripts/components/plans/services/svc-plans.js
+++ b/web/scripts/components/plans/services/svc-plans.js
@@ -174,6 +174,10 @@
       function (PLANS_LIST) {
         var _factory = {};
 
+        var _getProductCode = function (planId) {
+          return planId && planId.split('-')[0];
+        };
+
         _factory.getPlan = function (productCode) {
           var plan = _.find(PLANS_LIST, function (plan) {
             return plan.productCode === productCode;
@@ -183,7 +187,7 @@
         };
 
         _factory.getPlanById = function (planId) {
-          var productCode = planId && planId.split('-')[0];
+          var productCode = _getProductCode(planId);
 
           return _factory.getPlan(productCode);
         };

--- a/web/scripts/components/plans/services/svc-plans.js
+++ b/web/scripts/components/plans/services/svc-plans.js
@@ -182,6 +182,12 @@
           return plan;
         };
 
+        _factory.getPlanById = function (planId) {
+          var productCode = planId && planId.split('-')[0];
+
+          return _factory.getPlan(productCode);
+        };
+
         _factory.getFreePlan = function () {
           return _.find(PLANS_LIST, {
             type: 'free'


### PR DESCRIPTION
## Description
Show plan name and licenses conditionally

Update filter to use new plans service
Add extra utility function

[stage-19]

## Motivation and Context
Billing Frictions epic.

## How Has This Been Tested?
Tested changes locally with various subscriptions. Updated unit tests.

<img width="979" alt="Screen Shot 2021-01-14 at 10 45 12 AM" src="https://user-images.githubusercontent.com/6218188/104619272-aaa6c180-565b-11eb-820e-c5e50f340f2d.png">
<img width="990" alt="Screen Shot 2021-01-14 at 10 48 50 AM" src="https://user-images.githubusercontent.com/6218188/104619274-abd7ee80-565b-11eb-9ace-d38669a0d0fe.png">
<img width="992" alt="Screen Shot 2021-01-14 at 10 48 24 AM" src="https://user-images.githubusercontent.com/6218188/104619277-ac708500-565b-11eb-8f88-3faa851dc789.png">


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No