### PR TITLE
Feature/complete remove UI

### DIFF
--- a/test/unit/purchase/controllers/ctr-purchase-licenses-spec.js
+++ b/test/unit/purchase/controllers/ctr-purchase-licenses-spec.js
@@ -17,11 +17,6 @@ describe("controller: add-licenses", function() {
     $provide.value("$stateParams", {
       purchaseAction: 'add'
     });
-    $provide.service("currentPlanFactory", function() {
-      return {
-        currentPlan: {}
-      };
-    });
     $provide.service("purchaseLicensesFactory", function() {
       return {
         completePayment: sandbox.stub().returns(Q.resolve()),
@@ -67,7 +62,6 @@ describe("controller: add-licenses", function() {
 
   it("should initialize",function() {
     expect($scope.factory).to.equal(purchaseLicensesFactory);
-    expect($scope.currentPlan).to.be.ok;
 
     expect($scope.applyCouponCode).to.be.a("function");
     expect($scope.clearCouponCode).to.be.a("function");

--- a/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
+++ b/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
@@ -65,6 +65,7 @@ describe("Services: purchase licenses factory", function() {
   it("should exist", function() {
     expect(purchaseLicensesFactory).to.be.ok;
     expect(purchaseLicensesFactory.init).to.be.a("function");
+    expect(purchaseLicensesFactory.getCurrentDisplayCount).to.be.a("function");
     expect(purchaseLicensesFactory.getEstimate).to.be.a("function");
     expect(purchaseLicensesFactory.completePayment).to.be.a("function");
 
@@ -104,6 +105,14 @@ describe("Services: purchase licenses factory", function() {
       purchaseLicensesFactory.getEstimate.should.have.been.called;
     });
 
+  });
+
+  describe("getCurrentDisplayCount", function() {
+    it("should return the current display count from current plan", function() {
+      var count = purchaseLicensesFactory.getCurrentDisplayCount();
+
+      expect(count).to.equal(2);
+    });
   });
 
   describe("getEstimate: add:", function() {

--- a/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
+++ b/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
@@ -80,13 +80,25 @@ describe("Services: purchase licenses factory", function() {
       purchaseLicensesFactory.getEstimate.restore();
     });
 
-    it("should initialize values and retrieve estimate", function() {
+    it("should initialize values on add and retrieve estimate", function() {
       purchaseLicensesFactory.init('add');
 
       expect(purchaseLicensesFactory.purchase).to.be.ok;
       expect(purchaseLicensesFactory.purchase.completed).to.be.false;
       expect(purchaseLicensesFactory.purchase.licensesToAdd).to.equal('displayCount');
       expect(purchaseLicensesFactory.purchase.licensesToRemove).to.equal(0);
+      expect(purchaseLicensesFactory.purchase.couponCode).to.equal('')
+
+      purchaseLicensesFactory.getEstimate.should.have.been.called;
+    });
+
+    it("should initialize values on remove and retrieve estimate", function() {
+      purchaseLicensesFactory.init('remove');
+
+      expect(purchaseLicensesFactory.purchase).to.be.ok;
+      expect(purchaseLicensesFactory.purchase.completed).to.be.false;
+      expect(purchaseLicensesFactory.purchase.licensesToAdd).to.equal(0);
+      expect(purchaseLicensesFactory.purchase.licensesToRemove).to.equal('displayCount');
       expect(purchaseLicensesFactory.purchase.couponCode).to.equal('')
 
       purchaseLicensesFactory.getEstimate.should.have.been.called;

--- a/web/partials/purchase/add-licenses.html
+++ b/web/partials/purchase/add-licenses.html
@@ -24,7 +24,7 @@
           <p class="left-right-aligner mb-0">
             <span class="font-weight-bold">Total number of display licenses for this subscription:</span>
             <span>
-              {{currentPlan.playerProTotalLicenseCount + factory.purchase.licensesToAdd}}
+              {{factory.getCurrentDisplayCount() + factory.purchase.licensesToAdd}}
             </span>
           </p>
           <p class="mb-0" ng-show="factory.currentPricePerDisplay && factory.currentPricePerDisplay === factory.newPricePerDisplay">${{factory.currentPricePerDisplay | number : 2}} per display license, per month.</p>

--- a/web/partials/purchase/add-licenses.html
+++ b/web/partials/purchase/add-licenses.html
@@ -28,7 +28,7 @@
             </span>
           </p>
           <p class="mb-0" ng-show="factory.currentPricePerDisplay && factory.currentPricePerDisplay === factory.newPricePerDisplay">${{factory.currentPricePerDisplay | number : 2}} per display license, per month.</p>
-          <div class="madero-style alert alert-success price-decrease mt-3" ng-show="factory.currentPricePerDisplay !== factory.newPricePerDisplay">
+          <div class="madero-style alert alert-success price-update mt-3" ng-show="factory.currentPricePerDisplay !== factory.newPricePerDisplay">
             <p class="mb-0 text-success"><strong>Cost will decrease to ${{factory.newPricePerDisplay | number : 2}} per display license, per month.</strong></p>
           </div>
         </div>

--- a/web/partials/purchase/add-licenses.html
+++ b/web/partials/purchase/add-licenses.html
@@ -17,7 +17,7 @@
 
         <div class="left-right-aligner" ng-class="{'has-error': purchaseLicensesForm.licensesToAdd.$invalid }">
           <label for="licensesToAdd" class="control-label">Number of display licenses you want to add:</label>
-          <input class="display-count-input mt-0 pull-right" type="number" name="licensesToAdd" ng-model="factory.purchase.licensesToAdd" min="1" ng-pattern="/^[0-9]+$/" required ng-change="getEstimate()" ng-model-options="{ debounce: 1000 }" autofocus />
+          <input class="display-count-input mt-0 pull-right" type="number" name="licensesToAdd" ng-model="factory.purchase.licensesToAdd" min="1" max="10000" ng-pattern="/^[0-9]+$/" required ng-change="getEstimate()" ng-model-options="{ debounce: 1000 }" autofocus />
         </div>
 
         <div class="border-bottom py-4 mb-4">

--- a/web/partials/purchase/remove-licenses-success.html
+++ b/web/partials/purchase/remove-licenses-success.html
@@ -1,0 +1,16 @@
+<div id="checkout-success" class="checkout-centered-panel">
+  <h4 class="u_margin-md-bottom">
+    Display licenses have been removed.
+  </h4>
+  <p class="u_margin-md-bottom">
+    We’ve sent a confirmation email to <b>{{factory.userEmail}}</b>.
+  </p>
+  <p>
+    <b>Details:</b><br />
+    You’ve removed <b>{{factory.purchase.licensesToRemove}} display license{{ factory.purchase.licensesToRemove > 1 ? 's' : '' }}</b> from your subscription.<br/>
+    You will be credited <b>${{factory.getCreditTotal() | number:2}}</b>.
+  </p>
+  <div class="button-row mt-5">
+    <button id="doneButton" class="btn btn-primary btn-block" ng-click="close()" aria-label="Done" tabindex="1">Continue</button>
+  </div>
+</div>

--- a/web/partials/purchase/remove-licenses.html
+++ b/web/partials/purchase/remove-licenses.html
@@ -17,14 +17,14 @@
 
         <div class="left-right-aligner" ng-class="{'has-error': purchaseLicensesForm.$invalid }">
           <label for="licensesToRemove" class="control-label">Number of display licenses you want to remove:</label>
-          <input class="display-count-input mt-0 pull-right" type="number" name="licensesToRemove" ng-model="factory.purchase.licensesToRemove" min="1" max="{{currentPlan.playerProTotalLicenseCount-1}}" ng-pattern="/^[0-9]+$/" required ng-change="getEstimate()" ng-model-options="{ debounce: 1000 }" autofocus />
+          <input class="display-count-input mt-0 pull-right" type="number" name="licensesToRemove" ng-model="factory.purchase.licensesToRemove" min="1" max="{{factory.getCurrentDisplayCount()-1}}" ng-pattern="/^[0-9]+$/" required ng-change="getEstimate()" ng-model-options="{ debounce: 1000 }" autofocus />
         </div>
 
         <div class="border-bottom py-4 mb-4">
           <p class="left-right-aligner mb-0">
             <span class="font-weight-bold">Total number of display licenses for this subscription:</span>
             <span>
-              {{currentPlan.playerProTotalLicenseCount - factory.purchase.licensesToRemove}}
+              {{factory.getCurrentDisplayCount() - factory.purchase.licensesToRemove}}
             </span>
           </p>
           <p class="mb-0" ng-show="factory.currentPricePerDisplay && factory.currentPricePerDisplay === factory.newPricePerDisplay">${{factory.currentPricePerDisplay | number : 2}} per display license, per month.</p>

--- a/web/partials/purchase/remove-licenses.html
+++ b/web/partials/purchase/remove-licenses.html
@@ -30,18 +30,18 @@
         </div>
 
         <div class="pt-4">
-          <p id="prorated-amount-row" class="left-right-aligner mb-4" ng-if="factory.estimate.invoice_estimate">
-            <span class="font-weight-bold">Generated invoice:</span>
-            <span>
-              <span class="u_margin-right text-subtle">{{factory.estimate.invoice_estimate.currency_code}}</span>
-              <span class="purchase-total">${{factory.estimate.invoice_estimate.total/100 | number:2}}</span>
-            </span>
-          </p>
           <p id="prorated-credit-row" class="left-right-aligner mb-4">
             <span class="font-weight-bold">Prorated credit added to your account:</span>
             <span>
               <span class="u_margin-right text-subtle">{{factory.estimate.credit_note_estimates[0].currency_code}}</span>
               <span class="purchase-total">${{factory.getCreditTotal() | number:2}}</span>
+            </span>
+          </p>
+          <p id="prorated-amount-row" class="left-right-aligner mb-4" ng-if="factory.estimate.invoice_estimate">
+            <span class="font-weight-bold">Prorated amount, due now:</span>
+            <span>
+              <span class="u_margin-right text-subtle">{{factory.estimate.invoice_estimate.currency_code}}</span>
+              <span class="purchase-total">${{factory.estimate.invoice_estimate.total/100 | number:2}}</span>
             </span>
           </p>
           <p id="next-invoice-row" class="left-right-aligner mb-0">
@@ -62,6 +62,8 @@
       </div>
     </form>
   </div>
+
+  <div ng-show="factory.purchase.completed" ng-include="'partials/purchase/remove-licenses-success.html'"></div>
 
   <div class="mt-5 border-top">
     <purchase-footer></purchase-footer>

--- a/web/partials/purchase/remove-licenses.html
+++ b/web/partials/purchase/remove-licenses.html
@@ -27,6 +27,10 @@
               {{currentPlan.playerProTotalLicenseCount - factory.purchase.licensesToRemove}}
             </span>
           </p>
+          <p class="mb-0" ng-show="factory.currentPricePerDisplay && factory.currentPricePerDisplay === factory.newPricePerDisplay">${{factory.currentPricePerDisplay | number : 2}} per display license, per month.</p>
+          <div class="madero-style alert alert-danger price-increase mt-3" ng-show="factory.currentPricePerDisplay !== factory.newPricePerDisplay">
+            <p class="mb-0 text-success"><strong>Cost will increase to ${{factory.newPricePerDisplay | number : 2}} per display license, per month.</strong></p>
+          </div>
         </div>
 
         <div class="pt-4">

--- a/web/partials/purchase/remove-licenses.html
+++ b/web/partials/purchase/remove-licenses.html
@@ -28,7 +28,7 @@
             </span>
           </p>
           <p class="mb-0" ng-show="factory.currentPricePerDisplay && factory.currentPricePerDisplay === factory.newPricePerDisplay">${{factory.currentPricePerDisplay | number : 2}} per display license, per month.</p>
-          <div class="madero-style alert alert-danger price-increase mt-3" ng-show="factory.currentPricePerDisplay !== factory.newPricePerDisplay">
+          <div class="madero-style alert alert-danger price-update mt-3" ng-show="factory.currentPricePerDisplay !== factory.newPricePerDisplay">
             <p class="mb-0 text-success"><strong>Cost will increase to ${{factory.newPricePerDisplay | number : 2}} per display license, per month.</strong></p>
           </div>
         </div>

--- a/web/scripts/purchase/controllers/ctr-purchase-licenses.js
+++ b/web/scripts/purchase/controllers/ctr-purchase-licenses.js
@@ -3,11 +3,10 @@
 angular.module('risevision.apps.purchase')
 
   .controller('PurchaseLicensesCtrl', ['$scope', '$stateParams', '$loading',
-    'purchaseLicensesFactory', '$location', 'redirectTo', 'currentPlanFactory',
+    'purchaseLicensesFactory', '$location', 'redirectTo',
     function ($scope, $stateParams, $loading, purchaseLicensesFactory,
-      $location, redirectTo, currentPlanFactory) {
+      $location, redirectTo) {
       $scope.factory = purchaseLicensesFactory;
-      $scope.currentPlan = currentPlanFactory.currentPlan;
       $scope.couponCode = null;
 
       purchaseLicensesFactory.init($stateParams.purchaseAction);

--- a/web/scripts/purchase/services/svc-purchase-licenses-factory.js
+++ b/web/scripts/purchase/services/svc-purchase-licenses-factory.js
@@ -33,22 +33,32 @@
           factory.getEstimate();
         };
 
+        factory.getCurrentDisplayCount = function() {
+          return currentPlanFactory.currentPlan.playerProTotalLicenseCount;
+        };
+
+        var _getSubscriptionId = function() {
+          return currentPlanFactory.currentPlan.subscriptionId;
+        };
+
+        var _getCompanyId = function() {
+          return currentPlanFactory.currentPlan.billToId;
+        };
+
         var _getChangeInLicenses = function() {
           return factory.purchase.licensesToAdd - factory.purchase.licensesToRemove;
         };
 
         var _getTotalDisplayCount = function () {
-          var currentLicenses = currentPlanFactory.currentPlan.playerProTotalLicenseCount;
-
-          return currentLicenses + _getChangeInLicenses();
+          return factory.getCurrentDisplayCount() + _getChangeInLicenses();
         };
 
         var _getTrackingProperties = function () {
           return {
-            subscriptionId: currentPlanFactory.currentPlan.subscriptionId,
+            subscriptionId: _getSubscriptionId(),
             changeInLicenses: _getChangeInLicenses(),
             totalLicenses: _getTotalDisplayCount(),
-            companyId: currentPlanFactory.currentPlan.billToId
+            companyId: _getCompanyId()
           };
         };
 
@@ -57,7 +67,7 @@
             return;
           }
 
-          var currentDisplayCount = currentPlanFactory.currentPlan.playerProTotalLicenseCount;
+          var currentDisplayCount = factory.getCurrentDisplayCount();
           var displayCount = _getTotalDisplayCount();
 
           var lineItem = factory.estimate.next_invoice_estimate.line_items[0];
@@ -79,8 +89,8 @@
 
           var couponCode = factory.purchase.couponCode;
           var displayCount = _getTotalDisplayCount();
-          var subscriptionId = currentPlanFactory.currentPlan.subscriptionId;
-          var companyId = currentPlanFactory.currentPlan.billToId;
+          var subscriptionId = _getSubscriptionId();
+          var companyId = _getCompanyId();
 
           return storeService.estimateSubscriptionUpdate(displayCount, subscriptionId, companyId, couponCode)
             .then(function (result) {
@@ -119,8 +129,8 @@
 
           var couponCode = factory.purchase.couponCode;
           var displayCount = _getTotalDisplayCount();
-          var subscriptionId = currentPlanFactory.currentPlan.subscriptionId;
-          var companyId = currentPlanFactory.currentPlan.billToId;
+          var subscriptionId = _getSubscriptionId();
+          var companyId = _getCompanyId();
 
           return storeService.updateSubscription(displayCount, subscriptionId, companyId, couponCode)
             .then(function () {

--- a/web/scss/sections/checkout.scss
+++ b/web/scss/sections/checkout.scss
@@ -92,10 +92,10 @@
   .purchase-licenses-centered-panel {
     @extend .mx-auto;
 
-    max-width: 554px; 
+    max-width: 554px;
   }
 
-  .madero-style.alert.price-decrease {
+  .madero-style.alert.price-decrease, .madero-style.alert.price-increase {
     padding: 10px;
   }
 
@@ -140,7 +140,7 @@
     .btn {
       font-weight: normal;
     }
-  } 
+  }
 
   .education-discount {
     .madero-checkbox {
@@ -167,8 +167,8 @@
 
 .display-count-input {
   @extend .form-control;
-  
-  width: 75px;    
+
+  width: 75px;
   font-size: 18px;
   font-weight: bold;
   text-align: center;

--- a/web/scss/sections/checkout.scss
+++ b/web/scss/sections/checkout.scss
@@ -95,7 +95,7 @@
     max-width: 554px;
   }
 
-  .madero-style.alert.price-decrease, .madero-style.alert.price-increase {
+  .madero-style.alert.price-update {
     padding: 10px;
   }
 


### PR DESCRIPTION
## Description
- Display per license and cost increase notice are now shown.
- Order of totals updated and label for immediate invoice as per @ezequielc suggestions.
- Added success confirmation page.
- Limited add display licenses ( currently 10000 but can be adjusted later ). 

[stage-9]

![remove01](https://user-images.githubusercontent.com/33162690/104626678-c742f980-565b-11eb-8f74-b6b4cc2e0b44.jpg)

![remove02](https://user-images.githubusercontent.com/33162690/104626693-cca04400-565b-11eb-9361-16cd6842df11.jpg)

![remove03](https://user-images.githubusercontent.com/33162690/104626699-d033cb00-565b-11eb-9e3d-a5d5e3750d5c.jpg)

## Motivation and Context
Required by epic

## How Has This Been Tested?
Tested locally and in stage 9

## Release Plan:
To be merged to parent branch, and maybe to master later today or on Monday

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
