### PR TITLE
Chore/refactor extract current plan dependencies

### DIFF
--- a/test/unit/purchase/controllers/ctr-purchase-licenses-spec.js
+++ b/test/unit/purchase/controllers/ctr-purchase-licenses-spec.js
@@ -17,11 +17,6 @@ describe("controller: add-licenses", function() {
     $provide.value("$stateParams", {
       purchaseAction: 'add'
     });
-    $provide.service("currentPlanFactory", function() {
-      return {
-        currentPlan: {}
-      };
-    });
     $provide.service("purchaseLicensesFactory", function() {
       return {
         completePayment: sandbox.stub().returns(Q.resolve()),
@@ -67,7 +62,6 @@ describe("controller: add-licenses", function() {
 
   it("should initialize",function() {
     expect($scope.factory).to.equal(purchaseLicensesFactory);
-    expect($scope.currentPlan).to.be.ok;
 
     expect($scope.applyCouponCode).to.be.a("function");
     expect($scope.clearCouponCode).to.be.a("function");

--- a/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
+++ b/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
@@ -65,6 +65,7 @@ describe("Services: purchase licenses factory", function() {
   it("should exist", function() {
     expect(purchaseLicensesFactory).to.be.ok;
     expect(purchaseLicensesFactory.init).to.be.a("function");
+    expect(purchaseLicensesFactory.getCurrentDisplayCount).to.be.a("function");
     expect(purchaseLicensesFactory.getEstimate).to.be.a("function");
     expect(purchaseLicensesFactory.completePayment).to.be.a("function");
 
@@ -104,6 +105,14 @@ describe("Services: purchase licenses factory", function() {
       purchaseLicensesFactory.getEstimate.should.have.been.called;
     });
 
+  });
+
+  describe("getCurrentDisplayCount", function() {
+    it("should return the current display count from current plan", function() {
+      var count = purchaseLicensesFactory.getCurrentDisplayCount();
+
+      expect(count).to.equal(2);
+    });
   });
 
   describe("getEstimate: add:", function() {

--- a/web/partials/purchase/add-licenses.html
+++ b/web/partials/purchase/add-licenses.html
@@ -24,7 +24,7 @@
           <p class="left-right-aligner mb-0">
             <span class="font-weight-bold">Total number of display licenses for this subscription:</span>
             <span>
-              {{currentPlan.playerProTotalLicenseCount + factory.purchase.licensesToAdd}}
+              {{factory.getCurrentDisplayCount() + factory.purchase.licensesToAdd}}
             </span>
           </p>
           <p class="mb-0" ng-show="factory.currentPricePerDisplay && factory.currentPricePerDisplay === factory.newPricePerDisplay">${{factory.currentPricePerDisplay | number : 2}} per display license, per month.</p>

--- a/web/partials/purchase/remove-licenses.html
+++ b/web/partials/purchase/remove-licenses.html
@@ -17,7 +17,7 @@
 
         <div class="left-right-aligner" ng-class="{'has-error': purchaseLicensesForm.$invalid }">
           <label for="licensesToRemove" class="control-label">Number of display licenses you want to remove:</label>
-          <input class="display-count-input mt-0 pull-right" type="number" name="licensesToRemove" ng-model="factory.purchase.licensesToRemove" min="1" max="{{currentPlan.playerProTotalLicenseCount-1}}" ng-pattern="/^[0-9]+$/" required ng-change="getEstimate()" ng-model-options="{ debounce: 1000 }" autofocus />
+          <input class="display-count-input mt-0 pull-right" type="number" name="licensesToRemove" ng-model="factory.purchase.licensesToRemove" min="1" max="{{factory.getCurrentDisplayCount()-1}}" ng-pattern="/^[0-9]+$/" required ng-change="getEstimate()" ng-model-options="{ debounce: 1000 }" autofocus />
         </div>
 
         <div class="border-bottom py-4 mb-4">

--- a/web/partials/purchase/remove-licenses.html
+++ b/web/partials/purchase/remove-licenses.html
@@ -24,7 +24,7 @@
           <p class="left-right-aligner mb-0">
             <span class="font-weight-bold">Total number of display licenses for this subscription:</span>
             <span>
-              {{currentPlan.playerProTotalLicenseCount - factory.purchase.licensesToRemove}}
+              {{factory.getCurrentDisplayCount() - factory.purchase.licensesToRemove}}
             </span>
           </p>
           <p class="mb-0" ng-show="factory.currentPricePerDisplay && factory.currentPricePerDisplay === factory.newPricePerDisplay">${{factory.currentPricePerDisplay | number : 2}} per display license, per month.</p>

--- a/web/scripts/purchase/controllers/ctr-purchase-licenses.js
+++ b/web/scripts/purchase/controllers/ctr-purchase-licenses.js
@@ -3,11 +3,10 @@
 angular.module('risevision.apps.purchase')
 
   .controller('PurchaseLicensesCtrl', ['$scope', '$stateParams', '$loading',
-    'purchaseLicensesFactory', '$location', 'redirectTo', 'currentPlanFactory',
+    'purchaseLicensesFactory', '$location', 'redirectTo',
     function ($scope, $stateParams, $loading, purchaseLicensesFactory,
-      $location, redirectTo, currentPlanFactory) {
+      $location, redirectTo) {
       $scope.factory = purchaseLicensesFactory;
-      $scope.currentPlan = currentPlanFactory.currentPlan;
       $scope.couponCode = null;
 
       purchaseLicensesFactory.init($stateParams.purchaseAction);

--- a/web/scripts/purchase/services/svc-purchase-licenses-factory.js
+++ b/web/scripts/purchase/services/svc-purchase-licenses-factory.js
@@ -33,14 +33,16 @@
           factory.getEstimate();
         };
 
+        factory.getCurrentDisplayCount = function() {
+          return currentPlanFactory.currentPlan.playerProTotalLicenseCount;
+        };
+
         var _getChangeInLicenses = function() {
           return factory.purchase.licensesToAdd - factory.purchase.licensesToRemove;
         };
 
         var _getTotalDisplayCount = function () {
-          var currentLicenses = currentPlanFactory.currentPlan.playerProTotalLicenseCount;
-
-          return currentLicenses + _getChangeInLicenses();
+          return factory.getCurrentDisplayCount() + _getChangeInLicenses();
         };
 
         var _getTrackingProperties = function () {
@@ -57,7 +59,7 @@
             return;
           }
 
-          var currentDisplayCount = currentPlanFactory.currentPlan.playerProTotalLicenseCount;
+          var currentDisplayCount = factory.getCurrentDisplayCount();
           var displayCount = _getTotalDisplayCount();
 
           var lineItem = factory.estimate.next_invoice_estimate.line_items[0];

--- a/web/scripts/purchase/services/svc-purchase-licenses-factory.js
+++ b/web/scripts/purchase/services/svc-purchase-licenses-factory.js
@@ -37,6 +37,14 @@
           return currentPlanFactory.currentPlan.playerProTotalLicenseCount;
         };
 
+        var _getSubscriptionId = function() {
+          return currentPlanFactory.currentPlan.subscriptionId;
+        };
+
+        var _getCompanyId = function() {
+          return currentPlanFactory.currentPlan.billToId;
+        };
+
         var _getChangeInLicenses = function() {
           return factory.purchase.licensesToAdd - factory.purchase.licensesToRemove;
         };
@@ -47,10 +55,10 @@
 
         var _getTrackingProperties = function () {
           return {
-            subscriptionId: currentPlanFactory.currentPlan.subscriptionId,
+            subscriptionId: _getSubscriptionId(),
             changeInLicenses: _getChangeInLicenses(),
             totalLicenses: _getTotalDisplayCount(),
-            companyId: currentPlanFactory.currentPlan.billToId
+            companyId: _getCompanyId()
           };
         };
 
@@ -81,8 +89,8 @@
 
           var couponCode = factory.purchase.couponCode;
           var displayCount = _getTotalDisplayCount();
-          var subscriptionId = currentPlanFactory.currentPlan.subscriptionId;
-          var companyId = currentPlanFactory.currentPlan.billToId;
+          var subscriptionId = _getSubscriptionId();
+          var companyId = _getCompanyId();
 
           return storeService.estimateSubscriptionUpdate(displayCount, subscriptionId, companyId, couponCode)
             .then(function (result) {
@@ -121,8 +129,8 @@
 
           var couponCode = factory.purchase.couponCode;
           var displayCount = _getTotalDisplayCount();
-          var subscriptionId = currentPlanFactory.currentPlan.subscriptionId;
-          var companyId = currentPlanFactory.currentPlan.billToId;
+          var subscriptionId = _getSubscriptionId();
+          var companyId = _getCompanyId();
 
           return storeService.updateSubscription(displayCount, subscriptionId, companyId, couponCode)
             .then(function () {


### PR DESCRIPTION
## Description
I extracted all current plan dependencies in for add/remove licenses to just three methods ( subscription id, company id and current display count ).

[stage-8]

## Motivation and Context
In preparation to making the purchase-licences-factory service to work with any subscription. This is just a refactoring, no behavior has been changed.

## How Has This Been Tested?
Tested add and remove license scenarios locally and in stage-8

## Release Plan:
To be merged on Monday.

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify support.
