### PR TITLE
Chore/reuse total display count function

### DIFF
--- a/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
+++ b/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
@@ -160,6 +160,14 @@ describe("Services: purchase licenses factory", function() {
 
         expect(count).to.equal(7);
       });
+
+      it("should not consider change when input validation fails", function() {
+        purchaseLicensesFactory.purchase.licensesToAdd = undefined;
+
+        var count = purchaseLicensesFactory.getTotalDisplayCount();
+
+        expect(count).to.equal(2);
+      });
     });
 
     describe('_updatePerDisplayPrice:', function() {
@@ -332,6 +340,14 @@ describe("Services: purchase licenses factory", function() {
         var count = purchaseLicensesFactory.getTotalDisplayCount();
 
         expect(count).to.equal(1);
+      });
+
+      it("should not consider change when input validation fails", function() {
+        purchaseLicensesFactory.purchase.licensesToRemove = undefined;
+
+        var count = purchaseLicensesFactory.getTotalDisplayCount();
+
+        expect(count).to.equal(2);
       });
     });
   });

--- a/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
+++ b/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
@@ -107,7 +107,7 @@ describe("Services: purchase licenses factory", function() {
 
   });
 
-  describe("getCurrentDisplayCount", function() {
+  describe("getCurrentDisplayCount:", function() {
     it("should return the current display count from current plan", function() {
       var count = purchaseLicensesFactory.getCurrentDisplayCount();
 
@@ -151,6 +151,14 @@ describe("Services: purchase licenses factory", function() {
       .then(null,function(e) {
         console.error(e);
         done("error");
+      });
+    });
+
+    describe('getTotalDisplayCount:', function() {
+      it("should add for the total display count", function() {
+        var count = purchaseLicensesFactory.getTotalDisplayCount();
+
+        expect(count).to.equal(7);
       });
     });
 
@@ -316,6 +324,14 @@ describe("Services: purchase licenses factory", function() {
       .then(null,function(e) {
         console.error(e);
         done("error");
+      });
+    });
+
+    describe('getTotalDisplayCount:', function() {
+      it("should subtract for the total display count", function() {
+        var count = purchaseLicensesFactory.getTotalDisplayCount();
+
+        expect(count).to.equal(1);
       });
     });
   });

--- a/web/partials/purchase/add-licenses.html
+++ b/web/partials/purchase/add-licenses.html
@@ -24,7 +24,7 @@
           <p class="left-right-aligner mb-0">
             <span class="font-weight-bold">Total number of display licenses for this subscription:</span>
             <span>
-              {{factory.getCurrentDisplayCount() + factory.purchase.licensesToAdd}}
+              {{factory.getTotalDisplayCount()}}
             </span>
           </p>
           <p class="mb-0" ng-show="factory.currentPricePerDisplay && factory.currentPricePerDisplay === factory.newPricePerDisplay">${{factory.currentPricePerDisplay | number : 2}} per display license, per month.</p>

--- a/web/partials/purchase/remove-licenses.html
+++ b/web/partials/purchase/remove-licenses.html
@@ -24,7 +24,7 @@
           <p class="left-right-aligner mb-0">
             <span class="font-weight-bold">Total number of display licenses for this subscription:</span>
             <span>
-              {{factory.getCurrentDisplayCount() - factory.purchase.licensesToRemove}}
+              {{factory.getTotalDisplayCount()}}
             </span>
           </p>
           <p class="mb-0" ng-show="factory.currentPricePerDisplay && factory.currentPricePerDisplay === factory.newPricePerDisplay">${{factory.currentPricePerDisplay | number : 2}} per display license, per month.</p>

--- a/web/scripts/purchase/services/svc-purchase-licenses-factory.js
+++ b/web/scripts/purchase/services/svc-purchase-licenses-factory.js
@@ -46,10 +46,13 @@
         };
 
         var _getChangeInLicenses = function() {
-          return factory.purchase.licensesToAdd - factory.purchase.licensesToRemove;
+          var licensesToAdd = factory.purchase.licensesToAdd || 0;
+          var licensesToRemove = factory.purchase.licensesToRemove || 0;
+
+          return licensesToAdd - licensesToRemove;
         };
 
-        var _getTotalDisplayCount = function () {
+        factory.getTotalDisplayCount = function () {
           return factory.getCurrentDisplayCount() + _getChangeInLicenses();
         };
 
@@ -57,7 +60,7 @@
           return {
             subscriptionId: _getSubscriptionId(),
             changeInLicenses: _getChangeInLicenses(),
-            totalLicenses: _getTotalDisplayCount(),
+            totalLicenses: factory.getTotalDisplayCount(),
             companyId: _getCompanyId()
           };
         };
@@ -68,7 +71,7 @@
           }
 
           var currentDisplayCount = factory.getCurrentDisplayCount();
-          var displayCount = _getTotalDisplayCount();
+          var displayCount = factory.getTotalDisplayCount();
 
           var lineItem = factory.estimate.next_invoice_estimate.line_items[0];
           var isMonthly = lineItem.entity_id.endsWith('m');
@@ -88,7 +91,7 @@
           factory.loading = true;
 
           var couponCode = factory.purchase.couponCode;
-          var displayCount = _getTotalDisplayCount();
+          var displayCount = factory.getTotalDisplayCount();
           var subscriptionId = _getSubscriptionId();
           var companyId = _getCompanyId();
 
@@ -128,7 +131,7 @@
           factory.loading = true;
 
           var couponCode = factory.purchase.couponCode;
-          var displayCount = _getTotalDisplayCount();
+          var displayCount = factory.getTotalDisplayCount();
           var subscriptionId = _getSubscriptionId();
           var companyId = _getCompanyId();
 


### PR DESCRIPTION
## Description
Refactoring: calculation of total is done in a single place and reused from partials. 

## Motivation and Context
Improvement to provide a single place for the calculation, as suggested in previous PR.

## How Has This Been Tested?
Tested count still works ok both locally and in stage-9
Unit tests were created for the exposed function.

## Release Plan:
To be merged with parent branch and released on Monday.

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
-
