### PR TITLE
Reset license price with factory reset

### DIFF
--- a/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
+++ b/test/unit/purchase/services/svc-purchase-licenses-factory-spec.js
@@ -201,13 +201,13 @@ describe("Services: purchase licenses factory", function() {
 
     describe('_updatePerDisplayPrice:', function() {
       it('should not update prices if estimate does not contain correct fields', function(done) {
-        purchaseLicensesFactory.currentPricePerDisplay = 'currentPrice';
-        purchaseLicensesFactory.newPricePerDisplay = 'newPrice';
+        purchaseLicensesFactory.purchase.currentPricePerDisplay = 'currentPrice';
+        purchaseLicensesFactory.purchase.newPricePerDisplay = 'newPrice';
 
         purchaseLicensesFactory.getEstimate()
           .then(function() {
-            expect(purchaseLicensesFactory.currentPricePerDisplay).to.equal('currentPrice');
-            expect(purchaseLicensesFactory.newPricePerDisplay).to.equal('newPrice');
+            expect(purchaseLicensesFactory.purchase.currentPricePerDisplay).to.equal('currentPrice');
+            expect(purchaseLicensesFactory.purchase.newPricePerDisplay).to.equal('newPrice');
 
             done();
           });
@@ -227,8 +227,8 @@ describe("Services: purchase licenses factory", function() {
 
         purchaseLicensesFactory.getEstimate()
           .then(function() {
-            expect(purchaseLicensesFactory.currentPricePerDisplay).to.equal('false2false');
-            expect(purchaseLicensesFactory.newPricePerDisplay).to.equal('false7false');
+            expect(purchaseLicensesFactory.purchase.currentPricePerDisplay).to.equal('false2false');
+            expect(purchaseLicensesFactory.purchase.newPricePerDisplay).to.equal('false7false');
 
             done();
           });
@@ -250,8 +250,8 @@ describe("Services: purchase licenses factory", function() {
 
         purchaseLicensesFactory.getEstimate()
           .then(function() {
-            expect(purchaseLicensesFactory.currentPricePerDisplay).to.equal('true2false');
-            expect(purchaseLicensesFactory.newPricePerDisplay).to.equal('true7false');
+            expect(purchaseLicensesFactory.purchase.currentPricePerDisplay).to.equal('true2false');
+            expect(purchaseLicensesFactory.purchase.newPricePerDisplay).to.equal('true7false');
 
             done();
           });
@@ -273,8 +273,8 @@ describe("Services: purchase licenses factory", function() {
 
         purchaseLicensesFactory.getEstimate()
           .then(function() {
-            expect(purchaseLicensesFactory.currentPricePerDisplay).to.equal('false2true');
-            expect(purchaseLicensesFactory.newPricePerDisplay).to.equal('false7true');
+            expect(purchaseLicensesFactory.purchase.currentPricePerDisplay).to.equal('false2true');
+            expect(purchaseLicensesFactory.purchase.newPricePerDisplay).to.equal('false7true');
 
             done();
           });

--- a/web/partials/purchase/add-licenses.html
+++ b/web/partials/purchase/add-licenses.html
@@ -27,9 +27,9 @@
               {{factory.getTotalDisplayCount()}}
             </span>
           </p>
-          <p class="mb-0" ng-show="factory.currentPricePerDisplay && factory.currentPricePerDisplay === factory.newPricePerDisplay">${{factory.currentPricePerDisplay | number : 2}} per display license, per month.</p>
-          <div class="madero-style alert alert-success price-update mt-3" ng-show="factory.currentPricePerDisplay !== factory.newPricePerDisplay">
-            <p class="mb-0 text-success"><strong>Cost will decrease to ${{factory.newPricePerDisplay | number : 2}} per display license, per month.</strong></p>
+          <p class="mb-0" ng-show="factory.purchase.currentPricePerDisplay && factory.purchase.currentPricePerDisplay === factory.purchase.newPricePerDisplay">${{factory.purchase.currentPricePerDisplay | number : 2}} per display license, per month.</p>
+          <div class="madero-style alert alert-success price-update mt-3" ng-show="factory.purchase.currentPricePerDisplay !== factory.purchase.newPricePerDisplay">
+            <p class="mb-0 text-success"><strong>Cost will decrease to ${{factory.purchase.newPricePerDisplay | number : 2}} per display license, per month.</strong></p>
           </div>
         </div>
 

--- a/web/partials/purchase/remove-licenses.html
+++ b/web/partials/purchase/remove-licenses.html
@@ -27,9 +27,9 @@
               {{factory.getTotalDisplayCount()}}
             </span>
           </p>
-          <p class="mb-0" ng-show="factory.currentPricePerDisplay && factory.currentPricePerDisplay === factory.newPricePerDisplay">${{factory.currentPricePerDisplay | number : 2}} per display license, per month.</p>
-          <div class="madero-style alert alert-danger price-update mt-3" ng-show="factory.currentPricePerDisplay !== factory.newPricePerDisplay">
-            <p class="mb-0 text-success"><strong>Cost will increase to ${{factory.newPricePerDisplay | number : 2}} per display license, per month.</strong></p>
+          <p class="mb-0" ng-show="factory.purchase.currentPricePerDisplay && factory.purchase.currentPricePerDisplay === factory.purchase.newPricePerDisplay">${{factory.purchase.currentPricePerDisplay | number : 2}} per display license, per month.</p>
+          <div class="madero-style alert alert-danger price-update mt-3" ng-show="factory.purchase.currentPricePerDisplay !== factory.purchase.newPricePerDisplay">
+            <p class="mb-0 text-success"><strong>Cost will increase to ${{factory.purchase.newPricePerDisplay | number : 2}} per display license, per month.</strong></p>
           </div>
         </div>
 

--- a/web/scripts/purchase/services/svc-purchase-licenses-factory.js
+++ b/web/scripts/purchase/services/svc-purchase-licenses-factory.js
@@ -87,8 +87,8 @@
           });
           var isEducation = !!educationDiscount;
 
-          factory.currentPricePerDisplay = pricingFactory.getPricePerDisplay(isMonthly, currentDisplayCount, isEducation);
-          factory.newPricePerDisplay = pricingFactory.getPricePerDisplay(isMonthly, displayCount, isEducation);
+          factory.purchase.currentPricePerDisplay = pricingFactory.getPricePerDisplay(isMonthly, currentDisplayCount, isEducation);
+          factory.purchase.newPricePerDisplay = pricingFactory.getPricePerDisplay(isMonthly, displayCount, isEducation);
         };
 
         factory.getEstimate = function () {


### PR DESCRIPTION
## Description
Reset license price with factory reset

Fixes issue where price difference panel
can show while loading the estimate

[stage-15]

## Motivation and Context
Billing frictions epic.

## How Has This Been Tested?
Tested that issue no longer occurs. Updated tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No