### PR TITLE
Redirect all billing/purchase pages to billing page

### DIFF
--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -186,14 +186,17 @@ angular.module('risevision.apps', [
           $state.current.name === 'apps.displays.list' ||
           $state.current.name === 'apps.displays.alerts' ||
           $state.current.name === 'apps.storage.home' ||
-          $state.current.name === 'apps.home' ||
-          $state.current.name === 'apps.billing.home') {
+          $state.current.name === 'apps.home') {
 
           $state.go($state.current, null, {
             reload: true
           });
-        } else if ($state.current.name.indexOf('apps.purchase') !== -1) {
-          $state.go('apps.home');
+        } else if ($state.current.name.indexOf('apps.purchase') !== -1 ||
+          $state.current.name.indexOf('apps.billing') !== -1) {
+
+          $state.go('apps.billing.home', null, {
+            reload: true
+          });
         }
       });
     }


### PR DESCRIPTION
## Description
Redirect all billing/purchase pages to billing page

One selectedCompanyChange

[stage-16]

## Motivation and Context
Billing frictions epic.

Fixes missing redirects and incorrect redirect to home for purchase.

## How Has This Been Tested?
Tested locally. Could not update unit tests as I could not figure out a way to mock `$state.current.name` because the `$digest` cycle overwrites any value I set to it.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
Unit tests as described.