### PR TITLE
Use a setup intent for credit card add

### DIFF
--- a/test/unit/billing/controllers/ctr-add-payment-source.tests.js
+++ b/test/unit/billing/controllers/ctr-add-payment-source.tests.js
@@ -70,7 +70,6 @@ describe('controller: AddPaymentSourceCtrl', function () {
     expect($scope).to.be.ok;
 
     expect($scope.subscriptionFactory).to.equal(subscriptionFactory);
-    expect($scope.creditCardFactory).to.equal(creditCardFactory);
     expect($scope.addPaymentSourceFactory).to.equal(addPaymentSourceFactory);
     expect($scope.contactEmail).to.equal('userEmail');
 

--- a/test/unit/billing/services/svc-add-payment-source-factory.tests.js
+++ b/test/unit/billing/services/svc-add-payment-source-factory.tests.js
@@ -30,7 +30,7 @@ describe('service: addPaymentSourceFactory:', function() {
     $provide.value("creditCardFactory", {
       initPaymentMethods: sinon.stub().returns(Q.resolve()),
       validatePaymentMethod: sinon.stub().returns(Q.resolve({})),
-      authenticate3ds: sinon.stub().returns(Q.resolve()),
+      confirmCardSetup: sinon.stub().returns(Q.resolve()),
       paymentMethods: {
         newCreditCard: {}
       },
@@ -165,7 +165,7 @@ describe('service: addPaymentSourceFactory:', function() {
         addPaymentSourceFactory.changePaymentSource()
           .then(function() {
             billing.preparePaymentSource.should.have.been.calledWith('paymentMethodId');
-            creditCardFactory.authenticate3ds.should.not.have.been.called;
+            creditCardFactory.confirmCardSetup.should.not.have.been.called;
 
             expect(creditCardFactory.paymentMethods.intentResponse).to.equal('intentResponse');
 
@@ -187,8 +187,8 @@ describe('service: addPaymentSourceFactory:', function() {
           });
       });
 
-      describe('authenticate3ds:', function() {
-        it('should authenticate3ds if authentication is required', function(done) {
+      describe('confirmCardSetup:', function() {
+        it('should confirmCardSetup if authentication is required', function(done) {
           billing.preparePaymentSource.returns(Q.resolve({
             authenticationRequired: true,
             intentSecret: 'intentSecret'
@@ -196,18 +196,18 @@ describe('service: addPaymentSourceFactory:', function() {
 
           addPaymentSourceFactory.changePaymentSource()
             .then(function() {
-              creditCardFactory.authenticate3ds.should.have.been.calledWith('intentSecret');
+              creditCardFactory.confirmCardSetup.should.have.been.calledWith('intentSecret');
 
               done();
             });
         });
 
-        it('should handle failure to authenticate3ds', function(done) {
+        it('should handle failure to confirmCardSetup', function(done) {
           billing.preparePaymentSource.returns(Q.resolve({
             authenticationRequired: true,
             intentSecret: 'intentSecret'
           }));
-          creditCardFactory.authenticate3ds.returns(Q.reject('error'));
+          creditCardFactory.confirmCardSetup.returns(Q.reject('error'));
 
           addPaymentSourceFactory.changePaymentSource()
             .catch(function() {

--- a/test/unit/billing/services/svc-invoice-factory.tests.js
+++ b/test/unit/billing/services/svc-invoice-factory.tests.js
@@ -34,7 +34,7 @@ describe('service: invoiceFactory:', function() {
         initPaymentMethods: sinon.stub(),
         getPaymentMethodId: sinon.stub().returns('paymentMethodId'),
         validatePaymentMethod: sinon.stub().returns(Q.resolve()),
-        authenticate3ds: sinon.stub().returns(Q.resolve({item: 'invoice'})),
+        handleCardAction: sinon.stub().returns(Q.resolve({item: 'invoice'})),
         paymentMethods: {}
       };
     });
@@ -333,12 +333,12 @@ describe('service: invoiceFactory:', function() {
         }, 10);
       });
 
-      describe('authenticate3ds:', function() {
+      describe('handleCardAction:', function() {
         it('should not authenticate if its not needed', function(done) {
           invoiceFactory.payInvoice();
 
           setTimeout(function() {
-            creditCardFactory.authenticate3ds.should.not.have.been.called;
+            creditCardFactory.handleCardAction.should.not.have.been.called;
 
             done();
           }, 10);
@@ -353,7 +353,7 @@ describe('service: invoiceFactory:', function() {
           invoiceFactory.payInvoice();
 
           setTimeout(function() {
-            creditCardFactory.authenticate3ds.should.have.been.calledWith('intentSecret');
+            creditCardFactory.handleCardAction.should.have.been.calledWith('intentSecret');
 
             expect(invoiceFactory.invoice.status).to.equal('paid');
 
@@ -366,7 +366,7 @@ describe('service: invoiceFactory:', function() {
             authenticationRequired: true,
             intentSecret: 'intentSecret'
           }));
-          creditCardFactory.authenticate3ds.returns(Q.reject('error'));
+          creditCardFactory.handleCardAction.returns(Q.reject('error'));
 
           invoiceFactory.payInvoice();
 

--- a/test/unit/purchase/services/svc-purchase-factory-spec.js
+++ b/test/unit/purchase/services/svc-purchase-factory-spec.js
@@ -81,7 +81,7 @@ describe("Services: purchase factory", function() {
     $provide.value("creditCardFactory", {
       initPaymentMethods: sinon.stub().returns(Q.resolve()),
       validatePaymentMethod: sinon.stub().returns(Q.resolve({})),
-      authenticate3ds: sinon.stub().returns(Q.resolve()),
+      handleCardAction: sinon.stub().returns(Q.resolve()),
       paymentMethods: {
         newCreditCard: {}
       },
@@ -481,7 +481,7 @@ describe("Services: purchase factory", function() {
         .then(function() {
           expect(purchaseFactory.loading).to.be.false;
 
-          creditCardFactory.authenticate3ds.should.not.have.been.called;
+          creditCardFactory.handleCardAction.should.not.have.been.called;
 
           expect(creditCardFactory.paymentMethods.intentResponse).to.equal('intentResponse');
 
@@ -513,8 +513,8 @@ describe("Services: purchase factory", function() {
         });
     });
 
-    describe('authenticate3ds:', function() {
-      it('should authenticate3ds if authentication is required', function(done) {
+    describe('handleCardAction:', function() {
+      it('should handleCardAction if authentication is required', function(done) {
         storeService.preparePurchase.returns(Q.resolve({
           authenticationRequired: true,
           intentSecret: 'intentSecret'
@@ -522,18 +522,18 @@ describe("Services: purchase factory", function() {
 
         purchaseFactory.preparePaymentIntent()
           .then(function() {
-            creditCardFactory.authenticate3ds.should.have.been.calledWith('intentSecret');
+            creditCardFactory.handleCardAction.should.have.been.calledWith('intentSecret');
 
             done();
           });
       });
 
-      it('should handle failure to authenticate3ds', function(done) {
+      it('should handle failure to handleCardAction', function(done) {
         storeService.preparePurchase.returns(Q.resolve({
           authenticationRequired: true,
           intentSecret: 'intentSecret'
         }));
-        creditCardFactory.authenticate3ds.returns(Q.reject({message: 'error'}));
+        creditCardFactory.handleCardAction.returns(Q.reject({message: 'error'}));
 
         purchaseFactory.preparePaymentIntent()
           .catch(function() {

--- a/test/unit/purchase/services/svc-stripe-spec.js
+++ b/test/unit/purchase/services/svc-stripe-spec.js
@@ -14,6 +14,7 @@ describe("Services: stripe service", function() {
         return Q.resolve(stripeClient = {
           createPaymentMethod: sinon.stub().returns(Q.resolve()),
           handleCardAction: sinon.stub().returns(Q.resolve()),
+          confirmCardSetup: sinon.stub().returns(Q.resolve()),
           elements: sinon.stub().returns(elements)
         });
       };
@@ -33,7 +34,8 @@ describe("Services: stripe service", function() {
   it("should exist", function() {
     expect(stripeService).to.be.ok;
     expect(stripeService.createPaymentMethod).to.be.a('function');
-    expect(stripeService.authenticate3ds).to.be.a('function');
+    expect(stripeService.handleCardAction).to.be.a('function');
+    expect(stripeService.confirmCardSetup).to.be.a('function');
     expect(stripeService.initializeStripeElements).to.be.a('function');
   });
 
@@ -46,10 +48,19 @@ describe("Services: stripe service", function() {
       });
   });
 
-  it('authenticate3ds', function(done) {
-    stripeService.authenticate3ds('secret')
+  it('handleCardAction', function(done) {
+    stripeService.handleCardAction('secret')
       .then(function() {
         stripeClient.handleCardAction.should.have.been.calledWith('secret');
+
+        done();
+      });
+  });
+
+  it('confirmCardSetup', function(done) {
+    stripeService.confirmCardSetup('secret')
+      .then(function() {
+        stripeClient.confirmCardSetup.should.have.been.calledWith('secret');
 
         done();
       });

--- a/web/partials/billing/add-payment-source.html
+++ b/web/partials/billing/add-payment-source.html
@@ -14,10 +14,6 @@
     <strong>{{addPaymentSourceFactory.apiError}}</strong>
   </div>
 
-  <div id="errorBox" ng-show="creditCardFactory.paymentMethods.tokenError" class="madero-style alert alert-danger" role="alert">
-    <strong>{{creditCardFactory.paymentMethods.tokenError}}</strong>
-  </div>
-
   <h4 class="mb-4">Payment Method</h4>
 
   <form id="form.paymentMethodsForm" role="form" name="form.paymentMethodsForm" novalidate>

--- a/web/scripts/billing/controllers/ctr-add-payment-source.js
+++ b/web/scripts/billing/controllers/ctr-add-payment-source.js
@@ -8,7 +8,6 @@ angular.module('risevision.apps.billing.controllers')
     function ($scope, $loading, $state, userState, subscriptionFactory, creditCardFactory,
     addPaymentSourceFactory) {
       $scope.subscriptionFactory = subscriptionFactory;
-      $scope.creditCardFactory = creditCardFactory;
       $scope.addPaymentSourceFactory = addPaymentSourceFactory;
 
       $scope.$watchGroup(['subscriptionFactory.loading', 'addPaymentSourceFactory.loading'], function (values) {

--- a/web/scripts/billing/services/svc-add-payment-source-factory.js
+++ b/web/scripts/billing/services/svc-add-payment-source-factory.js
@@ -47,7 +47,7 @@ angular.module('risevision.apps.billing.services')
             creditCardFactory.paymentMethods.intentResponse = response;
 
             if (response.authenticationRequired) {
-              return creditCardFactory.authenticate3ds(response.intentSecret);
+              return creditCardFactory.confirmCardSetup(response.intentSecret);
             } else {
               return $q.resolve();
             }

--- a/web/scripts/billing/services/svc-invoice-factory.js
+++ b/web/scripts/billing/services/svc-invoice-factory.js
@@ -88,7 +88,7 @@ angular.module('risevision.apps.billing.services')
             } else {
               creditCardFactory.paymentMethods.intentResponse = response;
               if (response.authenticationRequired) {
-                return creditCardFactory.authenticate3ds(response.intentSecret);
+                return creditCardFactory.handleCardAction(response.intentSecret);
               } else {
                 return $q.resolve();
               }

--- a/web/scripts/purchase/services/svc-credit-card-factory.js
+++ b/web/scripts/purchase/services/svc-credit-card-factory.js
@@ -99,8 +99,24 @@
           }
         };
 
-        factory.authenticate3ds = function (intentSecret) {
-          return stripeService.authenticate3ds(intentSecret)
+        factory.handleCardAction = function (intentSecret) {
+          return stripeService.handleCardAction(intentSecret)
+            .then(function (result) {
+              if (result.error) {
+                factory.paymentMethods.tokenError = result.error;
+                return $q.reject(result.error);
+              }
+            })
+            .catch(function (error) {
+              console.log(error);
+              factory.paymentMethods.tokenError =
+                'Something went wrong, please retry or contact support@risevision.com';
+              return $q.reject(error);
+            });
+        };
+
+        factory.confirmCardSetup = function (intentSecret) {
+          return stripeService.confirmCardSetup(intentSecret)
             .then(function (result) {
               if (result.error) {
                 factory.paymentMethods.tokenError = result.error;

--- a/web/scripts/purchase/services/svc-purchase-factory.js
+++ b/web/scripts/purchase/services/svc-purchase-factory.js
@@ -90,7 +90,7 @@
                 } else {
                   paymentMethods.intentResponse = response;
                   if (response.authenticationRequired) {
-                    return creditCardFactory.authenticate3ds(response.intentSecret);
+                    return creditCardFactory.handleCardAction(response.intentSecret);
                   } else {
                     return $q.resolve();
                   }

--- a/web/scripts/purchase/services/svc-stripe.js
+++ b/web/scripts/purchase/services/svc-stripe.js
@@ -12,9 +12,15 @@ angular.module('risevision.apps.purchase')
         });
       };
 
-      this.authenticate3ds = function (secret) {
+      this.handleCardAction = function (clientSecret) {
         return stripeLoader().then(function (stripeClient) {
-          return stripeClient.handleCardAction(secret);
+          return stripeClient.handleCardAction(clientSecret);
+        });
+      };
+
+      this.confirmCardSetup = function (clientSecret) {
+        return stripeLoader().then(function (stripeClient) {
+          return stripeClient.confirmCardSetup(clientSecret);
         });
       };
 


### PR DESCRIPTION
## Description
Use a setup intent for credit card add

Re-name the stripe functions to indicate difference
Using the purchase intent throws an error

Remove the creditCardFactory error message as it shows
duplicates

[stage-16]

## Motivation and Context
Fix issues where setup intent verification fails.

## How Has This Been Tested?
Tested changes locally. Ensured both intents still work as expected. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No