### PR TITLE
Allow setting default card as payment method when on invoice

### DIFF
--- a/test/unit/billing/services/svc-subscription-factory.tests.js
+++ b/test/unit/billing/services/svc-subscription-factory.tests.js
@@ -386,6 +386,24 @@ describe('service: subscriptionFactory:', function() {
       confirmModal.should.not.have.been.called;
     });
 
+    it('should update if the subscription is invoiced', function() {
+      subscriptionFactory.item = {
+        subscription: {
+          id: 'subscriptionId',
+          payment_source_id: 'paymentId',
+          auto_collection: 'off'
+        }
+      };
+
+      subscriptionFactory.changePaymentMethod($event, {
+        payment_source: {
+          id: 'paymentId'
+        }
+      });
+
+      confirmModal.should.have.been.called;
+    });
+
     it('should prompt for change', function(done) {
       subscriptionFactory.changePaymentMethod($event, {
         payment_source: {

--- a/web/scripts/billing/services/svc-subscription-factory.js
+++ b/web/scripts/billing/services/svc-subscription-factory.js
@@ -106,7 +106,7 @@ angular.module('risevision.apps.billing.services')
         // prevent the radio ng-model from being updated
         event.preventDefault();
 
-        if (factory.getPaymentSourceId() === card.payment_source.id) {
+        if (!factory.isInvoiced() && factory.getPaymentSourceId() === card.payment_source.id) {
           return;
         }
 


### PR DESCRIPTION
## Description
Allow setting default card as payment method when on invoice

[stage-19]

## Motivation and Context
Fix issue where the default card for the customer cannot be selected as the payment method when the Subscription is set to On Invoice.

## How Has This Been Tested?
Tested changes locally. Added unit test.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No