### PR TITLE
Fix long PO Number issues

### DIFF
--- a/web/partials/billing/edit-po-number.html
+++ b/web/partials/billing/edit-po-number.html
@@ -6,8 +6,8 @@
     <span ng-show="!item.po_number && !editPoNumber">
       <a aria-label="Add PO Number" class="madero-link u_clickable" tabindex="1" ng-click="editPoNumber = true">Add</a>
     </span>
-    <span ng-show="item.po_number && !editPoNumber">
-      <span class="mr-2">
+    <span ng-show="item.po_number && !editPoNumber" class="flex-row">
+      <span class="mr-2 u_ellipsis">
       {{item.po_number}}
       </span>
       <a aria-label="Edit PO Number" class="madero-link u_clickable" tabindex="1" ng-click="editPoNumber = true">Edit</a>
@@ -20,7 +20,7 @@
 <div class="row" ng-if="editPoNumber">
   <div class="col-md-12">
     <div class="flex-row">
-      <input id="po-number" aria-required="false" type="text" class="form-control mr-3" name="poNumber" ng-model="item.poNumber" ng-value="item.po_number">
+      <input id="po-number" aria-required="false" type="text" class="form-control mr-3" name="poNumber" ng-model="item.poNumber" ng-value="item.po_number" maxlength="100">
       <button id="update-po-number" type="button" aria-label="Update PO Number" class="btn btn-default" ng-click="updatePoNumber()">Update</button>
     </div>
   </div>


### PR DESCRIPTION
## Description
- Chargebee throws error if longer than 100, so we limited the field to that
- Use ellipsis for long PO numbers

## Motivation and Context
Subscription details epic

## How Has This Been Tested?
Locally and on [stage-1]
Sample: https://apps-stage-1.risevision.com/billing/subscription/AzZm2kSMBhYUNb21?cid=5908e3ce-1ae3-42af-a6b0-77cde4684f4a


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
