### PR TITLE
No longer filter expired trials

### DIFF
--- a/web/partials/billing/app-billing.html
+++ b/web/partials/billing/app-billing.html
@@ -90,7 +90,7 @@
             </td>
           </tr>
 
-          <tr ng-show="filteredSubscriptions.length === 0 && !currentPlan.isPurchasedByParent">
+          <tr ng-show="subscriptions.items.list.length === 0 && !currentPlan.isPurchasedByParent">
             <td colspan="5" class="text-center"><span translate>You haven't Subscribed to any Products yet.</span></td>
           </tr>
         </tbody>

--- a/web/partials/billing/app-billing.html
+++ b/web/partials/billing/app-billing.html
@@ -69,7 +69,7 @@
             </td>
           </tr>
 
-          <tr class="table-body__row" ng-repeat="item in (filteredSubscriptions = (subscriptions.items.list | filter: { subscription: { current_term_end: '!!' }}))">
+          <tr class="table-body__row" ng-repeat="item in subscriptions.items.list">
             <td class="table-body__cell font-weight-bold">
               <a class="madero-link u_clickable" ui-sref="apps.billing.subscription({subscriptionId: item.subscription.id})" ng-if="showSubscriptionLink(item.subscription)">{{item.subscription | subscriptionDescription}}</a>
               <span ng-if="!showSubscriptionLink(item.subscription)">{{item.subscription | subscriptionDescription}}</span>


### PR DESCRIPTION
## Description
No longer filter expired trials as they are no longer returned by the server (status cancelled is being filtered out)

## Motivation and Context
https://trello.com/c/1vMcTi9X/7031-dont-show-cancelled-subscriptions-in-the-list-1

## How Has This Been Tested?
Locally and on [stage-20]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
