### PR TITLE
E2E test to confirm Shared schedule URL matches Chrome extension URL

### DIFF
--- a/test/e2e/schedules/cases/scheduleadd.js
+++ b/test/e2e/schedules/cases/scheduleadd.js
@@ -109,6 +109,11 @@ var ScheduleAddScenarios = function() {
         expect(shareSchedulePopoverPage.getCopyLinkButton().isDisplayed()).to.eventually.be.true;
       });
 
+      it('should provide a link accepted by Rise Chrome Extension', function() {
+        //It needs to use widgets.risevision.com subdomain to be accepted by Rise Chrome Extension. In case it ever changes again, we need to update it in both places.
+        expect(shareSchedulePopoverPage.getCopyLinkInput().getAttribute('value')).to.eventually.contain('https://widgets.risevision.com/');
+      });
+
       it('should show Social Media sharing buttons', function() {
         expect(shareSchedulePopoverPage.getTwitterShareButton().isDisplayed()).to.eventually.be.true;
       });

--- a/test/e2e/schedules/pages/shareSchedulePopoverPage.js
+++ b/test/e2e/schedules/pages/shareSchedulePopoverPage.js
@@ -9,6 +9,7 @@ var ShareSchedulePopoverPage = function() {
   var chromeExtensionTabLink = element(by.css('.tooltip.tooltip-share-options #extensionButton')); 
 
   var copyLinkButton = element(by.css('.tooltip.tooltip-share-options #copyUrlButton'));
+  var copyLinkInput = element(by.css('.tooltip.tooltip-share-options input.copy-text-box'));
   var copyEmbedCodeButton = element(by.css('.tooltip.tooltip-share-options #copyEmbedCodeButton'));
 
   var twitterShareButton = element(by.css('.tooltip.tooltip-share-options #twitterShareButton'));
@@ -38,6 +39,10 @@ var ShareSchedulePopoverPage = function() {
 
   this.getCopyLinkButton = function() {
     return copyLinkButton;
+  };
+
+  this.getCopyLinkInput = function() {
+    return copyLinkInput;
   };
 
   this.getCopyEmbedCodeButton = function() {


### PR DESCRIPTION
[stage-1]

## Description
Adds E2E test to confirm that Shared schedule URL matches the subdomain supported by Rise Chrome extension.

## Motivation and Context
https://trello.com/c/99pWmU3v/7016-add-e2e-test-to-confirm-shared-schedule-url-matches-chrome-extension-url-1

## How Has This Been Tested?
E2E tests pass

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
