### PR TITLE
Fix users/add path not opening user add modal

### DIFF
--- a/test/e2e/apps-sections.cases.js
+++ b/test/e2e/apps-sections.cases.js
@@ -5,6 +5,7 @@
   var SigninGoogleScenarios = require('./common/cases/signin-google.js');
   var SigninCustomScenarios = require('./common/cases/signin-custom.js');
   var WeeklyTemplatesScenarios = require('./common/cases/weekly-templates.js');
+  var DismissModalScenarios = require('./common/cases/dismiss-modal.js');
 
   var CompanySettingsScenarios = require("./common-header/cases/company-settings.js");
   var CompanySubcompaniesScenarios = require("./common-header/cases/company-subcompanies.js");
@@ -21,13 +22,13 @@
   var DownloadScenarios = require('./storage/cases/download.js');
   var TrashScenarios = require('./storage/cases/trash.js');
   var IframeScenarios = require('./storage/cases/iframe.js');
-  var DismissModalScenarios = require('./storage/cases/dismiss-modal.js');
 
   describe('Apps Common', function () {
     var homepageScenarios = new HomepageScenarios();
     var signinGoogleScenarios = new SigninGoogleScenarios();
     var signinCustomScenarios = new SigninCustomScenarios();
     var weeklyTemplatesScenarios = new WeeklyTemplatesScenarios();
+    var dismissModalScenarios = new DismissModalScenarios();
   });
 
   describe('Common Header', function () {
@@ -50,7 +51,6 @@
     var downloadScenarios = new DownloadScenarios();
     var trashScenarios = new TrashScenarios();
     var iframeScenarios = new IframeScenarios();
-    var dismissModalScenarios = new DismissModalScenarios();
   });
 
 })();

--- a/test/e2e/common/cases/dismiss-modal.js
+++ b/test/e2e/common/cases/dismiss-modal.js
@@ -1,22 +1,26 @@
 'use strict';
 var expect = require('rv-common-e2e').expect;
 var helper = require('rv-common-e2e').helper;
-var StorageSelectorModalPage = require('./../pages/storageSelectorModalPage.js');
-var NewFolderModalPage = require('./../pages/newFolderModalPage.js');
+var HomePage = require('./../pages/homepage.js');
+var StorageSelectorModalPage = require('./../../storage/pages/storageSelectorModalPage.js');
+var NewFolderModalPage = require('./../../storage/pages/newFolderModalPage.js');
 var CommonHeaderPage = require('./../../common-header/pages/commonHeaderPage.js');
-var StorageHelper = require('./../pages/helper.js');
-var StorageHomePage = require('./../pages/storageHomePage.js');
-var FilesListPage = require('./../pages/filesListPage.js');
-
+var UserSettingsModalPage = require('./../../common-header/pages/userSettingsModalPage.js');
+var StorageHelper = require('./../../storage/pages/helper.js');
+var StorageHomePage = require('./../../storage/pages/storageHomePage.js');
+var FilesListPage = require('./../../storage/pages/filesListPage.js');
 
 var DismissModalScenarios = function() {
 
   browser.driver.manage().window().setSize(1400, 900);
   describe('Dismiss Modal', function () {
+    var homepage = new HomePage();
+
     var storageSelectorModalPage = new StorageSelectorModalPage();
     var newFolderModalPage = new NewFolderModalPage();
 
     var commonHeaderPage = new CommonHeaderPage();
+    var userSettingsModalPage = new UserSettingsModalPage();
     var storageHomePage = new StorageHomePage();
     var filesListPage = new FilesListPage();
 
@@ -47,6 +51,19 @@ var DismissModalScenarios = function() {
         helper.waitDisappear(filesListPage.getFilesListLoader(), 'Storage Files Loader');
       });
       describe('Dismiss Modal:', describeNewFolder);
+    });
+
+    describe('User Add', function() {
+      before(function () {        
+        homepage.getUsersAdd();
+        helper.waitDisappear(commonHeaderPage.getLoader(), 'CH spinner loader');
+      });
+      
+      it('should show the user add modal', function() {
+        helper.wait(userSettingsModalPage.getUserSettingsModal(), 'User Settings Modal');
+
+        expect(userSettingsModalPage.getUserSettingsModal().isPresent()).to.eventually.be.true;
+      });
     });
 
   });

--- a/test/e2e/common/pages/homepage.js
+++ b/test/e2e/common/pages/homepage.js
@@ -11,6 +11,7 @@ var HomePage = function() {
   var schedulesUrl = config.rootUrl + '/schedules/list';
   var storageUrl = config.rootUrl + '/storage';
   var defaultSubscriptionUrl = config.rootUrl + '/billing/subscription/';
+  var usersAddUrl = config.rootUrl + '/users/add';
 
   var displaysLink = element(by.css('.nav.navbar-nav #DisplaysLink'));
   var editorLink = element(by.css('.nav.navbar-nav #PresentationsLink'));
@@ -65,6 +66,10 @@ var HomePage = function() {
 
   this.getDefaultSubscription = function() {
     this.confirmGet(defaultSubscriptionUrl);
+  };
+
+  this.getUsersAdd = function() {
+    this.confirmGet(usersAddUrl);
   };
 
   this.getUrl = function() {

--- a/web/scripts/app.js
+++ b/web/scripts/app.js
@@ -86,7 +86,6 @@ angular.module('risevision.apps', [
 
         .state('apps.users', {
           abstract: true,
-          url: '?cid',
           template: '<div ui-view></div>'
         })
         .state('apps.users.add', {
@@ -153,17 +152,11 @@ angular.module('risevision.apps', [
       }
     }
   ])
-  .run(['$rootScope', '$state', '$modalStack', 'userState', '$window', '$exceptionHandler',
-    function ($rootScope, $state, $modalStack, userState, $window, $exceptionHandler) {
+  .run(['$rootScope', '$state', '$exceptionHandler',
+    function ($rootScope, $state, $exceptionHandler) {
 
       $rootScope.$on('risevision.user.signedOut', function () {
         $state.go('common.auth.unauthorized');
-      });
-
-      $rootScope.$on('$stateChangeStart', function (event) {
-        if (userState.isRiseVisionUser()) {
-          $modalStack.dismissAll();
-        }
       });
 
       $rootScope.$on('$stateChangeSuccess', function (event, toState) {
@@ -202,12 +195,20 @@ angular.module('risevision.apps', [
       });
     }
   ])
-  .run(['$rootScope', '$modal', 'canAccessApps', 'userState',
-    function ($rootScope, $modal, canAccessApps, userState) {
+  .run(['$rootScope', '$modal', '$modalStack', 'canAccessApps', 'userState',
+    function ($rootScope, $modal, $modalStack, canAccessApps, userState) {
+      var $modalInstance;
+      
+      $rootScope.$on('$stateChangeStart', function (event) {
+        if (userState.isRiseVisionUser() && !$modalInstance) {
+          $modalStack.dismissAll();
+        }
+      });
+
       $rootScope.$on('$stateChangeStart', function (event, toState, toParams, fromState, fromParams) {
         if (toState.name === 'apps.users.add') {
           canAccessApps().then(function () {
-            $modal.open({
+            $modalInstance = $modal.open({
               templateUrl: 'partials/common-header/user-settings-modal.html',
               controller: 'AddUserModalCtrl',
               resolve: {
@@ -215,6 +216,9 @@ angular.module('risevision.apps', [
                   return userState.getSelectedCompanyId();
                 }
               }
+            })
+            .result.finally(function() {
+              $modalInstance = null;
             });
           });
 


### PR DESCRIPTION
## Description
Fix users/add path not opening user add modal

Add exception for the modal dismiss functionality

Add e2e test for the users/add route
Move modal dismissal tests to common

[stage-18]

## Motivation and Context
Fix issue where the `users/add` route is not opening the modal correctly when accessed directly via the URL.

## How Has This Been Tested?
Tested locally. Updated unit tests and added an e2e test. Can test at https://apps-stage-18.risevision.com/users/add

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No