### PR TITLE
Use an updated node version 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  browser-tools: circleci/browser-tools@1.1.1
+
 commands:
   run_e2e_cases:
     description: "Runs a specific cases file as a workflow step"
@@ -10,12 +13,8 @@ commands:
     steps:
       - attach_workspace:
           at: ~/
-      - run: echo $CHROME_INSTANCES
       # Install latest chrome
-      - run: wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-      - run: echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee -a /etc/apt/sources.list
-      - run: sudo apt-get update -qq
-      - run: sudo apt-get install -y google-chrome-stable
+      - browser-tools/install-chrome
       - run:
           name: e2e_tests
           command: |
@@ -34,7 +33,7 @@ jobs:
   dependencies:
     working_directory: ~/rise-vision-apps
     docker: &BUILDIMAGE
-      - image: jenkinsrise/apps-node:8.9.4-stretch
+      - image: jenkinsrise/apps-node:10.23.2-browsers
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD 
@@ -72,10 +71,7 @@ jobs:
       - attach_workspace:
           at: ~/
       # Install latest chrome
-      - run: wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-      - run: echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee -a /etc/apt/sources.list
-      - run: sudo apt-get update -qq
-      - run: sudo apt-get install -y google-chrome-stable
+      - browser-tools/install-chrome
       - run: 
           name: test_build
           command: NODE_ENV=test npm run ci-build


### PR DESCRIPTION
## Description
Use an updated node version 10

Next version 12 breaks the build process
because of Gulp 3

Use brower-tools orb to install Chrome

[stage-11]

## Motivation and Context
Update node version for the build.

## How Has This Been Tested?
Build passes, staging works as expected.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No