### PR TITLE
Validate emails on key up if text matches placeholder

### DIFF
--- a/test/unit/common-header/directives/dtv-emails-field-spec.js
+++ b/test/unit/common-header/directives/dtv-emails-field-spec.js
@@ -1,17 +1,20 @@
 /*jshint expr:true */
 
-"use strict";
-describe("directive: emails field", function() {
-  beforeEach(module("risevision.common.header.directives"));
+'use strict';
+describe('directive: emails field', function() {
+  beforeEach(module('ngTagsInput'));
+  beforeEach(module('risevision.common.header.directives'));
 
-  var $scope, form, elem, elemScope;
+  var $scope, form, elem, elemScope, $timeout;
 
-  beforeEach(inject(function($compile, $rootScope) {
+  beforeEach(inject(function($compile, $rootScope, $templateCache, $injector) {
+    $timeout = $injector.get('$timeout');
+    $templateCache.put('partials/common-header/emails-field.html', '<tags-input ng-model="emailsList" placeholder="{{placeholderText}}"></tags-input>');
     $scope = $rootScope.$new();
     var validHTML = 
-      "<form name=\"form\">" +
-      "  <emails-field name=\"monitoringEmails\" ng-model=\"display.monitoringEmails\" require-emails-on-change=\"true\" />" +
-      "</form>";
+      '<form name="form">' +
+      '  <emails-field name="monitoringEmails" ng-model="display.monitoringEmails" require-emails-on-change="true" />' +
+      '</form>';
     $scope.display = { 
     };
     elem = $compile(validHTML)($scope);
@@ -21,13 +24,24 @@ describe("directive: emails field", function() {
     $scope.$digest();
   }));
 
-  it("should initialize", function(done) {
-    $scope.display.monitoringEmails = ["email1@test.com", "email2@test.com"];
+  function _findBySelector(selector) {
+    var queryResult = elem[0].querySelector(selector);
+    return angular.element(queryResult);
+  }
+
+  it('should initialize', function(done) {
+    $scope.display.monitoringEmails = ['email1@test.com', 'email2@test.com'];
     $scope.$digest();
+    $timeout.flush();
 
     setTimeout(function() {
       expect(elemScope.emailsList.length).to.equal(2);
-      expect(elemScope.emailsList[0].text).to.equal("email1@test.com");
+      expect(elemScope.emailsList[0].text).to.equal('email1@test.com');
+
+      expect(elemScope.placeholderText).to.equal('example1@email.com, example2@email.com');
+      var spanField = _findBySelector('tags-input > div > div > span');
+      expect(spanField.text()).to.equal(elemScope.placeholderText);
+
       done();
     });
   });
@@ -48,24 +62,57 @@ describe("directive: emails field", function() {
     });
 
     it('should not set error when at least one email is provided',function(){
-      $scope.display.monitoringEmails = ["email1@test.com"];
+      $scope.display.monitoringEmails = ['email1@test.com'];
       $scope.$digest();
       elemScope.updateModel();
       expect(form.monitoringEmails.$error['require-emails']).to.be.undefined;
     });
   });
 
-  describe("isValidEmail:", function() {
-    it("should return true if it is a valid email", function () {
+  describe('keyUp:', function() {
+    beforeEach(function() {
+      $scope.display.monitoringEmails = [];
+      $scope.$digest();
+      elemScope.updateModel();
+      $timeout.flush();
+      expect(form.monitoringEmails.$error['require-emails']).to.be.true;
+
+      $scope.display.monitoringEmails = ['email1@test.com'];
+      $scope.$digest();
+    });
+
+    it('should validate on key up', function() {
+      var inputField = _findBySelector('tags-input > div > div > input');
+
+      inputField.keyup();
+
+      $timeout.flush();
+      expect(form.monitoringEmails.$error['require-emails']).to.be.undefined;
+    });
+
+    it('should not trigger validation on key up if span text is not placeholder', function() {
+      var spanField = _findBySelector('tags-input > div > div > span');
+      spanField.text('anotherText');
+
+      var inputField = _findBySelector('tags-input > div > div > input');
+      inputField.keyup();
+
+      $timeout.flush();
+      expect(form.monitoringEmails.$error['require-emails']).to.be.true;
+    });
+  });
+
+  describe('isValidEmail:', function() {
+    it('should return true if it is a valid email', function () {
       expect(elemScope.isValidEmail()).to.be.false;
       expect(elemScope.isValidEmail({})).to.be.false;
-      expect(elemScope.isValidEmail({ text: "" })).to.be.false;
-      expect(elemScope.isValidEmail({ text: "aaaa" })).to.be.false;
-      expect(elemScope.isValidEmail({ text: "aaaa@" })).to.be.false;
-      expect(elemScope.isValidEmail({ text: "aaaa@a" })).to.be.false;
-      expect(elemScope.isValidEmail({ text: "aaaa@a." })).to.be.false;
-      expect(elemScope.isValidEmail({ text: "aaaa@a.b.c" })).to.be.true;
-      expect(elemScope.isValidEmail({ text: "aaaa@a.com" })).to.be.true;
+      expect(elemScope.isValidEmail({ text: '' })).to.be.false;
+      expect(elemScope.isValidEmail({ text: 'aaaa' })).to.be.false;
+      expect(elemScope.isValidEmail({ text: 'aaaa@' })).to.be.false;
+      expect(elemScope.isValidEmail({ text: 'aaaa@a' })).to.be.false;
+      expect(elemScope.isValidEmail({ text: 'aaaa@a.' })).to.be.false;
+      expect(elemScope.isValidEmail({ text: 'aaaa@a.b.c' })).to.be.true;
+      expect(elemScope.isValidEmail({ text: 'aaaa@a.com' })).to.be.true;
     });
   });
   

--- a/web/partials/common-header/emails-field.html
+++ b/web/partials/common-header/emails-field.html
@@ -1,5 +1,5 @@
 <tags-input type="email"
-            placeholder="example1@email.com, example2@email.com"
+            placeholder="{{placeholderText}}"
             class="email-tags"
             ng-model="emailsList"
             add-on-enter="true"

--- a/web/scripts/common-header/directives/dtv-emails-field.js
+++ b/web/scripts/common-header/directives/dtv-emails-field.js
@@ -15,6 +15,8 @@ angular.module('risevision.common.header.directives')
         },
         template: $templateCache.get('partials/common-header/emails-field.html'),
         link: function ($scope, elem, attr, ngModel) {
+          $scope.placeholderText = 'example1@email.com, example2@email.com';
+
           var updatingEmails = false;
           var validationError = false;
 
@@ -33,7 +35,7 @@ angular.module('risevision.common.header.directives')
             inputField.keyup(function () {
               // Needed to wait an extra cycle
               $timeout(function () {
-                if (spanField.text() === 'Add an email') {
+                if (spanField.text() === $scope.placeholderText) {
                   _setValid(true);
                   _checkRequireEmailsOnChange();
                   $scope.$digest();


### PR DESCRIPTION
## Description
The workaround in place to deal with key up was no longer working as it relied on a placeholder text that got changed.
I refactored that into a variable, so that we no longer face this issue.

## Motivation and Context
Fixes #2428

## How Has This Been Tested?
Locally and on [stage-20]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
