### PR TITLE
Add select_account prompt to google auth

### DIFF
--- a/test/unit/components/userstate/services/svc-openid-connect-loader.tests.js
+++ b/test/unit/components/userstate/services/svc-openid-connect-loader.tests.js
@@ -80,6 +80,7 @@ describe("Services: openidConnectLoader", function() {
         expect(client).to.be.ok;
         expect(client.settings).to.be.ok;
         expect(client.settings.authority).to.equal('https://accounts.google.com/');
+        expect(client.settings.prompt).to.equal('select_account');
 
         expect(client.signinSilent).to.be.ok;
         expect(client.signinSilent).to.be.a("function");

--- a/web/scripts/components/userstate/services/svc-openid-connect.js
+++ b/web/scripts/components/userstate/services/svc-openid-connect.js
@@ -29,6 +29,7 @@
           client_id: CLIENT_ID,
           response_type: 'token id_token',
           scope: OAUTH2_SCOPES,
+          prompt: 'select_account',
           redirect_uri: loc,
           post_logout_redirect_uri: loc + 'oidc-client-sample.html',
 


### PR DESCRIPTION
## Description
Add select_account prompt to google auth

[stage-19]

## Motivation and Context
Allow users to sign in to a separate google account than the one selected.

## How Has This Been Tested?
Tested changes locally. Ensured silent refresh and account selector work as expected. Unit tests updated and e2e tests pass.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No