### PR TITLE
Import angular instead of using dependency

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -640,9 +640,7 @@
               "src/assets"
             ],
             "styles": [],
-            "scripts": [
-              "node_modules/angular/angular.js"
-            ]
+            "scripts": []
           }
         },
         "lint": {

--- a/src/app/editor/components/last-revised/last-revised.component.ts
+++ b/src/app/editor/components/last-revised/last-revised.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { downgradeComponent } from '@angular/upgrade/static';
-declare var angular: angular.IAngularStatic;
+
+import * as angular from 'angular';
 
 @Component({
   selector: 'last-revised',

--- a/src/test.ts
+++ b/src/test.ts
@@ -7,6 +7,8 @@ import {
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
 
+import * as angular from 'angular';
+
 declare const require: {
   context(path: string, deep?: boolean, filter?: RegExp): {
     keys(): string[];
@@ -14,8 +16,6 @@ declare const require: {
   };
 };
 
-//TODO: Refactor
-declare var angular: any;
 angular.module('risevision.editor.directives',[])
 
 // First, initialize the Angular testing environment.

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
     "types": [
-      "angular",
       "jasmine",
       "node"
     ]


### PR DESCRIPTION
## Description
Import angular instead of using dependency

[stage-12]

## Motivation and Context
Fix build and the need for @types/angular

## How Has This Been Tested?
App builds and deploys correctly.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No