### PR TITLE
Limit modals width

### DIFF
--- a/src/scss/ui-components/modals.scss
+++ b/src/scss/ui-components/modals.scss
@@ -1,3 +1,12 @@
+.modal-dialog {
+  max-width: 1140px;
+  margin: 10px auto;
+}
+
+.modal-content {
+  margin: 0 10px;
+}
+
 .modal-custom > div {
     width: auto;
     display: table;


### PR DESCRIPTION
## Description
Replicate commented out code from https://github.com/Rise-Vision/rise-vision-apps/blob/master/src/scss/sections/store-cart.scss#L686

## Motivation and Context
Partial fix for https://github.com/Rise-Vision/rise-vision-apps/issues/2466

## How Has This Been Tested?
Locally and on [stage-1]


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
