### PR TITLE
Add led and cscape ticker plan names

### DIFF
--- a/src/scripts/components/plans/services/svc-plans.js
+++ b/src/scripts/components/plans/services/svc-plans.js
@@ -169,6 +169,32 @@
       productCode: '356ab5e0541a41e96e4ef0b45ecac9f72af454ac',
       // cannot use type 'volume', it may interfere with the other plan
       type: 'volume for financial',
+    }, {
+      name: 'C-Scape iCandy LED Ticker License',
+      productCode: '2374db80249aa3b862df6feea177a55e97015319'
+    }, {
+      name: 'LED Ticker License',
+      // productCode: 'led-ticker-license',
+      productCode: 'led',
+      type: 'volume for led ticker'
+    },
+    // Archived:
+    {
+      name: 'Premium Financial MarketWall',
+      productCode: '0c583c663655c246c3e7b3c1be0ec05a442211aa',
+      type: 'volume for premium marketwall'
+    }, {
+      name: 'Basic Financial MarketWall',
+      productCode: '0dbb19f8394612730c2673b092d811e46413b132',
+      type: 'volume for basic marketwall'
+    }, {
+      name: 'Premium LED Ticker License',
+      productCode: 'c91e5b9762036cb6f0f0d7b93032c11897a9da1b',
+      type: 'volume for premium ticker'
+    }, {
+      name: 'Basic LED Ticker License',
+      productCode: '74eb12a1c0ade021f875213bf796b2ef8b174753',
+      type: 'volume for basic ticker'  
     }])
     .factory('plansService', ['PLANS_LIST',
       function (PLANS_LIST) {


### PR DESCRIPTION
## Description
Add led and cscape ticker plan names

Also some other archived plans

Note, since the product code is split by dash (-)
the led ticker product code is cut to the first
dash

[stage-19]

## Motivation and Context
Fix for #2467 

## How Has This Been Tested?
Tested locally.

Can review some plans at:
https://apps-stage-19.risevision.com/billing?cid=4b5870e7-c7c3-40bf-9290-ef3e668f3a95

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No