### PR TITLE
Sign user out of google account on auth failure

### DIFF
--- a/test/unit/components/userstate/services/svc-user-auth-factory.spec.js
+++ b/test/unit/components/userstate/services/svc-user-auth-factory.spec.js
@@ -198,8 +198,20 @@ describe("Services: userAuthFactory", function() {
           expect(userState._state.userToken).to.be.undefined;
           rvTokenStore.clear.should.have.been.called;
           userState._resetState.should.have.been.calledOnce;
+          googleAuthFactory.signOut.should.have.been.called;
 
           $broadcastSpy.should.not.have.been.calledWith("risevision.user.authorized");
+
+          done();
+        })
+        .then(null,done);
+      });
+
+      it("should not sign user out if not using rise auth", function(done) {
+        isRiseAuthUser = true;
+
+        userAuthFactory.authenticate(true).then(done, function(msg) {
+          googleAuthFactory.signOut.should.not.have.been.called;
 
           done();
         })


### PR DESCRIPTION
## Description
Sign user out of google account on auth failure

Prevents issues where the same problem persists and
cannot be corrected

[stage-18]

## Motivation and Context
Partial of the fix for #2474 

## How Has This Been Tested?
Tested changes locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No