### PR TITLE
Handle gapi client request failures

### DIFF
--- a/src/scripts/components/gapi-loader/svc-gapi.js
+++ b/src/scripts/components/gapi-loader/svc-gapi.js
@@ -36,6 +36,13 @@ angular.module('risevision.common.gapi', [
           var fileref = document.createElement('script');
           fileref.setAttribute('type', 'text/javascript');
           fileref.setAttribute('src', src);
+
+          fileref.onerror = function(error) {
+            console.log('gapi load error', error);
+            deferred.reject(error);
+            $window.removeEventListener('gapi.loaded', gapiLoaded, false);
+          };
+
           if (typeof fileref !== 'undefined') {
             document.getElementsByTagName('body')[0].appendChild(fileref);
           }
@@ -72,6 +79,8 @@ angular.module('risevision.common.gapi', [
               }
             });
           }
+        }).catch(function(err) {
+          deferred.reject(err);
         });
         return deferred.promise;
       };
@@ -106,6 +115,8 @@ angular.module('risevision.common.gapi', [
                   deferred.reject(err || errMsg);
                 });
             }
+          }).catch(function(err) {
+            deferred.reject(err);
           });
           return deferred.promise;
         };

--- a/src/scripts/components/gapi-loader/svc-gapi.js
+++ b/src/scripts/components/gapi-loader/svc-gapi.js
@@ -3,16 +3,13 @@
 'use strict';
 
 /* jshint ignore:start */
-var gapiLoadingStatus = null;
-var handleClientJSLoad = function () {
-  gapiLoadingStatus = 'loaded';
+window.gapiLoadingStatus = null;
+window.handleClientJSLoad = function () {
+  window.gapiLoadingStatus = 'loaded';
+
   console.debug('ClientJS is loaded.');
-  //Ready: create a generic event
-  var evt = document.createEvent('Events');
-  //Aim: initialize it to be the event we want
-  evt.initEvent('gapi.loaded', true, true);
-  //FIRE!
-  window.dispatchEvent(evt);
+
+  window.dispatchEvent(new CustomEvent('gapi.loaded'));
 };
 /* jshint ignore:end */
 
@@ -33,7 +30,7 @@ angular.module('risevision.common.gapi', [
 
           var src = $window.gapiSrc ||
             '//apis.google.com/js/client.js?onload=handleClientJSLoad';
-          var fileref = document.createElement('script');
+          var fileref = $window.document.createElement('script');
           fileref.setAttribute('type', 'text/javascript');
           fileref.setAttribute('src', src);
 
@@ -44,15 +41,16 @@ angular.module('risevision.common.gapi', [
           };
 
           if (typeof fileref !== 'undefined') {
-            document.getElementsByTagName('body')[0].appendChild(fileref);
+            $window.document.getElementsByTagName('body')[0].appendChild(fileref);
           }
 
           gapiLoaded = function () {
             deferred.resolve($window.gapi);
-            $window.removeEventListener('gapi.loaded', gapiLoaded, false);
+            $window.removeEventListener('gapi.loaded', gapiLoaded);
           };
-          $window.addEventListener('gapi.loaded', gapiLoaded, false);
+          $window.addEventListener('gapi.loaded', gapiLoaded);
         }
+
         return deferred.promise;
       };
     }
@@ -61,12 +59,15 @@ angular.module('risevision.common.gapi', [
   .factory('clientAPILoader', ['$q', '$log', 'gapiLoader',
     function ($q, $log, gapiLoader) {
       return function () {
-        var deferred = $q.defer();
-        gapiLoader().then(function (gApi) {
-          if (gApi.client) {
-            //already loaded. return right away
-            deferred.resolve(gApi);
-          } else {
+        return gapiLoader()
+          .then(function (gApi) {
+            var deferred = $q.defer();
+
+            if (gApi.client) {
+              //already loaded. return right away
+              return gApi;
+            }
+
             gApi.load('client', function (err) {
               if (gApi.client) {
                 $log.debug('client API Loaded');
@@ -75,14 +76,12 @@ angular.module('risevision.common.gapi', [
               } else {
                 var errMsg = 'client API Load Failed';
                 $log.error(errMsg, err);
-                deferred.reject(err || errMsg);
+                return deferred.reject(err || errMsg);
               }
             });
-          }
-        }).catch(function(err) {
-          deferred.reject(err);
-        });
-        return deferred.promise;
+
+            return deferred.promise;
+          });
       };
     }
   ])
@@ -94,17 +93,19 @@ angular.module('risevision.common.gapi', [
     function ($q, $log, clientAPILoader) {
       return function (libName, libVer, baseUrl) {
         return function () {
-          var deferred = $q.defer();
-          clientAPILoader().then(function (gApi) {
-            if (gApi.client[libName]) {
-              // already loaded. return right away
-              deferred.resolve(gApi.client[libName]);
-            } else {
-              gApi.client.load(libName, libVer, null, baseUrl)
+          return clientAPILoader()
+            .then(function (gApi) {
+              if (gApi.client[libName]) {
+                // already loaded. return right away
+                return gApi.client[libName];
+              }
+
+              return gApi.client.load(libName, libVer, null, baseUrl)
                 .then(function () {
                   if (gApi.client[libName]) {
                     $log.debug(libName + '.' + libVer + ' Loaded');
-                    deferred.resolve(gApi.client[libName]);
+
+                    return gApi.client[libName];
                   } else {
                     return $q.reject();
                   }
@@ -112,13 +113,9 @@ angular.module('risevision.common.gapi', [
                 .catch(function (err) {
                   var errMsg = libName + '.' + libVer + ' Load Failed';
                   $log.error(errMsg, err);
-                  deferred.reject(err || errMsg);
+                  return $q.reject(err || errMsg);
                 });
-            }
-          }).catch(function(err) {
-            deferred.reject(err);
-          });
-          return deferred.promise;
+            });
         };
       };
     }

--- a/src/scripts/components/userstate/controllers/ctr-login.js
+++ b/src/scripts/components/userstate/controllers/ctr-login.js
@@ -36,6 +36,14 @@ angular.module('risevision.common.components.userstate')
         }
       };
 
+      var _init = function () {
+        if ($stateParams.authError && $stateParams.authError !== 'No user') {
+          _processErrorCode($stateParams.authError, 'in');
+        }
+      };
+
+      _init();
+
       $scope.googleLogin = function (endStatus) {
         $loading.startGlobal('auth-buttons-login');
         googleAuthFactory.forceAuthenticate()

--- a/src/scripts/components/userstate/services/svc-access.js
+++ b/src/scripts/components/userstate/services/svc-access.js
@@ -15,7 +15,7 @@ angular.module('risevision.common.components.userstate')
               return $q.reject();
             }
           })
-          .then(null, function () {
+          .catch(function () {
             var newState;
 
             if (!userState.isLoggedIn()) {

--- a/test/unit/components/gapi-loader/svc-gapi.spec.js
+++ b/test/unit/components/gapi-loader/svc-gapi.spec.js
@@ -1,93 +1,455 @@
 /* jshint expr:true */
 "use strict";
 
-describe("Services: gapi loader", function() {
-
+describe("Services: gapi", function() {
   beforeEach(module("risevision.common.gapi"));
-  beforeEach(module(function ($provide) {
-    //stub services
-    $provide.service("$q", function() {return Q;});
-    $provide.value("CORE_URL", "coreUrl");
-    $provide.value("STORE_ENDPOINT_URL", "storeUrl");
-    $provide.value("STORAGE_ENDPOINT_URL", "storageUrl");
-    
-    $provide.value("$location", {
-      search: sinon.stub().returns({}),
-      protocol: function () {
-        return "protocol";
-      }
-    });
-    $provide.service("getBaseDomain", function() {
-      return function() {
-        return "domain";
-      };
-    });
 
-  }));
-  
-  var $window, $location, loadApi;
-  
-  beforeEach(function () {
-    loadApi = true;
-
-    inject(function($injector) {
-      $window = $injector.get("$window");
-      $location = $injector.get("$location");
-
-      var gapiClient = {
-        load: sinon.spy(function(path, version, cb, url) {
-          if (loadApi) {
-            $window.gapi.client[path] = {version: version};
-            return Q.resolve();
-          } else {
-            return Q.reject({});
-          }
-        })
-      };
-
-      $window.gapi = {};
+  describe("gapi loader (old)", function() {
+    beforeEach(module(function ($provide) {
+      //stub services
+      $provide.service("$q", function() {return Q;});
+      $provide.value("CORE_URL", "coreUrl");
+      $provide.value("STORE_ENDPOINT_URL", "storeUrl");
+      $provide.value("STORAGE_ENDPOINT_URL", "storageUrl");
       
-      $window.gapi.load = function(path, cb) {
-        if (path === "client") {
-          $window.gapi[path] = gapiClient;
-        } else {
-          $window.gapi[path] = {};
+      $provide.value("$location", {
+        search: sinon.stub().returns({}),
+        protocol: function () {
+          return "protocol";
         }
-        cb();
-      };
-      
-      $window.handleClientJSLoad();
-    });
-  });
+      });
+      $provide.service("getBaseDomain", function() {
+        return function() {
+          return "domain";
+        };
+      });
 
-  describe("gapiLoader", function () {
-    it("should load gapi", function(done) {
-      inject(function (gapiLoader) {
-        expect(gapiLoader).to.be.ok;
-        gapiLoader().then(function () {
+    }));
+    
+    var $window, $location, loadApi;
+    
+    beforeEach(function () {
+      loadApi = true;
+
+      inject(function($injector) {
+        $window = $injector.get("$window");
+        $location = $injector.get("$location");
+
+        var gapiClient = {
+          load: sinon.spy(function(path, version, cb, url) {
+            if (loadApi) {
+              $window.gapi.client[path] = {version: version};
+              return Q.resolve();
+            } else {
+              return Q.reject({});
+            }
+          })
+        };
+
+        $window.gapi = {};
+        
+        $window.gapi.load = function(path, cb) {
+          if (path === "client") {
+            $window.gapi[path] = gapiClient;
+          } else {
+            $window.gapi[path] = {};
+          }
+          cb();
+        };
+
+        $window.handleClientJSLoad();
+      });
+    });
+
+    describe("gapiLoader", function () {
+      it("should load gapi", function(done) {
+        inject(function (gapiLoader) {
+          expect(gapiLoader).to.be.ok;
+          gapiLoader().then(function () {
+            done();
+          });
+        });
+      });
+    });
+    
+    describe("clientAPILoader", function () {
+      it("should load", function(done) {
+        inject(function (clientAPILoader) {
+          expect(clientAPILoader).to.be.ok;
+          clientAPILoader().then(function () {
+            expect($window.gapi.client).to.be.ok;
+            done();
+          }, done);
+        });
+      });
+    });
+
+    describe("gapiClientLoaderGenerator", function () {
+      var gapiClientLoaderGenerator;
+      beforeEach(function() {
+        inject(function($injector) {
+          gapiClientLoaderGenerator = $injector.get("gapiClientLoaderGenerator");
+        });
+      });
+
+      it("should exist", function() {
+        expect(gapiClientLoaderGenerator).to.be.ok;      
+        expect(gapiClientLoaderGenerator).to.be.a('function');
+      });
+
+      it("should load a gapi client lib", function (done) {
+        var loaderFn = gapiClientLoaderGenerator("custom", "v0", "someUrls");
+        loaderFn().then(function () {
+          expect($window.gapi).to.be.ok;
+          expect($window.gapi.client.custom).to.be.ok;
+          done();
+        }, done);
+      });
+
+      it("should handle failure to load a gapi client lib", function (done) {
+        loadApi = false;
+        var loaderFn = gapiClientLoaderGenerator("custom", "v0", "someUrls");
+        loaderFn().then(done)
+        .catch(function() {
+          expect($window.gapi).to.be.ok;
+          expect($window.gapi.client.custom).to.not.be.ok;
           done();
         });
       });
     });
-  });
-  
-  describe("clientAPILoader", function () {
-    it("should load", function(done) {
-      inject(function (clientAPILoader) {
-        expect(clientAPILoader).to.be.ok;
-        clientAPILoader().then(function () {
-          expect($window.gapi.client).to.be.ok;
+
+    describe("DedupingGenerator", function () {
+      var DedupingGenerator;
+
+      beforeEach(function() {
+        inject(function($injector) {
+          DedupingGenerator = $injector.get("DedupingGenerator");
+        });
+      });
+
+      it("should exist", function() {
+        expect(DedupingGenerator).to.be.ok;      
+        expect(DedupingGenerator).to.be.a('function');
+        expect(new DedupingGenerator()).to.be.a('function');
+      });
+
+      it("should return load the gapi version", function (done) {
+        var loaderFn = new DedupingGenerator("custom", "v0", "someUrls");
+
+        loaderFn().then(function () {
+          $window.gapi.client.load.should.have.been.calledWith("custom", "v0", null, "someUrls");
+
           done();
         }, done);
+      });
+
+      it("should call load once", function (done) {
+        var loaderFn = new DedupingGenerator("custom", "v0", "someUrls");
+
+        loaderFn();
+        loaderFn();
+        
+        setTimeout(function() {
+          expect($window.gapi).to.be.ok;
+          expect($window.gapi.client.custom).to.be.ok;
+
+          $window.gapi.client.load.should.have.been.calledOnce;
+
+          done();
+        }, 10);
+      });
+
+      it("should clear response and call load again", function (done) {
+        var loaderFn = new DedupingGenerator("custom", "v0", "someUrls");
+
+        loaderFn().then(function () {
+          $window.gapi.client.load.should.have.been.calledOnce;
+
+          loaderFn().then(function () {
+            $window.gapi.client.load.should.have.been.calledTwice;
+            done();
+          }, done);
+
+          done();
+        }, done);
+      });
+
+      it("should load separate apis", function(done) {
+        inject(function (coreAPILoader, storeAPILoader) {
+          coreAPILoader();
+          storeAPILoader();
+          
+          setTimeout(function () {
+            expect($window.gapi.client.core).to.be.ok;
+            expect($window.gapi.client.store).to.be.ok;
+
+            $window.gapi.client.load.should.have.been.calledWith("core", "v1", null, "coreUrl");
+            $window.gapi.client.load.should.have.been.calledWith("store", "v0.01", null, "storeUrl");
+
+            done();
+          }, 10);
+        });
+      });
+    });
+
+    describe("storeAPILoader", function () {
+      it("should load", function(done) {
+        inject(function (storeAPILoader) {
+          expect(storeAPILoader).to.be.ok;
+          storeAPILoader().then(function () {
+            expect($window.gapi.client.store).to.be.ok;
+
+            $window.gapi.client.load.should.have.been.calledWith("store", "v0.01", null, "storeUrl");
+
+            done();
+          }, done);
+        });
+      });
+
+      it("should use custom url", function(done) {
+        $location.search.returns({
+          store_api_base_url: 'customUrl'
+        });
+
+        inject(function (storeAPILoader) {
+          storeAPILoader().then(function () {
+            expect($window.gapi.client.store).to.be.ok;
+
+            $window.gapi.client.load.should.have.been.calledWith("store", "v0.01", null, "customUrl/_ah/api");
+
+            done();
+          }, 10);
+        });
+      });
+
+      it("should use deduping and call load only once", function (done) {
+        inject(function (storeAPILoader) {
+          storeAPILoader();
+          storeAPILoader();
+          
+          setTimeout(function() {
+            $window.gapi.client.load.should.have.been.calledOnce;
+
+            done();
+          }, 10);
+        });
       });
     });
   });
 
-  describe("gapiClientLoaderGenerator", function () {
-    var gapiClientLoaderGenerator;
+  // NEW
+  describe("gapiLoader:", function() {
+    beforeEach(module(function ($provide) {
+      $provide.service("$q", function() {return Q;});
+    }));
+    
+    var $window, gapiLoader, element;
+    
+    beforeEach(function () {
+      inject(function($injector) {
+        $window = $injector.get("$window");
+        gapiLoader = $injector.get("gapiLoader");
+
+        element = $window.document.createElement('script');
+
+        sinon.stub(element, "setAttribute");
+        sinon.stub($window.document, "createElement").returns(element);
+
+        delete $window.gapiLoadingStatus;
+      });
+    });
+
+    afterEach(function() {
+      $window.document.createElement.restore();
+    });
+
+    it("should initialize handler", function() {
+      expect($window.handleClientJSLoad).to.be.a("function");
+    });
+
+    it("should dispatch event", function(done) {
+      $window.addEventListener('gapi.loaded', function() {
+        done();
+      });
+
+      $window.handleClientJSLoad();
+
+      expect($window.gapiLoadingStatus).to.equal("loaded");
+    });
+
+    it("should set loading status", function() {
+      gapiLoader();
+
+      expect($window.gapiLoadingStatus).to.equal("loading");
+    });
+
+    it("should initialize and add script element", function() {
+      gapiLoader();
+
+      element.setAttribute.should.have.been.calledTwice;
+      element.setAttribute.should.have.been.calledWith('type', 'text/javascript');
+      element.setAttribute.should.have.been.calledWith('src', '//apis.google.com/js/client.js?onload=handleClientJSLoad');
+
+      expect(element.onerror).to.be.a("function");
+    });
+
+    it("should load gapi", function(done) {
+      $window.gapi = {};
+
+      $window.handleClientJSLoad();
+
+      gapiLoader().then(function (gApi) {
+        expect(gApi).to.equal($window.gapi);
+
+        done();
+      });
+    });
+
+    it("should handle element load failure", function(done) {
+      gapiLoader()
+        .then(done)
+        .catch(function (error) {
+          expect(error).to.equal("loadError");
+
+          done();
+        });
+
+      element.onerror("loadError");
+    });
+
+  });
+
+  describe("clientAPILoader:", function() {
+    beforeEach(module(function ($provide) {
+      gApi = {
+        load: sinon.stub().callsFake(function(client, cb) {
+          gApi.client = "API";
+
+          cb();
+        })
+      };
+
+      $provide.service("$q", function() {return Q;});
+      $provide.service("gapiLoader", function() {
+        return sinon.stub().returns(Q.resolve(gApi));
+      });
+    }));
+
+    var clientAPILoader, gapiLoader, gApi;
+
+    beforeEach(function() {
+      inject(function($injector) {
+        clientAPILoader = $injector.get("clientAPILoader");
+        gapiLoader = $injector.get("gapiLoader");
+      });
+    });
+
+    it("should exist", function() {
+      expect(clientAPILoader).to.be.ok;      
+      expect(clientAPILoader).to.be.a('function');
+    });
+
+    it("should load a gapi client", function (done) {
+      clientAPILoader()
+        .then(function (clientAPI) {
+          gApi.load.should.have.been.called;
+          gApi.load.should.have.been.calledWith("client", sinon.match.func);
+
+          expect(clientAPI).to.equal(gApi);
+
+          done();
+        }, done);
+    });
+
+    it("should return gapi client if existing", function (done) {
+      gApi.client = "existingAPI";
+
+      clientAPILoader()
+        .then(function (clientAPI) {
+          gApi.load.should.not.have.been.called;
+
+          expect(clientAPI).to.equal(gApi);
+
+          done();
+        }, done);
+    });
+
+    it("should handle failure to load a gapi client", function (done) {
+      gApi.load.callsFake(function(client, cb) {
+        cb();
+      });
+
+      clientAPILoader()
+        .then(done)
+        .catch(function(err) {
+          gApi.load.should.have.been.called;
+
+          expect(gApi.client).to.not.be.ok;
+
+          expect(err).to.be.ok;
+          expect(err).to.equal('client API Load Failed');
+
+          done();
+        });
+    });
+
+    it("should return gapi client error", function (done) {
+      gApi.load.callsFake(function(client, cb) {
+        cb("error");
+      });
+
+      clientAPILoader()
+        .then(done)
+        .catch(function(err) {
+          expect(err).to.be.ok;
+          expect(err).to.equal("error");
+
+          done();
+        });
+    });
+
+    it("should handle gapiLoader failures", function (done) {
+      gapiLoader.returns(Q.reject("failure"));
+
+      clientAPILoader()
+        .then(done)
+        .catch(function(err) {
+          gApi.load.should.not.have.been.called;
+
+          expect(gApi.client).to.not.be.ok;
+
+          expect(err).to.be.ok;
+          expect(err).to.equal('failure');
+
+          done();
+        });
+    });
+
+  });
+
+  describe("gapiClientLoaderGenerator:", function() {
+    beforeEach(module(function ($provide) {
+      gApi = {
+        client: {
+          load: sinon.stub().callsFake(function() {
+            gApi.client.custom = "API";
+            return Q.resolve();
+          })
+        }
+      };
+
+      $provide.service("$q", function() {return Q;});
+      $provide.service("clientAPILoader", function() {
+        return sinon.stub().returns(Q.resolve(gApi));
+      });
+    }));
+
+    var gapiClientLoaderGenerator, clientAPILoader, gApi;
+
     beforeEach(function() {
       inject(function($injector) {
         gapiClientLoaderGenerator = $injector.get("gapiClientLoaderGenerator");
+        clientAPILoader = $injector.get("clientAPILoader");
       });
     });
 
@@ -98,31 +460,99 @@ describe("Services: gapi loader", function() {
 
     it("should load a gapi client lib", function (done) {
       var loaderFn = gapiClientLoaderGenerator("custom", "v0", "someUrls");
-      loaderFn().then(function () {
-        expect($window.gapi).to.be.ok;
-        expect($window.gapi.client.custom).to.be.ok;
+
+      loaderFn().then(function (clientAPI) {
+        gApi.client.load.should.have.been.called;
+        gApi.client.load.should.have.been.calledWith("custom", "v0", null, "someUrls");
+
+        expect(clientAPI).to.equal("API");
+
+        done();
+      }, done);
+    });
+
+    it("should return lib if existing", function (done) {
+      gApi.client.custom = "existingAPI";
+      var loaderFn = gapiClientLoaderGenerator("custom", "v0", "someUrls");
+
+      loaderFn().then(function (clientAPI) {
+        gApi.client.load.should.not.have.been.called;
+
+        expect(clientAPI).to.equal("existingAPI");
+
         done();
       }, done);
     });
 
     it("should handle failure to load a gapi client lib", function (done) {
-      loadApi = false;
+      gApi.client.load.returns(Q.resolve());
+
       var loaderFn = gapiClientLoaderGenerator("custom", "v0", "someUrls");
       loaderFn().then(done)
-      .catch(function() {
-        expect($window.gapi).to.be.ok;
-        expect($window.gapi.client.custom).to.not.be.ok;
+      .catch(function(err) {
+        gApi.client.load.should.have.been.called;
+
+        expect(gApi.client.custom).to.not.be.ok;
+
+        expect(err).to.be.ok;
+        expect(err).to.equal('custom.v0 Load Failed');
+
         done();
       });
     });
+
+    it("should handle gapi client load failure", function (done) {
+      gApi.client.load.returns(Q.reject("error"));
+
+      var loaderFn = gapiClientLoaderGenerator("custom", "v0", "someUrls");
+      loaderFn().then(done)
+      .catch(function(err) {
+        gApi.client.load.should.have.been.called;
+
+        expect(gApi.client.custom).to.not.be.ok;
+
+        expect(err).to.be.ok;
+        expect(err).to.equal('error');
+
+        done();
+      });
+    });
+
+    it("should handle clientAPILoader failures", function (done) {
+      clientAPILoader.returns(Q.reject("failure"));
+
+      var loaderFn = gapiClientLoaderGenerator("custom", "v0", "someUrls");
+      loaderFn().then(done)
+      .catch(function(err) {
+        gApi.client.load.should.not.have.been.called;
+
+        expect(gApi.client.custom).to.not.be.ok;
+
+        expect(err).to.be.ok;
+        expect(err).to.equal('failure');
+
+        done();
+      });
+    });
+
   });
 
-  describe("DedupingGenerator", function () {
-    var DedupingGenerator;
+  describe("DedupingGenerator:", function () {
+    beforeEach(module(function ($provide) {
+      $provide.value("CORE_URL", "coreUrl");
+      $provide.value("STORE_ENDPOINT_URL", "storeUrl");
+
+      $provide.service("gapiClientLoaderGenerator", function() {
+        return sinon.stub().returns(generatorFn = sinon.stub().returns(Q.resolve()));
+      });
+    }));
+
+    var DedupingGenerator, gapiClientLoaderGenerator, generatorFn;
 
     beforeEach(function() {
       inject(function($injector) {
         DedupingGenerator = $injector.get("DedupingGenerator");
+        gapiClientLoaderGenerator = $injector.get("gapiClientLoaderGenerator");
       });
     });
 
@@ -132,11 +562,14 @@ describe("Services: gapi loader", function() {
       expect(new DedupingGenerator()).to.be.a('function');
     });
 
-    it("should return load the gapi version", function (done) {
+    it("should load the gapi version", function (done) {
       var loaderFn = new DedupingGenerator("custom", "v0", "someUrls");
 
       loaderFn().then(function () {
-        $window.gapi.client.load.should.have.been.calledWith("custom", "v0", null, "someUrls");
+        gapiClientLoaderGenerator.should.have.been.called;
+        gapiClientLoaderGenerator.should.have.been.calledWith("custom", "v0", "someUrls");
+
+        generatorFn.should.have.been.called;
 
         done();
       }, done);
@@ -149,10 +582,8 @@ describe("Services: gapi loader", function() {
       loaderFn();
       
       setTimeout(function() {
-        expect($window.gapi).to.be.ok;
-        expect($window.gapi.client.custom).to.be.ok;
-
-        $window.gapi.client.load.should.have.been.calledOnce;
+        gapiClientLoaderGenerator.should.have.been.calledOnce;
+        generatorFn.should.have.been.calledOnce;
 
         done();
       }, 10);
@@ -162,10 +593,13 @@ describe("Services: gapi loader", function() {
       var loaderFn = new DedupingGenerator("custom", "v0", "someUrls");
 
       loaderFn().then(function () {
-        $window.gapi.client.load.should.have.been.calledOnce;
+        gapiClientLoaderGenerator.should.have.been.calledOnce;
+        generatorFn.should.have.been.calledOnce;
 
         loaderFn().then(function () {
-          $window.gapi.client.load.should.have.been.calledTwice;
+          gapiClientLoaderGenerator.should.have.been.calledTwice;
+          generatorFn.should.have.been.calledTwice;
+
           done();
         }, done);
 
@@ -179,56 +613,11 @@ describe("Services: gapi loader", function() {
         storeAPILoader();
         
         setTimeout(function () {
-          expect($window.gapi.client.core).to.be.ok;
-          expect($window.gapi.client.store).to.be.ok;
+          gapiClientLoaderGenerator.should.have.been.calledTwice;
+          generatorFn.should.have.been.calledTwice;
 
-          $window.gapi.client.load.should.have.been.calledWith("core", "v1", null, "coreUrl");
-          $window.gapi.client.load.should.have.been.calledWith("store", "v0.01", null, "storeUrl");
-
-          done();
-        }, 10);
-      });
-    });
-  });
-
-  describe("coreAPILoader", function () {
-    it("should load", function(done) {
-      inject(function (coreAPILoader) {
-        expect(coreAPILoader).to.be.ok;
-        coreAPILoader().then(function () {
-          expect($window.gapi.client.core).to.be.ok;
-
-          $window.gapi.client.load.should.have.been.calledWith("core", "v1", null, "coreUrl");
-
-          done();
-        }, done);
-      });
-    });
-
-    it("should use custom url", function(done) {
-      $location.search.returns({
-        core_api_base_url: 'customUrl'
-      });
-
-      inject(function (coreAPILoader) {
-        coreAPILoader();
-        setTimeout(function () {
-          expect($window.gapi.client.core).to.be.ok;
-
-          $window.gapi.client.load.should.have.been.calledWith("core", "v1", null, "customUrl/_ah/api");
-
-          done();
-        }, 10);
-      });
-    });
-
-    it("should use deduping and call load only once", function (done) {
-      inject(function (coreAPILoader) {
-        coreAPILoader();
-        coreAPILoader();
-        
-        setTimeout(function() {
-          $window.gapi.client.load.should.have.been.calledOnce;
+          gapiClientLoaderGenerator.should.have.been.calledWith("core", "v1", "coreUrl");
+          gapiClientLoaderGenerator.should.have.been.calledWith("store", "v0.01", "storeUrl");
 
           done();
         }, 10);
@@ -236,137 +625,117 @@ describe("Services: gapi loader", function() {
     });
   });
 
-  describe("riseAPILoader", function () {
-    it("should load", function(done) {
-      inject(function (riseAPILoader) {
-        expect(riseAPILoader).to.be.ok;
-        riseAPILoader().then(function () {
-          expect($window.gapi.client.rise).to.be.ok;
+  describe("client API loaders:", function() {
+    beforeEach(module(function ($provide) {
+      //stub services
+      $provide.value("CORE_URL", "coreUrl");
+      $provide.value("STORE_ENDPOINT_URL", "storeUrl");
+      $provide.value("STORAGE_ENDPOINT_URL", "storageUrl");
+      
+      $provide.value("$location", {
+        search: sinon.stub().returns({})
+      });
+      $provide.service("DedupingGenerator", function() {
+        return sinon.stub().returns({
+          api: "API"
+        });
+      });
 
-          $window.gapi.client.load.should.have.been.calledWith("rise", "v0", null, "coreUrl");
-
-          done();
-        }, done);
+    }));
+    
+    var $location, DedupingGenerator;
+    
+    beforeEach(function () {
+      inject(function($injector) {
+        $location = $injector.get("$location");
+        DedupingGenerator = $injector.get("DedupingGenerator");
       });
     });
 
-    it("should use custom url", function(done) {
-      $location.search.returns({
-        core_api_base_url: 'customUrl'
+    describe("coreAPILoader", function () {
+      it("should load", function() {
+        inject(function (coreAPILoader) {
+          expect(coreAPILoader).to.be.ok;
+          expect(coreAPILoader.api).to.equal("API");
+
+          DedupingGenerator.should.have.been.calledWith("core", "v1", "coreUrl");
+        });
       });
 
-      inject(function (riseAPILoader) {
-        riseAPILoader();
-        setTimeout(function () {
-          expect($window.gapi.client.rise).to.be.ok;
+      it("should use custom url", function() {
+        $location.search.returns({
+          core_api_base_url: 'customUrl'
+        });
 
-          $window.gapi.client.load.should.have.been.calledWith("rise", "v0", null, "customUrl/_ah/api");
-
-          done();
-        }, 10);
-      });
-    });
-
-    it("should use deduping and call load only once", function (done) {
-      inject(function (riseAPILoader) {
-        riseAPILoader();
-        riseAPILoader();
-        
-        setTimeout(function() {
-          $window.gapi.client.load.should.have.been.calledOnce;
-
-          done();
-        }, 10);
-      });
-    });
-  });
-
-  describe("storeAPILoader", function () {
-    it("should load", function(done) {
-      inject(function (storeAPILoader) {
-        expect(storeAPILoader).to.be.ok;
-        storeAPILoader().then(function () {
-          expect($window.gapi.client.store).to.be.ok;
-
-          $window.gapi.client.load.should.have.been.calledWith("store", "v0.01", null, "storeUrl");
-
-          done();
-        }, done);
+        inject(function (coreAPILoader) {
+          DedupingGenerator.should.have.been.calledWith("core", "v1", "customUrl/_ah/api");
+        });
       });
     });
 
-    it("should use custom url", function(done) {
-      $location.search.returns({
-        store_api_base_url: 'customUrl'
+    describe("riseAPILoader", function () {
+      it("should load", function() {
+        inject(function (riseAPILoader) {
+          expect(riseAPILoader).to.be.ok;
+          expect(riseAPILoader.api).to.equal("API");
+
+          DedupingGenerator.should.have.been.calledWith("rise", "v0", "coreUrl");
+        });
       });
 
-      inject(function (storeAPILoader) {
-        storeAPILoader().then(function () {
-          expect($window.gapi.client.store).to.be.ok;
+      it("should use custom url", function() {
+        $location.search.returns({
+          core_api_base_url: 'customUrl'
+        });
 
-          $window.gapi.client.load.should.have.been.calledWith("store", "v0.01", null, "customUrl/_ah/api");
-
-          done();
-        }, 10);
-      });
-    });
-
-    it("should use deduping and call load only once", function (done) {
-      inject(function (storeAPILoader) {
-        storeAPILoader();
-        storeAPILoader();
-        
-        setTimeout(function() {
-          $window.gapi.client.load.should.have.been.calledOnce;
-
-          done();
-        }, 10);
-      });
-    });
-  });
-
-  describe("storageAPILoader", function () {
-    it("should load", function(done) {
-      inject(function (storageAPILoader) {
-        expect(done).to.be.ok;
-        storageAPILoader().then(function () {
-          expect($window.gapi.client.storage).to.be.ok;
-
-          $window.gapi.client.load.should.have.been.calledWith("storage", "v0.02", null, "storageUrl");
-
-          done();
-        }, done);
+        inject(function (riseAPILoader) {
+          DedupingGenerator.should.have.been.calledWith("rise", "v0", "customUrl/_ah/api");
+        });
       });
     });
 
-    it("should use custom url", function(done) {
-      $location.search.returns({
-        storage_api_base_url: 'customUrl'
+    describe("storeAPILoader", function () {
+      it("should load", function() {
+        inject(function (storeAPILoader) {
+          expect(storeAPILoader).to.be.ok;
+          expect(storeAPILoader.api).to.equal("API");
+
+          DedupingGenerator.should.have.been.calledWith("store", "v0.01", "storeUrl");
+        });
       });
 
-      inject(function (storageAPILoader) {
-        storageAPILoader().then(function () {
-          expect($window.gapi.client.storage).to.be.ok;
+      it("should use custom url", function() {
+        $location.search.returns({
+          store_api_base_url: 'customUrl'
+        });
 
-          $window.gapi.client.load.should.have.been.calledWith("storage", "v0.02", null, "customUrl/_ah/api");
+        inject(function (storeAPILoader) {
+          DedupingGenerator.should.have.been.calledWith("store", "v0.01", "customUrl/_ah/api");
+        });
+      });
+    });
+    
+    describe("storageAPILoader", function () {
+      it("should load", function() {
+        inject(function (storageAPILoader) {
+          expect(storageAPILoader).to.be.ok;
+          expect(storageAPILoader.api).to.equal("API");
 
-          done();
-        }, 10);
+          DedupingGenerator.should.have.been.calledWith("storage", "v0.02", "storageUrl");
+        });
+      });
+
+      it("should use custom url", function() {
+        $location.search.returns({
+          storage_api_base_url: 'customUrl'
+        });
+
+        inject(function (storageAPILoader) {
+          DedupingGenerator.should.have.been.calledWith("storage", "v0.02", "customUrl/_ah/api");
+        });
       });
     });
 
-    it("should use deduping and call load only once", function (done) {
-      inject(function (storageAPILoader) {
-        storageAPILoader();
-        storageAPILoader();
-        
-        setTimeout(function() {
-          $window.gapi.client.load.should.have.been.calledOnce;
-
-          done();
-        }, 10);
-      });
-    });
   });
 
 });

--- a/test/unit/components/userstate/app.spec.js
+++ b/test/unit/components/userstate/app.spec.js
@@ -87,11 +87,11 @@ describe("app:", function() {
           openidConnect = { signinRedirectCallback: sinon.stub().returns(Q.resolve()) };
 
           var args = urlRouterProvider.when.getCall(0).args[1];
-          rootMatcher = args[3];
+          rootMatcher = args[4];
         });
 
         it("should signin redirect callback", function(done) {
-          rootMatcher($window, userAuthFactory, openidConnect);
+          rootMatcher($window, $state, userAuthFactory, openidConnect);
 
           setTimeout(function() {
             openidConnect.signinRedirectCallback.should.have.been.calledWith('https://apps.risevision.com/#id_token=1234&client_id=A1223');
@@ -104,7 +104,7 @@ describe("app:", function() {
 
         it("should clear hash even if there's an issue with signing redirect", function(done) {
           openidConnect.signinRedirectCallback.returns(Q.reject());
-          rootMatcher($window, userAuthFactory, openidConnect); // force a null pointer error
+          rootMatcher($window, $state, userAuthFactory, openidConnect); // force a null pointer error
 
           setTimeout(function() {
             openidConnect.signinRedirectCallback.should.have.been.calledOnce;
@@ -121,9 +121,9 @@ describe("app:", function() {
       var args = urlRouterProvider.when.getCall(1).args[1];
 
       expect(args).to.be.ok;
-      expect(args.length).to.equal(4);
+      expect(args.length).to.equal(5);
 
-      var matcher = args[3];
+      var matcher = args[4];
       expect(matcher).to.be.ok;
       expect(matcher).to.be.a("function");
     });
@@ -139,11 +139,11 @@ describe("app:", function() {
         openidConnect = { signinRedirectCallback: sinon.stub().resolves() };
 
         var args = urlRouterProvider.when.getCall(1).args[1];
-        rootMatcher = args[3];
+        rootMatcher = args[4];
       });
 
       it("should return false if there's no hash and no search code", function() {
-        var response = rootMatcher(location, userAuthFactory, openidConnect)
+        var response = rootMatcher(location, $state, userAuthFactory, openidConnect)
 
         expect(response).to.be.false;
       });
@@ -151,7 +151,7 @@ describe("app:", function() {
       it("should return false if there's hash but with no tokens", function() {
         location.hash = function() { return 'some_hash' };
 
-        var response = rootMatcher(location, userAuthFactory, openidConnect)
+        var response = rootMatcher(location, $state, userAuthFactory, openidConnect)
 
         expect(response).to.be.false;
       });
@@ -160,7 +160,7 @@ describe("app:", function() {
         window.location.hash = '&id_token=1234';
         location.hash = function() { return '&id_token=1234' };
 
-        rootMatcher(location, userAuthFactory, openidConnect);
+        rootMatcher(location, $state, userAuthFactory, openidConnect);
 
         setTimeout(function() {
           openidConnect.signinRedirectCallback.should.have.been.calledOnce;
@@ -175,7 +175,7 @@ describe("app:", function() {
         window.location.hash = '&access_token=1234';
         location.hash = function() { return '&access_token=1234' };
 
-        rootMatcher(location, userAuthFactory, openidConnect);
+        rootMatcher(location, $state, userAuthFactory, openidConnect);
 
         setTimeout(function() {
           openidConnect.signinRedirectCallback.should.have.been.calledOnce;
@@ -189,7 +189,7 @@ describe("app:", function() {
       it("should clear hash even if there's an issue with signing redirect", function(done) {
         location.hash = function() { return '&access_token=1234' };
 
-        rootMatcher(location, null, openidConnect); // force a null pointer error
+        rootMatcher(location, $state, null, openidConnect); // force a null pointer error
 
         setTimeout(function() {
           openidConnect.signinRedirectCallback.should.have.been.calledOnce;


### PR DESCRIPTION
## Description
Handle gapi client request failures

Refactor gapi services and update test coverage
Use non deprecated event creation
Use returns for promise chaining

Update unit tests; left existing tests for validation

[stage-17]

## Motivation and Context
Partial fix for #2474 

## How Has This Been Tested?
Tested locally. Updated unit test coverage.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No