### PR TITLE
Catch and redirect on oidc errors as well

### DIFF
--- a/src/scripts/components/userstate/app.js
+++ b/src/scripts/components/userstate/app.js
@@ -39,8 +39,8 @@
         $locationProvider.hashPrefix('/');
 
         $urlRouterProvider
-          .when(/\/.*(id_token|access_token)=.*/, ['$window', '$state', 'userAuthFactory', 'openidConnect',
-            function ($window, $state, userAuthFactory, openidConnect) {
+          .when(/\/.*(id_token|access_token)=.*/, ['$window', 'userAuthFactory', 'openidConnect',
+            function ($window, userAuthFactory, openidConnect) {
               console.log('Google Auth result received');
 
               var location = $window.location.href;
@@ -50,12 +50,7 @@
                 .then(function (user) {
                   $window.location.hash = '';
 
-                  return userAuthFactory.authenticate(true)
-                    .catch(function(e) {
-                      return $state.go('common.auth.unauthorized', {
-                        authError: e
-                      });
-                    });
+                  return userAuthFactory.authenticate(true);
                 })
                 .catch(function () {
                   $window.location.hash = '';
@@ -71,15 +66,15 @@
 
                 openidConnect.signinRedirectCallback()
                   .then(function (user) {
-                    return userAuthFactory.authenticate(true)
-                      .catch(function(e) {
-                        return $state.go('common.auth.unauthorized', {
-                          authError: e
-                        });
-                      });
+                    return userAuthFactory.authenticate(true);
                   })
-                  .finally(function () {
+                  .then(function () {
                     window.location.hash = '';
+                  })
+                  .catch(function(e) {
+                    return $state.go('common.auth.unauthorized', {
+                      authError: e
+                    });
                   });
               } else {
                 return false;

--- a/test/unit/components/gapi-loader/svc-gapi.spec.js
+++ b/test/unit/components/gapi-loader/svc-gapi.spec.js
@@ -217,16 +217,70 @@ describe("Services: gapi", function() {
   });
 
   // NEW
+  describe("rejectOnTimeout:", function() {
+    var $timeout, $log, rejectOnTimeout;
+    
+    beforeEach(function () {
+      inject(function($injector) {
+        $timeout = $injector.get("$timeout");
+        $log = $injector.get("$log");
+        rejectOnTimeout = $injector.get("rejectOnTimeout");
+
+        sinon.stub($log, 'error');
+      });
+    });
+
+    it("should reject if the timeout expires", function(done) {
+      var deferred = Q.defer();
+
+      deferred.promise
+        .then(done)
+        .catch(function(error) {
+          expect(error).to.equal('api Load Timeout');
+
+          $log.error.should.have.been.calledWith('api Load Timeout');
+
+          done();
+        });
+
+      rejectOnTimeout(deferred, 'api');
+
+      $timeout.flush();
+    });
+
+    it("should not reject if the promise is resolved", function(done) {
+      var deferred = Q.defer();
+
+      deferred.promise
+        .catch(done)
+        .finally(function() {
+          $timeout.verifyNoPendingTasks();
+
+          $log.error.should.not.have.been.called;
+
+          done();            
+        });
+
+      rejectOnTimeout(deferred, 'api');
+
+      deferred.resolve();
+    });
+
+  });  
+
   describe("gapiLoader:", function() {
     beforeEach(module(function ($provide) {
       $provide.service("$q", function() {return Q;});
+
+      $provide.value("rejectOnTimeout", sinon.stub());
     }));
     
-    var $window, gapiLoader, element;
+    var $window, rejectOnTimeout, gapiLoader, element;
     
     beforeEach(function () {
       inject(function($injector) {
         $window = $injector.get("$window");
+        rejectOnTimeout = $injector.get("rejectOnTimeout");
         gapiLoader = $injector.get("gapiLoader");
 
         element = $window.document.createElement('script');
@@ -260,6 +314,23 @@ describe("Services: gapi", function() {
       gapiLoader();
 
       expect($window.gapiLoadingStatus).to.equal("loading");
+
+      rejectOnTimeout.should.have.been.calledWith(sinon.match.object, "gapi");
+    });
+
+    it("should return window.gapi object if already exists", function(done) {
+      $window.gapiLoadingStatus = "loaded";
+      $window.gapi = {};
+
+      gapiLoader().then(function (gApi) {
+        expect(gApi).to.equal($window.gapi);
+
+        element.setAttribute.should.not.have.been.called;
+
+        rejectOnTimeout.should.not.have.been.called;
+
+        done();
+      });
     });
 
     it("should initialize and add script element", function() {
@@ -313,14 +384,16 @@ describe("Services: gapi", function() {
       $provide.service("gapiLoader", function() {
         return sinon.stub().returns(Q.resolve(gApi));
       });
+      $provide.value("rejectOnTimeout", sinon.stub());
     }));
 
-    var gapiClientLoaderGenerator, gapiLoader, gApi;
+    var gapiClientLoaderGenerator, gapiLoader, rejectOnTimeout, gApi;
 
     beforeEach(function() {
       inject(function($injector) {
         gapiClientLoaderGenerator = $injector.get("gapiClientLoaderGenerator");
         gapiLoader = $injector.get("gapiLoader");
+        rejectOnTimeout = $injector.get("rejectOnTimeout");
       });
     });
 
@@ -336,6 +409,8 @@ describe("Services: gapi", function() {
         gApi.client.load.should.have.been.called;
         gApi.client.load.should.have.been.calledWith("custom", "v0", null, "someUrls");
 
+        rejectOnTimeout.should.have.been.calledWith(sinon.match.object, "custom.v0");
+
         expect(clientAPI).to.equal("API");
 
         done();
@@ -348,6 +423,8 @@ describe("Services: gapi", function() {
 
       loaderFn().then(function (clientAPI) {
         gApi.client.load.should.not.have.been.called;
+
+        rejectOnTimeout.should.not.have.been.called;
 
         expect(clientAPI).to.equal("existingAPI");
 

--- a/test/unit/components/userstate/app.spec.js
+++ b/test/unit/components/userstate/app.spec.js
@@ -87,11 +87,11 @@ describe("app:", function() {
           openidConnect = { signinRedirectCallback: sinon.stub().returns(Q.resolve()) };
 
           var args = urlRouterProvider.when.getCall(0).args[1];
-          rootMatcher = args[4];
+          rootMatcher = args[3];
         });
 
         it("should signin redirect callback", function(done) {
-          rootMatcher($window, $state, userAuthFactory, openidConnect);
+          rootMatcher($window, userAuthFactory, openidConnect);
 
           setTimeout(function() {
             openidConnect.signinRedirectCallback.should.have.been.calledWith('https://apps.risevision.com/#id_token=1234&client_id=A1223');
@@ -104,7 +104,7 @@ describe("app:", function() {
 
         it("should clear hash even if there's an issue with signing redirect", function(done) {
           openidConnect.signinRedirectCallback.returns(Q.reject());
-          rootMatcher($window, $state, userAuthFactory, openidConnect); // force a null pointer error
+          rootMatcher($window, userAuthFactory, openidConnect); // force a null pointer error
 
           setTimeout(function() {
             openidConnect.signinRedirectCallback.should.have.been.calledOnce;
@@ -135,11 +135,13 @@ describe("app:", function() {
         location = {
           hash: function() { return null }
         };
-        userAuthFactory = { authenticate: sinon.stub() };
+        userAuthFactory = { authenticate: sinon.stub().resolves() };
         openidConnect = { signinRedirectCallback: sinon.stub().resolves() };
 
         var args = urlRouterProvider.when.getCall(1).args[1];
         rootMatcher = args[4];
+
+        sinon.stub($state, "go");
       });
 
       it("should return false if there's no hash and no search code", function() {
@@ -186,18 +188,36 @@ describe("app:", function() {
         }, 10);
       });
 
-      it("should clear hash even if there's an issue with signing redirect", function(done) {
+      it("should redirect to unauthorized page on signing redirect callback failure", function(done) {
         location.hash = function() { return '&access_token=1234' };
+        openidConnect.signinRedirectCallback.returns(Q.reject('error'));
 
-        rootMatcher(location, $state, null, openidConnect); // force a null pointer error
+        rootMatcher(location, $state, userAuthFactory, openidConnect);
 
         setTimeout(function() {
-          openidConnect.signinRedirectCallback.should.have.been.calledOnce;
-          expect(window.location.hash).to.equal('');
+          $state.go.should.have.been.calledWith('common.auth.unauthorized', {
+            authError: 'error'
+          });
 
           done();
         }, 10);
       });
+
+      it("should redirect to unauthorized page on authenticate failure", function(done) {
+        location.hash = function() { return '&access_token=1234' };
+        userAuthFactory.authenticate.returns(Q.reject('authError'));
+
+        rootMatcher(location, $state, userAuthFactory, openidConnect);
+
+        setTimeout(function() {
+          $state.go.should.have.been.calledWith('common.auth.unauthorized', {
+            authError: 'authError'
+          });
+
+          done();
+        }, 10);
+      });
+
     });
   });
 


### PR DESCRIPTION
## Description
Catch and redirect on oidc errors as well

Only clear hash on successful authentication
Restore changes for non html5Mode authentication

[stage-2]

## Motivation and Context
Partial fix for #2474 

Clearing out the hash before redirecting causes a double redirect. The hash clear redirects to `/` which redirects to `editor`, calls `canAccessApps`, and then redirects to the `unauthorized` page. `$state.go` will clear the hash in this case.

## How Has This Been Tested?
Tested changes locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No