### PR TITLE
Toggle display license on Save

### DIFF
--- a/src/locales/en/displays-app.json
+++ b/src/locales/en/displays-app.json
@@ -85,8 +85,6 @@
   "details": {
     "deleteTitle": "Delete Display?",
     "deleteWarning": "Are you sure you want to delete this Display?",
-    "rpp-is": "Licensed Display is",
-    "rpp-loading": "LOADING",
     "unsavedTitle": "Unsaved Changes",
     "unsavedWarning": "You have unsaved changes. Do you want to Save or Discard them?"
   },

--- a/src/partials/displays/display-fields.html
+++ b/src/partials/displays/display-fields.html
@@ -88,16 +88,8 @@
         <div class="flex-row form-group mb-0">
           <div class="row-entry">
             <label class="control-label pull-left mb-0">License Display?</label>
-
-            <span class="mr-auto" ng-show="updatingRPP">
-              <span translate>displays-app.details.rpp-loading</span> <i class="fa fa-spinner fa-spin fa-fw"></i>
-            </span>
-
-            <yes-no-toggle ng-model="factory.display.playerProAuthorized" ng-change="toggleProAuthorized()" ng-disabled="updatingRPP || !playerLicenseFactory.isProToggleEnabled(factory.display)" ng-hide="updatingRPP"></yes-no-toggle> 
+            <yes-no-toggle ng-model="factory.display.playerProAuthorized" ng-change="toggleProAuthorized()" ng-disabled="!playerLicenseFactory.isProToggleEnabled(factory.display)"></yes-no-toggle> 
           </div>
-        </div>
-        <div class="text-danger mt-2" ng-show="errorUpdatingRPP">
-          {{errorUpdatingRPP}}
         </div>
       </div>
 

--- a/src/scripts/displays/directives/dtv-display-fields.js
+++ b/src/scripts/displays/directives/dtv-display-fields.js
@@ -19,8 +19,6 @@ angular.module('risevision.displays.directives')
           $scope.playerProFactory = playerProFactory;
           $scope.playerActionsFactory = playerActionsFactory;
 
-          $scope.updatingRPP = false;
-
           $scope.toggleProAuthorized = function () {
             if (!playerLicenseFactory.isProAvailable(displayFactory.display)) {
               displayFactory.display.playerProAuthorized = false;

--- a/src/scripts/displays/directives/dtv-display-fields.js
+++ b/src/scripts/displays/directives/dtv-display-fields.js
@@ -3,13 +3,10 @@
 angular.module('risevision.displays.directives')
   .directive('displayFields', ['$sce', 'userState', 'display', 'displayFactory', 'playerLicenseFactory',
     'playerProFactory', 'displayControlFactory', 'playerActionsFactory', 'scheduleFactory',
-    'enableCompanyProduct', 'plansFactory',
-    'processErrorCode', 'messageBox', 'confirmModal',
-    'SHARED_SCHEDULE_URL', 'PLAYER_PRO_PRODUCT_CODE',
+    'plansFactory', 'messageBox', 'confirmModal', 'SHARED_SCHEDULE_URL',
     function ($sce, userState, display, displayFactory, playerLicenseFactory, playerProFactory,
-      displayControlFactory, playerActionsFactory, scheduleFactory, enableCompanyProduct, plansFactory,
-      processErrorCode, messageBox, confirmModal,
-      SHARED_SCHEDULE_URL, PLAYER_PRO_PRODUCT_CODE) {
+      displayControlFactory, playerActionsFactory, scheduleFactory, plansFactory,
+      messageBox, confirmModal, SHARED_SCHEDULE_URL) {
       return {
         restrict: 'E',
         templateUrl: 'partials/displays/display-fields.html',

--- a/src/scripts/displays/directives/dtv-display-fields.js
+++ b/src/scripts/displays/directives/dtv-display-fields.js
@@ -20,7 +20,7 @@ angular.module('risevision.displays.directives')
           $scope.playerActionsFactory = playerActionsFactory;
 
           $scope.toggleProAuthorized = function () {
-            if (!playerLicenseFactory.isProAvailable(displayFactory.display)) {
+            if (!playerLicenseFactory.isProAvailable(displayFactory.display) && !displayFactory.display.originalPlayerProAuthorized) {
               displayFactory.display.playerProAuthorized = false;
               plansFactory.confirmAndPurchase();
             } else {

--- a/src/scripts/displays/directives/dtv-display-fields.js
+++ b/src/scripts/displays/directives/dtv-display-fields.js
@@ -24,7 +24,7 @@ angular.module('risevision.displays.directives')
               displayFactory.display.playerProAuthorized = false;
               plansFactory.confirmAndPurchase();
             } else {
-              playerLicenseFactory.updateDisplayLicenseLocal();
+              playerLicenseFactory.updateDisplayLicenseLocal(displayFactory.display);
             }
           };
 

--- a/src/scripts/displays/directives/dtv-display-fields.js
+++ b/src/scripts/displays/directives/dtv-display-fields.js
@@ -21,58 +21,12 @@ angular.module('risevision.displays.directives')
 
           $scope.updatingRPP = false;
 
-          var _updateDisplayLicenseLocal = function () {
-            var playerProAuthorized = displayFactory.display.playerProAuthorized;
-            var company = userState.getCopyOfSelectedCompany(true);
-
-            displayFactory.display.playerProAssigned = playerProAuthorized;
-            displayFactory.display.playerProAuthorized = company.playerProAvailableLicenseCount > 0 &&
-              playerProAuthorized;
-          };
-
-          var _updateDisplayLicense = function () {
-            var apiParams = {};
-            var playerProAuthorized = displayFactory.display.playerProAuthorized;
-
-            $scope.errorUpdatingRPP = false;
-            $scope.updatingRPP = true;
-            apiParams[displayFactory.display.id] = playerProAuthorized;
-
-            enableCompanyProduct(displayFactory.display.companyId, PLAYER_PRO_PRODUCT_CODE, apiParams)
-              .then(function (resp) {
-                var resultDisplays = resp && resp.item && resp.item.displays;
-                if (resultDisplays && resultDisplays[displayFactory.display.id] === apiParams[displayFactory
-                    .display.id]) {
-                  _updateDisplayLicenseLocal();
-                  playerLicenseFactory.toggleDisplayLicenseLocal(displayFactory.display.playerProAuthorized);
-                } else {
-                  throw new Error('License could not be updated. Please try again.');
-                }
-              })
-              .catch(function (err) {
-                $scope.errorUpdatingRPP = processErrorCode(err);
-
-                displayFactory.display.playerProAuthorized = !playerProAuthorized;
-              })
-              .finally(function () {
-                if (!playerProAuthorized) {
-                  displayFactory.display.monitoringEnabled = false;
-                }
-
-                $scope.updatingRPP = false;
-              });
-          };
-
           $scope.toggleProAuthorized = function () {
             if (!playerLicenseFactory.isProAvailable(displayFactory.display)) {
               displayFactory.display.playerProAuthorized = false;
               plansFactory.confirmAndPurchase();
             } else {
-              if (displayFactory.display.id) {
-                _updateDisplayLicense();
-              } else {
-                _updateDisplayLicenseLocal();
-              }
+              playerLicenseFactory.updateDisplayLicenseLocal();
             }
           };
 

--- a/src/scripts/displays/services/svc-player-license-factory.js
+++ b/src/scripts/displays/services/svc-player-license-factory.js
@@ -52,7 +52,7 @@ angular.module('risevision.displays.services')
         var company = userState.getCopyOfSelectedCompany(true);
 
         display.playerProAssigned = playerProAuthorized;
-        display.playerProAuthorized = company.playerProAvailableLicenseCount > 0 && playerProAuthorized;
+        display.playerProAuthorized = (display.originalPlayerProAuthorized || company.playerProAvailableLicenseCount > 0) && playerProAuthorized;
       };
 
       factory.updateDisplayLicense = function (display) {

--- a/test/unit/displays/services/svc-display-factory.spec.js
+++ b/test/unit/displays/services/svc-display-factory.spec.js
@@ -82,7 +82,8 @@ describe('service: displayFactory:', function() {
         toggleDisplayLicenseLocal: sinon.stub(),
         getProLicenseCount: sinon.stub(),
         areAllProLicensesUsed: sinon.stub().returns(true),
-        isProAvailable: sinon.stub().returns(false)
+        isProAvailable: sinon.stub().returns(false),
+        updateDisplayLicense: sinon.stub().returns(Q.resolve())
       };
     });
     $provide.factory('plansFactory', function() {
@@ -210,6 +211,7 @@ describe('service: displayFactory:', function() {
       .then(function() {
         expect(displayFactory.display).to.be.ok;
         expect(displayFactory.display.name).to.equal("some display");
+        expect(displayFactory.display.originalPlayerProAuthorized).to.equal(displayFactory.display.playerProAuthorized);
 
         setTimeout(function() {
           expect(displayFactory.loadingDisplay).to.be.false;
@@ -413,6 +415,51 @@ describe('service: displayFactory:', function() {
         expect(displayFactory.loadingDisplay).to.be.false;
 
         expect(displayFactory.apiError).to.be.ok;
+        done();
+      },10);
+    });
+
+    it('should update license if changed', function(done) {
+      updateDisplay = true;
+      displayFactory.display.originalPlayerProAuthorized = false;
+      displayFactory.display.playerProAuthorized = true;
+
+      displayFactory.updateDisplay();
+      
+      setTimeout(function(){
+        expect(playerLicenseFactory.updateDisplayLicense).to.have.been.called;
+        expect(displayFactory.display.originalPlayerProAuthorized).to.be.true;
+
+        expect(displayFactory.apiError).to.not.be.ok;
+        done();
+      },10);
+    });
+
+    it('should not update license if not changed', function(done) {
+      updateDisplay = true;
+      displayFactory.display.originalPlayerProAuthorized = true;
+      displayFactory.display.playerProAuthorized = true;
+
+      displayFactory.updateDisplay();
+      
+      setTimeout(function(){
+        expect(playerLicenseFactory.updateDisplayLicense).to.not.have.been.called;
+        expect(displayFactory.apiError).to.not.be.ok;
+        done();
+      },10);
+    });
+
+    it('should handle error on updating license', function(done) {
+      updateDisplay = true;
+      displayFactory.display.originalPlayerProAuthorized = false;
+      displayFactory.display.playerProAuthorized = true;
+
+      playerLicenseFactory.updateDisplayLicense.returns(Q.reject());
+
+      displayFactory.updateDisplay();
+      
+      setTimeout(function(){        
+        expect(displayFactory.apiError).to.equal('error');  
         done();
       },10);
     });


### PR DESCRIPTION
## Description

- No longer license display immediately when toggling license buttons, instead, checks for license change and update it when user Saves the display changes.
- Removed license toggle local spinner and related variables
- Moved license update code to playerLicenseFactory

## Motivation and Context
Fix for #2493

## How Has This Been Tested?
Manually validated multiple use cases. 
Pending unit tests updates on subsequent PRs.
[stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
