### PR TITLE
Use a timeout to reject api requests

### DIFF
--- a/test/unit/components/gapi-loader/svc-gapi.spec.js
+++ b/test/unit/components/gapi-loader/svc-gapi.spec.js
@@ -1,7 +1,7 @@
 /* jshint expr:true */
 "use strict";
 
-describe.only("Services: gapi", function() {
+describe("Services: gapi", function() {
   beforeEach(module("risevision.common.gapi"));
 
   describe("gapi loader (old)", function() {


### PR DESCRIPTION
## Description
Use a timeout to reject api requests

If the api request succeeds, cancel timeout
If the time elapses, reject the promise with an error

[stage-15]

## Motivation and Context
Final fix for #2474 

## How Has This Been Tested?
Tested changes locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No