### PR TITLE
Clean up more waitForAutosave calls; reduce spinner wait

### DIFF
--- a/test/e2e/template-editor/cases/components/branding.js
+++ b/test/e2e/template-editor/cases/components/branding.js
@@ -119,11 +119,6 @@ var BrandingComponentScenarios = function () {
           expect(imageComponentPage.getThumbnails().count()).to.eventually.equal(1);
         });
 
-        it('should auto-save the Branding after adding file from storage', function () {
-          //wait for presentation to be auto-saved
-          templateEditorPage.waitForAutosave();
-        });
-
       });
 
       describe('subsequent upload - should list a single file', function () {
@@ -143,11 +138,6 @@ var BrandingComponentScenarios = function () {
           expect(imageComponentPage.getSelectedImagesMain().count()).to.eventually.equal(1);
         });
 
-        it('should auto-save the Branding after adding file from storage', function () {
-          //wait for presentation to be auto-saved
-          templateEditorPage.waitForAutosave();
-        });
-
       });
 
       describe('storage',function(){
@@ -165,11 +155,6 @@ var BrandingComponentScenarios = function () {
           helper.clickWhenClickable(imageComponentPage.getStorageAddSelected(), 'Storage Add Selected');
           browser.sleep(1000);
           expect(imageComponentPage.getSelectedImagesMain().count()).to.eventually.equal(1);
-        });
-
-        it('should auto-save the Branding after adding file from storage', function () {
-          //wait for presentation to be auto-saved
-          templateEditorPage.waitForAutosave();
         });
 
       });

--- a/test/e2e/template-editor/cases/components/image.js
+++ b/test/e2e/template-editor/cases/components/image.js
@@ -58,11 +58,6 @@ var ImageComponentScenarios = function () {
       it('should have a thumbnail', function() {
         expect(imageComponentPage.getThumbnails().count()).to.eventually.equal(1);
       });
-
-      it('should auto-save the Presentation after updating the image list', function () {
-        //wait for presentation to be auto-saved
-        templateEditorPage.waitForAutosave();
-      });
     });
 
     describe('storage', function () {
@@ -179,11 +174,6 @@ var ImageComponentScenarios = function () {
         helper.clickWhenClickable(removeLink, 'Image Row Remove');
 
         expect(imageComponentPage.getSelectedImagesMain().count()).to.eventually.equal(3);
-      });
-
-      it('should auto-save the Presentation after removing a row', function () {
-        //wait for presentation to be auto-saved
-        templateEditorPage.waitForAutosave();
       });
     });
 

--- a/test/e2e/template-editor/cases/components/video.js
+++ b/test/e2e/template-editor/cases/components/video.js
@@ -63,11 +63,6 @@ var VideoComponentScenarios = function () {
       it('should list uploaded file only, with sample files removed', function() {
         expect(videoComponentPage.getSelectedVideosMain().count()).to.eventually.equal(1);
       });
-
-      it('should auto-save the Presentation after updating the video list', function () {
-        //wait for presentation to be auto-saved
-        templateEditorPage.waitForAutosave();
-      });
     });
 
     describe('storage', function () {
@@ -172,11 +167,6 @@ var VideoComponentScenarios = function () {
         expect(videoComponentPage.getVolumeValue().getText()).to.eventually.equal('1');
       });
 
-      it('should auto-save the Presentation after updating volume', function () {
-        //wait for presentation to be auto-saved
-        templateEditorPage.waitForAutosave();
-      });
-
       it('should remove a video row', function () {
         var removeLink = videoComponentPage.getRemoveLinkFor('Beach-Ball.mp4');
 
@@ -185,11 +175,6 @@ var VideoComponentScenarios = function () {
 
         expect(videoComponentPage.getSelectedVideosMain().count()).to.eventually.equal(1);
         expect(videoComponentPage.getVolumeComponent().isDisplayed()).to.eventually.be.true;
-      });
-
-      it('should auto-save the Presentation after removing a row', function () {
-        //wait for presentation to be auto-saved
-        templateEditorPage.waitForAutosave();
       });
 
       it('should remove another video row and hide volume', function () {

--- a/test/e2e/template-editor/pages/presentationListPage.js
+++ b/test/e2e/template-editor/pages/presentationListPage.js
@@ -49,7 +49,7 @@ var PresentationListPage = function() {
 
   this.loadCurrentCompanyPresentationList = function() {
     helper.clickWhenClickable(templateEditorPage.getPresentationsListLink(), 'Presentations List');
-    helper.wait(this.getPresentationsLoader(), 'Presentation loader')
+    helper.wait(this.getPresentationsLoader(), 'Presentation loader', 5000)
     .catch(function(err) {
       console.log('Presentation loader never appeared; assume it already disappeared.', err);
     });


### PR DESCRIPTION
## Description
Clean up more waitForAutosave calls

Set Presentation spinner wait timeout to 5 seconds

[stage-11]

## Motivation and Context
Speed up e2e test execution.

## How Has This Been Tested?
Tests pass.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No