### PR TITLE
Initialize CodeMirror options after initial load

### DIFF
--- a/src/partials/template-editor/components/component-html.html
+++ b/src/partials/template-editor/components/component-html.html
@@ -3,7 +3,7 @@
     <label>HTML:</label>
     <div class="row">
       <div class="col-xs-12">
-        <ui-codemirror id="codemirror-html-input" placeholder="Enter your HTML" ng-model="html" ng-model-options="{ debounce: 1000 }" ng-change="save()" ui-codemirror-opts="codemirrorOptions"></ui-codemirror>
+        <ui-codemirror id="codemirror-html-input" ng-model="html" ng-model-options="{ debounce: 1000 }" ng-change="save()" ui-codemirror-opts="codemirrorOptions"></ui-codemirror>
 
         <!-- ​<textarea id="html-input" class="form-control resize-vertical" rows="4" ng-model="html" ng-model-options="{ debounce: 1000 }" placeholder="Enter your HTML" ng-change="save()"></textarea> -->
       </div>

--- a/src/scripts/template-editor/components/directives/dtv-component-html.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-html.js
@@ -10,12 +10,7 @@ angular.module('risevision.template-editor.directives')
         link: function ($scope, element) {
           $scope.factory = templateEditorFactory;
 
-          $scope.codemirrorOptions = {
-            lineNumbers: true,
-            theme: 'default',
-            lineWrapping: false,
-            mode: 'htmlmixed'
-          };
+          $scope.codemirrorOptions = {};
 
           function _load() {
             var html = $scope.getAvailableAttributeData($scope.componentId, 'html');
@@ -23,7 +18,12 @@ angular.module('risevision.template-editor.directives')
             $scope.html = html;
 
             $timeout(function () {
-              $window.dispatchEvent(new Event('resize'));
+              $scope.codemirrorOptions = {
+                lineNumbers: true,
+                theme: 'default',
+                lineWrapping: false,
+                mode: 'htmlmixed'
+              };
             }, 400);
           }
 

--- a/test/e2e/template-editor/cases/components/html.js
+++ b/test/e2e/template-editor/cases/components/html.js
@@ -32,32 +32,49 @@ var HtmlComponentScenarios = function () {
     });
 
     describe('basic operations', function () {
-      it('should open properties of Html Component', function () {
+      it('should open properties of Html Component', function (done) {
         templateEditorPage.selectComponent(componentLabel);
 
-        expect(htmlComponentPage.getTextArea().getAttribute('value')).to.eventually.contain("Hello World");
+        helper.wait(htmlComponentPage.getCodeMirrorElement(), 'HTML component editor');
+
+        browser.sleep(1000);
+
+        htmlComponentPage.getCodeMirrorText()
+          .then(function (text) {
+            expect(text).to.contain("Hello World");
+            
+            done();
+          });
       });
 
       it('should clear and update the component html', function () {
         // Note: Disconnect from Angular to prevent Autosave timeout from interrupting edits
         browser.waitForAngularEnabled(false);
-        helper.wait(htmlComponentPage.getTextArea(), 'Text component Text Area');
-        browser.sleep(500);
-        htmlComponentPage.getTextArea().clear();
-        browser.sleep(500);
-        htmlComponentPage.getTextArea().sendKeys("Changed Text");
+
+        htmlComponentPage.updateCodeMirrorText('Changed Text');
+
         browser.waitForAngularEnabled(true);
 
         //wait for presentation to be auto-saved
         templateEditorPage.waitForAutosave();
       });
 
-      it('should reload the Presentation, and validate changes were saved', function () {
+      it('should reload the Presentation, and validate changes were saved', function (done) {
         presentationsListPage.loadPresentation(presentationName);
 
         templateEditorPage.selectComponent(componentLabel);
-        expect(htmlComponentPage.getTextArea().isEnabled()).to.eventually.be.true;
-        expect(htmlComponentPage.getTextArea().getAttribute('value')).to.eventually.equal("Changed Text");
+
+        helper.wait(htmlComponentPage.getCodeMirrorElement(), 'HTML component editor');
+
+        browser.sleep(1000);
+
+        htmlComponentPage.getCodeMirrorText()
+          .then(function (text) {
+            expect(text).to.contain("Changed Text");
+            
+            done();
+          });
+
       });
 
     });

--- a/test/e2e/template-editor/pages/components/htmlComponentPage.js
+++ b/test/e2e/template-editor/pages/components/htmlComponentPage.js
@@ -1,10 +1,20 @@
 'use strict';
 
 var HtmlComponentPage = function() {
-  var textArea = element(by.id('html-input'));
+  var codeMirrorElement = element(by.css('#codemirror-html-input .CodeMirror'));
 
-  this.getTextArea = function () {
-    return textArea;
+  this.getCodeMirrorElement = function () {
+    return codeMirrorElement;
+  };
+
+  this.getCodeMirrorText = function () {
+    return browser.executeScript('var editor = $("#codemirror-html-input .CodeMirror")[0].CodeMirror;' +
+      'return editor.getValue();');
+  }
+
+  this.updateCodeMirrorText = function (text) {
+    browser.executeScript('var editor = $("#codemirror-html-input .CodeMirror")[0].CodeMirror;' +
+      'editor.setValue("' + text + '");')
   };
 };
 

--- a/test/unit/template-editor/components/directives/dtv-component-html.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-html.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 describe('directive: templateComponentHtml', function() {
-  var $scope,
+  var $scope, $timeout,
       element,
       factory;
 
@@ -20,7 +20,9 @@ describe('directive: templateComponentHtml', function() {
     });
   }));
 
-  beforeEach(inject(function($compile, $rootScope, $templateCache){
+  beforeEach(inject(function($compile, $rootScope, $templateCache, $injector){
+    $timeout = $injector.get('$timeout');
+
     $templateCache.put('partials/template-editor/components/component-html.html', '<p>mock</p>');
     $scope = $rootScope.$new();
 
@@ -39,6 +41,8 @@ describe('directive: templateComponentHtml', function() {
     expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" } })
     expect($scope.registerDirective).to.have.been.called;
 
+    expect($scope.codemirrorOptions).to.deep.equal({});
+
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
     expect(directive.type).to.equal('rise-html');
@@ -56,6 +60,21 @@ describe('directive: templateComponentHtml', function() {
 
     expect($scope.componentId).to.equal("TEST-ID");
     expect($scope.html).to.equal(sampleValue);
+  });
+
+  it('should set codemirror options asynchronously', function() {
+    var directive = $scope.registerDirective.getCall(0).args[0];
+
+    directive.show();
+
+    $timeout.flush();
+
+    expect($scope.codemirrorOptions).to.deep.equal({
+      lineNumbers: true,
+      theme: 'default',
+      lineWrapping: false,
+      mode: 'htmlmixed'
+    });
   });
 
   it('should save html to attribute data', function() {


### PR DESCRIPTION
## Description
Initialize CodeMirror options after initial load

Fixes issues where settings are not applied
and the editor doesnt render correctly

Remove placeholder text as it is not working

[stage-18]

## Motivation and Context
HTML Component Epic

## How Has This Been Tested?
Tested changes locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No