### PR TITLE
Clear icon html if no icon is sent

### DIFF
--- a/src/scripts/template-editor/directives/dtv-component-icon.js
+++ b/src/scripts/template-editor/directives/dtv-component-icon.js
@@ -32,6 +32,8 @@ angular.module('risevision.template-editor.directives')
           $scope.$watch('icon', function (icon) {
             if (icon) {
               element.html(_html());
+            } else {
+              element.html('');
             }
           });
         }

--- a/test/unit/template-editor/directives/dtv-component-icon.spec.js
+++ b/test/unit/template-editor/directives/dtv-component-icon.spec.js
@@ -12,7 +12,7 @@ describe('directive: ComponentIcon', function () {
   beforeEach(inject(function ($compile, $rootScope) {
     $scope = $rootScope.$new();
 
-    element = $compile('<component-icon icon="{{iconValue}}" type="{{typeValue}}"></component-icon>')($scope);
+    element = $compile('<component-icon icon="{{iconValue}}" type="{{typeValue}}">someicon</component-icon>')($scope);
     elementScope = element.isolateScope();
     $scope.$digest();
   }));
@@ -21,6 +21,8 @@ describe('directive: ComponentIcon', function () {
     expect($scope).to.be.ok;
     expect(elementScope.icon).to.be.empty;
     expect(elementScope.type).to.be.empty;
+
+    expect(element.html()).to.equal("");
   });
 
   it("should render Font Awesome icon", function (done) {


### PR DESCRIPTION
## Description
Clear icon html if no icon is sent

[stage-19]

## Motivation and Context
Fixes issue where if navigating to a component and then to Schedules, the previous component's icon is showing up.

## How Has This Been Tested?
Tested locally, updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No