### PR TITLE
License routes redirect to purchase if company does not have a plan

### DIFF
--- a/src/scripts/components/gapi-loader/svc-gapi.js
+++ b/src/scripts/components/gapi-loader/svc-gapi.js
@@ -17,9 +17,9 @@ angular.module('risevision.common.gapi', [
     'risevision.common.components.util'
   ])
   .factory('rejectOnTimeout', ['$timeout',
-    function($timeout) {
-      return function(deferred, entry) {
-        var rejectTimeout = $timeout(function() {
+    function ($timeout) {
+      return function (deferred, entry) {
+        var rejectTimeout = $timeout(function () {
           var err = {
             code: -1,
             message: entry + ' Load Timeout'
@@ -29,7 +29,7 @@ angular.module('risevision.common.gapi', [
         }, 60 * 1000);
 
         deferred.promise
-          .finally(function() {
+          .finally(function () {
             $timeout.cancel(rejectTimeout);
           });
       };
@@ -41,7 +41,7 @@ angular.module('risevision.common.gapi', [
       var deferred = $q.defer();
 
       deferred.promise
-        .catch(function(err) {
+        .catch(function (err) {
           $exceptionHandler(err, 'gapiLoader Error.', true);
 
           return $q.reject(err);
@@ -63,7 +63,7 @@ angular.module('risevision.common.gapi', [
           fileref.setAttribute('type', 'text/javascript');
           fileref.setAttribute('src', src);
 
-          fileref.onerror = function(error) {
+          fileref.onerror = function (error) {
             deferred.reject(error);
 
             $window.removeEventListener('gapi.loaded', gapiLoaded, false);
@@ -114,12 +114,12 @@ angular.module('risevision.common.gapi', [
                     deferred.reject();
                   }
                 })
-                .catch(function(err) {
+                .catch(function (err) {
                   deferred.reject(err);
                 });
 
               return deferred.promise
-                .catch(function(err) {
+                .catch(function (err) {
                   var errMsg = libName + '.' + libVer + ' Load Failed';
 
                   $exceptionHandler(err, errMsg, true);

--- a/src/scripts/components/plans/services/svc-plans.js
+++ b/src/scripts/components/plans/services/svc-plans.js
@@ -3,199 +3,200 @@
   'use strict';
   angular.module('risevision.common.components.plans')
     .value('PLANS_LIST', [{
-      name: 'Free',
-      type: 'free',
-      order: 0,
-      productId: '000',
-      productCode: '000',
-      status: 'Active',
-      proLicenseCount: 0,
-      monthly: {
-        priceDisplayMonth: 0,
-        billAmount: 0,
-        save: 0
+        name: 'Free',
+        type: 'free',
+        order: 0,
+        productId: '000',
+        productCode: '000',
+        status: 'Active',
+        proLicenseCount: 0,
+        monthly: {
+          priceDisplayMonth: 0,
+          billAmount: 0,
+          save: 0
+        },
+        yearly: {
+          priceDisplayMonth: 0,
+          priceDisplayYear: 0,
+          billAmount: 0,
+          save: 0
+        }
+      }, {
+        name: 'Display Licenses',
+        type: 'volume',
+        order: 1,
+        productId: '2317',
+        productCode: '34e8b511c4cc4c2affa68205cd1faaab427657dc',
+        proLicenseCount: 3,
+        monthly: {
+          priceDisplayMonth: 10,
+          billAmount: 10,
+          save: 0
+        },
+        yearly: {
+          priceDisplayMonth: 10,
+          priceDisplayYear: 110,
+          billAmount: 110,
+          save: 10
+        },
+        trialPeriod: 14,
+        discountIndustries: [
+          'PRIMARY_SECONDARY_EDUCATION',
+          'HIGHER_EDUCATION',
+          'LIBRARIES',
+          'PHILANTHROPY',
+          'NON_PROFIT_ORGANIZATION_MANAGEMENT',
+          'RELIGIOUS_INSTITUTIONS'
+        ]
+      }, {
+        name: 'Display Licenses for Education',
+        // cannot use type 'volume', it may interfere with the other plan
+        type: 'volume for education',
+        order: 1,
+        productId: '2320',
+        productCode: '88725121a2c7a57deefcf06688ffc8e84cc4f93b',
+        proLicenseCount: 3,
+        monthly: {
+          priceDisplayMonth: 10,
+          billAmount: 10,
+          save: 0
+        },
+        yearly: {
+          priceDisplayMonth: 10,
+          priceDisplayYear: 110,
+          billAmount: 110,
+          save: 10
+        },
+        trialPeriod: 14,
+        discountIndustries: [
+          'PRIMARY_SECONDARY_EDUCATION',
+          'HIGHER_EDUCATION',
+          'LIBRARIES',
+          'PHILANTHROPY',
+          'NON_PROFIT_ORGANIZATION_MANAGEMENT',
+          'RELIGIOUS_INSTITUTIONS'
+        ]
+      }, {
+        name: 'Starter',
+        type: 'starter',
+        order: 1,
+        productId: '335',
+        productCode: '019137f7bb35f5f90085a033c013672471faadae',
+        proLicenseCount: 1,
+        monthly: {
+          priceDisplayMonth: 10,
+          billAmount: 10,
+          save: 0
+        },
+        yearly: {
+          priceDisplayMonth: 10,
+          priceDisplayYear: 110,
+          billAmount: 110,
+          save: 10
+        },
+        trialPeriod: 14
+      }, {
+        name: 'Basic',
+        type: 'basic',
+        order: 2,
+        productId: '289',
+        productCode: '40c092161f547f8f72c9f173cd8eebcb9ca5dd25',
+        proLicenseCount: 3,
+        monthly: {
+          priceDisplayMonth: 9,
+          billAmount: 27,
+          save: 36
+        },
+        yearly: {
+          priceDisplayMonth: 9,
+          priceDisplayYear: 99,
+          billAmount: 297,
+          save: 63
+        },
+        trialPeriod: 14
+      }, {
+        name: 'Advanced',
+        type: 'advanced',
+        order: 3,
+        productId: '290',
+        productCode: '93b5595f0d7e4c04a3baba1102ffaecb17607bf4',
+        proLicenseCount: 11,
+        monthly: {
+          priceDisplayMonth: 8,
+          billAmount: 88,
+          save: 264
+        },
+        yearly: {
+          priceDisplayMonth: 8,
+          priceDisplayYear: 88,
+          billAmount: 968,
+          save: 352
+        },
+        trialPeriod: 14
+      }, {
+        name: 'Enterprise',
+        type: 'enterprise',
+        order: 4,
+        productId: '301',
+        productCode: 'b1844725d63fde197f5125b58b6cba6260ee7a57',
+        proLicenseCount: 70,
+        monthly: {
+          priceDisplayMonth: 7,
+          billAmount: 490,
+          save: 2520
+        },
+        yearly: {
+          priceDisplayMonth: 7,
+          priceDisplayYear: 77,
+          billAmount: 5390,
+          save: 3010
+        }
+      }, {
+        name: 'Enterprise',
+        type: 'enterprisesub',
+        order: 5,
+        productId: '303',
+        productCode: 'd521f5bfbc1eef109481eebb79831e11c7804ad8',
+        proLicenseCount: 0
+      }, {
+        name: 'Basic Financial MarketWall',
+        productCode: '0dbb19f8394612730c2673b092d811e46413b132'
+      }, {
+        name: 'Premium Financial MarketWall',
+        productCode: '0c583c663655c246c3e7b3c1be0ec05a442211aa'
+      }, {
+        name: 'Financial Data License',
+        productCode: '356ab5e0541a41e96e4ef0b45ecac9f72af454ac',
+        // cannot use type 'volume', it may interfere with the other plan
+        type: 'volume for financial',
+      }, {
+        name: 'C-Scape iCandy LED Ticker License',
+        productCode: '2374db80249aa3b862df6feea177a55e97015319'
+      }, {
+        name: 'LED Ticker License',
+        // productCode: 'led-ticker-license',
+        productCode: 'led',
+        type: 'volume for led ticker'
       },
-      yearly: {
-        priceDisplayMonth: 0,
-        priceDisplayYear: 0,
-        billAmount: 0,
-        save: 0
+      // Archived:
+      {
+        name: 'Premium Financial MarketWall',
+        productCode: '0c583c663655c246c3e7b3c1be0ec05a442211aa',
+        type: 'volume for premium marketwall'
+      }, {
+        name: 'Basic Financial MarketWall',
+        productCode: '0dbb19f8394612730c2673b092d811e46413b132',
+        type: 'volume for basic marketwall'
+      }, {
+        name: 'Premium LED Ticker License',
+        productCode: 'c91e5b9762036cb6f0f0d7b93032c11897a9da1b',
+        type: 'volume for premium ticker'
+      }, {
+        name: 'Basic LED Ticker License',
+        productCode: '74eb12a1c0ade021f875213bf796b2ef8b174753',
+        type: 'volume for basic ticker'
       }
-    }, {
-      name: 'Display Licenses',
-      type: 'volume',
-      order: 1,
-      productId: '2317',
-      productCode: '34e8b511c4cc4c2affa68205cd1faaab427657dc',
-      proLicenseCount: 3,
-      monthly: {
-        priceDisplayMonth: 10,
-        billAmount: 10,
-        save: 0
-      },
-      yearly: {
-        priceDisplayMonth: 10,
-        priceDisplayYear: 110,
-        billAmount: 110,
-        save: 10
-      },
-      trialPeriod: 14,
-      discountIndustries: [
-        'PRIMARY_SECONDARY_EDUCATION',
-        'HIGHER_EDUCATION',
-        'LIBRARIES',
-        'PHILANTHROPY',
-        'NON_PROFIT_ORGANIZATION_MANAGEMENT',
-        'RELIGIOUS_INSTITUTIONS'
-      ]
-    }, {
-      name: 'Display Licenses for Education',
-      // cannot use type 'volume', it may interfere with the other plan
-      type: 'volume for education',
-      order: 1,
-      productId: '2320',
-      productCode: '88725121a2c7a57deefcf06688ffc8e84cc4f93b',
-      proLicenseCount: 3,
-      monthly: {
-        priceDisplayMonth: 10,
-        billAmount: 10,
-        save: 0
-      },
-      yearly: {
-        priceDisplayMonth: 10,
-        priceDisplayYear: 110,
-        billAmount: 110,
-        save: 10
-      },
-      trialPeriod: 14,
-      discountIndustries: [
-        'PRIMARY_SECONDARY_EDUCATION',
-        'HIGHER_EDUCATION',
-        'LIBRARIES',
-        'PHILANTHROPY',
-        'NON_PROFIT_ORGANIZATION_MANAGEMENT',
-        'RELIGIOUS_INSTITUTIONS'
-      ]
-    }, {
-      name: 'Starter',
-      type: 'starter',
-      order: 1,
-      productId: '335',
-      productCode: '019137f7bb35f5f90085a033c013672471faadae',
-      proLicenseCount: 1,
-      monthly: {
-        priceDisplayMonth: 10,
-        billAmount: 10,
-        save: 0
-      },
-      yearly: {
-        priceDisplayMonth: 10,
-        priceDisplayYear: 110,
-        billAmount: 110,
-        save: 10
-      },
-      trialPeriod: 14
-    }, {
-      name: 'Basic',
-      type: 'basic',
-      order: 2,
-      productId: '289',
-      productCode: '40c092161f547f8f72c9f173cd8eebcb9ca5dd25',
-      proLicenseCount: 3,
-      monthly: {
-        priceDisplayMonth: 9,
-        billAmount: 27,
-        save: 36
-      },
-      yearly: {
-        priceDisplayMonth: 9,
-        priceDisplayYear: 99,
-        billAmount: 297,
-        save: 63
-      },
-      trialPeriod: 14
-    }, {
-      name: 'Advanced',
-      type: 'advanced',
-      order: 3,
-      productId: '290',
-      productCode: '93b5595f0d7e4c04a3baba1102ffaecb17607bf4',
-      proLicenseCount: 11,
-      monthly: {
-        priceDisplayMonth: 8,
-        billAmount: 88,
-        save: 264
-      },
-      yearly: {
-        priceDisplayMonth: 8,
-        priceDisplayYear: 88,
-        billAmount: 968,
-        save: 352
-      },
-      trialPeriod: 14
-    }, {
-      name: 'Enterprise',
-      type: 'enterprise',
-      order: 4,
-      productId: '301',
-      productCode: 'b1844725d63fde197f5125b58b6cba6260ee7a57',
-      proLicenseCount: 70,
-      monthly: {
-        priceDisplayMonth: 7,
-        billAmount: 490,
-        save: 2520
-      },
-      yearly: {
-        priceDisplayMonth: 7,
-        priceDisplayYear: 77,
-        billAmount: 5390,
-        save: 3010
-      }
-    }, {
-      name: 'Enterprise',
-      type: 'enterprisesub',
-      order: 5,
-      productId: '303',
-      productCode: 'd521f5bfbc1eef109481eebb79831e11c7804ad8',
-      proLicenseCount: 0
-    }, {
-      name: 'Basic Financial MarketWall',
-      productCode: '0dbb19f8394612730c2673b092d811e46413b132'
-    }, {
-      name: 'Premium Financial MarketWall',
-      productCode: '0c583c663655c246c3e7b3c1be0ec05a442211aa'
-    }, {
-      name: 'Financial Data License',
-      productCode: '356ab5e0541a41e96e4ef0b45ecac9f72af454ac',
-      // cannot use type 'volume', it may interfere with the other plan
-      type: 'volume for financial',
-    }, {
-      name: 'C-Scape iCandy LED Ticker License',
-      productCode: '2374db80249aa3b862df6feea177a55e97015319'
-    }, {
-      name: 'LED Ticker License',
-      // productCode: 'led-ticker-license',
-      productCode: 'led',
-      type: 'volume for led ticker'
-    },
-    // Archived:
-    {
-      name: 'Premium Financial MarketWall',
-      productCode: '0c583c663655c246c3e7b3c1be0ec05a442211aa',
-      type: 'volume for premium marketwall'
-    }, {
-      name: 'Basic Financial MarketWall',
-      productCode: '0dbb19f8394612730c2673b092d811e46413b132',
-      type: 'volume for basic marketwall'
-    }, {
-      name: 'Premium LED Ticker License',
-      productCode: 'c91e5b9762036cb6f0f0d7b93032c11897a9da1b',
-      type: 'volume for premium ticker'
-    }, {
-      name: 'Basic LED Ticker License',
-      productCode: '74eb12a1c0ade021f875213bf796b2ef8b174753',
-      type: 'volume for basic ticker'  
-    }])
+    ])
     .factory('plansService', ['PLANS_LIST',
       function (PLANS_LIST) {
         var _factory = {};

--- a/src/scripts/components/userstate/app.js
+++ b/src/scripts/components/userstate/app.js
@@ -71,7 +71,7 @@
                   .then(function () {
                     window.location.hash = '';
                   })
-                  .catch(function(e) {
+                  .catch(function (e) {
                     return $state.go('common.auth.unauthorized', {
                       authError: e
                     });

--- a/src/scripts/components/userstate/services/svc-user-auth-factory.js
+++ b/src/scripts/components/userstate/services/svc-user-auth-factory.js
@@ -226,10 +226,10 @@
           // The flag the indicates a user is potentially
           // authenticated already, must be destroyed.
           return _resetUserState(signOutGoogle)
-            .finally(function() {
+            .finally(function () {
               //call google api to sign out
               $rootScope.$broadcast('risevision.user.signedOut');
-              $log.debug('User is signed out.');              
+              $log.debug('User is signed out.');
             });
         };
 

--- a/src/scripts/displays/directives/dtv-display-fields.js
+++ b/src/scripts/displays/directives/dtv-display-fields.js
@@ -17,7 +17,8 @@ angular.module('risevision.displays.directives')
           $scope.playerActionsFactory = playerActionsFactory;
 
           $scope.toggleProAuthorized = function () {
-            if (!playerLicenseFactory.isProAvailable(displayFactory.display) && !displayFactory.display.originalPlayerProAuthorized) {
+            if (!playerLicenseFactory.isProAvailable(displayFactory.display) && !displayFactory.display
+              .originalPlayerProAuthorized) {
               displayFactory.display.playerProAuthorized = false;
               plansFactory.confirmAndPurchase();
             } else {

--- a/src/scripts/displays/services/svc-display-factory.js
+++ b/src/scripts/displays/services/svc-display-factory.js
@@ -159,13 +159,13 @@ angular.module('risevision.displays.services')
         });
       };
 
-      var _updateLicenseIfNeeded = function() {
+      var _updateLicenseIfNeeded = function () {
         if (factory.display.playerProAuthorized !== factory.display.originalPlayerProAuthorized) {
           return playerLicenseFactory.updateDisplayLicense(factory.display)
-            .then(function() {
+            .then(function () {
               factory.display.originalPlayerProAuthorized = factory.display.playerProAuthorized;
             })
-            .catch(function(err) {
+            .catch(function (err) {
               factory.apiError = playerLicenseFactory.apiError;
               return $q.reject(err);
             });

--- a/src/scripts/displays/services/svc-player-license-factory.js
+++ b/src/scripts/displays/services/svc-player-license-factory.js
@@ -52,7 +52,8 @@ angular.module('risevision.displays.services')
         var company = userState.getCopyOfSelectedCompany(true);
 
         display.playerProAssigned = playerProAuthorized;
-        display.playerProAuthorized = (display.originalPlayerProAuthorized || company.playerProAvailableLicenseCount > 0) && playerProAuthorized;
+        display.playerProAuthorized = (display.originalPlayerProAuthorized || company
+          .playerProAvailableLicenseCount > 0) && playerProAuthorized;
       };
 
       factory.updateDisplayLicense = function (display) {

--- a/src/scripts/purchase/app.js
+++ b/src/scripts/purchase/app.js
@@ -73,9 +73,15 @@ angular.module('risevision.apps')
           templateUrl: 'partials/purchase/update-subscription.html',
           controller: 'UpdateSubscriptionCtrl',
           resolve: {
-            canAccessApps: ['canAccessApps',
-              function (canAccessApps) {
-                return canAccessApps();
+            canAccessApps: ['canAccessApps', 'currentPlanFactory', '$state',
+              function (canAccessApps, currentPlanFactory, $state) {
+                return canAccessApps().then(function () {
+                  if (!$state.params.subscriptionId && !currentPlanFactory.isSubscribed()) {
+                    $state.go('apps.purchase.home', {
+                      displayCount: $state.params.displayCount
+                    });
+                  }
+                });
               }
             ],
             redirectTo: ['$location',

--- a/src/scripts/purchase/app.js
+++ b/src/scripts/purchase/app.js
@@ -34,28 +34,30 @@ angular.module('risevision.apps')
                 return canAccessApps()
                   .then(function () {
                     if (currentPlanFactory.isSubscribed()) {
-                     if (currentPlanFactory.isParentPlan() || currentPlanFactory.currentPlan.isPurchasedByParent) {
-                       var contactInfo = currentPlanFactory.currentPlan.parentPlanContactEmail ? ' at ' +
-                         currentPlanFactory.currentPlan.parentPlanContactEmail : '';
+                      if (currentPlanFactory.isParentPlan() || currentPlanFactory.currentPlan
+                        .isPurchasedByParent) {
+                        var contactInfo = currentPlanFactory.currentPlan.parentPlanContactEmail ? ' at ' +
+                          currentPlanFactory.currentPlan.parentPlanContactEmail : '';
 
-                       return messageBox(
-                         'You can\'t edit your current plan.',
-                         'Your plan is managed by your parent company. Please contact your account administrator' +
-                         contactInfo + ' for additional licenses.',
-                         'Ok', 'madero-style centered-modal', 'partials/template-editor/message-box.html', 'sm'
-                       ).finally(function() {
-                         if (!$state.current.name) {
-                           $state.go('apps.home');
-                         } else {
-                           return $q.reject();
-                         }
-                       });
-                     } else {
-                       $state.go('apps.purchase.licenses.add', {
-                        displayCount: $stateParams.displayCount
-                      });
-                     }
-                   }
+                        return messageBox(
+                          'You can\'t edit your current plan.',
+                          'Your plan is managed by your parent company. Please contact your account administrator' +
+                          contactInfo + ' for additional licenses.',
+                          'Ok', 'madero-style centered-modal', 'partials/template-editor/message-box.html',
+                          'sm'
+                        ).finally(function () {
+                          if (!$state.current.name) {
+                            $state.go('apps.home');
+                          } else {
+                            return $q.reject();
+                          }
+                        });
+                      } else {
+                        $state.go('apps.purchase.licenses.add', {
+                          displayCount: $stateParams.displayCount
+                        });
+                      }
+                    }
                   });
               }
             ],

--- a/src/scripts/purchase/app.js
+++ b/src/scripts/purchase/app.js
@@ -79,9 +79,7 @@ angular.module('risevision.apps')
               function (canAccessApps, currentPlanFactory, $state) {
                 return canAccessApps().then(function () {
                   if (!$state.params.subscriptionId && !currentPlanFactory.isSubscribed()) {
-                    $state.go('apps.purchase.home', {
-                      displayCount: $state.params.displayCount
-                    });
+                    $state.go('apps.purchase.home');
                   }
                 });
               }

--- a/src/scripts/purchase/directives/dtv-plan-picker.js
+++ b/src/scripts/purchase/directives/dtv-plan-picker.js
@@ -36,7 +36,7 @@ angular.module('risevision.apps.purchase')
                 .applyDiscount);
 
               $scope.yearlySavings = ($scope.basePricePerDisplay * $scope.displayCount * 12) - $scope
-              .totalPrice;
+                .totalPrice;
             });
 
             $scope.updatePlan = function () {

--- a/src/scripts/template-editor/components/directives/dtv-component-playlist.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-playlist.js
@@ -118,7 +118,7 @@ angular.module('risevision.template-editor.directives')
               return;
             }
 
-            var presentationIds = _.map(_.filter(templates, $scope.isEmbeddedTemplate), 
+            var presentationIds = _.map(_.filter(templates, $scope.isEmbeddedTemplate),
               function (item) {
                 return 'id:' + item.id;
               });

--- a/src/scripts/template-editor/directives/dtv-attribute-editor.js
+++ b/src/scripts/template-editor/directives/dtv-attribute-editor.js
@@ -202,8 +202,7 @@ angular.module('risevision.template-editor.directives')
             if ('string' === typeof event.data) {
               try {
                 data = JSON.parse(event.data);
-              }
-              catch(e) {}
+              } catch (e) {}
             }
 
             if (data.type === 'editComponent') {

--- a/src/scripts/template-editor/directives/dtv-component-icon.js
+++ b/src/scripts/template-editor/directives/dtv-component-icon.js
@@ -32,6 +32,8 @@ angular.module('risevision.template-editor.directives')
           $scope.$watch('icon', function (icon) {
             if (icon) {
               element.html(_html());
+            } else {
+              element.html('');
             }
           });
         }

--- a/test/e2e/template-editor/cases/components/html.js
+++ b/test/e2e/template-editor/cases/components/html.js
@@ -13,7 +13,7 @@ var HtmlComponentScenarios = function () {
     var presentationsListPage;
     var templateEditorPage;
     var htmlComponentPage;
-    var componentLabel = "HTML Component 1";
+    var componentLabel = "HTML Embed";
 
     before(function () {
       presentationsListPage = new PresentationListPage();

--- a/test/unit/purchase/app.spec.js
+++ b/test/unit/purchase/app.spec.js
@@ -247,6 +247,32 @@ describe('app:', function() {
       $rootScope.$digest();
       canAccessApps.should.have.been.called;
     });
+
+    it('should redirect to apps.purchase.home if no subscriptionId is provided and company does not have a plan', function(done) {
+      currentPlanFactory.isSubscribed.returns(false);
+
+      $state.go('apps.purchase.licenses.add');
+      $rootScope.$digest();
+
+      setTimeout(function(){
+        $state.go.should.have.been.calledWith('apps.purchase.home');
+
+        done();
+      },10);
+    });
+
+    it('should not redirect to apps.purchase.home if subscriptionId is not provided but company has a plan', function(done) {
+      currentPlanFactory.isSubscribed.returns(true);
+
+      $state.go('apps.purchase.licenses.add');
+      $rootScope.$digest();
+      
+      setTimeout(function(){
+        $state.go.should.not.have.been.calledWith('apps.purchase.home');
+
+        done();
+      },10);
+    });
   });
 
   describe('state apps.purchase.licenses.remove:',function(){
@@ -261,6 +287,32 @@ describe('app:', function() {
       $state.go('apps.purchase.licenses.remove');
       $rootScope.$digest();
       canAccessApps.should.have.been.called;
+    });
+
+    it('should redirect to apps.purchase.home if no subscriptionId is provided and company does not have a plan', function(done) {
+      currentPlanFactory.isSubscribed.returns(false);
+
+      $state.go('apps.purchase.licenses.remove');
+      $rootScope.$digest();
+
+      setTimeout(function(){
+        $state.go.should.have.been.calledWith('apps.purchase.home');
+
+        done();
+      },10);
+    });
+
+    it('should not redirect to apps.purchase.home if subscriptionId is not provided but company has a plan', function(done) {
+      currentPlanFactory.isSubscribed.returns(true);
+
+      $state.go('apps.purchase.licenses.remove');
+      $rootScope.$digest();
+      
+      setTimeout(function(){
+        $state.go.should.not.have.been.calledWith('apps.purchase.home');
+
+        done();
+      },10);
     });
   });
 

--- a/test/unit/template-editor/directives/dtv-component-icon.spec.js
+++ b/test/unit/template-editor/directives/dtv-component-icon.spec.js
@@ -12,7 +12,7 @@ describe('directive: ComponentIcon', function () {
   beforeEach(inject(function ($compile, $rootScope) {
     $scope = $rootScope.$new();
 
-    element = $compile('<component-icon icon="{{iconValue}}" type="{{typeValue}}"></component-icon>')($scope);
+    element = $compile('<component-icon icon="{{iconValue}}" type="{{typeValue}}">someicon</component-icon>')($scope);
     elementScope = element.isolateScope();
     $scope.$digest();
   }));
@@ -21,6 +21,8 @@ describe('directive: ComponentIcon', function () {
     expect($scope).to.be.ok;
     expect(elementScope.icon).to.be.empty;
     expect(elementScope.type).to.be.empty;
+
+    expect(element.html()).to.equal("");
   });
 
   it("should render Font Awesome icon", function (done) {


### PR DESCRIPTION
## Description
License routes redirect to purchase if company does not have a plan and no subscription id was provided.

Also ran `gulp pretty`

## Motivation and Context
Additional checks for https://github.com/Rise-Vision/rise-vision-apps/pull/2527
If no subscription id is provided, it tries to edit current company plan. Added a check to prevent the case where company does not have a plan.


## How Has This Been Tested?
Locally and on [stage-1].
Company with a plan (edits default subscription ): https://apps-stage-1.risevision.com/licenses/add/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443
Company without a plan (redirects to purchase): https://apps-stage-1.risevision.com/licenses/add/?cid=ed1e1a8a-dd09-48fb-879e-7fb56316afc6

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
