### PR TITLE
Improve 'no license' message when plan is owned by parent company

### DIFF
--- a/src/locales/en/template.json
+++ b/src/locales/en/template.json
@@ -7,7 +7,7 @@
     "delete-warning": "Are you sure you want to delete this Presentation?"
   },
   "message-box": {
-    "confirmation-message": "Okay I Got It"
+    "confirmation-message": "Okay, I Got It"
   },
   "image": {
     "upload": "Upload Images"

--- a/src/scripts/components/plans/services/svc-plans-factory.js
+++ b/src/scripts/components/plans/services/svc-plans-factory.js
@@ -3,8 +3,9 @@
   'use strict';
   angular.module('risevision.common.components.plans')
     .factory('plansFactory', ['$modal', 'userState', 'plansService', 'analyticsFactory',
-      '$state', 'confirmModal',
-      function ($modal, userState, plansService, analyticsFactory, $state, confirmModal) {
+      '$state', 'confirmModal', 'currentPlanFactory', 'messageBox',
+      function ($modal, userState, plansService, analyticsFactory, $state, confirmModal, currentPlanFactory,
+        messageBox) {
         var _factory = {};
 
         _factory.showPurchaseOptions = function (displayCount) {
@@ -14,13 +15,23 @@
         };
 
         _factory.confirmAndPurchase = function (displayCount) {
-          confirmModal('Almost there!',
-              'There aren\'t available licenses to assign to the selected displays. Subscribe to additional licenses?',
-              'Yes', 'No', 'madero-style centered-modal',
-              'partials/components/confirm-modal/madero-confirm-modal.html', 'sm')
-            .then(function () {
-              _factory.showPurchaseOptions(displayCount);
-            });
+          if (currentPlanFactory.isParentPlan() || currentPlanFactory.currentPlan.isPurchasedByParent) {
+            var contactInfo = currentPlanFactory.currentPlan.parentPlanContactEmail ? ' at ' +
+              currentPlanFactory.currentPlan.parentPlanContactEmail : '';
+            messageBox('Almost there!',
+              'There aren\'t available display licenses to assign to the selected displays. Contact your account administrator' +
+              contactInfo + ' for additional display licenses.',
+              'Okay, I Got It', 'madero-style centered-modal', 'partials/template-editor/message-box.html', 'sm'
+              );
+          } else {
+            confirmModal('Almost there!',
+                'There aren\'t available display licenses to assign to the selected displays. Subscribe to additional licenses?',
+                'Yes', 'No', 'madero-style centered-modal',
+                'partials/components/confirm-modal/madero-confirm-modal.html', 'sm')
+              .then(function () {
+                _factory.showPurchaseOptions(displayCount);
+              });
+          }
         };
 
         _factory.showUnlockThisFeatureModal = function () {

--- a/test/unit/app.spec.js
+++ b/test/unit/app.spec.js
@@ -31,6 +31,10 @@ describe('app:', function() {
         }
       });
 
+      $provide.service('plansFactory', function() {
+        return {}
+      });
+
       $provide.value('$exceptionHandler', sinon.stub());
     });
 


### PR DESCRIPTION
## Description
Shows a better 'no licenses available' message when plan is inherited or managed by parent company.

## Motivation and Context
Improves message as per https://github.com/Rise-Vision/rise-vision-apps/issues/2503.

## How Has This Been Tested?
Locally and on [stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
