### PR TITLE
Set default names for component directives

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -478,6 +478,7 @@
               "src/scripts/template-editor/services/svc-auto-save-service.js",
               "src/scripts/template-editor/services/svc-blueprint-factory.js",
               "src/scripts/template-editor/services/svc-financial-license-factory.js",
+              "src/scripts/template-editor/services/svc-components-factory.js",
 
               "src/scripts/template-editor/components/services/svc-storage-manager-factory.js",
               "src/scripts/template-editor/components/services/svc-branding-factory.js",

--- a/src/scripts/template-editor/components/directives/dtv-branding-colors.js
+++ b/src/scripts/template-editor/components/directives/dtv-branding-colors.js
@@ -18,11 +18,7 @@ angular.module('risevision.template-editor.directives')
 
           $scope.registerDirective({
             type: 'rise-branding-colors',
-            iconType: 'streamline',
-            icon: 'palette',
-            title: 'Color Settings',
             element: element,
-            panel: '.branding-colors-container'
           });
         }
       };

--- a/src/scripts/template-editor/components/directives/dtv-component-branding.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-branding.js
@@ -22,11 +22,7 @@ angular.module('risevision.template-editor.directives')
 
           $scope.registerDirective({
             type: 'rise-branding',
-            iconType: 'streamline',
-            icon: 'ratingStar',
-            title: 'Brand Settings',
-            element: element,
-            panel: '.branding-component-container'
+            element: element
           });
 
         }

--- a/src/scripts/template-editor/components/directives/dtv-component-colors.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-colors.js
@@ -27,9 +27,6 @@ angular.module('risevision.template-editor.directives')
 
           $scope.registerDirective({
             type: 'rise-override-brand-colors',
-            iconType: 'streamline',
-            icon: 'palette',
-            title: 'Override Brand Colors',
             element: element,
             show: function () {
               $scope.componentId = $scope.factory.selected.id;

--- a/src/scripts/template-editor/components/directives/dtv-component-counter.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-counter.js
@@ -35,8 +35,6 @@ angular.module('risevision.template-editor.directives')
 
               $scope.registerDirective({
                 type: 'rise-data-counter',
-                iconType: 'streamline',
-                icon: 'hourglass',
                 element: element,
                 show: function () {
                   $scope.componentId = $scope.factory.selected.id;

--- a/src/scripts/template-editor/components/directives/dtv-component-financial.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-financial.js
@@ -108,8 +108,6 @@ angular.module('risevision.template-editor.directives')
 
           $scope.registerDirective({
             type: 'rise-data-financial',
-            iconType: 'streamline',
-            icon: 'financial',
             element: element,
             show: function () {
               _reset();

--- a/src/scripts/template-editor/components/directives/dtv-component-html.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-html.js
@@ -33,8 +33,6 @@ angular.module('risevision.template-editor.directives')
 
           $scope.registerDirective({
             type: 'rise-html',
-            iconType: 'streamline',
-            icon: 'html',
             element: element,
             show: function () {
               $scope.componentId = $scope.factory.selected.id;

--- a/src/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-image.js
@@ -174,15 +174,9 @@ angular.module('risevision.template-editor.directives')
             _loadSelectedImages();
           };
 
-          var baseDirective = {
-            iconType: 'streamline',
-            element: element,
-            panel: '.image-component-container'
-          };
-
-          var componentDirective = angular.extend({}, baseDirective, {
+          var componentDirective = {
             type: 'rise-image',
-            icon: 'image',
+            element: element,
             show: function () {
               imageFactory = baseImageFactory;
               imageFactory.componentId = $scope.factory.selected.id;
@@ -220,12 +214,11 @@ angular.module('risevision.template-editor.directives')
                   });
               });
             }
-          });
+          };
 
-          var logoDirective = angular.extend({}, baseDirective, {
+          var logoDirective = {
             type: 'rise-image-logo',
-            icon: 'circleStar',
-            title: 'Logo Settings',
+            element: element,
             show: function () {
               imageFactory = logoImageFactory;
               imageFactory.componentId = null;
@@ -236,7 +229,7 @@ angular.module('risevision.template-editor.directives')
               _loadTransition();
               _loadHelpText();
             }
-          });
+          };
 
           $scope.registerDirective(componentDirective);
           $scope.registerDirective(logoDirective);

--- a/src/scripts/template-editor/components/directives/dtv-component-playlist.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-playlist.js
@@ -32,8 +32,6 @@ angular.module('risevision.template-editor.directives')
 
           $scope.registerDirective({
             type: 'rise-playlist',
-            iconType: 'streamline',
-            icon: 'embedded-template',
             element: element,
             show: function () {
               $scope.componentId = $scope.factory.selected.id;

--- a/src/scripts/template-editor/components/directives/dtv-component-rss.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-rss.js
@@ -35,8 +35,6 @@ angular.module('risevision.template-editor.directives')
 
           $scope.registerDirective({
             type: 'rise-data-rss',
-            iconType: 'streamline',
-            icon: 'rss',
             element: element,
             show: function () {
               $scope.componentId = $scope.factory.selected.id;

--- a/src/scripts/template-editor/components/directives/dtv-component-schedules.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-schedules.js
@@ -20,7 +20,6 @@ angular.module('risevision.template-editor.directives')
 
           $scope.registerDirective({
             type: 'rise-schedules',
-            title: 'Schedules',
             element: element
           });
 

--- a/src/scripts/template-editor/components/directives/dtv-component-slides.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-slides.js
@@ -57,8 +57,6 @@ angular.module('risevision.template-editor.directives')
 
           $scope.registerDirective({
             type: 'rise-slides',
-            iconType: 'streamline',
-            icon: 'slides',
             element: element,
             show: function () {
               $scope.componentId = $scope.factory.selected.id;

--- a/src/scripts/template-editor/components/directives/dtv-component-storage-selector.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-storage-selector.js
@@ -36,11 +36,7 @@ angular.module('risevision.template-editor.directives')
 
           $scope.registerDirective({
             type: 'rise-storage-selector',
-            iconType: 'riseSvg',
-            icon: 'riseStorage',
             element: element,
-            panel: '.storage-selector-container',
-            title: 'Rise Storage',
             show: function () {
               storageManagerFactory.isListView = true;
 

--- a/src/scripts/template-editor/components/directives/dtv-component-text.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-text.js
@@ -48,8 +48,6 @@ angular.module('risevision.template-editor.directives')
 
           $scope.registerDirective({
             type: 'rise-text',
-            iconType: 'streamline',
-            icon: 'text',
             element: element,
             show: function () {
               $scope.componentId = $scope.factory.selected.id;

--- a/src/scripts/template-editor/components/directives/dtv-component-time-date.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-time-date.js
@@ -21,8 +21,6 @@ angular.module('risevision.template-editor.directives')
 
           $scope.registerDirective({
             type: 'rise-time-date',
-            iconType: 'streamline',
-            icon: 'time',
             element: element,
             show: function () {
               element.show();

--- a/src/scripts/template-editor/components/directives/dtv-component-twitter.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-twitter.js
@@ -60,8 +60,6 @@ angular.module('risevision.template-editor.directives')
 
           $scope.registerDirective({
             type: 'rise-data-twitter',
-            iconType: 'streamline',
-            icon: 'twitter',
             element: element,
             show: function () {
               element.show();

--- a/src/scripts/template-editor/components/directives/dtv-component-video.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-video.js
@@ -126,10 +126,7 @@ angular.module('risevision.template-editor.directives')
 
           $scope.registerDirective({
             type: 'rise-video',
-            iconType: 'streamline',
-            icon: 'video',
             element: element,
-            panel: '.video-component-container',
             show: function () {
               _reset();
               $scope.componentId = $scope.factory.selected.id;

--- a/src/scripts/template-editor/components/directives/dtv-component-weather.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-weather.js
@@ -30,8 +30,6 @@ angular.module('risevision.template-editor.directives')
 
           $scope.registerDirective({
             type: 'rise-data-weather',
-            iconType: 'streamline',
-            icon: 'sun',
             element: element,
             show: function () {
               $scope.componentId = $scope.factory.selected.id;

--- a/src/scripts/template-editor/directives/dtv-attribute-editor.js
+++ b/src/scripts/template-editor/directives/dtv-attribute-editor.js
@@ -25,6 +25,8 @@ angular.module('risevision.template-editor.directives')
             directive.element.hide();
             $scope.directives[directive.type] = directive;
 
+            angular.extend(directive, COMPONENTS_MAP[directive.type]);
+
             if (directive.onPresentationOpen) {
               directive.onPresentationOpen();
             }
@@ -50,8 +52,6 @@ angular.module('risevision.template-editor.directives')
 
           $scope.editComponent = function (component) {
             var directive = _getDirective(component);
-
-            angular.extend(directive, COMPONENTS_MAP[directive.type]);
 
             $scope.factory.selected = component;
 

--- a/src/scripts/template-editor/directives/dtv-attribute-editor.js
+++ b/src/scripts/template-editor/directives/dtv-attribute-editor.js
@@ -2,9 +2,9 @@
 
 angular.module('risevision.template-editor.directives')
   .directive('templateAttributeEditor', ['$timeout', 'templateEditorFactory', 'templateEditorUtils',
-    'blueprintFactory', '$window', 'HTML_TEMPLATE_DOMAIN',
+    'blueprintFactory', '$window', 'COMPONENTS_MAP', 'HTML_TEMPLATE_DOMAIN',
     function ($timeout, templateEditorFactory, templateEditorUtils, blueprintFactory, $window,
-      HTML_TEMPLATE_DOMAIN) {
+      COMPONENTS_MAP, HTML_TEMPLATE_DOMAIN) {
       return {
         restrict: 'E',
         templateUrl: 'partials/template-editor/attribute-editor.html',
@@ -50,6 +50,8 @@ angular.module('risevision.template-editor.directives')
 
           $scope.editComponent = function (component) {
             var directive = _getDirective(component);
+
+            angular.extend(directive, COMPONENTS_MAP[directive.type]);
 
             $scope.factory.selected = component;
 
@@ -109,10 +111,10 @@ angular.module('risevision.template-editor.directives')
 
             if ($scope.panelTitle) {
               return $scope.panelTitle;
-            } else if (directive && directive.title) {
-              return directive.title;
             } else if (component && component.label) {
               return component.label;
+            } else if (directive && directive.title) {
+              return directive.title;
             } else {
               return '';
             }

--- a/src/scripts/template-editor/services/svc-components-factory.js
+++ b/src/scripts/template-editor/services/svc-components-factory.js
@@ -1,0 +1,137 @@
+'use strict';
+
+angular.module('risevision.template-editor.services')
+  .constant('COMPONENTS_MAP', {
+    'rise-branding-colors': {
+      type: 'rise-branding-colors',
+      iconType: 'streamline',
+      icon: 'palette',
+      panel: '.branding-colors-container',
+      title: 'Color Settings',
+    },
+    'rise-branding': {
+      type: 'rise-branding',
+      iconType: 'streamline',
+      icon: 'ratingStar',
+      panel: '.branding-component-container',
+      title: 'Brand Settings',
+    },
+    'rise-override-brand-colors': {
+      type: 'rise-override-brand-colors',
+      iconType: 'streamline',
+      icon: 'palette',
+      title: 'Override Brand Colors',
+    },
+    'rise-data-counter': {
+      type: 'rise-data-counter',
+      iconType: 'streamline',
+      icon: 'hourglass',
+      title: 'Counter'
+    },
+    'rise-data-financial': {
+      type: 'rise-data-financial',
+      iconType: 'streamline',
+      icon: 'financial',
+      title: 'Financial'
+    },
+    'rise-html': {
+      type: 'rise-html',
+      iconType: 'streamline',
+      icon: 'html',
+      title: 'HTML Embed',
+      visual: true
+    },
+    'rise-image': {
+      type: 'rise-image',
+      icon: 'image',
+      iconType: 'streamline',
+      panel: '.image-component-container',
+      title: 'Image',
+      playUntilDone: true,
+      visual: true
+    },
+    'rise-playlist': {
+      type: 'rise-playlist',
+      iconType: 'streamline',
+      icon: 'embedded-template',
+      title: 'Playlist'
+    },
+    'rise-data-rss': {
+      type: 'rise-data-rss',
+      iconType: 'streamline',
+      icon: 'rss',
+      title: 'RSS'
+    },
+    'rise-schedules': {
+      type: 'rise-schedules',
+      title: 'Schedules'
+    },
+    'rise-slides': {
+      type: 'rise-slides',
+      iconType: 'streamline',
+      icon: 'slides',
+      title: 'Google Slides',
+      visual: true
+    },
+    'rise-storage-selector': {
+      type: 'rise-storage-selector',
+      iconType: 'riseSvg',
+      icon: 'riseStorage',
+      panel: '.storage-selector-container',
+      title: 'Rise Storage',
+    },
+    'rise-text': {
+      type: 'rise-text',
+      iconType: 'streamline',
+      icon: 'text',
+      title: 'Text',
+      visual: true
+    },
+    'rise-time-date': {
+      type: 'rise-time-date',
+      iconType: 'streamline',
+      icon: 'time',
+      title: 'Time and Date',
+      visual: true
+    },
+    'rise-data-twitter': {
+      type: 'rise-data-twitter',
+      iconType: 'streamline',
+      icon: 'twitter',
+      title: 'Twitter'
+    },
+    'rise-video': {
+      type: 'rise-video',
+      iconType: 'streamline',
+      icon: 'video',
+      panel: '.video-component-container',
+      title: 'Video',
+      playUntilDone: true,
+      visual: true
+    },
+    'rise-data-weather': {
+      type: 'rise-data-weather',
+      iconType: 'streamline',
+      icon: 'sun',
+      title: 'Weather'
+    }
+  })
+  .factory('COMPONENTS_ARRAY', ['COMPONENTS_MAP', 
+    function(COMPONENTS_MAP) {
+      return _.values(COMPONENTS_MAP);
+    }
+  ])
+  .factory('PLAYLIST_COMPONENTS', ['COMPONENTS_ARRAY',
+    function(COMPONENTS_ARRAY) {
+      return _.filter(COMPONENTS_ARRAY, {
+        visual: true
+      });
+    }
+  ])
+  .factory('componentsFactory', ['COMPONENTS_MAP',
+    function (COMPONENTS_MAP) {
+      var factory = {};
+
+      return factory;
+    }
+  ]);

--- a/src/scripts/template-editor/services/svc-components-factory.js
+++ b/src/scripts/template-editor/services/svc-components-factory.js
@@ -52,8 +52,8 @@ angular.module('risevision.template-editor.services')
     },
     'rise-image-logo': {
       type: 'rise-image-logo',
-      icon: 'image',
       icon: 'circleStar',
+      iconType: 'streamline',
       panel: '.image-component-container',
       title: 'Logo Settings'
     },

--- a/src/scripts/template-editor/services/svc-components-factory.js
+++ b/src/scripts/template-editor/services/svc-components-factory.js
@@ -50,6 +50,13 @@ angular.module('risevision.template-editor.services')
       playUntilDone: true,
       visual: true
     },
+    'rise-image-logo': {
+      type: 'rise-image-logo',
+      icon: 'image',
+      icon: 'circleStar',
+      panel: '.image-component-container',
+      title: 'Logo Settings'
+    },
     'rise-playlist': {
       type: 'rise-playlist',
       iconType: 'streamline',

--- a/test/unit/template-editor/components/directives/dtv-branding-colors.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-branding-colors.spec.js
@@ -38,10 +38,6 @@ describe('directive: templateBrandingColors', function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
     expect(directive.type).to.equal('rise-branding-colors');
-    expect(directive.iconType).to.equal('streamline');
-    expect(directive.icon).to.equal('palette');
-    expect(directive.title).to.equal('Color Settings');
-    expect(directive.panel).to.equal('.branding-colors-container');
   });
 
   it('saveBranding: ', function() {

--- a/test/unit/template-editor/components/directives/dtv-component-branding.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-branding.spec.js
@@ -44,10 +44,6 @@ describe('directive: templateComponentBranding', function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
     expect(directive.type).to.equal('rise-branding');
-    expect(directive.iconType).to.equal('streamline');
-    expect(directive.icon).to.equal('ratingStar');
-    expect(directive.title).to.equal('Brand Settings');
-    expect(directive.panel).to.equal('.branding-component-container');
   });
 
   it('editLogo:', function() {

--- a/test/unit/template-editor/components/directives/dtv-component-colors.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-colors.spec.js
@@ -42,8 +42,6 @@ describe('directive: templateComponentColors', function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
     expect(directive.type).to.equal('rise-override-brand-colors');
-    expect(directive.iconType).to.equal('streamline');
-    expect(directive.icon).to.exist;
     expect(directive.show).to.be.a('function');
   });
 

--- a/test/unit/template-editor/components/directives/dtv-component-counter.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-counter.spec.js
@@ -49,8 +49,6 @@ describe('directive: templateComponentCounter', function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
     expect(directive.type).to.equal('rise-data-counter');
-    expect(directive.iconType).to.equal('streamline');
-    expect(directive.icon).to.exist;
     expect(directive.show).to.be.a('function');
   });
 

--- a/test/unit/template-editor/components/directives/dtv-component-financial.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-financial.spec.js
@@ -93,8 +93,6 @@ describe('directive: TemplateComponentFinancial', function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
     expect(directive.type).to.equal('rise-data-financial');
-    expect(directive.icon).to.equal('financial');
-    expect(directive.iconType).to.equal('streamline');
     expect(directive.show).to.be.a('function');
     expect(directive.onBackHandler).to.be.a('function');
   });

--- a/test/unit/template-editor/components/directives/dtv-component-html.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-html.spec.js
@@ -46,8 +46,6 @@ describe('directive: templateComponentHtml', function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
     expect(directive.type).to.equal('rise-html');
-    expect(directive.iconType).to.equal('streamline');
-    expect(directive.icon).to.equal('html');
     expect(directive.show).to.be.a('function');
   });
 

--- a/test/unit/template-editor/components/directives/dtv-component-image.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.spec.js
@@ -111,10 +111,7 @@ describe('directive: TemplateComponentImage', function() {
         var directive = $scope.registerDirective.getCall(0).args[0];
         expect(directive).to.be.ok;
         expect(directive.type).to.equal('rise-image');
-        expect(directive.iconType).to.equal('streamline');
-        expect(directive.icon).to.equal('image');
         expect(directive.element).to.be.an('object');
-        expect(directive.panel).to.equal('.image-component-container');
         expect(directive.show).to.be.a('function');
         expect(directive.onBackHandler).to.be.a('function');
       });
@@ -133,11 +130,7 @@ describe('directive: TemplateComponentImage', function() {
         var directive = $scope.registerDirective.getCall(1).args[0];
         expect(directive).to.be.ok;
         expect(directive.type).to.equal('rise-image-logo');
-        expect(directive.iconType).to.equal('streamline');
-        expect(directive.icon).to.equal('circleStar');
-        expect(directive.title).to.equal('Logo Settings');
         expect(directive.element).to.be.an('object');
-        expect(directive.panel).to.equal('.image-component-container');
         expect(directive.show).to.be.a('function');
       });
 

--- a/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
@@ -155,8 +155,6 @@ describe("directive: templateComponentPlaylist", function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
     expect(directive.type).to.equal("rise-playlist");
-    expect(directive.iconType).to.equal("streamline");
-    expect(directive.icon).to.exist;
     expect(directive.show).to.be.a("function");
   });
 

--- a/test/unit/template-editor/components/directives/dtv-component-rss.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-rss.spec.js
@@ -52,8 +52,6 @@ describe('directive: templateComponentRss', function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
     expect(directive.type).to.equal('rise-data-rss');
-    expect(directive.iconType).to.equal('streamline');
-    expect(directive.icon).to.equal('rss');
     expect(directive.show).to.be.a('function');
   });
 

--- a/test/unit/template-editor/components/directives/dtv-component-schedules.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-schedules.spec.js
@@ -58,7 +58,6 @@ describe('directive: templateComponentSchedules', function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
     expect(directive.type).to.equal('rise-schedules');
-    expect(directive.title).to.equal('Schedules');
   });
 
   describe('watch loadingSchedules:', function() {

--- a/test/unit/template-editor/components/directives/dtv-component-slides.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-slides.spec.js
@@ -53,8 +53,6 @@ describe('directive: templateComponentSlides', function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
     expect(directive.type).to.equal('rise-slides');
-    expect(directive.iconType).to.equal('streamline');
-    expect(directive.icon).to.equal('slides');
     expect(directive.show).to.be.a('function');
   });
 

--- a/test/unit/template-editor/components/directives/dtv-component-storage-selector.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-storage-selector.spec.js
@@ -150,11 +150,7 @@ describe('directive: componentStorageSelector', function() {
       var directive = $scope.registerDirective.getCall(0).args[0];
       expect(directive).to.be.ok;
       expect(directive.type).to.equal('rise-storage-selector');
-      expect(directive.iconType).to.equal('riseSvg');
-      expect(directive.icon).to.equal('riseStorage');
       expect(directive.element).to.be.an('object');
-      expect(directive.panel).to.equal('.storage-selector-container');
-      expect(directive.title).to.equal('Rise Storage');
       expect(directive.show).to.be.a('function');
       expect(directive.onBackHandler).to.be.a('function');
     });

--- a/test/unit/template-editor/components/directives/dtv-component-text.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-text.spec.js
@@ -43,8 +43,6 @@ describe('directive: templateComponentText', function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
     expect(directive.type).to.equal('rise-text');
-    expect(directive.iconType).to.equal('streamline');
-    expect(directive.icon).to.exist;
     expect(directive.show).to.be.a('function');
   });
 

--- a/test/unit/template-editor/components/directives/dtv-component-time-date.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-time-date.spec.js
@@ -46,8 +46,6 @@ describe('directive: templateComponentTimeDate', function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
     expect(directive.type).to.equal('rise-time-date');
-    expect(directive.iconType).to.equal('streamline');
-    expect(directive.icon).to.exist;
     expect(directive.show).to.be.a('function');
   });
 

--- a/test/unit/template-editor/components/directives/dtv-component-twitter.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-twitter.spec.js
@@ -60,8 +60,6 @@ describe('directive: templateComponentTwitter', function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
     expect(directive.type).to.equal('rise-data-twitter');
-    expect(directive.iconType).to.equal('streamline');
-    expect(directive.icon).to.exist;
     expect(directive.show).to.be.a('function');
   });
 

--- a/test/unit/template-editor/components/directives/dtv-component-video.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-video.spec.js
@@ -62,10 +62,7 @@ describe('directive: templateComponentVideo', function() {
       var directive = $scope.registerDirective.getCall(0).args[0];
       expect(directive).to.be.ok;
       expect(directive.type).to.equal('rise-video');
-      expect(directive.iconType).to.equal('streamline');
-      expect(directive.icon).to.equal('video');
       expect(directive.element).to.be.an('object');
-      expect(directive.panel).to.equal('.video-component-container');
       expect(directive.show).to.be.a('function');
     });
 

--- a/test/unit/template-editor/components/directives/dtv-component-weather.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-weather.spec.js
@@ -73,8 +73,6 @@ describe('directive: templateComponentWeather', function() {
     var directive = $scope.registerDirective.getCall(0).args[0];
     expect(directive).to.be.ok;
     expect(directive.type).to.equal('rise-data-weather');
-    expect(directive.iconType).to.equal('streamline');
-    expect(directive.icon).to.equal('sun');
     expect(directive.show).to.be.a('function');
   });
 

--- a/test/unit/template-editor/directives/dtv-attribute-editor.spec.js
+++ b/test/unit/template-editor/directives/dtv-attribute-editor.spec.js
@@ -80,9 +80,9 @@ describe('directive: TemplateAttributeEditor', function() {
     sinon.assert.calledWith($window.removeEventListener, 'message');
   });
 
-  it('registerDirective:', function() {
-    it('Registers a directive', function() {
-      var directive = {
+  describe('registerDirective:', function() {
+    it('Registers a component', function() {
+      var component = {
         type: 'rise-test',
         icon: 'fa-test',
         element: {
@@ -91,16 +91,16 @@ describe('directive: TemplateAttributeEditor', function() {
         show: function() {}
       };
 
-      $scope.registerDirective(directive);
+      $scope.registerDirective(component);
 
       expect($scope.directives["rise-test"]).to.be.ok;
       expect($scope.directives["rise-test"].type).to.equal("rise-test");
 
-      expect(directive.element.hide).to.have.been.called;
+      expect(component.element.hide).to.have.been.called;
     });
 
     it('Runs the open presentation handler', function() {
-      var directive = {
+      var component = {
         type: 'rise-test',
         icon: 'fa-test',
         element: {
@@ -110,13 +110,90 @@ describe('directive: TemplateAttributeEditor', function() {
         onPresentationOpen: sandbox.stub()
       };
 
+      $scope.registerDirective(component);
+
+      expect(component.onPresentationOpen).to.have.been.called;
+    });
+
+    it('should populate directive properties', function() {
+      var directive = {
+        type: 'rise-text',
+        element: {
+          hide: function() {},
+          show: function() {}
+        }
+      };
+
       $scope.registerDirective(directive);
 
-      expect(directive.onPresentationOpen).to.have.been.called;
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('text');
+      expect(directive.title).to.equal('Text');
     });
+
   });
 
-  describe('editComponent', function() {
+  describe('editComponent:', function() {
+    describe('_getDirective:', function() {
+      beforeEach(function() {
+        sandbox.stub($scope, 'showNextPage');
+      });
+
+      it('should handle missing component', function() {
+        $scope.editComponent();
+
+        expect($scope.factory.selected).to.not.be.ok;
+      });
+
+      it('should use component directive', function() {
+        var component = {
+          directive: {
+            type: 'rise-text',
+            element: {
+              hide: function() {},
+              show: sandbox.stub()
+            },
+            show: sandbox.stub()
+          }
+        };
+
+        $scope.editComponent(component);
+
+        expect($scope.factory.selected).to.equal(component);
+
+        expect(component.directive.element.show).to.have.been.called;
+        expect(component.directive.show).to.have.been.called;
+
+        $scope.showNextPage.should.have.been.calledWith(component);
+      });
+
+      it('should get directive from registered list', function() {
+        var directive = {
+          type: 'rise-text',
+          element: {
+            hide: function() {},
+            show: sandbox.stub()
+          },
+          show: sandbox.stub()
+        };
+
+        var component = {
+          type: 'rise-text'
+        }
+
+        $scope.registerDirective(directive);
+        $scope.editComponent(component);
+
+        expect($scope.factory.selected).to.equal(component);
+
+        expect(directive.element.show).to.have.been.called;
+        expect(directive.show).to.have.been.called;
+
+        $scope.showNextPage.should.have.been.calledWith(component);
+      });
+
+    });
+
     it('Edits a component', function() {
       var directive = {
         type: 'rise-test',
@@ -145,6 +222,98 @@ describe('directive: TemplateAttributeEditor', function() {
       timeout.flush();
       expect($scope.showAttributeList).to.be.false;
     });    
+  });
+  
+  describe('getComponentIcon:', function() {
+    it('should return empty if null', function() {
+      expect($scope.getComponentIcon()).to.equal('');
+    });
+
+    it('should return empty if directive is not found', function() {
+      var component = {};
+
+      expect($scope.getComponentIcon(component)).to.equal('');
+    });
+
+    it('should return directive icon', function() {
+      var component = {
+        directive: {
+          icon: 'sampleIcon'
+        }
+      };
+
+      expect($scope.getComponentIcon(component)).to.equal('sampleIcon');
+    });
+
+  });
+
+  describe('getComponentIconType:', function() {
+    it('should return empty if null', function() {
+      expect($scope.getComponentIconType()).to.equal('');
+    });
+
+    it('should return empty if directive is not found', function() {
+      var component = {};
+
+      expect($scope.getComponentIconType(component)).to.equal('');
+    });
+
+    it('should return directive icontype', function() {
+      var component = {
+        directive: {
+          iconType: 'iconType'
+        }
+      };
+
+      expect($scope.getComponentIconType(component)).to.equal('iconType');
+    });
+
+  });
+
+  describe('getComponentTitle:', function() {
+    it('should return empty if null', function() {
+      expect($scope.getComponentTitle()).to.equal('');
+    });
+
+    it('should return empty if directive is not found', function() {
+      var component = {};
+
+      expect($scope.getComponentTitle(component)).to.equal('');
+    });
+
+    it('should return panel title', function() {
+      $scope.panelTitle = 'panelTitle';
+      var component = {
+        label: 'directiveLabel',
+        directive: {
+          title: 'directiveTitle'
+        }
+      };
+
+      expect($scope.getComponentTitle(component)).to.equal('panelTitle');
+    });
+
+    it('should return component label', function() {
+      var component = {
+        label: 'directiveLabel',
+        directive: {
+          title: 'directiveTitle'
+        }
+      };
+
+      expect($scope.getComponentTitle(component)).to.equal('directiveLabel');
+    });
+
+    it('should return directive title if label is missing', function() {
+      var component = {
+        directive: {
+          title: 'directiveTitle'
+        }
+      };
+
+      expect($scope.getComponentTitle(component)).to.equal('directiveTitle');
+    });
+
   });
 
   describe('editHighlightedComponent:', function() {

--- a/test/unit/template-editor/directives/dtv-attribute-editor.spec.js
+++ b/test/unit/template-editor/directives/dtv-attribute-editor.spec.js
@@ -80,351 +80,363 @@ describe('directive: TemplateAttributeEditor', function() {
     sinon.assert.calledWith($window.removeEventListener, 'message');
   });
 
-  it('Registers a directive', function() {
-    var directive = {
-      type: 'rise-test',
-      icon: 'fa-test',
-      element: {
-        hide: sandbox.stub()
-      },
-      show: function() {}
-    };
+  it('registerDirective:', function() {
+    it('Registers a directive', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: sandbox.stub()
+        },
+        show: function() {}
+      };
 
-    $scope.registerDirective(directive);
+      $scope.registerDirective(directive);
 
-    expect($scope.directives["rise-test"]).to.be.ok;
-    expect($scope.directives["rise-test"].type).to.equal("rise-test");
+      expect($scope.directives["rise-test"]).to.be.ok;
+      expect($scope.directives["rise-test"].type).to.equal("rise-test");
 
-    expect(directive.element.hide).to.have.been.called;
+      expect(directive.element.hide).to.have.been.called;
+    });
+
+    it('Runs the open presentation handler', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: function() {},
+          show: function() {}
+        },
+        onPresentationOpen: sandbox.stub()
+      };
+
+      $scope.registerDirective(directive);
+
+      expect(directive.onPresentationOpen).to.have.been.called;
+    });
   });
 
-  it('Edits a component', function() {
-    var directive = {
-      type: 'rise-test',
-      icon: 'fa-test',
-      element: {
-        hide: function() {},
+  describe('editComponent', function() {
+    it('Edits a component', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: function() {},
+          show: sandbox.stub()
+        },
         show: sandbox.stub()
-      },
-      show: sandbox.stub()
-    };
+      };
 
-    var component = {
-      type: 'rise-test'
-    }
+      var component = {
+        type: 'rise-test'
+      }
 
-    $scope.registerDirective(directive);
-    $scope.editComponent(component);
+      $scope.registerDirective(directive);
+      $scope.editComponent(component);
 
-    expect(factory.selected).to.deep.equal(component);
+      expect(factory.selected).to.deep.equal(component);
 
-    expect(directive.element.show).to.have.been.called;
-    expect(directive.show).to.have.been.called;
+      expect(directive.element.show).to.have.been.called;
+      expect(directive.show).to.have.been.called;
 
-    expect($scope.showAttributeList).to.be.true;
+      expect($scope.showAttributeList).to.be.true;
 
-    timeout.flush();
-    expect($scope.showAttributeList).to.be.false;
+      timeout.flush();
+      expect($scope.showAttributeList).to.be.false;
+    });    
   });
 
-  it('Edits a highlighted component', function() {
-    var directive = {
-      type: 'rise-test',
-      icon: 'fa-test',
-      element: {
-        hide: function() {},
+  describe('editHighlightedComponent:', function() {
+    it('Edits a highlighted component', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: function() {},
+          show: sandbox.stub()
+        },
         show: sandbox.stub()
-      },
-      show: sandbox.stub()
-    };
+      };
 
-    var component = {
-      id: 'test',
-      type: 'rise-test'
-    }
+      var component = {
+        id: 'test',
+        type: 'rise-test'
+      }
 
-    blueprintFactory.blueprintData = {
-      components: [component]
-    };
+      blueprintFactory.blueprintData = {
+        components: [component]
+      };
 
-    $scope.registerDirective(directive);
-    $scope.editHighlightedComponent(component.id);
+      $scope.registerDirective(directive);
+      $scope.editHighlightedComponent(component.id);
 
-    expect(factory.selected).to.deep.equal(component);
+      expect(factory.selected).to.deep.equal(component);
 
-    expect(directive.element.show).to.have.been.called;
-    expect(directive.show).to.have.been.called;
+      expect(directive.element.show).to.have.been.called;
+      expect(directive.show).to.have.been.called;
 
-    expect($scope.showAttributeList).to.be.true;
+      expect($scope.showAttributeList).to.be.true;
 
-    timeout.flush();
-    expect($scope.showAttributeList).to.be.false;
-  });
+      timeout.flush();
+      expect($scope.showAttributeList).to.be.false;
+    });
 
-  it('Resets selected pages when editing a highlighted component', function() {
-    var directive = {
-      type: 'rise-test',
-      icon: 'fa-test',
-      element: {
-        hide: function() {},
+    it('Resets selected pages when editing a highlighted component', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: function() {},
+          show: sandbox.stub()
+        },
         show: sandbox.stub()
-      },
-      show: sandbox.stub()
-    };
+      };
 
-    var component = {
-      id: 'test',
-      type: 'rise-test'
-    }
-    
-    $scope.registerDirective(directive);
+      var component = {
+        id: 'test',
+        type: 'rise-test'
+      }
+      
+      $scope.registerDirective(directive);
 
-    blueprintFactory.blueprintData = {
-      components: [component]
-    };
+      blueprintFactory.blueprintData = {
+        components: [component]
+      };
 
-    factory.selected = component;
-    $scope.pages = [{}, {}, {}];
-    $scope.setPanelIcon('previous-icon', 'streamline');
-    $scope.setPanelTitle('Previous Title');
-    
-    $scope.editHighlightedComponent(component.id);
+      factory.selected = component;
+      $scope.pages = [{}, {}, {}];
+      $scope.setPanelIcon('previous-icon', 'streamline');
+      $scope.setPanelTitle('Previous Title');
+      
+      $scope.editHighlightedComponent(component.id);
 
-    expect(factory.selected).to.deep.equal(component);
+      expect(factory.selected).to.deep.equal(component);
 
-    expect($scope.pages).to.have.length(1);
-    expect($scope.pages[0]).to.equal(component);
-    expect($scope.panelIcon).to.be.null;
-    expect($scope.panelIconType).to.be.null;
-    expect($scope.panelTitle).to.be.null;
+      expect($scope.pages).to.have.length(1);
+      expect($scope.pages[0]).to.equal(component);
+      expect($scope.panelIcon).to.be.null;
+      expect($scope.panelIconType).to.be.null;
+      expect($scope.panelTitle).to.be.null;
 
-    expect(directive.element.show).to.have.been.called;
-    expect(directive.show).to.have.been.called;
+      expect(directive.element.show).to.have.been.called;
+      expect(directive.show).to.have.been.called;
 
-    expect($scope.showAttributeList).to.be.true;
+      expect($scope.showAttributeList).to.be.true;
 
-    timeout.flush();
-    expect($scope.showAttributeList).to.be.false;
+      timeout.flush();
+      expect($scope.showAttributeList).to.be.false;
+    });
   });
 
-  it('Runs the open presentation handler', function() {
-    var directive = {
-      type: 'rise-test',
-      icon: 'fa-test',
-      element: {
-        hide: function() {},
+  describe('backToList:', function() {
+    it('Goes back to list', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: sandbox.stub(),
+          show: function() {}
+        },
         show: function() {}
-      },
-      onPresentationOpen: sandbox.stub()
-    };
+      };
 
-    $scope.registerDirective(directive);
+      var component = {
+        type: 'rise-test'
+      }
 
-    expect(directive.onPresentationOpen).to.have.been.called;
+      $scope.registerDirective(directive);
+      $scope.editComponent(component);
+      timeout.flush();
+
+      $scope.backToList();
+
+      expect(factory.selected).to.be.null;
+      expect(directive.element.hide).to.have.been.called.twice;
+
+      expect($scope.showAttributeList).to.be.false;
+
+      timeout.flush();
+      expect($scope.showAttributeList).to.be.true;
+    });
   });
 
-  it('Goes back to list', function() {
-    var directive = {
-      type: 'rise-test',
-      icon: 'fa-test',
-      element: {
-        hide: sandbox.stub(),
+  describe('onBackButton:', function() {
+    it('Goes back to list if there is no back handler', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: sandbox.stub(),
+          show: function() {}
+        },
         show: function() {}
-      },
-      show: function() {}
-    };
+      };
 
-    var component = {
-      type: 'rise-test'
-    }
+      var component = {
+        type: 'rise-test'
+      }
 
-    $scope.registerDirective(directive);
-    $scope.editComponent(component);
-    timeout.flush();
+      $scope.highlightComponent = sandbox.stub();
+      $scope.registerDirective(directive);
+      $scope.editComponent(component);
+      timeout.flush();
 
-    $scope.backToList();
+      $scope.onBackButton();
 
-    expect(factory.selected).to.be.null;
-    expect(directive.element.hide).to.have.been.called.twice;
+      expect(factory.selected).to.be.null;
+      expect(directive.element.hide).to.have.been.called.twice;
+      expect($scope.highlightComponent).to.have.been.called.once;
 
-    expect($scope.showAttributeList).to.be.false;
+      expect($scope.showAttributeList).to.be.false;
 
-    timeout.flush();
-    expect($scope.showAttributeList).to.be.true;
+      timeout.flush();
+      expect($scope.showAttributeList).to.be.true;
+    });
+
+    it('Goes back to list if back handler returns false', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: sandbox.stub(),
+          show: function() {}
+        },
+        show: function() {},
+        onBackHandler: function() { return false; }
+      };
+
+      var component = {
+        type: 'rise-test'
+      }
+
+      $scope.highlightComponent = sandbox.stub();
+      $scope.registerDirective(directive);
+      $scope.editComponent(component);
+      timeout.flush();
+
+      $scope.onBackButton();
+
+      expect(factory.selected).to.be.null;
+      expect(directive.element.hide).to.have.been.called.twice;
+      expect($scope.highlightComponent).to.have.been.called.once;
+
+      expect($scope.showAttributeList).to.be.false;
+
+      timeout.flush();
+      expect($scope.showAttributeList).to.be.true;
+    });
+
+    it('Does not go back to list if back handler returns true', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: sandbox.stub(),
+          show: function() {}
+        },
+        show: function() {},
+        onBackHandler: function() { return true; }
+      };
+
+      var component = {
+        type: 'rise-test'
+      }
+
+      $scope.highlightComponent = sandbox.stub();
+      $scope.registerDirective(directive);
+      $scope.editComponent(component);
+      timeout.flush();
+
+      $scope.onBackButton();
+
+      expect(factory.selected).to.not.be.null;
+      expect(directive.element.hide).to.have.been.called.once;
+      expect($scope.highlightComponent).to.have.been.called.once;
+      expect($scope.showAttributeList).to.be.false;
+    });
   });
 
-  it('Goes back to list if there is no back handler', function() {
-    var directive = {
-      type: 'rise-test',
-      icon: 'fa-test',
-      element: {
-        hide: sandbox.stub(),
-        show: function() {}
-      },
-      show: function() {}
-    };
+  describe('isHeaderBottomRuleVisible:', function() {
+    it('Shows header bottom rule if isHeaderBottomRuleVisible is not defined for directive', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: sandbox.stub(),
+          show: function() {}
+        },
+        show: function() {},
+        onBackHandler: function() { return true; }
+      };
 
-    var component = {
-      type: 'rise-test'
-    }
+      var component = {
+        type: 'rise-test'
+      }
 
-    $scope.highlightComponent = sandbox.stub();
-    $scope.registerDirective(directive);
-    $scope.editComponent(component);
-    timeout.flush();
+      $scope.registerDirective(directive);
+      $scope.editComponent(component);
+      timeout.flush();
 
-    $scope.onBackButton();
+      var visible = $scope.isHeaderBottomRuleVisible(component);
 
-    expect(factory.selected).to.be.null;
-    expect(directive.element.hide).to.have.been.called.twice;
-    expect($scope.highlightComponent).to.have.been.called.once;
+      expect(visible).to.be.true;
+    });
 
-    expect($scope.showAttributeList).to.be.false;
+    it('Shows header bottom rule if isHeaderBottomRuleVisible allows it', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: sandbox.stub(),
+          show: function() {}
+        },
+        show: function() {},
+        isHeaderBottomRuleVisible: function() { return true; },
+        onBackHandler: function() { return true; }
+      };
 
-    timeout.flush();
-    expect($scope.showAttributeList).to.be.true;
+      var component = {
+        type: 'rise-test'
+      }
+
+      $scope.registerDirective(directive);
+      $scope.editComponent(component);
+      timeout.flush();
+
+      var visible = $scope.isHeaderBottomRuleVisible(component);
+
+      expect(visible).to.be.true;
+    });
+
+    it('Does not show header bottom rule if isHeaderBottomRuleVisible not allows it', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: sandbox.stub(),
+          show: function() {}
+        },
+        show: function() {},
+        isHeaderBottomRuleVisible: function() { return false; },
+        onBackHandler: function() { return true; }
+      };
+
+      var component = {
+        type: 'rise-test'
+      }
+
+      $scope.registerDirective(directive);
+      $scope.editComponent(component);
+      timeout.flush();
+
+      var visible = $scope.isHeaderBottomRuleVisible(component);
+
+      expect(visible).to.be.false;
+    });    
   });
 
-  it('Goes back to list if back handler returns false', function() {
-    var directive = {
-      type: 'rise-test',
-      icon: 'fa-test',
-      element: {
-        hide: sandbox.stub(),
-        show: function() {}
-      },
-      show: function() {},
-      onBackHandler: function() { return false; }
-    };
-
-    var component = {
-      type: 'rise-test'
-    }
-
-    $scope.highlightComponent = sandbox.stub();
-    $scope.registerDirective(directive);
-    $scope.editComponent(component);
-    timeout.flush();
-
-    $scope.onBackButton();
-
-    expect(factory.selected).to.be.null;
-    expect(directive.element.hide).to.have.been.called.twice;
-    expect($scope.highlightComponent).to.have.been.called.once;
-
-    expect($scope.showAttributeList).to.be.false;
-
-    timeout.flush();
-    expect($scope.showAttributeList).to.be.true;
-  });
-
-  it('Does not go back to list if back handler returns true', function() {
-    var directive = {
-      type: 'rise-test',
-      icon: 'fa-test',
-      element: {
-        hide: sandbox.stub(),
-        show: function() {}
-      },
-      show: function() {},
-      onBackHandler: function() { return true; }
-    };
-
-    var component = {
-      type: 'rise-test'
-    }
-
-    $scope.highlightComponent = sandbox.stub();
-    $scope.registerDirective(directive);
-    $scope.editComponent(component);
-    timeout.flush();
-
-    $scope.onBackButton();
-
-    expect(factory.selected).to.not.be.null;
-    expect(directive.element.hide).to.have.been.called.once;
-    expect($scope.highlightComponent).to.have.been.called.once;
-    expect($scope.showAttributeList).to.be.false;
-  });
-
-  it('Shows header bottom rule if isHeaderBottomRuleVisible is not defined for directive', function() {
-    var directive = {
-      type: 'rise-test',
-      icon: 'fa-test',
-      element: {
-        hide: sandbox.stub(),
-        show: function() {}
-      },
-      show: function() {},
-      onBackHandler: function() { return true; }
-    };
-
-    var component = {
-      type: 'rise-test'
-    }
-
-    $scope.registerDirective(directive);
-    $scope.editComponent(component);
-    timeout.flush();
-
-    var visible = $scope.isHeaderBottomRuleVisible(component);
-
-    expect(visible).to.be.true;
-  });
-
-  it('Shows header bottom rule if isHeaderBottomRuleVisible allows it', function() {
-    var directive = {
-      type: 'rise-test',
-      icon: 'fa-test',
-      element: {
-        hide: sandbox.stub(),
-        show: function() {}
-      },
-      show: function() {},
-      isHeaderBottomRuleVisible: function() { return true; },
-      onBackHandler: function() { return true; }
-    };
-
-    var component = {
-      type: 'rise-test'
-    }
-
-    $scope.registerDirective(directive);
-    $scope.editComponent(component);
-    timeout.flush();
-
-    var visible = $scope.isHeaderBottomRuleVisible(component);
-
-    expect(visible).to.be.true;
-  });
-
-  it('Does not show header bottom rule if isHeaderBottomRuleVisible not allows it', function() {
-    var directive = {
-      type: 'rise-test',
-      icon: 'fa-test',
-      element: {
-        hide: sandbox.stub(),
-        show: function() {}
-      },
-      show: function() {},
-      isHeaderBottomRuleVisible: function() { return false; },
-      onBackHandler: function() { return true; }
-    };
-
-    var component = {
-      type: 'rise-test'
-    }
-
-    $scope.registerDirective(directive);
-    $scope.editComponent(component);
-    timeout.flush();
-
-    var visible = $scope.isHeaderBottomRuleVisible(component);
-
-    expect(visible).to.be.false;
-  });
-
-  describe('showNextPage', function () {
+  describe('showNextPage:', function () {
     it('should show a new page', function () {
       expect($scope.pages).to.have.length(0);
 
@@ -442,7 +454,7 @@ describe('directive: TemplateAttributeEditor', function() {
     });
   });
 
-  describe('showPreviousPage', function () {
+  describe('showPreviousPage:', function () {
     it('should hide the first page', function () {
       $scope.showNextPage('selector1');
 

--- a/test/unit/template-editor/services/svc-components-factory.spec.js
+++ b/test/unit/template-editor/services/svc-components-factory.spec.js
@@ -25,9 +25,177 @@ describe('service: componentsFactory:', function() {
       expect(COMPONENTS_MAP).to.be.an('object');
     });
 
-    it('should configure component objects', function() {
-      expect(COMPONENTS_MAP['rise-text']).to.be.ok;
+    it('rise-branding-colors', function() {
+      var directive = COMPONENTS_MAP['rise-branding-colors'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-branding-colors');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('palette');
+      expect(directive.title).to.equal('Color Settings');
+      expect(directive.panel).to.equal('.branding-colors-container');
     });
+
+    it('rise-branding', function() {
+      var directive = COMPONENTS_MAP['rise-branding'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-branding');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('ratingStar');
+      expect(directive.title).to.equal('Brand Settings');
+      expect(directive.panel).to.equal('.branding-component-container');
+    });
+
+    it('rise-override-brand-colors', function() {
+      var directive = COMPONENTS_MAP['rise-override-brand-colors'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-override-brand-colors');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.exist;
+    });
+
+    it('rise-data-counter', function() {
+      var directive = COMPONENTS_MAP['rise-data-counter'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-data-counter');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.exist;
+    });
+
+    it('rise-data-financial', function() {
+      var directive = COMPONENTS_MAP['rise-data-financial'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-data-financial');
+      expect(directive.icon).to.equal('financial');
+      expect(directive.iconType).to.equal('streamline');
+    });
+
+    it('rise-html', function() {
+      var directive = COMPONENTS_MAP['rise-html'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-html');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('html');
+    });
+
+    it('rise-image', function() {
+      var directive = COMPONENTS_MAP['rise-image'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-image');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('image');
+      expect(directive.panel).to.equal('.image-component-container');
+    });
+
+    it('rise-image-logo', function() {
+      var directive = COMPONENTS_MAP['rise-image-logo'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-image-logo');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('circleStar');
+      expect(directive.title).to.equal('Logo Settings');
+      expect(directive.panel).to.equal('.image-component-container');
+    });
+
+    it('rise-playlist', function() {
+      var directive = COMPONENTS_MAP['rise-playlist'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal("rise-playlist");
+      expect(directive.iconType).to.equal("streamline");
+      expect(directive.icon).to.exist;
+    });
+
+    it('rise-data-rss', function() {
+      var directive = COMPONENTS_MAP['rise-data-rss'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-data-rss');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('rss');
+    });
+
+    it('rise-schedules', function() {
+      var directive = COMPONENTS_MAP['rise-schedules'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-schedules');
+      expect(directive.title).to.equal('Schedules');
+    });
+
+    it('rise-slides', function() {
+      var directive = COMPONENTS_MAP['rise-slides'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-slides');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('slides');
+    });
+
+    it('rise-storage-selector', function() {
+      var directive = COMPONENTS_MAP['rise-storage-selector'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-storage-selector');
+      expect(directive.iconType).to.equal('riseSvg');
+      expect(directive.icon).to.equal('riseStorage');
+      expect(directive.panel).to.equal('.storage-selector-container');
+      expect(directive.title).to.equal('Rise Storage');
+    });
+
+    it('rise-text', function() {
+      var directive = COMPONENTS_MAP['rise-text'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-text');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.exist;
+    });
+
+    it('rise-time-date', function() {
+      var directive = COMPONENTS_MAP['rise-time-date'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-time-date');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.exist;
+    });
+
+    it('rise-data-twitter', function() {
+      var directive = COMPONENTS_MAP['rise-data-twitter'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-data-twitter');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.exist;
+    });
+
+    it('rise-video', function() {
+      var directive = COMPONENTS_MAP['rise-video'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-video');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('video');
+      expect(directive.panel).to.equal('.video-component-container');
+    });
+
+    it('rise-data-weather', function() {
+      var directive = COMPONENTS_MAP['rise-data-weather'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-data-weather');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('sun');
+    });
+
   });
 
   it('COMPONENTS_ARRAY', function() {

--- a/test/unit/template-editor/services/svc-components-factory.spec.js
+++ b/test/unit/template-editor/services/svc-components-factory.spec.js
@@ -1,0 +1,50 @@
+'use strict';
+
+describe('service: componentsFactory:', function() {
+  var sandbox = sinon.sandbox.create();
+
+  beforeEach(module('risevision.template-editor.services'));
+
+  var componentsFactory, COMPONENTS_MAP, COMPONENTS_ARRAY, PLAYLIST_COMPONENTS;
+
+  beforeEach(function() {
+    inject(function($injector) {
+      componentsFactory = $injector.get('componentsFactory');
+      COMPONENTS_MAP = $injector.get('COMPONENTS_MAP');
+      COMPONENTS_ARRAY = $injector.get('COMPONENTS_ARRAY');
+      PLAYLIST_COMPONENTS = $injector.get('PLAYLIST_COMPONENTS');
+    });
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  describe('COMPONENTS_MAP', function() {
+    it('should exist', function() {
+      expect(COMPONENTS_MAP).to.be.an('object');
+    });
+
+    it('should configure component objects', function() {
+      expect(COMPONENTS_MAP['rise-text']).to.be.ok;
+    });
+  });
+
+  it('COMPONENTS_ARRAY', function() {
+    expect(COMPONENTS_ARRAY).to.have.length(17);
+
+    for (var i = 0; i < COMPONENTS_ARRAY.length; i++) {
+      expect(COMPONENTS_ARRAY[i].type).to.be.ok;
+      expect(COMPONENTS_ARRAY[i].title).to.be.ok;
+    }
+  });
+
+  it('PLAYLIST_COMPONENTS', function() {
+    expect(PLAYLIST_COMPONENTS).to.have.length(6);
+  });
+
+  it('should initialize', function() {
+    expect(componentsFactory).to.be.ok;
+  });
+
+});

--- a/test/unit/template-editor/services/svc-components-factory.spec.js
+++ b/test/unit/template-editor/services/svc-components-factory.spec.js
@@ -31,7 +31,7 @@ describe('service: componentsFactory:', function() {
   });
 
   it('COMPONENTS_ARRAY', function() {
-    expect(COMPONENTS_ARRAY).to.have.length(17);
+    expect(COMPONENTS_ARRAY).to.have.length(18);
 
     for (var i = 0; i < COMPONENTS_ARRAY.length; i++) {
       expect(COMPONENTS_ARRAY[i].type).to.be.ok;


### PR DESCRIPTION
## Description
Set default names for component directives

Add component array and map utilities
Extend component directive and move common properties

[stage-18]

## Motivation and Context
Playlist UI

## How Has This Been Tested?
Tested locally. Updated test coverage. Will have another PR for more test coverage updates for `dtv-attribute-editor.js`.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No