### PR TITLE
Wait for spinner before using the search box

### DIFF
--- a/test/e2e/template-editor/cases/components/playlist.js
+++ b/test/e2e/template-editor/cases/components/playlist.js
@@ -40,13 +40,13 @@ var PlaylistComponentScenarios = function () {
 
       it('should show no results message when there are no templates', function () {
         helper.clickWhenClickable(playlistComponentPage.getSelectTemplatesButton(), 'Select Templates');
-        helper.waitDisappear(playlistComponentPage.getTemplatesLoaderSpinner(), 'Spinner');
+
+        helper.waitAppearDisappear(playlistComponentPage.getTemplatesLoaderSpinner(), 'Templates Loader');
 
         //search for something that returns no results
         playlistComponentPage.getSearchInput().sendKeys("purple unicorn" + protractor.Key.ENTER);
 
         helper.waitAppearDisappear(playlistComponentPage.getTemplatesLoaderSpinner(), 'Templates Loader');
-        browser.sleep(1000);
 
         expect(playlistComponentPage.getAddTemplateButton().isDisplayed()).to.eventually.be.true;
         expect(playlistComponentPage.getAddTemplateButton().isEnabled()).to.eventually.be.false;


### PR DESCRIPTION
## Description
Wait for spinner before using the search box

[stage-11]

## Motivation and Context
Try to fix e2e test failure related to this.

## How Has This Been Tested?
So far it has passed.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No