### PR TITLE
Unique filename to upload canva design

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -297,6 +297,7 @@
               "src/scripts/common/directives/dtv-weekly-templates.js",
 
               "src/scripts/common/services/svc-cached-request.js",
+              "src/scripts/common/services/svc-file-downloader.js",
               "src/scripts/common/services/svc-gadgets-api.js",
               "src/scripts/common/services/svc-resource-loader.js",
               "src/scripts/common/services/svc-company-assets-factory.js",

--- a/src/app/editor/components/canva-button/canva-button.component.ts
+++ b/src/app/editor/components/canva-button/canva-button.component.ts
@@ -10,13 +10,13 @@ import { CanvaApiService } from '../../services/canva-api.service';
 })
 export class CanvaButtonComponent {
 
-  @Output() designPublished = new EventEmitter<string>();
+  @Output() designPublished = new EventEmitter<any>();
 
   constructor(private canvaApi: CanvaApiService) { }
 
   designWithCanva(): void {
-    this.canvaApi.createDesign().then((exportUrl: string) => {
-      this.designPublished.emit(exportUrl);
+    this.canvaApi.createDesign().then((options) => {
+      this.designPublished.emit(options);
     });  	
   }
 

--- a/src/app/editor/services/canva-api.service.ts
+++ b/src/app/editor/services/canva-api.service.ts
@@ -54,8 +54,7 @@ export class CanvaApiService {
             type: 'Logo',
           },
           onDesignPublish: function (options) {
-            var exportUrl = options.exportUrl;
-            resolve(exportUrl);
+            resolve(options);
           },
           onDesignClose: function () {              
             reject('closed');

--- a/src/scripts/common/services/svc-file-downloader.js
+++ b/src/scripts/common/services/svc-file-downloader.js
@@ -2,7 +2,7 @@
 
 angular.module('risevision.apps.services')
   .service('fileDownloader', ['$q', function ($q) {
-    return function (url, filename) {
+    return function (url, filepath) {
       var deferred = $q.defer();
       var xhr = new XMLHttpRequest();
 
@@ -13,7 +13,7 @@ angular.module('risevision.apps.services')
       xhr.onload = function () {
         if (xhr.status === 200) {
           var blob = xhr.response;
-          var file = new File([blob], filename);
+          var file = new File([blob], filepath);
           deferred.resolve(file);  
         } else {
           deferred.reject({

--- a/src/scripts/common/services/svc-file-downloader.js
+++ b/src/scripts/common/services/svc-file-downloader.js
@@ -1,0 +1,37 @@
+'use strict';
+
+angular.module('risevision.apps.services')
+  .service('fileDownloader', ['$q', function ($q) {
+    return function (url, filename) {
+      var deferred = $q.defer();
+      var xhr = new XMLHttpRequest();
+
+      xhr.open('GET', url, true);
+      xhr.responseType = 'blob';
+      xhr.timeout = 15000;
+
+      xhr.onload = function () {
+        if (xhr.status === 200) {
+          var blob = xhr.response;
+          var file = new File([blob], filename);
+          deferred.resolve(file);  
+        } else {
+          deferred.reject({
+            status: xhr.status,
+            err: 'Status Error'
+          });
+        }
+      };
+
+      xhr.onerror = xhr.ontimeout = function (err) {
+        deferred.reject({
+          status: xhr.status,
+          err: err
+        });
+      };
+
+      xhr.send();
+
+      return deferred.promise;
+    };
+  }]);

--- a/src/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-image.js
@@ -279,15 +279,17 @@ angular.module('risevision.template-editor.directives')
               });
           }
 
-          $scope.onDesignPublished = function(exportUrl) {
+          $scope.onDesignPublished = function(options) {
+            console.log('Canva result:', options);
             var xhr = new XMLHttpRequest();
-            xhr.open('GET', exportUrl);
+            xhr.open('GET', options.exportUrl);
             xhr.responseType = 'blob';
             xhr.onload = function() 
             {
-              console.log('image loaded');
+              var filename = options.designTitle? options.designTitle + '_' : '';
+              filename += options.designId + '.png';
               var blob = xhr.response;
-              var file = new File([blob], 'canva.png');
+              var file = new File([blob], 'canva/'+filename);
               $scope.canvaUploadList = [file];                          
             };
             xhr.send();

--- a/src/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-image.js
@@ -6,10 +6,10 @@ angular.module('risevision.template-editor.directives')
   .constant('SUPPORTED_IMAGE_TYPES', '.bmp, .gif, .jpeg, .jpg, .png, .svg, .webp')
   .directive('templateComponentImage', ['$log', '$q', '$timeout', 'templateEditorFactory',
     'storageManagerFactory', 'fileExistenceCheckService', 'fileMetadataUtilsService', 'DEFAULT_IMAGE_THUMBNAIL',
-    'SUPPORTED_IMAGE_TYPES', 'logoImageFactory', 'baseImageFactory',
+    'SUPPORTED_IMAGE_TYPES', 'logoImageFactory', 'baseImageFactory', 'fileDownloader',
     function ($log, $q, $timeout, templateEditorFactory, storageManagerFactory,
       fileExistenceCheckService, fileMetadataUtilsService, DEFAULT_IMAGE_THUMBNAIL, SUPPORTED_IMAGE_TYPES,
-      logoImageFactory, baseImageFactory) {
+      logoImageFactory, baseImageFactory, fileDownloader) {
       return {
         restrict: 'E',
         scope: true,
@@ -281,21 +281,15 @@ angular.module('risevision.template-editor.directives')
 
           $scope.onDesignPublished = function(options) {
             console.log('Canva result:', options);
-            var xhr = new XMLHttpRequest();
-            xhr.open('GET', options.exportUrl);
-            xhr.responseType = 'blob';
-            xhr.onload = function() 
-            {
-              var filename = options.designTitle? options.designTitle + '_' : '';
-              filename += options.designId + '.png';
-              var blob = xhr.response;
-              var file = new File([blob], 'canva/'+filename);
+            var filename = options.designTitle? options.designTitle + '_' : '';
+            filename += options.designId + '.png';
+            fileDownloader(options.exportUrl, filename)
+            .then(function(file) {
               $scope.canvaUploadList = [file];
-            };
-            xhr.onerror = function() {
-              $log.error('Could not import Canva design.', options);
-            }
-            xhr.send();
+            })
+            .catch(function(err) {
+              $log.error('Could not import Canva design.', err);
+            });
           };
 
           $scope.selectFromStorage = function () {

--- a/src/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-image.js
@@ -290,8 +290,11 @@ angular.module('risevision.template-editor.directives')
               filename += options.designId + '.png';
               var blob = xhr.response;
               var file = new File([blob], 'canva/'+filename);
-              $scope.canvaUploadList = [file];                          
+              $scope.canvaUploadList = [file];
             };
+            xhr.onerror = function() {
+              $log.error('Could not import Canva design.', options);
+            }
             xhr.send();
           };
 

--- a/src/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-image.js
@@ -4,12 +4,13 @@ angular.module('risevision.template-editor.directives')
   .constant('DEFAULT_IMAGE_THUMBNAIL',
     'https://s3.amazonaws.com/Rise-Images/UI/storage-image-icon-no-transparency%402x.png')
   .constant('SUPPORTED_IMAGE_TYPES', '.bmp, .gif, .jpeg, .jpg, .png, .svg, .webp')
+  .constant('CANVA_FOLDER', 'canva/')
   .directive('templateComponentImage', ['$log', '$q', '$timeout', 'templateEditorFactory',
     'storageManagerFactory', 'fileExistenceCheckService', 'fileMetadataUtilsService', 'DEFAULT_IMAGE_THUMBNAIL',
-    'SUPPORTED_IMAGE_TYPES', 'logoImageFactory', 'baseImageFactory', 'fileDownloader',
+    'SUPPORTED_IMAGE_TYPES', 'logoImageFactory', 'baseImageFactory', 'fileDownloader', 'CANVA_FOLDER',
     function ($log, $q, $timeout, templateEditorFactory, storageManagerFactory,
       fileExistenceCheckService, fileMetadataUtilsService, DEFAULT_IMAGE_THUMBNAIL, SUPPORTED_IMAGE_TYPES,
-      logoImageFactory, baseImageFactory, fileDownloader) {
+      logoImageFactory, baseImageFactory, fileDownloader, CANVA_FOLDER) {
       return {
         restrict: 'E',
         scope: true,
@@ -281,9 +282,10 @@ angular.module('risevision.template-editor.directives')
 
           $scope.onDesignPublished = function(options) {
             console.log('Canva result:', options);
-            var filename = options.designTitle? options.designTitle + '_' : '';
-            filename += options.designId + '.png';
-            fileDownloader(options.exportUrl, filename)
+            var filepath = CANVA_FOLDER;
+            filepath += options.designTitle? options.designTitle + '_' : '';
+            filepath += options.designId + '.png';
+            fileDownloader(options.exportUrl, filepath)
             .then(function(file) {
               $scope.canvaUploadList = [file];
             })

--- a/src/scripts/template-editor/directives/dtv-basic-uploader.js
+++ b/src/scripts/template-editor/directives/dtv-basic-uploader.js
@@ -17,7 +17,6 @@ angular.module('risevision.template-editor.directives')
         },
         templateUrl: 'partials/template-editor/basic-uploader.html',
         link: function ($scope, element) {
-          var confirmOverwriteModal;
           var FileUploader = fileUploaderFactory();
           var inputElement = element.find('input');
 
@@ -31,11 +30,8 @@ angular.module('risevision.template-editor.directives')
 
           $scope.$watch('fileList',function(selectedFiles) {
             if (selectedFiles) {
-              $scope.uploadSelectedFiles(selectedFiles).then(function() {
-                $scope.fileList = null;
-              });  
+              $scope.uploadSelectedFiles(selectedFiles);
             }
-            
           });
 
           $scope.$watch($scope.uploadManager.isSingleFileSelector, function (value) {


### PR DESCRIPTION
## Description
Use Canva design title and id to generate a unique name for each design.
Uploads to canva/ folder in Storage
In case of conflict, a message asking to overwrite or not is shown.
Also, refactored the download and created a fileDownloader service


## Motivation and Context
Canva Integration

## How Has This Been Tested?
Tested locally
[stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
