### PR TITLE
Move branding colors component to components list

### DIFF
--- a/src/partials/template-editor/component.html
+++ b/src/partials/template-editor/component.html
@@ -29,6 +29,7 @@
 <div class="component-container">
   <component-storage-selector></component-storage-selector>
   <template-component-branding></template-component-branding>
+  <template-branding-colors></template-branding-colors>
   <template-component-schedules></template-component-schedules>
   <template-component-financial></template-component-financial>
   <template-component-image></template-component-image>

--- a/src/partials/template-editor/components/component-branding/component-branding.html
+++ b/src/partials/template-editor/components/component-branding/component-branding.html
@@ -33,5 +33,3 @@
   </div>
 
 </div>
-
-<template-branding-colors></template-branding-colors>

--- a/src/scripts/template-editor/services/svc-components-factory.js
+++ b/src/scripts/template-editor/services/svc-components-factory.js
@@ -61,6 +61,7 @@ angular.module('risevision.template-editor.services')
       type: 'rise-playlist',
       iconType: 'streamline',
       icon: 'embedded-template',
+      panel: '.rise-playlist-container',
       title: 'Playlist'
     },
     'rise-data-rss': {

--- a/test/e2e/template-editor/cases/components/playlist.js
+++ b/test/e2e/template-editor/cases/components/playlist.js
@@ -35,6 +35,8 @@ var PlaylistComponentScenarios = function () {
       it('should open properties of Playlist Component', function () {
         templateEditorPage.selectComponent(componentLabel);
 
+        helper.wait(playlistComponentPage.getSelectTemplatesButton(), 'Select Button');
+
         expect(playlistComponentPage.getSelectTemplatesButton().isDisplayed()).to.eventually.be.true;
       });
 

--- a/test/unit/template-editor/services/svc-components-factory.spec.js
+++ b/test/unit/template-editor/services/svc-components-factory.spec.js
@@ -111,6 +111,7 @@ describe('service: componentsFactory:', function() {
       expect(directive.type).to.equal("rise-playlist");
       expect(directive.iconType).to.equal("streamline");
       expect(directive.icon).to.exist;
+      expect(directive.panel).to.equal(".rise-playlist-container");
     });
 
     it('rise-data-rss', function() {


### PR DESCRIPTION
## Description
Move branding colors component to components list

Fixes issue where hide removes the parent container

Add panel id to the playlist component
Enables transitions for it

Add wait for element

[stage-19]

## Motivation and Context
Playlist UI

## How Has This Been Tested?
Tested locally. E2e tests pass.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No