### PR TITLE
Reconfigure css so dropdown container is full height

### DIFF
--- a/src/partials/template-editor/components/component-playlist.html
+++ b/src/partials/template-editor/components/component-playlist.html
@@ -40,8 +40,8 @@ rv-spinner rv-spinner-key="rise-playlist-templates-loader">
       </div>
     </div>
 
-    <div class="playlist-action-button-bar">
-      <div class="select-templates" ng-class="{'no-selected-templates' : !playlistItems.length || playlistItems.length === 0}">
+    <div class="playlist-action-button-bar" ng-class="{'no-selected-templates' : !playlistItems.length || playlistItems.length === 0}">
+      <div class="select-templates">
         <button id="te-playlist-select-templates" class="btn btn-primary btn-block" ng-click="showAddTemplates()" ng-if="!addVisualComponents">
           Select Presentations
         </button>

--- a/src/scss/sections/components/playlist.scss
+++ b/src/scss/sections/components/playlist.scss
@@ -269,16 +269,19 @@
 
 .playlist-action-button-bar {
   height: var(--playlist-button-bar-height);
-  padding: 0 20px;
+  margin: 0 20px;
   background: #FFF;
+
+  border-top: 1px solid #999;
+
+  &.no-selected-templates {
+    height: calc(var(--selector-body-height) - var(--playlist-selected-title-height));
+
+    border: none;
+  }
 
   .select-templates, .add-templates {
     padding: 27px 0 0 0;
-    border-top: 1px solid #999;
-
-    &.no-selected-templates {
-      border: none;
-    }
   }
 
   & > div {


### PR DESCRIPTION
## Description
Reconfigure css so dropdown container is full height

Allows dropdown content to overflow below the button

[stage-19]

## Motivation and Context
Playlist UI

## How Has This Been Tested?
Tested locally with various scenarios for the component

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No