### PR TITLE
Thumbnail for Canva images

### DIFF
--- a/src/scripts/common/services/svc-file-downloader.js
+++ b/src/scripts/common/services/svc-file-downloader.js
@@ -13,7 +13,9 @@ angular.module('risevision.apps.services')
       xhr.onload = function () {
         if (xhr.status === 200) {
           var blob = xhr.response;
-          var file = new File([blob], filepath);
+          var file = new File([blob], filepath, {
+            type: xhr.getResponseHeader('content-type')
+          });
           deferred.resolve(file);  
         } else {
           deferred.reject({

--- a/test/unit/common/services/svc-file-downloader.spec.js
+++ b/test/unit/common/services/svc-file-downloader.spec.js
@@ -27,10 +27,11 @@ describe('service: file downloader:', function() {
     var filepath = 'folder/file.jpg';
     var promise = fileDownloader('http://localhost/image.jpg',filepath);
 
-    sandbox.server.requests[0].respond(200, {}, 'Image data');
+    sandbox.server.requests[0].respond(200, {'Content-Type': 'image/png'}, 'Image data');
 
     promise.then(function(file) {
       expect(file.name).to.equal(filepath);
+      expect(file.type).to.equal('image/png');
 
       var reader = new FileReader();
       reader.onload = function(event) {


### PR DESCRIPTION
## Description
Generate thumbnails for images from Canva exports.

## Motivation and Context
Canva Integration
Thumbnails were not being generated as mime type was not being set. Storage server would skip it as file was not recognized as an accepted image type for thumbnail generation.

## How Has This Been Tested?
Locally and on [stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
