### PR TITLE
Reset folder name when selecting file

### DIFF
--- a/src/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-image.js
@@ -188,14 +188,7 @@ angular.module('risevision.template-editor.directives')
               _loadTransition();
               _loadHelpText();
             },
-            onBackHandler: function () {
-              if ($scope.isEditingLogo()) {
-                $scope.resetPanelHeader();
-              }
-              return false;
-            },
             onPresentationOpen: function () {
-              console.log('on presentation open');
               $scope.fileExistenceChecksCompleted = {};
 
               var imageComponentIds = $scope.getComponentIds(function (c) {
@@ -203,7 +196,7 @@ angular.module('risevision.template-editor.directives')
               });
 
               _.forEach(imageComponentIds, function (componentId) {
-                console.log('checking file existence for component', componentId);
+                $log.info('checking file existence for component', componentId);
 
                 $scope.fileExistenceChecksCompleted[componentId] = false;
 
@@ -266,7 +259,7 @@ angular.module('risevision.template-editor.directives')
                 return $scope.waitForPresentationId(metadata);
               })
               .then(function (metadata) {
-                console.log('received metadata', metadata);
+                $log.info('received metadata', metadata);
 
                 $scope.updateFileMetadata(componentId, metadata);
               })
@@ -276,7 +269,7 @@ angular.module('risevision.template-editor.directives')
           }
 
           $scope.onDesignPublished = function(options) {
-            console.log('Canva result:', options);
+            $log.info('Canva result:', options);
             var filepath = CANVA_FOLDER;
             filepath += options.designTitle? options.designTitle + '_' : '';
             filepath += options.designId + '.png';

--- a/src/scripts/template-editor/components/directives/dtv-component-storage-selector.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-storage-selector.js
@@ -61,6 +61,8 @@ angular.module('risevision.template-editor.directives')
           });
 
           function _reset() {
+            $scope.resetPanelHeader();
+
             $scope.folderItems = [];
             $scope.selectedItems = [];
             $scope.search.selectAll = false;

--- a/test/unit/template-editor/components/directives/dtv-component-image.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.spec.js
@@ -125,7 +125,6 @@ describe('directive: TemplateComponentImage', function() {
         expect(directive.type).to.equal('rise-image');
         expect(directive.element).to.be.an('object');
         expect(directive.show).to.be.a('function');
-        expect(directive.onBackHandler).to.be.a('function');
       });
 
       it('show:', function() {

--- a/test/unit/template-editor/components/directives/dtv-component-storage-selector.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-storage-selector.spec.js
@@ -316,6 +316,8 @@ describe('directive: componentStorageSelector', function() {
       expect($scope.search.selectAll).to.be.false;
       expect(storageManagerFactory.onSelectHandler).to.have.been.calledWith(selectedItems);
 
+      $scope.resetPanelHeader.should.have.been.called;
+
       $scope.showPreviousPage.should.have.been.called;
     });
   });


### PR DESCRIPTION
## Description
Reset folder name when selecting file

Fixes issue where folder name and icon persist

Remove back handler function from image
Logo has a separate directive and handler

[stage-19]

## Motivation and Context
Fix issue. Cleanup.

## How Has This Been Tested?
Tested locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No