### PR TITLE
Fix fontawesome fonts on rise.min.css for storage-selector

### DIFF
--- a/css-build.js
+++ b/css-build.js
@@ -9,7 +9,7 @@ var colors = require("colors");
 
 var paths = {
   sass: ["./src/scss/**/*.scss", "./src/scss/*.scss"],
-  appSass: "./src/scss/app.scss",
+  appSass: "./src/scss/rise.scss",
   alignmentSass: "./src/scss/ui-components/alignment.scss",
   tmpFonts: "./src/tmp/fonts",
   tmpCss: "./src/tmp/css",

--- a/src/scss/bootstrap-variables.scss
+++ b/src/scss/bootstrap-variables.scss
@@ -74,8 +74,8 @@ $headings-color:          inherit;
 //## Specify custom location and filename of the included Glyphicons icon font. Useful for those including Bootstrap via Bower.
 
 //** Load fonts from this directory.
-$fa-font-path: "../bower_components/font-awesome/fonts";
-$icon-font-path: "../bower_components/bootstrap-sass-official/assets/fonts/bootstrap/";
+$fa-font-path: "../bower_components/font-awesome/fonts" !default;
+$icon-font-path: "../bower_components/bootstrap-sass-official/assets/fonts/bootstrap/" !default;
 //** File name for all font files.
 $icon-font-name:          "glyphicons-halflings-regular";
 //** Element ID within SVG icon file.

--- a/src/scss/rise.scss
+++ b/src/scss/rise.scss
@@ -1,0 +1,4 @@
+$fa-font-path: "../fonts";
+$icon-font-path: "../fonts";
+
+@import "app";


### PR DESCRIPTION

## Description
Fix fontawesome fonts on rise.min.css for storage-selector

- Overwrites $fa-font-path and $icon-font-path when generating rise.css/risemin.css


## Motivation and Context
Fixes https://github.com/Rise-Vision/rise-vision-apps/issues/2566

## How Has This Been Tested?
Locally and on [stage-1]
Sample: https://apps-stage-1.risevision.com/storage-selector.html

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
