### PR TITLE
Setup environments for Angular and Canva API key based on environment

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -29,9 +29,7 @@
               "src/assets",
               "src/images",
               "src/vendor",
-              "src/bower_components/oidc-client/dist/oidc-client.js",
-              "src/scripts/user-manager-silent.js",
-              "src/user-manager-silent.html",
+              "src/bower_components/font-awesome/fonts",
               "src/tmp/locales/translation_en.json"
             ],
             "styles": [
@@ -586,14 +584,6 @@
           },
           "configurations": {
             "prod": {
-              "assets": [
-                "src/robots.txt",
-                "src/loading-preview.html",
-                "src/assets",
-                "src/images",
-                "src/vendor",
-                "src/bower_components/font-awesome/fonts"
-              ],
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",
@@ -653,8 +643,11 @@
             "browserTarget": "rise-vision-apps:build"
           },
           "configurations": {
-            "production": {
-              "browserTarget": "rise-vision-apps:build:production"
+            "prod": {
+              "browserTarget": "rise-vision-apps:build:prod"
+            },
+            "test": {
+              "browserTarget": "rise-vision-apps:build:test"
             }
           }
         },
@@ -696,11 +689,11 @@
           "builder": "@angular-devkit/build-angular:protractor",
           "options": {
             "protractorConfig": "e2e/protractor.conf.js",
-            "devServerTarget": "rise-vision-apps:serve"
+            "devServerTarget": "rise-vision-apps:serve:test"
           },
           "configurations": {
-            "production": {
-              "devServerTarget": "rise-vision-apps:serve:production"
+            "prod": {
+              "devServerTarget": "rise-vision-apps:serve:prod"
             }
           }
         }

--- a/angular.json
+++ b/angular.json
@@ -585,7 +585,7 @@
             ]
           },
           "configurations": {
-            "production": {
+            "prod": {
               "assets": [
                 "src/robots.txt",
                 "src/loading-preview.html",
@@ -620,13 +620,37 @@
                   "maximumError": "10kb"
                 }
               ]
+            },
+            "beta": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.beta.ts"
+                }
+              ]
+            },
+            "stage": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.stage.ts"
+                }
+              ]
+            },
+            "test": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.test.ts"
+                }
+              ]
             }
           }
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "rise-vision-apps:build",
+            "browserTarget": "rise-vision-apps:build"
           },
           "configurations": {
             "production": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "preng-start": "gulp build",
     "ng-start": "ng serve --port 8000",
     "preng-build": "gulp build",
-    "ng-build": "ng build --prod --delete-output-path false",
+    "ng-build": "ng build --configuration=$NODE_ENV --delete-output-path false",
     "ng-dist": "gulp dist-server",
     "ng-test": "ng test",
     "ng-test-headless": "ng test --watch=false --browsers=ChromeHeadless",

--- a/src/app/editor/services/canva-api.service.spec.ts
+++ b/src/app/editor/services/canva-api.service.spec.ts
@@ -88,7 +88,7 @@ describe('CanvaApiService', () => {
     it('should initialize button api',(done) => {
       service.initializeDesignButtonApi().then(() => {
         expect(mockCanvaApi.DesignButton.initialize).toHaveBeenCalledWith({
-          apiKey: '_Ow6FgJpQ3S_k0Mgyo1UX2nM',
+          apiKey: 'EwLWFws4Qjpa-n_2ZJgBMQbz',
         });
         done();
       });

--- a/src/app/editor/services/canva-api.service.ts
+++ b/src/app/editor/services/canva-api.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { AnalyticsFactory, CanvaTypePicker } from 'src/app/ajs-upgraded-providers';
+import { environment } from './../../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
@@ -39,7 +40,7 @@ export class CanvaApiService {
     } else {      
       this._designButtonPromise = this.loadCanvaApi().then(canvaApi => {
         return canvaApi.DesignButton.initialize({
-          apiKey: '_Ow6FgJpQ3S_k0Mgyo1UX2nM',
+          apiKey: environment.canvaApiKey
         });
       });       
       return this._designButtonPromise;

--- a/src/environments/environment.beta.ts
+++ b/src/environments/environment.beta.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  canvaApiKey: '_Ow6FgJpQ3S_k0Mgyo1UX2nM'
+};

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  canvaApiKey: '_Ow6FgJpQ3S_k0Mgyo1UX2nM'
 };

--- a/src/environments/environment.stage.ts
+++ b/src/environments/environment.stage.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  canvaApiKey: 'EwLWFws4Qjpa-n_2ZJgBMQbz'
+};

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  canvaApiKey: 'EwLWFws4Qjpa-n_2ZJgBMQbz'
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  canvaApiKey: 'EwLWFws4Qjpa-n_2ZJgBMQbz'
 };
 
 /*


### PR DESCRIPTION
## Description
Setup environments for Angular and Canva API key based on environment

## Motivation and Context
https://trello.com/c/Z9X6tiEP/7347-canva-use-config-variable-for-prod-test-api-keys-1

## How Has This Been Tested?
Locally by running  `NODE_ENV=prod npm run ng-build` and on [stage-1]
Confirmed Canva API key is properly set based on environment.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
