### PR TITLE
Merge unit tests coverage reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,6 @@ jobs:
           name: Angular JS unit tests
           command: NODE_ENV=test npm run test
       - run:
-          name: 'Install coverage report merger'
-          command: npm install lcov-result-merger
-      - run:
           name: 'Merge coverage reports'
           command: ./node_modules/.bin/lcov-result-merger 'reports/coverage/**/lcov.info' reports/merged_lcov.info
       - coveralls/upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   browser-tools: circleci/browser-tools@1.1.1
+  coveralls: coveralls/coveralls@1.0.6
 
 commands:
   run_e2e_cases:
@@ -81,6 +82,14 @@ jobs:
       - run: 
           name: Angular JS unit tests
           command: NODE_ENV=test npm run test
+      - run:
+          name: 'Install coverage report merger'
+          command: npm install lcov-result-merger
+      - run:
+          name: 'Merge coverage reports'
+          command: ./node_modules/.bin/lcov-result-merger 'reports/coverage/**/lcov.info' reports/merged_lcov.info
+      - coveralls/upload:
+          path_to_lcov: reports/merged_lcov.info
       - run: 
           name: Build app for e2e tests
           command: NODE_ENV=test npm run ng-build

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -272,9 +272,7 @@ gulp.task("test:unit", factory.testUnitAngular({
     testFiles: unitTestFiles
 }));
 
-gulp.task("coveralls", factory.coveralls());
-
-gulp.task("test", gulp.series("config", "test:unit", "coveralls"));
+gulp.task("test", gulp.series("config", "test:unit"));
 
 /*---- e2e testing ----*/
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10729,6 +10729,17 @@
       "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
       "dev": true
     },
+    "lcov-result-merger": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lcov-result-merger/-/lcov-result-merger-3.1.0.tgz",
+      "integrity": "sha512-vGXaMNGZRr4cYvW+xMVg+rg7qd5DX9SbGXl+0S3k85+gRZVK4K7UvxPWzKb/qiMwe+4bx3EOrW2o4mbdb1WnsA==",
+      "dev": true,
+      "requires": {
+        "through2": "^2.0.3",
+        "vinyl": "^2.1.0",
+        "vinyl-fs": "^3.0.2"
+      }
+    },
     "lead": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
@@ -11311,9 +11322,9 @@
           }
         },
         "ssri": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+          "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
@@ -13154,9 +13165,9 @@
           "dev": true
         },
         "ssri": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+          "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
@@ -18499,8 +18510,7 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "resolved": "",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "zone.js": "~0.10.2"
   },
   "devDependencies": {
-    "http-server": "^0.12.3",
     "@angular-devkit/build-angular": "~0.901.14",
     "@angular/cli": "~9.1.14",
     "@angular/compiler-cli": "~9.1.13",
@@ -54,8 +53,8 @@
     "connect-modrewrite": "^0.10.2",
     "fancy-log": "1.3.3",
     "gulp": "^4.0.2",
-    "gulp-cli": "^2.3.0",
     "gulp-clean-css": "^4.3.0",
+    "gulp-cli": "^2.3.0",
     "gulp-concat": "^2.6.1",
     "gulp-folders-4x": "^1.0.1",
     "gulp-htmlmin": "5.0.1",
@@ -70,6 +69,7 @@
     "gulp-sourcemaps": "3.0.0",
     "gulp-uglify-es": "~2.0.0",
     "gulp-usemin": "^0.3.30",
+    "http-server": "^0.12.3",
     "jasmine-core": "~3.5.0",
     "jasmine-spec-reporter": "~4.2.1",
     "jshint": "^2.12.0",
@@ -79,12 +79,13 @@
     "karma-coverage-istanbul-reporter": "~2.1.0",
     "karma-jasmine": "~3.0.1",
     "karma-jasmine-html-reporter": "^1.4.2",
+    "lcov-result-merger": "^3.1.0",
     "protractor": "~7.0.0",
     "rimraf": "^2.5.4",
+    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
     "typescript": "~3.8.3",
-    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git",
     "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
   },
   "repository": {


### PR DESCRIPTION
## Description
Merges unit tests coverage reports to fix report issue with coveralls
Also, uses Coveralls Orb from CCI, to avoid messing with widget-tester and gulp-coveralls.

## Motivation and Context
Coveralls report was inconsistent

## How Has This Been Tested?
Coveralls report looks accurate.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
