### PR TITLE
Reusable 'deployment' build configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ gulp
 
 * Start a server at port 8000 and watch angular files
 ```bash
-npm run ng-start
+npm run ng-serve
 ```
 
 * Build angular & angularjs to the dist folder

--- a/angular.json
+++ b/angular.json
@@ -29,7 +29,10 @@
               "src/assets",
               "src/images",
               "src/vendor",
-              "src/tmp/locales"
+              "src/tmp/locales",
+              "src/bower_components/oidc-client/dist/oidc-client.js",
+              "src/scripts/user-manager-silent.js",
+              "src/user-manager-silent.html"
             ],
             "styles": [
               "src/scss/app.scss",
@@ -582,12 +585,14 @@
             ]
           },
           "configurations": {
-            "prod": {
-              "fileReplacements": [
-                {
-                  "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.prod.ts"
-                }
+            "deployment": {
+              "assets": [
+                "src/robots.txt",
+                "src/loading-preview.html",
+                "src/assets",
+                "src/images",
+                "src/vendor",
+                "src/tmp/locales"
               ],
               "optimization": true,
               "outputHashing": "all",
@@ -606,6 +611,14 @@
                   "type": "anyComponentStyle",
                   "maximumWarning": "6kb",
                   "maximumError": "10kb"
+                }
+              ]
+            },
+            "prod": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
                 }
               ]
             },
@@ -632,19 +645,6 @@
                   "with": "src/environments/environment.test.ts"
                 }
               ]
-            },
-            "dev": {
-              "assets": [
-                "src/robots.txt",
-                "src/loading-preview.html",
-                "src/assets",
-                "src/images",
-                "src/vendor",
-                "src/tmp/locales",
-                "src/bower_components/oidc-client/dist/oidc-client.js",
-                "src/scripts/user-manager-silent.js",
-                "src/user-manager-silent.html"
-              ],
             }
           }
         },
@@ -659,9 +659,6 @@
             },
             "test": {
               "browserTarget": "rise-vision-apps:build:test"
-            },
-            "dev": {
-              "browserTarget": "rise-vision-apps:build:dev"
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "gulpfile.js",
   "scripts": {
     "ng": "ng",
-    "preng-start": "gulp build",
-    "ng-start": "ng serve --port 8000 --configuration=dev",
+    "preng-serve": "gulp build",
+    "ng-serve": "ng serve --port 8000",
     "preng-build": "gulp build",
-    "ng-build": "ng build --configuration=$NODE_ENV --delete-output-path false",
+    "ng-build": "ng build --configuration=deployment,$NODE_ENV --delete-output-path false",
     "ng-dist": "gulp dist-server",
     "ng-test": "ng test",
     "ng-test-headless": "ng test --watch=false --browsers=ChromeHeadless --code-coverage",


### PR DESCRIPTION
## Description
Reusable 'deployment' build configuration so that stage and test environments match production configuration.
Rename ng-start to ng-serve for consistency with Angular command

## Motivation and Context
Stage and Test environments had different configurations than production and missed catching build failures.

## How Has This Been Tested?
Build passes
[stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
