### PR TITLE
Check visual component play until done support

### DIFF
--- a/src/scripts/template-editor/components/directives/dtv-component-playlist.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-playlist.js
@@ -4,10 +4,10 @@ angular.module('risevision.template-editor.directives')
   .constant('FILTER_HTML_TEMPLATES', 'presentationType:"HTML Template"')
   .directive('templateComponentPlaylist', ['templateEditorFactory', 'presentation', '$loading',
     '$q', 'FILTER_HTML_TEMPLATES', 'ScrollingListService', 'editorFactory', 'blueprintFactory',
-    'PLAYLIST_COMPONENTS',
+    'PLAYLIST_COMPONENTS', 'ENV_NAME',
     function (templateEditorFactory, presentation, $loading,
       $q, FILTER_HTML_TEMPLATES, ScrollingListService, editorFactory, blueprintFactory,
-      PLAYLIST_COMPONENTS) {
+      PLAYLIST_COMPONENTS, ENV_NAME) {
       return {
         restrict: 'E',
         scope: true,
@@ -21,7 +21,7 @@ angular.module('risevision.template-editor.directives')
             reverse: true
           };
           $scope.playlistComponents = PLAYLIST_COMPONENTS;
-          $scope.addVisualComponents = false;
+          $scope.addVisualComponents = !!ENV_NAME && ENV_NAME !== 'TEST';
 
           function _load() {
             var itemsJson = $scope.getAvailableAttributeData($scope.componentId, 'items');
@@ -160,9 +160,8 @@ angular.module('risevision.template-editor.directives')
                   }
                 });
                 $scope.playlistItems = playlistItems;
-                $loading.stop('rise-playlist-templates-loader');
               })
-              .catch(function () {
+              .finally(function () {
                 $loading.stop('rise-playlist-templates-loader');
               });
           };
@@ -240,11 +239,9 @@ angular.module('risevision.template-editor.directives')
                 $scope.playlistItems = $scope.playlistItems.concat(itemsToAdd);
                 $scope.save();
 
-                $loading.stop('rise-playlist-templates-loader');
-
                 $scope.showPlaylistItems();
               })
-              .catch(function (e) {
+              .finally(function (e) {
                 $loading.stop('rise-playlist-templates-loader');
               });
           };
@@ -269,6 +266,13 @@ angular.module('risevision.template-editor.directives')
             return item['play-until-done'] ? 'PUD' : (item.duration ? item.duration : '10') + ' seconds';
           };
 
+          var _updatePlayUntilDone = function (isSupported) {
+            $scope.selectedItem['play-until-done-supported'] = isSupported;
+
+            $scope.selectedItem['play-until-done'] = $scope.selectedItem['play-until-done-supported'] &&
+              $scope.selectedItem['play-until-done'] ? 'true' : 'false';
+          };
+
           $scope.editProperties = function (key) {
             $scope.selectedItem = angular.copy($scope.playlistItems[key]);
             $scope.selectedItem.key = key;
@@ -279,17 +283,24 @@ angular.module('risevision.template-editor.directives')
             $scope.selectedItem['transition-type'] = $scope.selectedItem['transition-type'] ? $scope.selectedItem[
               'transition-type'] : 'normal';
 
-            blueprintFactory.isPlayUntilDone($scope.selectedItem.productCode)
-              .then(function (res) {
-                $scope.selectedItem['play-until-done-supported'] = res;
-              })
-              .catch(function () {})
-              .finally(function () {
-                $scope.selectedItem['play-until-done'] = $scope.selectedItem['play-until-done-supported'] &&
-                  $scope.selectedItem['play-until-done'] ? 'true' : 'false';
+            if (!$scope.isEmbeddedTemplate($scope.selectedItem)) {
+              var component = $scope.getComponentByType($scope.selectedItem.tagName);
 
-                $scope.showProperties();
-              });
+              _updatePlayUntilDone(!!component.playUntilDone);
+
+              $scope.showProperties();
+            } else {
+              blueprintFactory.isPlayUntilDone($scope.selectedItem.productCode)
+                .then(function (res) {
+                  _updatePlayUntilDone(res);
+                })
+                .catch(function () {
+                  _updatePlayUntilDone(false);
+                })
+                .finally(function () {
+                  $scope.showProperties();
+                });
+            }
           };
 
           $scope.saveProperties = function () {

--- a/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
@@ -125,7 +125,7 @@ describe("directive: templateComponentPlaylist", function() {
 
     $provide.service("blueprintFactory", function() {
       return {
-        isPlayUntilDone: function() {return Q.resolve(true)}
+        isPlayUntilDone: sandbox.stub().resolves(true)
       };
     });
   }));
@@ -163,6 +163,32 @@ describe("directive: templateComponentPlaylist", function() {
     expect(directive).to.be.ok;
     expect(directive.type).to.equal("rise-playlist");
     expect(directive.show).to.be.a("function");
+  });
+
+  describe('registerDirective:', function() {
+    it('should initialize', function() {
+      $scope.registerDirective.should.have.been.called;
+
+      var directive = $scope.registerDirective.getCall(0).args[0];
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal("rise-playlist");
+      expect(directive.show).to.be.a("function");
+      expect(directive.onBackHandler).to.be.a("function");
+    });
+
+    describe('onBackHandler:', function() {
+      it ('should enable default navigation if no view is active:', function() {
+        expect($scope.registerDirective.getCall(0).args[0].onBackHandler()).to.not.be.ok;
+        expect($scope.view).to.not.be.ok;
+      });
+
+      it ('should reset view and return true:', function() {
+        $scope.view = 'some-view';
+
+        expect($scope.registerDirective.getCall(0).args[0].onBackHandler()).to.be.true;
+        expect($scope.view).to.not.be.ok;
+      });
+    });
   });
 
   it("should load items from attribute data", function(done) {
@@ -477,40 +503,88 @@ describe("directive: templateComponentPlaylist", function() {
     expect($scope.durationToText(item)).to.equal("12345 seconds");
   });
 
-  it("should edit properties of a playlist item", function(done) {
-    $scope.playlistItems = samplePlaylistItems;
+  describe('editProperties:', function() {
+    describe('embedded template:', function() {
+      it("should edit properties of a playlist item", function(done) {
+        $scope.playlistItems = samplePlaylistItems;
 
-    $scope.editProperties(0);
+        $scope.editProperties(0);
 
-    setTimeout(function() {
-      expect($scope.selectedItem["key"]).to.equal(0);
-      expect($scope.selectedItem["play-until-done"]).to.equal("true");
-      expect($scope.selectedItem["play-until-done-supported"]).to.equal(true);
-      expect($scope.selectedItem["duration"]).to.equal(20);
-      expect($scope.selectedItem["transition-type"]).to.equal("fadeIn");
+        blueprintFactory.isPlayUntilDone.should.have.been.calledWith($scope.selectedItem.productCode);
 
-      done();
-    }, 10);
+        setTimeout(function() {
+          expect($scope.selectedItem["key"]).to.equal(0);
+          expect($scope.selectedItem["play-until-done"]).to.equal("true");
+          expect($scope.selectedItem["play-until-done-supported"]).to.equal(true);
+          expect($scope.selectedItem["duration"]).to.equal(20);
+          expect($scope.selectedItem["transition-type"]).to.equal("fadeIn");
 
-  });
+          expect($scope.view).to.equal("edit");
 
-  it("should set play-until-done-supported to false", function(done) {
-    $scope.playlistItems = samplePlaylistItems;
+          done();
+        }, 10);
 
-    blueprintFactory.isPlayUntilDone = function() {return Q.resolve(false)};
+      });
+      
+      it("should set play-until-done-supported to false", function(done) {
+        $scope.playlistItems = samplePlaylistItems;
 
-    $scope.editProperties(0);
+        blueprintFactory.isPlayUntilDone.resolves(false);
 
-    setTimeout(function() {
-      expect($scope.selectedItem["key"]).to.equal(0);
-      expect($scope.selectedItem["play-until-done"]).to.equal("false");
-      expect($scope.selectedItem["play-until-done-supported"]).to.equal(false);
-      expect($scope.selectedItem["duration"]).to.equal(20);
-      expect($scope.selectedItem["transition-type"]).to.equal("fadeIn");
+        $scope.editProperties(0);
 
-      done();
-    }, 10);
+        setTimeout(function() {
+          expect($scope.selectedItem["key"]).to.equal(0);
+          expect($scope.selectedItem["play-until-done"]).to.equal("false");
+          expect($scope.selectedItem["play-until-done-supported"]).to.equal(false);
+          expect($scope.selectedItem["duration"]).to.equal(20);
+          expect($scope.selectedItem["transition-type"]).to.equal("fadeIn");
 
+          expect($scope.view).to.equal("edit");
+
+          done();
+        }, 10);
+
+      });
+
+      it("should set play-until-done-supported to false on failure", function(done) {
+        $scope.playlistItems = samplePlaylistItems;
+
+        blueprintFactory.isPlayUntilDone.rejects();
+
+        $scope.editProperties(0);
+
+        setTimeout(function() {
+          expect($scope.selectedItem["key"]).to.equal(0);
+          expect($scope.selectedItem["play-until-done"]).to.equal("false");
+          expect($scope.selectedItem["play-until-done-supported"]).to.equal(false);
+          expect($scope.selectedItem["duration"]).to.equal(20);
+          expect($scope.selectedItem["transition-type"]).to.equal("fadeIn");
+
+          expect($scope.view).to.equal("edit");
+
+          done();
+        }, 10);
+      });
+    });
+
+    describe('visual components:', function() {
+      it('should populate play-until-done', function() {
+        $scope.playlistItems = samplePlaylistItems;
+
+        $scope.editProperties(1);
+
+        blueprintFactory.isPlayUntilDone.should.not.have.been.called;
+
+        expect($scope.selectedItem["key"]).to.equal(1);
+        expect($scope.selectedItem["play-until-done"]).to.equal("false");
+        expect($scope.selectedItem["play-until-done-supported"]).to.equal(false);
+        expect($scope.selectedItem["duration"]).to.equal(10);
+        expect($scope.selectedItem["transition-type"]).to.equal("fadeIn");
+
+        expect($scope.view).to.equal("edit");
+      });
+    });
   });
 
   it("should save properties of a playlist item", function() {


### PR DESCRIPTION
## Description
Check visual component play until done support

Update flag accordingly, and show option in the ui

Enable edit/add components for staging, disable in prod

[stage-2]

## Motivation and Context
Playlist UI

## How Has This Been Tested?
Tested locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No