### PR TITLE
Allow playlist components to have default attribute values

### DIFF
--- a/src/partials/template-editor/components/component-time-date.html
+++ b/src/partials/template-editor/components/component-time-date.html
@@ -1,7 +1,32 @@
 <div class="attribute-editor-component time-date-container">
+  <div class="attribute-editor-row" ng-show="!defaultType">
+    <label class="mb-0">Show:</label>
+
+    <div class="madero-radio" id="timedateRadio">
+      <input type="radio" ng-model="type" value="timedate" id="timedate" name="timedate" ng-change="save()" aria-required="true" required>
+      <label for="timedate" id="timedateLabel">
+        Time & Date
+      </label>
+    </div>
+
+    <div class="madero-radio" id="dateRadio">
+      <input type="radio" ng-model="type" value="date" id="date" name="date" ng-change="save()" aria-required="true" required>
+      <label for="date" id="dateLabel">
+        Date
+      </label>
+    </div>
+
+    <div class="madero-radio" id="timeRadio">
+      <input type="radio" ng-model="type" value="time" id="time" name="time" ng-change="save()" aria-required="true" required>
+      <label for="time" id="timeLabel">
+        Time
+      </label>
+    </div>
+  </div>
+
   <div class="attribute-editor-row" ng-show="type === 'timedate' || type === 'date'">
     <div class="form-group">
-      <label class="control-label" for="te-td-date-format">Date format:</label>
+      <label class="control-label u_margin-sm-top" for="te-td-date-format">Date format:</label>
       <select id="te-td-date-format"
               class="form-control"
               ng-model="dateFormat"

--- a/src/scripts/template-editor/components/directives/dtv-component-playlist.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-playlist.js
@@ -338,7 +338,8 @@ angular.module('risevision.template-editor.directives')
               'duration': 10,
               'play-until-done': !!component.playUntilDone,
               'transition-type': 'normal',
-              'tagName': type
+              'tagName': type,
+              'attributes': angular.copy(component.defaultAttributes) || {}
             };
 
             $scope.playlistItems.push(item);

--- a/src/scripts/template-editor/components/directives/dtv-component-text.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-text.js
@@ -15,7 +15,7 @@ angular.module('risevision.template-editor.directives')
           };
 
           function _load() {
-            $scope.isMultiline = $scope.getBlueprintData($scope.componentId, 'multiline');
+            $scope.isMultiline = $scope.getAvailableAttributeData($scope.componentId, 'multiline');
             var value = $scope.getAvailableAttributeData($scope.componentId, 'value');
             var fontsize = $scope.getAvailableAttributeData($scope.componentId, 'fontsize');
             var minfontsize = $scope.getAvailableAttributeData($scope.componentId, 'minfontsize');

--- a/src/scripts/template-editor/components/directives/dtv-component-time-date.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-time-date.js
@@ -33,6 +33,7 @@ angular.module('risevision.template-editor.directives')
           });
 
           $scope.load = function () {
+            var defaultType = $scope.getBlueprintData($scope.componentId, 'type');
             var type = $scope.getAvailableAttributeData($scope.componentId, 'type');
             var timeFormat = $scope.getAvailableAttributeData($scope.componentId, 'time');
             var dateFormat = $scope.getAvailableAttributeData($scope.componentId, 'date');
@@ -40,6 +41,7 @@ angular.module('risevision.template-editor.directives')
             var timeFormatVal = timeFormat || 'Hours12';
             var dateFormatVal = dateFormat || $scope.dateFormats[0].format;
 
+            $scope.defaultType = defaultType;
             $scope.type = type;
             $scope.timezoneType = !timezone ? 'DisplayTz' : 'SpecificTz';
             $scope.timezone = timezone;
@@ -61,6 +63,10 @@ angular.module('risevision.template-editor.directives')
           $scope.save = function () {
             if ($scope.timezoneType === 'DisplayTz' || !$scope.timezone) {
               $scope.timezone = null;
+            }
+
+            if (!$scope.defaultType) {
+              $scope.setAttributeData($scope.componentId, 'type', $scope.type);
             }
 
             if ($scope.type === 'timedate') {

--- a/src/scripts/template-editor/services/svc-components-factory.js
+++ b/src/scripts/template-editor/services/svc-components-factory.js
@@ -93,14 +93,21 @@ angular.module('risevision.template-editor.services')
       iconType: 'streamline',
       icon: 'text',
       title: 'Text',
-      visual: true
+      visual: true,
+      defaultAttributes: {
+        fontsize: 100,
+        multiline: true
+      }
     },
     'rise-time-date': {
       type: 'rise-time-date',
       iconType: 'streamline',
       icon: 'time',
       title: 'Time and Date',
-      visual: true
+      visual: true,
+      defaultAttributes: {
+        type: 'timedate'
+      }
     },
     'rise-data-twitter': {
       type: 'rise-data-twitter',

--- a/src/scripts/template-editor/services/svc-components-factory.js
+++ b/src/scripts/template-editor/services/svc-components-factory.js
@@ -48,7 +48,10 @@ angular.module('risevision.template-editor.services')
       panel: '.image-component-container',
       title: 'Image',
       playUntilDone: true,
-      visual: true
+      visual: true,
+      defaultAttributes: {
+        responsive: true
+      }
     },
     'rise-image-logo': {
       type: 'rise-image-logo',

--- a/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
@@ -661,12 +661,12 @@ describe("directive: templateComponentPlaylist", function() {
     it('should set playUntilDone', function() {
       $scope.playlistItems = [];
 
-      $scope.addPlaylistItem('rise-image');
+      $scope.addPlaylistItem('rise-video');
 
       expect($scope.playlistItems[0]['duration']).to.equal(10);
       expect($scope.playlistItems[0]['play-until-done']).to.be.true;
       expect($scope.playlistItems[0]['transition-type']).to.equal('normal');
-      expect($scope.playlistItems[0]['tagName']).to.equal('rise-image');
+      expect($scope.playlistItems[0]['tagName']).to.equal('rise-video');
       expect($scope.playlistItems[0]['attributes']).to.deep.equal({});
     });
 

--- a/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
@@ -644,12 +644,11 @@ describe("directive: templateComponentPlaylist", function() {
       $scope.addPlaylistItem('rise-text');
 
       expect($scope.playlistItems).to.have.length(2);
-      expect($scope.playlistItems[1]).to.deep.equal({
-        'duration': 10,
-        'play-until-done': false,
-        'transition-type': 'normal',
-        'tagName': 'rise-text'
-      });
+      expect($scope.playlistItems[1]['duration']).to.equal(10);
+      expect($scope.playlistItems[1]['play-until-done']).to.be.false;
+      expect($scope.playlistItems[1]['transition-type']).to.equal('normal');
+      expect($scope.playlistItems[1]['tagName']).to.equal('rise-text');
+      expect($scope.playlistItems[1]['attributes']).to.be.an('object');
 
       $scope.save.should.have.been.called;
 
@@ -664,12 +663,11 @@ describe("directive: templateComponentPlaylist", function() {
 
       $scope.addPlaylistItem('rise-image');
 
-      expect($scope.playlistItems[0]).to.deep.equal({
-        'duration': 10,
-        'play-until-done': true,
-        'transition-type': 'normal',
-        'tagName': 'rise-image'
-      });
+      expect($scope.playlistItems[0]['duration']).to.equal(10);
+      expect($scope.playlistItems[0]['play-until-done']).to.be.true;
+      expect($scope.playlistItems[0]['transition-type']).to.equal('normal');
+      expect($scope.playlistItems[0]['tagName']).to.equal('rise-image');
+      expect($scope.playlistItems[0]['attributes']).to.deep.equal({});
     });
 
   });

--- a/test/unit/template-editor/components/directives/dtv-component-text.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-text.spec.js
@@ -27,7 +27,6 @@ describe('directive: templateComponentText', function() {
     $scope.registerDirective = sinon.stub();
     $scope.setAttributeData = sinon.stub();
     $scope.getAvailableAttributeData = sinon.stub().returns('data');
-    $scope.getBlueprintData = sinon.stub().returns(false);
 
     element = $compile("<template-component-text></template-component-text>")($scope);
     $scope = element.scope();
@@ -58,12 +57,12 @@ describe('directive: templateComponentText', function() {
   });
 
   it('should load multiline attribute from blueprint', function() {
-    $scope.getBlueprintData.returns(true);
+    $scope.getAvailableAttributeData.returns(true);
     var directive = $scope.registerDirective.getCall(0).args[0];
 
     directive.show();
 
-    expect($scope.getBlueprintData).to.have.been.calledWith('TEST-ID', 'multiline');
+    expect($scope.getAvailableAttributeData).to.have.been.calledWith('TEST-ID', 'multiline');
     expect($scope.isMultiline).to.be.true;
   });
 

--- a/test/unit/template-editor/components/directives/dtv-component-time-date.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-time-date.spec.js
@@ -41,12 +41,27 @@ describe('directive: templateComponentTimeDate', function() {
     expect($scope).to.be.ok;
     expect($scope.factory).to.be.ok;
     expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" } });
-    expect($scope.registerDirective).to.have.been.called;
+  });
 
-    var directive = $scope.registerDirective.getCall(0).args[0];
-    expect(directive).to.be.ok;
-    expect(directive.type).to.equal('rise-time-date');
-    expect(directive.show).to.be.a('function');
+  describe('registerDirective:', function() {
+    it('should initialize', function() {
+      expect($scope.registerDirective).to.have.been.called;
+
+      var directive = $scope.registerDirective.getCall(0).args[0];
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-time-date');
+      expect(directive.show).to.be.a('function');
+    });
+
+    it('show:', function() {
+      sandbox.stub($scope, 'load');
+
+      $scope.registerDirective.getCall(0).args[0].show();
+
+      expect($scope.componentId).to.equal('TEST-ID');
+
+      $scope.load.should.have.been.called;
+    });
   });
 
   it('should return the correct title', function () {
@@ -62,6 +77,7 @@ describe('directive: templateComponentTimeDate', function() {
 
   describe('load', function () {
     function _initLoad(type, time, date, timezone) {
+      $scope.getBlueprintData = sandbox.stub().returns('timedate');
       $scope.getAvailableAttributeData = sandbox.stub();
       $scope.getAvailableAttributeData.onCall(0).returns(type);
       $scope.getAvailableAttributeData.onCall(1).returns(time);
@@ -82,11 +98,13 @@ describe('directive: templateComponentTimeDate', function() {
 
       $scope.load();
 
+      $scope.getBlueprintData.should.have.been.calledWith(sinon.match.any, 'type');
       expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('type');
       expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('time');
       expect($scope.getAvailableAttributeData.getCall(2).args[1]).to.equal('date');
       expect($scope.getAvailableAttributeData.getCall(3).args[1]).to.equal('timezone');
 
+      expect($scope.defaultType).to.equal('timedate');
       expect($scope.type).to.equal('time');
       expect($scope.dateFormat).to.not.be.ok;
       expect($scope.timeFormat).to.equal('Hours24');
@@ -99,11 +117,13 @@ describe('directive: templateComponentTimeDate', function() {
 
       $scope.load();
 
+      $scope.getBlueprintData.should.have.been.calledWith(sinon.match.any, 'type');
       expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('type');
       expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('time');
       expect($scope.getAvailableAttributeData.getCall(2).args[1]).to.equal('date');
       expect($scope.getAvailableAttributeData.getCall(3).args[1]).to.equal('timezone');
 
+      expect($scope.defaultType).to.equal('timedate');
       expect($scope.type).to.equal('date');
       expect($scope.timeFormat).to.not.be.ok;
       expect($scope.dateFormat).to.equal('DD/MM/YYYY');
@@ -116,11 +136,13 @@ describe('directive: templateComponentTimeDate', function() {
 
       $scope.load();
 
+      $scope.getBlueprintData.should.have.been.calledWith(sinon.match.any, 'type');
       expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('type');
       expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('time');
       expect($scope.getAvailableAttributeData.getCall(2).args[1]).to.equal('date');
       expect($scope.getAvailableAttributeData.getCall(3).args[1]).to.equal('timezone');
 
+      expect($scope.defaultType).to.equal('timedate');
       expect($scope.type).to.equal('timedate');
       expect($scope.timeFormat).to.equal('Hours24');
       expect($scope.dateFormat).to.equal('MMM DD YYYY');
@@ -133,11 +155,13 @@ describe('directive: templateComponentTimeDate', function() {
 
       $scope.load();
 
+      $scope.getBlueprintData.should.have.been.calledWith(sinon.match.any, 'type');
       expect($scope.getAvailableAttributeData.getCall(0).args[1]).to.equal('type');
       expect($scope.getAvailableAttributeData.getCall(1).args[1]).to.equal('time');
       expect($scope.getAvailableAttributeData.getCall(2).args[1]).to.equal('date');
       expect($scope.getAvailableAttributeData.getCall(3).args[1]).to.equal('timezone');
 
+      expect($scope.defaultType).to.equal('timedate');
       expect($scope.type).to.equal('timedate');
       expect($scope.timeFormat).to.equal('Hours12');
       expect($scope.dateFormat).to.equal('MMMM DD, YYYY');
@@ -148,9 +172,19 @@ describe('directive: templateComponentTimeDate', function() {
 
   describe('save', function () {
     beforeEach(function () {
+      $scope.defaultType = 'timedate';
       $scope.type = 'timedate';
       $scope.timeFormat = 'Hours12';
       $scope.dateFormat = 'MMMM DD, YYYY';
+    });
+
+    it('should only update type if defaultType is blank', function () {
+      $scope.defaultType = undefined;
+      $scope.type = 'time';
+
+      $scope.save();
+      expect($scope.setAttributeData.getCall(0).args[1]).to.equal('type');
+      expect($scope.setAttributeData.getCall(0).args[2]).to.equal('time');
     });
 
     it('should only save time format and not save date format if type is "time"', function () {


### PR DESCRIPTION
## Description
Allow playlist components to have default attribute values

Mostly visual options for improved rendering

For text, set multiline and show font size
For time & date, allow selecting type for
showing time and/or date

[stage-11]

## Motivation and Context
Playlist UI

## How Has This Been Tested?
Tested locally, and with the template playing in Viewer. Updated unit tests.

Notes:
- rise-time-date does not have the ability to apply font size or colour, so it requires external styling within the template.
- The rise-text multiline attribute is expected as an inline attribute, but we set it in polymer directly. So this setting does not apply correctly.
- Pending rise-image modifications for scaling to fit to the container. This will be released in a separate PR.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
As per the above.