### PR TITLE
Check template blueprint for rise-init and components

### DIFF
--- a/src/partials/template-editor/components/component-playlist.html
+++ b/src/partials/template-editor/components/component-playlist.html
@@ -42,11 +42,11 @@ rv-spinner rv-spinner-key="rise-playlist-templates-loader">
 
     <div class="playlist-action-button-bar" ng-class="{'no-selected-templates' : !playlistItems.length || playlistItems.length === 0}">
       <div class="select-templates">
-        <button id="te-playlist-select-templates" class="btn btn-primary btn-block" ng-click="showAddTemplates()" ng-if="!addVisualComponents">
+        <button id="te-playlist-select-templates" class="btn btn-primary btn-block" ng-click="showAddTemplates()" ng-if="!showComponentsDropdown()">
           Select Presentations
         </button>
         <div class="btn-group btn-block" dropdown ng-class="{'dropup' : playlistItems.length && playlistItems.length > 0}">
-          <button id="addPlaylistItemButton" type="button" dropdown-toggle class="btn btn-primary btn-block" ng-if="addVisualComponents">Add</button>
+          <button id="addPlaylistItemButton" type="button" dropdown-toggle class="btn btn-primary btn-block" ng-if="showComponentsDropdown()">Add</button>
           <div class="dropdown-menu playlist-menu" role="menu">
             <ul>
             <li>

--- a/src/scripts/template-editor/components/directives/dtv-component-playlist.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-playlist.js
@@ -29,7 +29,9 @@ angular.module('risevision.template-editor.directives')
             } else {
               var allowedComponents = $scope.getBlueprintData($scope.componentId, 'allowed-components');
 
-              if (allowedComponents && allowedComponents !== '*') {
+              if (!allowedComponents || allowedComponents === '*') {
+                $scope.playlistComponents = PLAYLIST_COMPONENTS;
+              } else {
                 var componentsArray = allowedComponents.split(',');
 
                 $scope.playlistComponents = _.filter(PLAYLIST_COMPONENTS, function(component) {

--- a/src/scripts/template-editor/components/directives/dtv-component-playlist.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-playlist.js
@@ -23,7 +23,25 @@ angular.module('risevision.template-editor.directives')
           $scope.playlistComponents = PLAYLIST_COMPONENTS;
           $scope.addVisualComponents = !!ENV_NAME && ENV_NAME !== 'TEST';
 
+          var _updatePlaylistComponents = function() {
+            if (!blueprintFactory.isRiseInit()) {
+              $scope.addVisualComponents = false;
+            } else {
+              var allowedComponents = $scope.getBlueprintData($scope.componentId, 'allowed-components');
+
+              if (allowedComponents && allowedComponents !== '*') {
+                var componentsArray = allowedComponents.split(',');
+
+                $scope.playlistComponents = _.filter(PLAYLIST_COMPONENTS, function(component) {
+                  return componentsArray.indexOf(component.type) !== -1;
+                });
+              }
+            }
+          };
+
           function _load() {
+            _updatePlaylistComponents();
+
             var itemsJson = $scope.getAvailableAttributeData($scope.componentId, 'items');
             var itemsArray = $scope.jsonToPlaylistItems(itemsJson);
             $scope.loadTemplateNames(itemsArray);
@@ -49,6 +67,10 @@ angular.module('risevision.template-editor.directives')
               }
             }
           });
+
+          $scope.showComponentsDropdown = function() {
+            return $scope.addVisualComponents && !!$scope.playlistComponents && $scope.playlistComponents.length > 0;
+          };
 
           var _mapItemToEditorFormat = function (item) {
             return {

--- a/src/scripts/template-editor/services/svc-blueprint-factory.js
+++ b/src/scripts/template-editor/services/svc-blueprint-factory.js
@@ -54,6 +54,10 @@ angular.module('risevision.template-editor.services')
         return (!!factory.blueprintData && factory.blueprintData.branding === true);
       };
 
+      factory.isRiseInit = function () {
+        return (!!factory.blueprintData && factory.blueprintData.riseInit === true);
+      };
+
       factory.getBlueprintData = function (componentId, attributeKey) {
         var components = factory.blueprintData.components;
         var component = _.find(components, {

--- a/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
@@ -222,22 +222,30 @@ describe("directive: templateComponentPlaylist", function() {
           expect($scope.playlistComponents).to.equal(playlistComponents);
         });
 
+        it('should reset playlist components', function() {
+          $scope.playlistComponents = null;
+
+          $scope.registerDirective.getCall(0).args[0].show();
+
+          expect($scope.playlistComponents).to.equal(playlistComponents);
+        });
+
         it('should handle * for allowed-components', function() {
-          $scope.getBlueprintData.returns('*')
+          $scope.getBlueprintData.returns('*');
           $scope.registerDirective.getCall(0).args[0].show();
 
           expect($scope.playlistComponents).to.equal(playlistComponents);
         });
 
         it('should parse csv values for allowed-components', function() {
-          $scope.getBlueprintData.returns('rise-video,rise-slides')
+          $scope.getBlueprintData.returns('rise-video,rise-slides');
           $scope.registerDirective.getCall(0).args[0].show();
 
           expect($scope.playlistComponents).to.have.length(2);
         });
 
         it('should ignore rise-embedded-template', function() {
-          $scope.getBlueprintData.returns('rise-embedded-template,rise-video,rise-slides')
+          $scope.getBlueprintData.returns('rise-embedded-template,rise-video,rise-slides');
           $scope.registerDirective.getCall(0).args[0].show();
 
           expect($scope.playlistComponents).to.have.length(2);

--- a/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
@@ -125,7 +125,8 @@ describe("directive: templateComponentPlaylist", function() {
 
     $provide.service("blueprintFactory", function() {
       return {
-        isPlayUntilDone: sandbox.stub().resolves(true)
+        isPlayUntilDone: sandbox.stub().resolves(true),
+        isRiseInit: sandbox.stub().returns(true)
       };
     });
   }));
@@ -137,9 +138,10 @@ describe("directive: templateComponentPlaylist", function() {
     editorFactory = $injector.get('editorFactory');
     blueprintFactory = $injector.get('blueprintFactory');
 
-    $scope.registerDirective = sinon.stub();
-    $scope.setAttributeData = sinon.stub();
-    $scope.editComponent = sinon.stub();
+    $scope.getBlueprintData = sandbox.stub();
+    $scope.registerDirective = sandbox.stub();
+    $scope.setAttributeData = sandbox.stub();
+    $scope.editComponent = sandbox.stub();
 
     element = $compile("<template-component-playlist></template-component-playlistt>")($scope);
     $scope = element.scope();
@@ -154,6 +156,8 @@ describe("directive: templateComponentPlaylist", function() {
 
     expect($scope.playlistComponents).to.be.an('array');
     expect($scope.addVisualComponents).to.be.false;
+
+    expect($scope.showComponentsDropdown).to.be.a('function')
 
     expect($scope.getComponentByType).to.be.a('function');
     expect($scope.addPlaylistItem).to.be.a('function');
@@ -188,6 +192,85 @@ describe("directive: templateComponentPlaylist", function() {
         expect($scope.registerDirective.getCall(0).args[0].onBackHandler()).to.be.true;
         expect($scope.view).to.not.be.ok;
       });
+    });
+
+    describe('show:', function() {
+      describe('_updatePlaylistComponents:', function() {
+        var playlistComponents;
+
+        beforeEach(function() {
+          playlistComponents = $scope.playlistComponents;
+
+          $scope.getAvailableAttributeData = sandbox.stub();
+        });
+
+        it('should set addVisualComponents to false based on isRiseInit being false', function() {
+          blueprintFactory.isRiseInit.returns(false);
+
+          $scope.addVisualComponents = true;
+
+          $scope.registerDirective.getCall(0).args[0].show();
+
+          expect($scope.addVisualComponents).to.be.false;
+        });
+
+        it('should check blueprint data for allowed-components', function() {
+          $scope.registerDirective.getCall(0).args[0].show();
+
+          $scope.getBlueprintData.should.have.been.calledWith('TEST-ID', 'allowed-components');
+
+          expect($scope.playlistComponents).to.equal(playlistComponents);
+        });
+
+        it('should handle * for allowed-components', function() {
+          $scope.getBlueprintData.returns('*')
+          $scope.registerDirective.getCall(0).args[0].show();
+
+          expect($scope.playlistComponents).to.equal(playlistComponents);
+        });
+
+        it('should parse csv values for allowed-components', function() {
+          $scope.getBlueprintData.returns('rise-video,rise-slides')
+          $scope.registerDirective.getCall(0).args[0].show();
+
+          expect($scope.playlistComponents).to.have.length(2);
+        });
+
+        it('should ignore rise-embedded-template', function() {
+          $scope.getBlueprintData.returns('rise-embedded-template,rise-video,rise-slides')
+          $scope.registerDirective.getCall(0).args[0].show();
+
+          expect($scope.playlistComponents).to.have.length(2);
+        });
+
+      });
+    });
+  });
+
+  describe('showComponentsDropdown:', function() {
+    it('should not show by default', function() {
+      expect($scope.showComponentsDropdown()).to.be.false;
+    });
+
+    it('should not show if playlistComponents does not exist', function() {
+      $scope.addVisualComponents = true;
+      $scope.playlistComponents = null;
+
+      expect($scope.showComponentsDropdown()).to.be.false;
+    });
+
+    it('should not show if there are no visual components', function() {
+      $scope.addVisualComponents = true;
+      $scope.playlistComponents = [];
+
+      expect($scope.showComponentsDropdown()).to.be.false;
+    });
+
+    it('should show if there are visual components', function() {
+      $scope.addVisualComponents = true;
+      $scope.playlistComponents = ['rise-video'];
+
+      expect($scope.showComponentsDropdown()).to.be.true;
     });
   });
 

--- a/test/unit/template-editor/services/svc-blueprint-factory.spec.js
+++ b/test/unit/template-editor/services/svc-blueprint-factory.spec.js
@@ -47,6 +47,7 @@ describe('service: blueprint factory', function() {
     expect(blueprintFactory.getBlueprintCached).to.be.a('function');
     expect(blueprintFactory.isPlayUntilDone).to.be.a('function');
     expect(blueprintFactory.hasBranding).to.be.a('function');
+    expect(blueprintFactory.isRiseInit).to.be.a('function');
   });
 
   describe('getBlueprintCached: ', function() {
@@ -170,6 +171,29 @@ describe('service: blueprint factory', function() {
       };
 
       expect(blueprintFactory.hasBranding()).to.be.false;
+    });
+  });
+
+  describe('isRiseInit: ', function() {
+
+    it('should return false if blueprintData is not populated',function() {
+      expect(blueprintFactory.isRiseInit()).to.be.false;
+    });
+
+    it('should return true if blueprintData.riseInit is true',function() {
+      blueprintFactory.blueprintData = {
+        riseInit: true
+      };
+
+      expect(blueprintFactory.isRiseInit()).to.be.true;
+    });
+
+    it('should return false otherwise',function() {
+      blueprintFactory.blueprintData = {
+        riseInit: false
+      };
+
+      expect(blueprintFactory.isRiseInit()).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Description
Check template blueprint for rise-init and components

If riseInit is not present show the Add Presentations option
If riseInit is present, check for the allowed-components property
If the property is empty or *, show all components
Otherwise show the listed components

For now, rise-embedded-template is always listed by default
and if it is the only option, we will show the button instead
of the dropdown

[stage-2]

## Motivation and Context
Playlist UI

## How Has This Been Tested?
Tested various scenarios in the blueprint. Update unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No