### PR TITLE
Remove templateEditorFactory from component scopes

### DIFF
--- a/src/scripts/template-editor/components/directives/dtv-component-colors.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-colors.js
@@ -8,8 +8,6 @@ angular.module('risevision.template-editor.directives')
         scope: true,
         templateUrl: 'partials/template-editor/components/component-colors.html',
         link: function ($scope, element) {
-          $scope.factory = templateEditorFactory;
-
           // TODO: refactor logic for Override Brand Settings epic
 
           $scope.save = function () {
@@ -29,7 +27,7 @@ angular.module('risevision.template-editor.directives')
             type: 'rise-override-brand-colors',
             element: element,
             show: function () {
-              $scope.componentId = $scope.factory.selected.id;
+              $scope.componentId = templateEditorFactory.selected.id;
               $scope.load();
             }
           });

--- a/src/scripts/template-editor/components/directives/dtv-component-counter.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-counter.js
@@ -31,13 +31,11 @@ angular.module('risevision.template-editor.directives')
               };
             },
             post: function ($scope, element) {
-              $scope.factory = templateEditorFactory;
-
               $scope.registerDirective({
                 type: 'rise-data-counter',
                 element: element,
                 show: function () {
-                  $scope.componentId = $scope.factory.selected.id;
+                  $scope.componentId = templateEditorFactory.selected.id;
                   $scope.load();
                 },
                 getTitle: function (component) {

--- a/src/scripts/template-editor/components/directives/dtv-component-html.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-html.js
@@ -8,8 +8,6 @@ angular.module('risevision.template-editor.directives')
         scope: true,
         templateUrl: 'partials/template-editor/components/component-html.html',
         link: function ($scope, element) {
-          $scope.factory = templateEditorFactory;
-
           $scope.codemirrorOptions = {};
 
           function _load() {
@@ -35,7 +33,7 @@ angular.module('risevision.template-editor.directives')
             type: 'rise-html',
             element: element,
             show: function () {
-              $scope.componentId = $scope.factory.selected.id;
+              $scope.componentId = templateEditorFactory.selected.id;
               _load();
             }
           });

--- a/src/scripts/template-editor/components/directives/dtv-component-playlist.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-playlist.js
@@ -13,7 +13,6 @@ angular.module('risevision.template-editor.directives')
         scope: true,
         templateUrl: 'partials/template-editor/components/component-playlist.html',
         link: function ($scope, element) {
-          $scope.factory = templateEditorFactory;
           $scope.playlistItems = [];
           $scope.searchKeyword = '';
           $scope.templatesSearch = {
@@ -58,7 +57,7 @@ angular.module('risevision.template-editor.directives')
             type: 'rise-playlist',
             element: element,
             show: function () {
-              $scope.componentId = $scope.factory.selected.id;
+              $scope.componentId = templateEditorFactory.selected.id;
               $scope.playlistItems = [];
               _load();
             },
@@ -196,7 +195,7 @@ angular.module('risevision.template-editor.directives')
               FILTER_HTML_TEMPLATES);
 
             //exclude a template that is being edited
-            $scope.templatesSearch.filter += ' AND NOT id:' + $scope.factory.presentation.id;
+            $scope.templatesSearch.filter += ' AND NOT id:' + templateEditorFactory.presentation.id;
 
             if (!$scope.templatesFactory) {
               $scope.initTemplatesFactory();

--- a/src/scripts/template-editor/components/directives/dtv-component-rss.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-rss.js
@@ -9,8 +9,6 @@ angular.module('risevision.template-editor.directives')
         scope: true,
         templateUrl: 'partials/template-editor/components/component-rss.html',
         link: function ($scope, element) {
-          $scope.factory = templateEditorFactory;
-
           $scope.$watch('spinner', function (loading) {
             if (loading) {
               $loading.start('rss-editor-loader');
@@ -37,7 +35,7 @@ angular.module('risevision.template-editor.directives')
             type: 'rise-data-rss',
             element: element,
             show: function () {
-              $scope.componentId = $scope.factory.selected.id;
+              $scope.componentId = templateEditorFactory.selected.id;
               _load();
               $scope.saveFeed(); // validate Feed URL
             }

--- a/src/scripts/template-editor/components/directives/dtv-component-slides.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-slides.js
@@ -9,8 +9,6 @@ angular.module('risevision.template-editor.directives')
         scope: true,
         templateUrl: 'partials/template-editor/components/component-slides.html',
         link: function ($scope, element) {
-          $scope.factory = templateEditorFactory;
-
           $rootScope.$on('risevision.page.visible', function (pageIsVisible) {
             if (_directiveIsVisible() && pageIsVisible) {
               $scope.saveSrc();
@@ -59,7 +57,7 @@ angular.module('risevision.template-editor.directives')
             type: 'rise-slides',
             element: element,
             show: function () {
-              $scope.componentId = $scope.factory.selected.id;
+              $scope.componentId = templateEditorFactory.selected.id;
               _load();
               $scope.saveSrc(); //validate Slides URL
             }

--- a/src/scripts/template-editor/components/directives/dtv-component-slides.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-slides.js
@@ -66,7 +66,7 @@ angular.module('risevision.template-editor.directives')
           function _directiveIsVisible() {
             // This directive is instantiated once by templateAttributeEditor
             // It becomes visible when <rise-slides> is selected
-            return $scope.factory.selected && ($scope.factory.selected.type === 'rise-slides');
+            return templateEditorFactory.selected && (templateEditorFactory.selected.type === 'rise-slides');
           }
 
           function _validateSrcLocally() {

--- a/src/scripts/template-editor/components/directives/dtv-component-text.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-text.js
@@ -8,7 +8,6 @@ angular.module('risevision.template-editor.directives')
         scope: true,
         templateUrl: 'partials/template-editor/components/component-text.html',
         link: function ($scope, element) {
-          $scope.factory = templateEditorFactory;
           $scope.sliderOptions = {
             hideLimitLabels: true,
             hidePointerLabels: true
@@ -50,7 +49,7 @@ angular.module('risevision.template-editor.directives')
             type: 'rise-text',
             element: element,
             show: function () {
-              $scope.componentId = $scope.factory.selected.id;
+              $scope.componentId = templateEditorFactory.selected.id;
               _load();
             }
           });

--- a/src/scripts/template-editor/components/directives/dtv-component-time-date.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-time-date.js
@@ -10,7 +10,6 @@ angular.module('risevision.template-editor.directives')
         link: function ($scope, element) {
           var DATE_FORMATS = ['MMMM DD, YYYY', 'MMM DD YYYY', 'MM/DD/YYYY', 'DD/MM/YYYY'];
 
-          $scope.factory = templateEditorFactory;
           $scope.dateFormats = DATE_FORMATS.map(function (format) {
             return {
               format: format,
@@ -24,7 +23,7 @@ angular.module('risevision.template-editor.directives')
             element: element,
             show: function () {
               element.show();
-              $scope.componentId = $scope.factory.selected.id;
+              $scope.componentId = templateEditorFactory.selected.id;
               $scope.load();
             },
             getTitle: function (component) {

--- a/src/scripts/template-editor/components/directives/dtv-component-twitter.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-twitter.js
@@ -10,7 +10,6 @@ angular.module('risevision.template-editor.directives')
         scope: true,
         templateUrl: 'partials/template-editor/components/component-twitter.html',
         link: function ($scope, element) {
-          $scope.factory = templateEditorFactory;
           $scope.MAX_ITEMS = 100;
 
           $scope.$watch('spinner', function (loading) {
@@ -63,7 +62,7 @@ angular.module('risevision.template-editor.directives')
             element: element,
             show: function () {
               element.show();
-              $scope.componentId = $scope.factory.selected.id;
+              $scope.componentId = templateEditorFactory.selected.id;
               _validateCredentials();
               _load();
             }
@@ -87,7 +86,7 @@ angular.module('risevision.template-editor.directives')
           function _validateCredentials() {
             $scope.spinner = true;
 
-            twitterCredentialsValidation.verifyCredentials($scope.factory.presentation.companyId)
+            twitterCredentialsValidation.verifyCredentials(templateEditorFactory.presentation.companyId)
               .then(function (hasCredentials) {
                 $scope.connected = hasCredentials;
                 $scope.connectionFailure = false;

--- a/src/scripts/template-editor/components/directives/dtv-component-weather.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-weather.js
@@ -8,7 +8,6 @@ angular.module('risevision.template-editor.directives')
         scope: true,
         templateUrl: 'partials/template-editor/components/component-weather.html',
         link: function ($scope, element) {
-          $scope.factory = templateEditorFactory;
           $scope.companySettingsFactory = companySettingsFactory;
           $scope.canEditCompany = userState.hasRole('ua');
 
@@ -32,7 +31,7 @@ angular.module('risevision.template-editor.directives')
             type: 'rise-data-weather',
             element: element,
             show: function () {
-              $scope.componentId = $scope.factory.selected.id;
+              $scope.componentId = templateEditorFactory.selected.id;
               _load();
             }
           });

--- a/test/unit/template-editor/components/directives/dtv-component-colors.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-colors.spec.js
@@ -3,12 +3,7 @@
 describe('directive: templateComponentColors', function() {
   var $scope,
     element,
-    factory,
     attributeDataFactory;
-
-  beforeEach(function() {
-    factory = { selected: { id: 'TEST-ID' } };
-  });
 
   beforeEach(module('risevision.template-editor.directives'));
   beforeEach(module('risevision.template-editor.controllers'));
@@ -17,7 +12,7 @@ describe('directive: templateComponentColors', function() {
   beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
-      return factory;
+      return { selected: { id: "TEST-ID" } };
     });
 
     $provide.service('attributeDataFactory', function() {
@@ -43,8 +38,6 @@ describe('directive: templateComponentColors', function() {
 
   it('should exist', function() {
     expect($scope).to.be.ok;
-    expect($scope.factory).to.be.ok;
-    expect($scope.factory).to.deep.equal({ selected: { id: 'TEST-ID' } });
     expect($scope.registerDirective).to.have.been.called;
 
     var directive = $scope.registerDirective.getCall(0).args[0];

--- a/test/unit/template-editor/components/directives/dtv-component-counter.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-counter.spec.js
@@ -3,13 +3,8 @@
 describe('directive: templateComponentCounter', function() {
   var $scope,
     element,
-    factory,
     attributeDataFactory,
     sandbox = sinon.sandbox.create();
-
-  beforeEach(function() {
-    factory = { selected: { id: "TEST-ID" } };
-  });
 
   beforeEach(module('risevision.template-editor.directives'));
   beforeEach(module('risevision.template-editor.controllers'));
@@ -18,7 +13,7 @@ describe('directive: templateComponentCounter', function() {
   beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
-      return factory;
+      return { selected: { id: "TEST-ID" } };
     });
 
     $provide.service('attributeDataFactory', function() {
@@ -47,8 +42,6 @@ describe('directive: templateComponentCounter', function() {
 
   it('should initialize', function() {
     expect($scope).to.be.ok;
-    expect($scope.factory).to.be.ok;
-    expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" } });
     expect($scope.registerDirective).to.have.been.called;
 
     expect($scope.dateOptions).to.be.an.object;

--- a/test/unit/template-editor/components/directives/dtv-component-html.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-html.spec.js
@@ -3,12 +3,7 @@
 describe('directive: templateComponentHtml', function() {
   var $scope, $timeout,
       element,
-      factory,
       attributeDataFactory;
-
-  beforeEach(function() {
-    factory = { selected: { id: "TEST-ID" } };
-  });
 
   beforeEach(module('risevision.template-editor.directives'));
   beforeEach(module('risevision.template-editor.controllers'));
@@ -17,7 +12,7 @@ describe('directive: templateComponentHtml', function() {
   beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
-      return factory;
+      return { selected: { id: "TEST-ID" } };
     });
 
     $provide.service('attributeDataFactory', function() {
@@ -45,8 +40,6 @@ describe('directive: templateComponentHtml', function() {
 
   it('should exist', function() {
     expect($scope).to.be.ok;
-    expect($scope.factory).to.be.ok;
-    expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" } })
     expect($scope.registerDirective).to.have.been.called;
 
     expect($scope.codemirrorOptions).to.deep.equal({});

--- a/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
@@ -5,7 +5,6 @@ describe("directive: templateComponentPlaylist", function() {
       $scope,
       $loading,
       element,
-      factory,
       attributeDataFactory,
       editorFactory,
       blueprintFactory,
@@ -21,11 +20,6 @@ describe("directive: templateComponentPlaylist", function() {
   };
 
   beforeEach(function() {
-    factory = {
-      selected: { id: "TEST-ID" },
-      presentation: { id: "TEST-ID" }
-    };
-
     sampleAttributeData = {
       "items": [
         {
@@ -97,7 +91,10 @@ describe("directive: templateComponentPlaylist", function() {
   beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service("templateEditorFactory", function() {
-      return factory;
+      return {
+        selected: { id: "TEST-ID" },
+        presentation: { id: "TEST-ID" }
+      };
     });
 
     $provide.service('attributeDataFactory', function() {
@@ -157,8 +154,6 @@ describe("directive: templateComponentPlaylist", function() {
 
   it("should exist", function() {
     expect($scope).to.be.ok;
-    expect($scope.factory).to.be.ok;
-    expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" }, presentation: { id: "TEST-ID" }});
     expect($scope.registerDirective).to.have.been.called;
 
     expect($scope.playlistComponents).to.be.an('array');

--- a/test/unit/template-editor/components/directives/dtv-component-rss.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-rss.spec.js
@@ -3,14 +3,11 @@
 describe('directive: templateComponentRss', function() {
   var $scope,
     element,
-    factory,
     attributeDataFactory,
     rssFeedValidation,
     sandbox = sinon.sandbox.create();
 
   beforeEach(function() {
-    factory = { selected: { id: "TEST-ID" } };
-
     rssFeedValidation = {
       isParsable: sandbox.stub().returns(Q.resolve('VALID')),
       isValid: sandbox.stub().returns(Q.resolve('VALID'))
@@ -24,7 +21,7 @@ describe('directive: templateComponentRss', function() {
   beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
-      return factory;
+      return { selected: { id: "TEST-ID" } };
     });
 
     $provide.service('attributeDataFactory', function() {
@@ -53,8 +50,6 @@ describe('directive: templateComponentRss', function() {
 
   it('should exist', function() {
     expect($scope).to.be.ok;
-    expect($scope.factory).to.be.ok;
-    expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" } })
     expect($scope.registerDirective).to.have.been.called;
 
     var directive = $scope.registerDirective.getCall(0).args[0];

--- a/test/unit/template-editor/components/directives/dtv-component-slides.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-slides.spec.js
@@ -3,14 +3,11 @@
 describe('directive: templateComponentSlides', function() {
   var $scope,
       element,
-      factory,
       attributeDataFactory,
       slidesUrlValidationService,
       sandbox = sinon.sandbox.create();
 
   beforeEach(function() {
-    factory = { selected: { id: "TEST-ID" } };
-
     slidesUrlValidationService = { validate: sandbox.stub().returns(Q.resolve()) };
   });
 
@@ -25,7 +22,7 @@ describe('directive: templateComponentSlides', function() {
   beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
-      return factory;
+      return { selected: { id: "TEST-ID" } };
     });
 
     $provide.service('attributeDataFactory', function() {
@@ -54,8 +51,6 @@ describe('directive: templateComponentSlides', function() {
 
   it('should exist', function() {
     expect($scope).to.be.ok;
-    expect($scope.factory).to.be.ok;
-    expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" } })
     expect($scope.registerDirective).to.have.been.called;
 
     var directive = $scope.registerDirective.getCall(0).args[0];

--- a/test/unit/template-editor/components/directives/dtv-component-text.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-text.spec.js
@@ -3,12 +3,7 @@
 describe('directive: templateComponentText', function() {
   var $scope,
       element,
-      factory,
       attributeDataFactory;
-
-  beforeEach(function() {
-    factory = { selected: { id: "TEST-ID" } };
-  });
 
   beforeEach(module('risevision.template-editor.directives'));
   beforeEach(module('risevision.template-editor.controllers'));
@@ -17,7 +12,7 @@ describe('directive: templateComponentText', function() {
   beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
-      return factory;
+      return { selected: { id: "TEST-ID" } };
     });
 
     $provide.service('attributeDataFactory', function() {
@@ -43,8 +38,6 @@ describe('directive: templateComponentText', function() {
 
   it('should exist', function() {
     expect($scope).to.be.ok;
-    expect($scope.factory).to.be.ok;
-    expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" } })
     expect($scope.registerDirective).to.have.been.called;
 
     var directive = $scope.registerDirective.getCall(0).args[0];

--- a/test/unit/template-editor/components/directives/dtv-component-time-date.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-time-date.spec.js
@@ -3,13 +3,8 @@
 describe('directive: templateComponentTimeDate', function() {
   var $scope,
     element,
-    factory,
     attributeDataFactory,
     sandbox = sinon.sandbox.create();
-
-  beforeEach(function() {
-    factory = { selected: { id: "TEST-ID" } };
-  });
 
   beforeEach(module('risevision.template-editor.directives'));
   beforeEach(module('risevision.template-editor.controllers'));
@@ -18,7 +13,7 @@ describe('directive: templateComponentTimeDate', function() {
   beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
-      return factory;
+      return { selected: { id: "TEST-ID" } };
     });
 
     $provide.service('attributeDataFactory', function() {
@@ -47,8 +42,6 @@ describe('directive: templateComponentTimeDate', function() {
 
   it('should exist', function() {
     expect($scope).to.be.ok;
-    expect($scope.factory).to.be.ok;
-    expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" } });
   });
 
   describe('registerDirective:', function() {

--- a/test/unit/template-editor/components/directives/dtv-component-twitter.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-twitter.spec.js
@@ -3,7 +3,6 @@
 describe('directive: templateComponentTwitter', function() {
   var $scope,
     element,
-    factory,
     attributeDataFactory,
     oauthService,
     twitterCredentialsValidation,
@@ -11,7 +10,6 @@ describe('directive: templateComponentTwitter', function() {
     sandbox = sinon.sandbox.create();
 
   beforeEach(function() {
-    factory = { selected: { id: "TEST-ID" }, presentation: {companyId: "abc123"} };
     oauthService = {};
     twitterCredentialsValidation = {};
     templateEditorUtils = {isStaging: sandbox.stub()};
@@ -24,7 +22,7 @@ describe('directive: templateComponentTwitter', function() {
   beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
-      return factory;
+      return { selected: { id: "TEST-ID" }, presentation: {companyId: "abc123"} };
     });
 
     $provide.service('attributeDataFactory', function() {
@@ -61,8 +59,6 @@ describe('directive: templateComponentTwitter', function() {
 
   it('should exist', function() {
     expect($scope).to.be.ok;
-    expect($scope.factory).to.be.ok;
-    expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" }, presentation: {companyId: "abc123"} });
     expect($scope.registerDirective).to.have.been.called;
 
     var directive = $scope.registerDirective.getCall(0).args[0];

--- a/test/unit/template-editor/components/directives/dtv-component-weather.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-weather.spec.js
@@ -3,7 +3,6 @@
 describe('directive: templateComponentWeather', function() {
   var $scope,
       element,
-      factory,
       attributeDataFactory,
       company,
       rootScope,
@@ -11,7 +10,6 @@ describe('directive: templateComponentWeather', function() {
       hasRole = true;
 
   beforeEach(function() {
-    factory = { selected: { id: "TEST-ID" } };
     company = {
       postalCode: '12345'
     };
@@ -24,7 +22,7 @@ describe('directive: templateComponentWeather', function() {
   beforeEach(module(mockTranslate()));
   beforeEach(module(function ($provide) {
     $provide.service('templateEditorFactory', function() {
-      return factory;
+      return { selected: { id: "TEST-ID" } };
     });
     $provide.service('attributeDataFactory', function() {
       return {
@@ -70,8 +68,6 @@ describe('directive: templateComponentWeather', function() {
 
   it('should exist', function() {
     expect($scope).to.be.ok;
-    expect($scope.factory).to.be.ok;
-    expect($scope.factory).to.deep.equal({ selected: { id: "TEST-ID" } })
     expect($scope.registerDirective).to.have.been.called;
     expect($scope.companySettingsFactory).to.be.ok;
     expect($scope.hasValidAddress).to.be.ok;


### PR DESCRIPTION
## Description
Remove templateEditorFactory from component scopes

Left in image, video, financial because of spinner

[stage-19]

## Motivation and Context
Clean up scope variables.

## How Has This Been Tested?
Tested locally, updated unit tests, e2e tests pass.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No