### PR TITLE
Set default panel class for components

### DIFF
--- a/src/partials/template-editor/components/component-video.html
+++ b/src/partials/template-editor/components/component-video.html
@@ -1,5 +1,3 @@
-<div>
-  <div class="video-component-container" style="display: none">
-    <ng-include src="getPartialPath('video-list.html')"></ng-include>
-  </div>
+<div class="video-component-container">
+  <ng-include src="getPartialPath('video-list.html')"></ng-include>
 </div>

--- a/src/scripts/template-editor/services/svc-components-factory.js
+++ b/src/scripts/template-editor/services/svc-components-factory.js
@@ -179,7 +179,9 @@ angular.module('risevision.template-editor.services')
         directive.element.hide();
         factory.directives[directive.type] = directive;
 
-        angular.extend(directive, COMPONENTS_MAP[directive.type]);
+        _.defaults(directive, COMPONENTS_MAP[directive.type], {
+          panel: '.attribute-editor-component'
+        });
 
         if (directive.onPresentationOpen) {
           directive.onPresentationOpen();
@@ -299,7 +301,7 @@ angular.module('risevision.template-editor.services')
 
       factory.showPreviousPage = function () {
         var currentPage = factory.pages.length > 0 ? factory.pages.pop() : null;
-        var previousPage = factory.pages.length > 0 ? factory.pages[factory.pages.length - 1] : null;
+        var previousPage = factory.getCurrentPage();
 
         if (!previousPage) {
           factory.backToList();
@@ -308,8 +310,6 @@ angular.module('risevision.template-editor.services')
 
           _swapToRight(currentPage, previousPage);
         }
-
-        return !!previousPage;
       };
 
       factory.resetPanelHeader = function () {
@@ -351,7 +351,7 @@ angular.module('risevision.template-editor.services')
 
       function _showElement(component, direction, delay) {
         var directive = _getDirective(component);
-        var element = directive && directive.panel && templateEditorUtils.findElement(directive.panel);
+        var element = directive && directive.panel && templateEditorUtils.findElement(directive.panel, directive.element);
 
         if (directive && directive.element) {
           directive.element.show();
@@ -371,9 +371,9 @@ angular.module('risevision.template-editor.services')
 
       function _hideElement(component, delay) {
         var directive = _getDirective(component);
-        var selectedDirective = _getDirective(factory.getCurrentPage());
+        var selectedDirective = _getSelectedDirective();
 
-        var element = directive && directive.panel && templateEditorUtils.findElement(directive.panel);
+        var element = directive && directive.panel && templateEditorUtils.findElement(directive.panel, directive.element);
 
         if (directive && directive.element && directive.element !== selectedDirective.element) {
           directive.element.hide();

--- a/src/scripts/template-editor/services/svc-template-editor-utils.js
+++ b/src/scripts/template-editor/services/svc-template-editor-utils.js
@@ -84,8 +84,12 @@ angular.module('risevision.template-editor.services')
         return regularFiles.length > 0;
       };
 
-      svc.findElement = function (selector) {
-        return document.querySelector(selector) && angular.element(document.querySelector(selector));
+      svc.findElement = function (selector, parent) {
+        if (parent) {
+          return parent.find(selector);
+        } else {
+          return document.querySelector(selector) && angular.element(document.querySelector(selector));          
+        }
       };
 
       svc.showMessageWindow = function (title, message, buttonLabel) {

--- a/test/unit/template-editor/services/svc-components-factory.spec.js
+++ b/test/unit/template-editor/services/svc-components-factory.spec.js
@@ -346,6 +346,53 @@ describe('service: componentsFactory:', function() {
       expect(directive.title).to.equal('Text');
     });
 
+    describe('panel:', function() {
+      it('should set default panel', function() {
+        var component = {
+          type: 'rise-test',
+          icon: 'fa-test',
+          element: {
+            hide: sandbox.stub()
+          }
+        };
+
+        componentsFactory.registerDirective(component);
+
+        expect(componentsFactory.directives["rise-test"]).to.be.ok;
+        expect(componentsFactory.directives["rise-test"].panel).to.equal('.attribute-editor-component');
+      });
+
+      it('should not override directive panel', function() {
+        var component = {
+          type: 'rise-test',
+          icon: 'fa-test',
+          panel: '.component-panel',
+          element: {
+            hide: sandbox.stub()
+          }
+        };
+
+        componentsFactory.registerDirective(component);
+
+        expect(componentsFactory.directives["rise-test"]).to.be.ok;
+        expect(componentsFactory.directives["rise-test"].panel).to.equal('.component-panel');
+      });
+
+      it('should not override default directive panel', function() {
+        var component = {
+          type: 'rise-video',
+          element: {
+            hide: sandbox.stub()
+          }
+        };
+
+        componentsFactory.registerDirective(component);
+
+        expect(componentsFactory.directives["rise-video"]).to.be.ok;
+        expect(componentsFactory.directives["rise-video"].panel).to.equal('.video-component-container');
+      });
+
+    });
   });
 
   describe('editComponent:', function() {
@@ -870,14 +917,15 @@ describe('service: componentsFactory:', function() {
 
       it('should swap left', function(done) {
         componentsFactory.pages.push(component1);
+        componentsFactory.selected = component2;
 
         componentsFactory.showNextPage(component2);
 
         directive1.element.hide.should.have.been.called;
-        templateEditorUtils.findElement.should.have.been.calledWith('panel1');
+        templateEditorUtils.findElement.should.have.been.calledWith('panel1', directive1.element);
 
         directive2.element.show.should.have.been.called;
-        templateEditorUtils.findElement.should.have.been.calledWith('panel2');
+        templateEditorUtils.findElement.should.have.been.calledWith('panel2', directive2.element);
 
         templateEditorUtils.elementStub.removeClass.should.have.been.calledWith('attribute-editor-show-from-right');
         templateEditorUtils.elementStub.removeClass.should.have.been.calledWith('attribute-editor-show-from-left');
@@ -894,6 +942,7 @@ describe('service: componentsFactory:', function() {
       
       it('should not hide the element if its the same', function() {
         directive2.element = directive1.element;
+        componentsFactory.selected = component2;
 
         componentsFactory.pages.push(component1);
 
@@ -907,7 +956,7 @@ describe('service: componentsFactory:', function() {
         componentsFactory.showNextPage(component2);
 
         directive2.element.show.should.have.been.called;
-        templateEditorUtils.findElement.should.have.been.calledWith('panel2');
+        templateEditorUtils.findElement.should.have.been.calledWith('panel2', directive2.element);
 
         templateEditorUtils.elementStub.addClass.should.have.been.calledWith('attribute-editor-show-from-right');
 
@@ -930,7 +979,7 @@ describe('service: componentsFactory:', function() {
     it('should hide the first page', function () {
       componentsFactory.showNextPage('selector1');
 
-      expect(componentsFactory.showPreviousPage()).to.be.false;
+      componentsFactory.showPreviousPage();
 
       componentsFactory.backToList.should.have.been.called;
 
@@ -941,7 +990,7 @@ describe('service: componentsFactory:', function() {
       componentsFactory.showNextPage('selector1');
       componentsFactory.showNextPage('selector2');
 
-      expect(componentsFactory.showPreviousPage()).to.be.true;
+      componentsFactory.showPreviousPage();
 
       componentsFactory.backToList.should.not.have.been.called;
 
@@ -995,10 +1044,10 @@ describe('service: componentsFactory:', function() {
         componentsFactory.showPreviousPage();
 
         directive1.element.show.should.have.been.called;
-        templateEditorUtils.findElement.should.have.been.calledWith('panel1');
+        templateEditorUtils.findElement.should.have.been.calledWith('panel1', directive1.element);
 
         directive2.element.hide.should.have.been.called;
-        templateEditorUtils.findElement.should.have.been.calledWith('panel2');
+        templateEditorUtils.findElement.should.have.been.calledWith('panel2', directive2.element);
 
         templateEditorUtils.elementStub.removeClass.should.have.been.calledWith('attribute-editor-show-from-right');
         templateEditorUtils.elementStub.removeClass.should.have.been.calledWith('attribute-editor-show-from-left');

--- a/test/unit/template-editor/services/svc-template-editor-utils.spec.js
+++ b/test/unit/template-editor/services/svc-template-editor-utils.spec.js
@@ -193,6 +193,27 @@ describe('service: templateEditorUtils:', function() {
     });
   });
 
+  describe('findElement:', function() {
+    it('should look for child elements if parent is available', function() {
+      var parent = {
+        find: sandbox.stub().returns('found')
+      };
+
+      expect(templateEditorUtils.findElement('.selector', parent)).to.equal('found');
+
+      parent.find.should.have.been.calledWith('.selector');
+    });
+
+    it('should search element', function() {
+      sandbox.spy(document, 'querySelector');
+
+      templateEditorUtils.findElement('.selector');
+
+      document.querySelector.should.have.been.calledWith('.selector');
+    });
+    
+  });
+
   describe('showInvalidExtensionsMessage', function () {
     it('should call the correct functions', function () {
       sandbox.stub(templateEditorUtils, 'showMessageWindow');


### PR DESCRIPTION
## Description
Set default panel class for components

Search for panel within element
Clean up by using utilities

[stage-2]

## Motivation and Context
Playlist Epic.

## How Has This Been Tested?
Tested locally. Updated unit tests. e2e tests pass.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No