### PR TITLE
Set playlist height to fix dropdown for empty list

### DIFF
--- a/src/scss/sections/components/playlist.scss
+++ b/src/scss/sections/components/playlist.scss
@@ -3,9 +3,7 @@
   --playlist-selected-title-height: 50px;
   --selector-search-box-height: 60px;
 }
-.rise-playlist-container {
-  --playlist-button-bar-height: 40px;
-}
+
 @media (min-width: $screen-sm) {
   .rise-playlist-container, .presentation-selector-container {
     --selector-body-height: calc(100vh - var(--body-height) - var(--component-header-height));
@@ -16,6 +14,11 @@
   .rise-playlist-container, .presentation-selector-container {    
     --selector-body-height: calc(100vh - var(--body-height));
   }
+}
+
+.rise-playlist-container {
+  --playlist-button-bar-height: 40px;
+  height: calc(var(--selector-body-height) - var(--playlist-selected-title-height));
 }
 
 .rise-playlist-container, .presentation-selector-container {


### PR DESCRIPTION

## Description
Set playlist container height to fix dropdown when list is empty

## Motivation and Context
Playlist UI

## How Has This Been Tested?
Locally and on [stage-20]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
