### PR TITLE
Load default Playlist items from string as provided by blueprint

### DIFF
--- a/src/scripts/template-editor/components/directives/dtv-component-playlist.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-playlist.js
@@ -100,6 +100,10 @@ angular.module('risevision.template-editor.directives')
           $scope.jsonToPlaylistItems = function (playlistItems) {
             var result = [];
 
+            if (typeof playlistItems === 'string' || playlistItems instanceof String) {
+              playlistItems = JSON.parse(playlistItems);
+            }
+
             if (Array.isArray(playlistItems)) {
               result = _.map(playlistItems, _mapItemToEditorFormat);
             }

--- a/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
@@ -304,6 +304,33 @@ describe("directive: templateComponentPlaylist", function() {
           playlistComponentFactory.loadPresentationNames.should.not.have.been.called;
         });
 
+        it("should load default attribute data from string, as provided by blueprint", function() {
+          var directive = componentsFactory.registerDirective.getCall(0).args[0];
+
+          attributeDataFactory.getAvailableAttributeData = function(componentId, attributeName) {
+            return '[{"duration": 10,"transition-type": "fadeIn","element": {"tagName": "rise-text","attributes": {"value": "Default text" }}}]';
+          };
+
+          $scope.playlistItems = samplePlaylistItems; //some garbage data from past session
+
+          directive.show();
+
+          expect($scope.componentId).to.equal("TEST-ID");
+
+          expect($scope.playlistItems.length).to.equal(1);
+          expect($scope.playlistItems[0]["duration"]).to.equal(10);
+          expect($scope.playlistItems[0]["transition-type"]).to.equal("fadeIn");
+          expect($scope.playlistItems[0]["tagName"]).to.equal("rise-text");
+          expect($scope.playlistItems[0].attributes).to.deep.equal({
+            "value": "Default text"
+          });
+          expect($scope.playlistItems[0]["play-until-done"]).to.not.be.ok;          
+          expect($scope.playlistItems[0]["id"]).to.not.be.ok;
+          expect($scope.playlistItems[0]["productCode"]).to.not.be.ok;        
+
+          playlistComponentFactory.loadPresentationNames.should.not.have.been.called;
+        });
+
       });
     });
   });


### PR DESCRIPTION
## Description
Load default Playlist items from string, as provided by blueprint.

## Motivation and Context
Playlist UI

## How Has This Been Tested?
Locally and on [stage-1] with Example Playlist template

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
