### PR TITLE
Parse duration string to integer or set default

### DIFF
--- a/src/scripts/template-editor/components/directives/dtv-component-playlist.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-playlist.js
@@ -2,9 +2,9 @@
 
 angular.module('risevision.template-editor.directives')
   .directive('templateComponentPlaylist', ['$loading', 'componentsFactory', 'attributeDataFactory',
-    'playlistComponentFactory', 'blueprintFactory', 'PLAYLIST_COMPONENTS', 'analyticsFactory',
+    'playlistComponentFactory', 'blueprintFactory', 'templateEditorUtils', 'PLAYLIST_COMPONENTS', 'analyticsFactory',
     function ($loading, componentsFactory, attributeDataFactory, playlistComponentFactory,
-      blueprintFactory, PLAYLIST_COMPONENTS, analyticsFactory) {
+      blueprintFactory, templateEditorUtils, PLAYLIST_COMPONENTS, analyticsFactory) {
       return {
         restrict: 'E',
         scope: true,
@@ -198,8 +198,7 @@ angular.module('risevision.template-editor.directives')
             $scope.selectedItem.key = key;
 
             //set default values
-            $scope.selectedItem.duration = Number.isInteger($scope.selectedItem.duration) ? $scope.selectedItem
-              .duration : 10;
+            $scope.selectedItem.duration = templateEditorUtils.intValueFor($scope.selectedItem.duration, 10);
             $scope.selectedItem['transition-type'] = $scope.selectedItem['transition-type'] ? $scope.selectedItem[
               'transition-type'] : 'normal';
 

--- a/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-playlist.spec.js
@@ -565,6 +565,14 @@ describe("directive: templateComponentPlaylist", function() {
       });
     });
 
+    it('should parse duration string', function() {
+      $scope.playlistItems[1].duration = '25';
+
+      $scope.editProperties(1);
+
+      expect($scope.selectedItem["duration"]).to.equal(25);
+    });
+
     it('should handle invalid duration and set default transition-type', function() {
       $scope.playlistItems[1].duration = 'invalid';
       $scope.playlistItems[1]['transition-type'] = '';


### PR DESCRIPTION
## Description
Parse duration string to integer or set default

[stage-18]

## Motivation and Context
Fix issue in https://github.com/Rise-Vision/rise-vision-apps/pull/2632

## How Has This Been Tested?
Tested locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No