### PR TITLE
Convert files list to array

### DIFF
--- a/src/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-image.js
@@ -112,7 +112,9 @@ angular.module('risevision.template-editor.directives')
             var metadata = attributeDataFactory.getAttributeData(componentId, 'metadata');
 
             if (!metadata) {
-              return attributeDataFactory.getBlueprintData(componentId, 'files');
+              var files = attributeDataFactory.getAvailableAttributeData(componentId, 'files');
+
+              return fileMetadataUtilsService.filesAttributeToArray(files);
             }
 
             return fileMetadataUtilsService.extractFileNamesFrom(metadata);

--- a/src/scripts/template-editor/components/directives/dtv-component-video.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-video.js
@@ -86,7 +86,9 @@ angular.module('risevision.template-editor.directives')
             var metadata = attributeDataFactory.getAttributeData(componentId, 'metadata');
 
             if (!metadata) {
-              return attributeDataFactory.getBlueprintData(componentId, 'files');
+              var files = attributeDataFactory.getAvailableAttributeData(componentId, 'files');
+
+              return fileMetadataUtilsService.filesAttributeToArray(files);
             }
 
             return fileMetadataUtilsService.extractFileNamesFrom(metadata);

--- a/src/scripts/template-editor/components/services/svc-file-existence-check.js
+++ b/src/scripts/template-editor/components/services/svc-file-existence-check.js
@@ -101,14 +101,7 @@ angular.module('risevision.template-editor.services')
       }
 
       service.requestMetadataFor = function (files, defaultThumbnailUrl) {
-        var fileNames;
-
-        if (files) {
-          fileNames = Array.isArray(files) ?
-            angular.copy(files) : files.split('|');
-        } else {
-          fileNames = [];
-        }
+        var fileNames = fileMetadataUtilsService.filesAttributeToArray(files);
 
         return _loadMetadata(fileNames, defaultThumbnailUrl);
       };

--- a/src/scripts/template-editor/components/services/svc-file-metadata-utils.js
+++ b/src/scripts/template-editor/components/services/svc-file-metadata-utils.js
@@ -49,6 +49,19 @@ angular.module('risevision.template-editor.services')
         return service.extractFileNamesFrom(metadata).join('|');
       };
 
+      service.filesAttributeToArray = function (files) {
+        var fileNames;
+
+        if (files) {
+          fileNames = Array.isArray(files) ?
+            angular.copy(files) : files.split('|');
+        } else {
+          fileNames = [];
+        }
+
+        return fileNames;
+      };
+
       service.metadataWithFile = function (previousMetadata, defaultThumbnailUrl, files, alwaysAppend) {
         var metadata = _.cloneDeep(previousMetadata);
 

--- a/src/scripts/template-editor/services/svc-template-editor-utils.js
+++ b/src/scripts/template-editor/services/svc-template-editor-utils.js
@@ -11,10 +11,6 @@ angular.module('risevision.template-editor.services')
         return isNaN(intValue) ? defaultValue : intValue;
       };
 
-      svc.fileNameOf = function (path) {
-        return path.split('/').pop();
-      };
-
       svc.addOrRemove = function (list, oldItem, newItem) {
         var idx = _.findIndex(list, oldItem);
 

--- a/test/unit/template-editor/components/directives/dtv-component-image.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.spec.js
@@ -158,14 +158,14 @@ describe('directive: TemplateComponentImage', function() {
       describe('getName:', function() {
         beforeEach(function() {
           attributeDataFactory.getAttributeData.reset();
-          attributeDataFactory.getBlueprintData.reset();
+          attributeDataFactory.getAvailableAttributeData.reset();
         });
 
         it('should return null if data is not found', function() {
           expect(componentsFactory.registerDirective.getCall(0).args[0].getName('component1')).to.be.null;
 
           attributeDataFactory.getAttributeData.should.have.been.calledWith('component1', 'metadata');
-          attributeDataFactory.getBlueprintData.should.have.been.calledWith('component1', 'files');
+          attributeDataFactory.getAvailableAttributeData.should.have.been.calledWith('component1', 'files');
         });
 
         it('should get first file name from attribute data', function() {
@@ -177,11 +177,11 @@ describe('directive: TemplateComponentImage', function() {
           expect(componentsFactory.registerDirective.getCall(0).args[0].getName('component1')).to.equal('image.png');
 
           attributeDataFactory.getAttributeData.should.have.been.calledWith('component1', 'metadata');
-          attributeDataFactory.getBlueprintData.should.not.have.been.called;
+          attributeDataFactory.getAvailableAttributeData.should.not.have.been.called;
         });
 
         it('should fallback to blueprint data', function() {
-          attributeDataFactory.getBlueprintData.returns([
+          attributeDataFactory.getAvailableAttributeData.returns([
             'bucketid/someFolder/image.png',
             'test.jpg'
           ]);
@@ -189,7 +189,7 @@ describe('directive: TemplateComponentImage', function() {
           expect(componentsFactory.registerDirective.getCall(0).args[0].getName('component1')).to.equal('image.png');
 
           attributeDataFactory.getAttributeData.should.have.been.calledWith('component1', 'metadata');
-          attributeDataFactory.getBlueprintData.should.have.been.calledWith('component1', 'files');
+          attributeDataFactory.getAvailableAttributeData.should.have.been.calledWith('component1', 'files');
         });
 
         it('should return null if files list is empty', function() {

--- a/test/unit/template-editor/components/directives/dtv-component-video.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-video.spec.js
@@ -96,14 +96,14 @@ describe('directive: templateComponentVideo', function() {
     describe('getName:', function() {
       beforeEach(function() {
         attributeDataFactory.getAttributeData.reset();
-        attributeDataFactory.getBlueprintData.reset();
+        attributeDataFactory.getAvailableAttributeData.reset();
       });
 
       it('should return null if data is not found', function() {
         expect(componentsFactory.registerDirective.getCall(0).args[0].getName('component1')).to.be.null;
 
         attributeDataFactory.getAttributeData.should.have.been.calledWith('component1', 'metadata');
-        attributeDataFactory.getBlueprintData.should.have.been.calledWith('component1', 'files');
+        attributeDataFactory.getAvailableAttributeData.should.have.been.calledWith('component1', 'files');
       });
 
       it('should get first file name from attribute data', function() {
@@ -115,11 +115,11 @@ describe('directive: templateComponentVideo', function() {
         expect(componentsFactory.registerDirective.getCall(0).args[0].getName('component1')).to.equal('video.webm');
 
         attributeDataFactory.getAttributeData.should.have.been.calledWith('component1', 'metadata');
-        attributeDataFactory.getBlueprintData.should.not.have.been.called;
+        attributeDataFactory.getAvailableAttributeData.should.not.have.been.called;
       });
 
       it('should fallback to blueprint data', function() {
-        attributeDataFactory.getBlueprintData.returns([
+        attributeDataFactory.getAvailableAttributeData.returns([
           'bucketid/someFolder/video.webm',
           'video2.mpg'
         ]);
@@ -127,7 +127,7 @@ describe('directive: templateComponentVideo', function() {
         expect(componentsFactory.registerDirective.getCall(0).args[0].getName('component1')).to.equal('video.webm');
 
         attributeDataFactory.getAttributeData.should.have.been.calledWith('component1', 'metadata');
-        attributeDataFactory.getBlueprintData.should.have.been.calledWith('component1', 'files');
+        attributeDataFactory.getAvailableAttributeData.should.have.been.calledWith('component1', 'files');
       });
 
       it('should return null if files list is empty', function() {

--- a/test/unit/template-editor/components/services/svc-file-metadata-utils.spec.js
+++ b/test/unit/template-editor/components/services/svc-file-metadata-utils.spec.js
@@ -91,6 +91,31 @@ describe('service: fileMetadataUtilsService:', function() {
 
   });
 
+  describe('filesAttributeToArray', function() {
+
+    it('should extract file names from separated string', function() {
+      var filesAttribute = fileMetadataUtilsService.filesAttributeToArray('a.txt|b.txt|c.txt');
+
+      expect(filesAttribute).to.deep.equal(['a.txt', 'b.txt', 'c.txt']);
+    });
+
+    it('should handle array and copy it', function() {
+      var filesArray = ['a.txt', 'b.txt', 'c.txt'];
+      var filesAttribute = fileMetadataUtilsService.filesAttributeToArray(filesArray);
+
+      expect(filesAttribute).to.not.equal(filesArray);
+      expect(filesAttribute).to.deep.equal(filesArray);
+    });
+
+    it('should handle undefined parameter', function() {
+      var filesArray = ['a.txt', 'b.txt', 'c.txt'];
+      var filesAttribute = fileMetadataUtilsService.filesAttributeToArray();
+
+      expect(filesAttribute).to.deep.equal([]);
+    });
+
+  });
+
   describe('metadataWithFile', function() {
 
     it('should add to metadata', function() {


### PR DESCRIPTION
## Description
Convert files list to array

Convert in both image and video
Array can be used to get the first file name
Use available attribute data function as it
parses playlist item id reference

[stage-2]

## Motivation and Context
Partial fix for #2648 

Fixes the playlist item names for Images/Videos in the blueprint.
The component will still not have the files available.

## How Has This Been Tested?
Tested locally with the new template from creative.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No