### PR TITLE
Always set play-until-done component to nonEditable

### DIFF
--- a/src/app/template-editor/services/blueprint.service.spec.ts
+++ b/src/app/template-editor/services/blueprint.service.spec.ts
@@ -203,6 +203,26 @@ describe('BlueprintService', () => {
           ]
         });
       });
+
+      it('should sanitize set play until done component to non editable', function(done) {
+        blueprintFactory.getBlueprintCached(PRODUCT_CODE)
+          .then(function(resp) {
+            expect(resp).to.be.an('object');
+            expect(resp.components[0].nonEditable).to.be.true;
+
+            done();
+          });
+
+        $httpBackend.expectOne('https://widgets.risevision.com/staging/templates/template123/blueprint.json').flush({
+          components: [
+            {
+              type: 'rise-play-until-done',
+              nonEditable: false
+            }
+          ]
+        });
+      });
+
     });
 
     it('should populate factory object on api response',function(done) {

--- a/src/app/template-editor/services/blueprint.service.ts
+++ b/src/app/template-editor/services/blueprint.service.ts
@@ -52,6 +52,8 @@ export class BlueprintService {
             attributes.maxfontsize = this.templateEditorUtils.intValueFor(attributes.maxfontsize, null);
           }
         });
+      } else if (component && component.type === 'rise-play-until-done') {
+        component.nonEditable = true;
       }
     });
   }


### PR DESCRIPTION
## Description
Always set play-until-done component to nonEditable

[stage-2]

## Motivation and Context
Fix issue where blueprint had the wrong flag applied to the field.

## How Has This Been Tested?
Tested locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No