### PR TITLE
Check for images in component on demand

### DIFF
--- a/src/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-image.js
@@ -76,43 +76,6 @@ angular.module('risevision.template-editor.directives')
             }
           }
 
-          function _loadDuration() {
-            var duration = imageFactory.getDuration();
-
-            if (!duration) {
-              duration = _getDefaultDurationAttribute();
-            }
-
-            duration = parseInt(duration, 10);
-
-            // default to value 10 if duration not defined
-            $scope.values.duration = (duration && !isNaN(duration)) ? duration : 10;
-          }
-
-          function _loadTransition() {
-            var transition = imageFactory.getTransition();
-            if (!transition) {
-              transition = _getBlueprint('transition');
-            }
-            $scope.values.transition = transition;
-          }
-
-          function _loadHelpText() {
-            $scope.helpText = imageFactory.getHelpText();
-          }
-
-          function _getBlueprint(key) {
-            return imageFactory.getBlueprintData(key);
-          }
-
-          function _getDefaultFilesAttribute() {
-            return _getBlueprint('files');
-          }
-
-          function _getDefaultDurationAttribute() {
-            return _getBlueprint('duration');
-          }
-
           function _getFilesFor(componentId) {
             var metadata = attributeDataFactory.getAttributeData(componentId, 'metadata');
 
@@ -159,7 +122,7 @@ angular.module('risevision.template-editor.directives')
             }
 
             $scope.selectedImages = selectedImages;
-            $scope.isDefaultImageList = filesAttribute === _getDefaultFilesAttribute();
+            $scope.isDefaultImageList = filesAttribute === imageFactory.getBlueprintData('files');
           }
 
           _reset();
@@ -183,9 +146,13 @@ angular.module('risevision.template-editor.directives')
 
             _loadSelectedImages();
 
-            _loadDuration();
-            _loadTransition();
-            _loadHelpText();
+            var duration = imageFactory.getAvailableAttributeData('duration');
+
+            // default to value 10 if duration not defined
+            $scope.values.duration = templateEditorUtils.intValueFor(duration, 10);
+
+            $scope.values.transition = imageFactory.getAvailableAttributeData('transition');
+            $scope.helpText = imageFactory.getHelpText();
           };
 
           var componentDirective = {

--- a/src/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-image.js
@@ -5,11 +5,11 @@ angular.module('risevision.template-editor.directives')
     'https://s3.amazonaws.com/Rise-Images/UI/storage-image-icon-no-transparency%402x.png')
   .constant('SUPPORTED_IMAGE_TYPES', '.bmp, .gif, .jpeg, .jpg, .png, .svg, .webp')
   .constant('CANVA_FOLDER', 'canva/')
-  .directive('templateComponentImage', ['$log', '$q', '$timeout', '$loading', 'componentsFactory', 'templateEditorFactory',
+  .directive('templateComponentImage', ['$log', '$timeout', '$loading', 'componentsFactory', 'templateEditorFactory',
     'attributeDataFactory', 'storageManagerFactory', 'fileExistenceCheckService', 'fileMetadataUtilsService',
     'logoImageFactory', 'baseImageFactory', 'fileDownloader', 'templateEditorUtils', 'DEFAULT_IMAGE_THUMBNAIL',
     'SUPPORTED_IMAGE_TYPES', 'CANVA_FOLDER',
-    function ($log, $q, $timeout, $loading, componentsFactory, templateEditorFactory, attributeDataFactory,
+    function ($log, $timeout, $loading, componentsFactory, templateEditorFactory, attributeDataFactory,
       storageManagerFactory, fileExistenceCheckService, fileMetadataUtilsService,
       logoImageFactory, baseImageFactory, fileDownloader, templateEditorUtils,
       DEFAULT_IMAGE_THUMBNAIL, SUPPORTED_IMAGE_TYPES, CANVA_FOLDER) {
@@ -64,7 +64,12 @@ angular.module('risevision.template-editor.directives')
 
             templateEditorFactory.loadingPresentation = true;
 
-            if (imageFactory.areChecksCompleted($scope.fileExistenceChecksCompleted)) {
+            if (imageFactory.componentId && !baseImageFactory.checksCompleted.hasOwnProperty([imageFactory.componentId])) {
+              _checkFileExistenceFor(imageFactory.componentId)
+                .finally(function() {
+                  templateEditorFactory.loadingPresentation = false;
+                });              
+            } else if (imageFactory.areChecksCompleted()) {
               $timeout(function () {
                 templateEditorFactory.loadingPresentation = false;
               });
@@ -167,7 +172,7 @@ angular.module('risevision.template-editor.directives')
             imageFactory.setTransition($scope.values.transition);
           };
 
-          var _initStorageFactory = function() {
+          var _init = function() {
             _reset();
 
             storageManagerFactory.fileType = 'image';
@@ -177,6 +182,10 @@ angular.module('risevision.template-editor.directives')
             };
 
             _loadSelectedImages();
+
+            _loadDuration();
+            _loadTransition();
+            _loadHelpText();
           };
 
           var componentDirective = {
@@ -186,29 +195,22 @@ angular.module('risevision.template-editor.directives')
               imageFactory = baseImageFactory;
               imageFactory.componentId = componentsFactory.selected.id;
 
-              _initStorageFactory();
-
-              _loadDuration();
-              _loadTransition();
-              _loadHelpText();
+              _init();
             },
             onPresentationOpen: function () {
-              $scope.fileExistenceChecksCompleted = {};
+              baseImageFactory.componentId = null;
+              baseImageFactory.checksCompleted = {};
 
-              var imageComponentIds = attributeDataFactory.getComponentIds(function (c) {
-                return c.type === 'rise-image';
+              var imageComponentIds = attributeDataFactory.getComponentIds({
+                type: 'rise-image'
               });
 
               _.forEach(imageComponentIds, function (componentId) {
                 $log.info('checking file existence for component', componentId);
 
-                $scope.fileExistenceChecksCompleted[componentId] = false;
-
                 _checkFileExistenceFor(componentId)
                   .finally(function () {
-                    $scope.fileExistenceChecksCompleted[componentId] = true;
-
-                    if (imageFactory.areChecksCompleted($scope.fileExistenceChecksCompleted)) {
+                    if (imageFactory.areChecksCompleted()) {
                       templateEditorFactory.loadingPresentation = false;
                     }
                   });
@@ -232,44 +234,18 @@ angular.module('risevision.template-editor.directives')
               imageFactory = logoImageFactory;
               imageFactory.componentId = null;
 
-              _initStorageFactory();
-
-              _loadDuration();
-              _loadTransition();
-              _loadHelpText();
+              _init();
             }
           };
 
           componentsFactory.registerDirective(componentDirective);
           componentsFactory.registerDirective(logoDirective);
 
-          $scope.waitForPresentationId = function (metadata) {
-            function _checkPresentationIdOrWait() {
-              var SMALL_CHECK_INTERVAL = 100;
-
-              if (templateEditorFactory.presentation && templateEditorFactory.presentation.id) {
-                deferred.resolve(metadata);
-              } else {
-                $timeout(function () {
-                  _checkPresentationIdOrWait();
-                }, SMALL_CHECK_INTERVAL);
-              }
-            }
-
-            var deferred = $q.defer();
-
-            _checkPresentationIdOrWait();
-
-            return deferred.promise;
-          };
-
           function _checkFileExistenceFor(componentId) {
             var files = _getFilesFor(componentId);
+            baseImageFactory.checksCompleted[componentId] = false;
 
             return fileExistenceCheckService.requestMetadataFor(files, DEFAULT_IMAGE_THUMBNAIL)
-              .then(function (metadata) {
-                return $scope.waitForPresentationId(metadata);
-              })
               .then(function (metadata) {
                 $log.info('received metadata', metadata);
 
@@ -277,6 +253,9 @@ angular.module('risevision.template-editor.directives')
               })
               .catch(function (error) {
                 $log.error('Could not check file existence for: ' + componentId, error);
+              })
+              .finally(function() {
+                baseImageFactory.checksCompleted[componentId] = true;
               });
           }
 

--- a/src/scripts/template-editor/components/services/svc-base-image-factory.js
+++ b/src/scripts/template-editor/components/services/svc-base-image-factory.js
@@ -11,14 +11,6 @@ angular.module('risevision.template-editor.services')
         return _getAttributeData('metadata');
       };
 
-      factory.getDuration = function () {
-        return _getAttributeData('duration');
-      };
-
-      factory.getTransition = function () {
-        return _getAttributeData('transition');
-      };
-
       factory.setDuration = function (duration) {
         _setAttributeData('duration', duration);
       };
@@ -69,6 +61,10 @@ angular.module('risevision.template-editor.services')
         }
 
         return selectedImages;
+      };
+
+      factory.getAvailableAttributeData = function (key) {
+        return attributeDataFactory.getAvailableAttributeData(factory.componentId, key);
       };
 
       var _getAttributeData = function (key) {

--- a/src/scripts/template-editor/components/services/svc-base-image-factory.js
+++ b/src/scripts/template-editor/components/services/svc-base-image-factory.js
@@ -35,8 +35,8 @@ angular.module('risevision.template-editor.services')
         return blueprintFactory.getBlueprintData(factory.componentId, key);
       };
 
-      factory.areChecksCompleted = function (checksCompleted) {
-        return !!checksCompleted && checksCompleted[factory.componentId] !== false;
+      factory.areChecksCompleted = function () {
+        return !!factory.checksCompleted && factory.checksCompleted[factory.componentId] !== false;
       };
 
       factory.isSetAsLogo = function () {

--- a/src/scripts/template-editor/components/services/svc-logo-image-factory.js
+++ b/src/scripts/template-editor/components/services/svc-logo-image-factory.js
@@ -56,7 +56,7 @@ angular.module('risevision.template-editor.services')
         return null;
       };
 
-      factory.areChecksCompleted = function (checksCompleted) {
+      factory.areChecksCompleted = function () {
         return !!brandingFactory.brandingSettings.logoFileMetadata;
       };
 

--- a/src/scripts/template-editor/components/services/svc-logo-image-factory.js
+++ b/src/scripts/template-editor/components/services/svc-logo-image-factory.js
@@ -19,14 +19,6 @@ angular.module('risevision.template-editor.services')
         }
       };
 
-      factory.getDuration = function () {
-        return null;
-      };
-
-      factory.getTransition = function () {
-        return null;
-      };
-
       factory.setDuration = function (duration) {
         return;
       };
@@ -50,6 +42,10 @@ angular.module('risevision.template-editor.services')
         }
         brandingFactory.setUnsavedChanges();
         return brandingFactory.brandingSettings.logoFileMetadata;
+      };
+
+      factory.getAvailableAttributeData = function (key) {
+        return null;
       };
 
       factory.getBlueprintData = function (key) {

--- a/test/unit/template-editor/components/directives/dtv-component-image.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.spec.js
@@ -47,6 +47,7 @@ describe('directive: TemplateComponentImage', function() {
     });
     $provide.service('logoImageFactory', function() {
       return {
+        getAvailableAttributeData: sinon.stub(),
         getBlueprintData: sandbox.stub().returns({}),
         getImagesAsMetadata: sandbox.stub().returns([]),
         areChecksCompleted: sandbox.stub().returns(true),
@@ -57,6 +58,7 @@ describe('directive: TemplateComponentImage', function() {
     });
     $provide.service('baseImageFactory', function() {
       return {
+        getAvailableAttributeData: sinon.stub(),
         getBlueprintData: sandbox.stub().returns({}),
         getImagesAsMetadata: sandbox.stub().returns([]),
         areChecksCompleted: sandbox.stub().returns(true),

--- a/test/unit/template-editor/components/services/svc-base-image-factory.spec.js
+++ b/test/unit/template-editor/components/services/svc-base-image-factory.spec.js
@@ -16,6 +16,7 @@ describe('service: baseImageFactory', function() {
     $provide.service('attributeDataFactory', function() {
       return {
         getAttributeData: sandbox.stub().returns('data'),
+        getAvailableAttributeData: sandbox.stub().returns('availabledata'),
         setAttributeData: sandbox.stub()
       };
     });
@@ -51,13 +52,12 @@ describe('service: baseImageFactory', function() {
   it('should initialize', function () {
     expect(baseImageFactory).to.be.ok;
     expect(baseImageFactory.getImagesAsMetadata).to.be.a('function');
-    expect(baseImageFactory.getDuration).to.be.a('function');
+    expect(baseImageFactory.getAvailableAttributeData).to.be.a('function');
     expect(baseImageFactory.setDuration).to.be.a('function');
     expect(baseImageFactory.getBlueprintData).to.be.a('function');
     expect(baseImageFactory.areChecksCompleted).to.be.a('function');
     expect(baseImageFactory.removeImage).to.be.a('function');
     expect(baseImageFactory.updateMetadata).to.be.a('function');
-    expect(baseImageFactory.getTransition).to.be.a('function');
     expect(baseImageFactory.setTransition).to.be.a('function');
   });
 
@@ -72,10 +72,10 @@ describe('service: baseImageFactory', function() {
 
   describe('getDuration: ', function() {
     it('should return Template Editor attributes duration', function() {
-      var data = baseImageFactory.getDuration();      
+      var data = baseImageFactory.getAvailableAttributeData('duration');      
 
-      expect(data).to.equals('data');
-      attributeDataFactory.getAttributeData.should.have.been.calledWith('componentId','duration');
+      expect(data).to.equals('availabledata');
+      attributeDataFactory.getAvailableAttributeData.should.have.been.calledWith('componentId','duration');
     });
   });
 
@@ -227,15 +227,6 @@ describe('service: baseImageFactory', function() {
         attributeDataFactory.getAttributeData.returns(false);
         expect(baseImageFactory.isSetAsLogo()).to.equals(false);
       });
-    });
-  });
-
-  describe('getTransition: ', function() {
-    it('should return Template Editor transition attribute', function() {
-      var data = baseImageFactory.getTransition();
-
-      expect(data).to.equals('data');
-      attributeDataFactory.getAttributeData.should.have.been.calledWith('componentId','transition');
     });
   });
 

--- a/test/unit/template-editor/components/services/svc-base-image-factory.spec.js
+++ b/test/unit/template-editor/components/services/svc-base-image-factory.spec.js
@@ -98,27 +98,37 @@ describe('service: baseImageFactory', function() {
 
   describe('areChecksCompleted: ', function() {
     it('should return true if componentId is in the list', function() {
-      expect(baseImageFactory.areChecksCompleted({componentId:true})).to.be.true;
-      expect(baseImageFactory.areChecksCompleted({otherID:true,componentId:true})).to.be.true;
+      baseImageFactory.checksCompleted = {componentId:true};
+      expect(baseImageFactory.areChecksCompleted()).to.be.true;
+
+      baseImageFactory.checksCompleted = {otherID:true,componentId:true};
+      expect(baseImageFactory.areChecksCompleted()).to.be.true;
     });
 
     it('should return false if check is not completed', function() {
-      expect(baseImageFactory.areChecksCompleted({componentId:false})).to.be.false;
-      expect(baseImageFactory.areChecksCompleted({otherID:true,componentId:false})).to.be.false;
+      baseImageFactory.checksCompleted = {componentId:false};
+      expect(baseImageFactory.areChecksCompleted()).to.be.false;
+
+      baseImageFactory.checksCompleted = {otherID:true,componentId:false};
+      expect(baseImageFactory.areChecksCompleted()).to.be.false;
     });
 
     it('should return false if empty', function() {
-      expect(baseImageFactory.areChecksCompleted(null)).to.be.false;
+      expect(baseImageFactory.areChecksCompleted()).to.be.false;
     });
     
     it('should return true if not present', function() {
-      expect(baseImageFactory.areChecksCompleted({})).to.be.true;
-      expect(baseImageFactory.areChecksCompleted({anotherId:true})).to.be.true;
+      baseImageFactory.checksCompleted = {};
+      expect(baseImageFactory.areChecksCompleted()).to.be.true;
+
+      baseImageFactory.checksCompleted = {anotherId:true};
+      expect(baseImageFactory.areChecksCompleted()).to.be.true;
     });
 
     it('should return true if componentId is not set', function() {
+      baseImageFactory.checksCompleted = {componentId:true};
       baseImageFactory.componentId = null;
-      expect(baseImageFactory.areChecksCompleted({componentId:true})).to.be.true;
+      expect(baseImageFactory.areChecksCompleted()).to.be.true;
     });
   });
 

--- a/test/unit/template-editor/components/services/svc-logo-image-factory.spec.js
+++ b/test/unit/template-editor/components/services/svc-logo-image-factory.spec.js
@@ -37,7 +37,7 @@ describe('service: logoImageFactory', function() {
   it('should initialize', function () {
     expect(logoImageFactory).to.be.ok;
     expect(logoImageFactory.getImagesAsMetadata).to.be.a('function');
-    expect(logoImageFactory.getDuration).to.be.a('function');
+    expect(logoImageFactory.getAvailableAttributeData).to.be.a('function');
     expect(logoImageFactory.setDuration).to.be.a('function');
     expect(logoImageFactory.getBlueprintData).to.be.a('function');
     expect(logoImageFactory.areChecksCompleted).to.be.a('function');
@@ -74,9 +74,9 @@ describe('service: logoImageFactory', function() {
     });
   });
 
-  describe('getDuration: ', function() {
+  describe('getAvailableAttributeData: ', function() {
     it('should return null, as it does not apply to logo', function() {
-      var data = logoImageFactory.getDuration();      
+      var data = logoImageFactory.getAvailableAttributeData();      
       expect(data).to.be.null;
     });
   });
@@ -84,7 +84,6 @@ describe('service: logoImageFactory', function() {
   describe('setDuration: ', function() {
     it('should not perform any action, as it does not apply to logo', function() {
       logoImageFactory.setDuration(55);      
-      expect(logoImageFactory.getDuration()).to.be.null;
     });
   });
 
@@ -201,17 +200,9 @@ describe('service: logoImageFactory', function() {
     });
   });
 
-  describe('getTransition: ', function() {
-    it('should return null, as it does not apply to logo', function() {
-      var data = logoImageFactory.getTransition();      
-      expect(data).to.be.null;
-    });
-  });
-
   describe('setTransition: ', function() {
     it('should not perform any action, as it does not apply to logo', function() {
       logoImageFactory.setTransition('fadeIn');      
-      expect(logoImageFactory.getTransition()).to.be.null;
     });
   });
 


### PR DESCRIPTION
## Description
Check for images in component on demand

If the check is missing, initiate it

Remove waiting for presentation id
Refactor init functions

[stage-2]

## Motivation and Context
Fix for #2648 

## How Has This Been Tested?
Tested scenarios for image, logo and image in playlist locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No