### PR TITLE
Add default empty src for slides component

### DIFF
--- a/src/scripts/template-editor/services/svc-components-factory.js
+++ b/src/scripts/template-editor/services/svc-components-factory.js
@@ -93,7 +93,10 @@ angular.module('risevision.template-editor.services')
       iconType: 'streamline',
       icon: 'slides',
       title: 'Google Slides',
-      visual: true
+      visual: true,
+      defaultAttributes: {
+        src: ''
+      }
     },
     'rise-storage-selector': {
       type: 'rise-storage-selector',


### PR DESCRIPTION
## Description
Add default empty src for slides component

Component expects blank value if src is not set

[stage-14]

## Motivation and Context
Partial fix for #2635

## How Has This Been Tested?
Tested locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No