### PR TITLE
Show unlock storage feature modal on upload

### DIFF
--- a/src/partials/template-editor/components/component-image/image-list.html
+++ b/src/partials/template-editor/components/component-image/image-list.html
@@ -61,17 +61,24 @@
 
 <div class="file-component-list-action-button-bar">
   <div class="upload-files">
+    <button id="upload-images-unsubscribed" class="btn btn-default btn-block" ng-click="plansFactory.showUnlockThisFeatureModal()" ng-hide="isPlanActive">
+      <strong ng-if="!isEditingLogo()">Upload Images</strong>
+      <strong ng-if="isEditingLogo()">Upload A Logo</strong>
+    </button>
     <label id="image-list-uploader-label"
       class="btn btn-default btn-block"
       for="image-list-uploader"
-      ng-disabled="isUploading"
+      ng-disabled="isUploading" ng-show="isPlanActive"
     >
       <strong ng-if="!isEditingLogo()">Upload Images</strong>
       <strong ng-if="isEditingLogo()">Upload A Logo</strong>
     </label>
   </div>
   <div class="edit-in-canva u_margin-sm-top">
-    <canva-button (design-published)="onDesignPublished($event)" [disabled]="isUploading"></canva-button>
+    <button id="canva-unsubscribed" class="btn btn-default btn-block" ng-click="plansFactory.showUnlockThisFeatureModal()" ng-hide="isPlanActive">
+      <strong>Design With Canva</strong>
+    </button>
+    <canva-button (design-published)="onDesignPublished($event)" [disabled]="isUploading" ng-show="isPlanActive"></canva-button>
   </div>
   <div class="select-from-storage">
     <button id="image-list-storage-button" class="btn btn-default btn-block" ng-click="selectFromStorage()" ng-disabled="isUploading">

--- a/src/partials/template-editor/components/component-storage-selector.html
+++ b/src/partials/template-editor/components/component-storage-selector.html
@@ -112,11 +112,14 @@
     ng-class="{ 'no-files': !hasRegularFileItems() }"
   >
     <div class="upload-files">
+      <button id="upload-{{fileType}}-unsubscribed" class="btn btn-default btn-block" ng-click="plansFactory.showUnlockThisFeatureModal()" ng-hide="isPlanActive">
+        <strong>{{ ( 'template.' + fileType + '.upload' ) | translate }}</strong>
+      </button>
       <label id="{{storageSelectorId}}-uploader-label"
         class="btn btn-block"
         ng-class="hasRegularFileItems() ? 'btn-default' : 'btn-primary'"
         for="{{storageSelectorId}}-uploader"
-        ng-disabled="isUploading"
+        ng-disabled="isUploading" ng-show="isPlanActive"
       >
         <strong>
           {{ ( 'template.' + fileType + '.upload' ) | translate }}

--- a/src/partials/template-editor/components/component-video/video-list.html
+++ b/src/partials/template-editor/components/component-video/video-list.html
@@ -52,10 +52,13 @@
 
 <div class="file-component-list-action-button-bar">
   <div class="upload-files">
+    <button id="upload-videos-unsubscribed" class="btn btn-default btn-block" ng-click="plansFactory.showUnlockThisFeatureModal()" ng-hide="isPlanActive">
+      <strong>Upload Videos</strong>
+    </button>
     <label id="video-list-uploader-label"
       class="btn btn-default btn-block"
       for="video-list-uploader"
-      ng-disabled="isUploading"
+      ng-disabled="isUploading" ng-show="isPlanActive"
     >
       <strong>Upload Videos</strong>
     </label>

--- a/src/scripts/template-editor/components/directives/dtv-component-image.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-image.js
@@ -7,11 +7,13 @@ angular.module('risevision.template-editor.directives')
   .constant('CANVA_FOLDER', 'canva/')
   .directive('templateComponentImage', ['$log', '$timeout', '$loading', 'componentsFactory', 'templateEditorFactory',
     'attributeDataFactory', 'storageManagerFactory', 'fileExistenceCheckService', 'fileMetadataUtilsService',
-    'logoImageFactory', 'baseImageFactory', 'fileDownloader', 'templateEditorUtils', 'DEFAULT_IMAGE_THUMBNAIL',
-    'SUPPORTED_IMAGE_TYPES', 'CANVA_FOLDER',
+    'logoImageFactory', 'baseImageFactory', 'fileDownloader', 'templateEditorUtils', 
+    '$rootScope', 'plansFactory', 'currentPlanFactory',
+    'DEFAULT_IMAGE_THUMBNAIL', 'SUPPORTED_IMAGE_TYPES', 'CANVA_FOLDER',
     function ($log, $timeout, $loading, componentsFactory, templateEditorFactory, attributeDataFactory,
       storageManagerFactory, fileExistenceCheckService, fileMetadataUtilsService,
       logoImageFactory, baseImageFactory, fileDownloader, templateEditorUtils,
+      $rootScope, plansFactory, currentPlanFactory,
       DEFAULT_IMAGE_THUMBNAIL, SUPPORTED_IMAGE_TYPES, CANVA_FOLDER) {
       return {
         restrict: 'E',
@@ -22,6 +24,13 @@ angular.module('risevision.template-editor.directives')
 
           $scope.templateEditorFactory = templateEditorFactory;
           $scope.validExtensions = SUPPORTED_IMAGE_TYPES;
+
+          $scope.plansFactory = plansFactory;
+          $scope.isPlanActive = currentPlanFactory.isPlanActive();
+
+          $rootScope.$on('risevision.plan.loaded', function () {
+            $scope.isPlanActive = currentPlanFactory.isPlanActive();
+          });
 
           $scope.isEditingLogo = function () {
             return imageFactory === logoImageFactory;

--- a/src/scripts/template-editor/components/directives/dtv-component-storage-selector.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-storage-selector.js
@@ -2,8 +2,9 @@
 
 angular.module('risevision.template-editor.directives')
   .directive('componentStorageSelector', ['$loading', 'filterFilter', 'componentsFactory', 'storageManagerFactory',
-    'templateEditorUtils',
-    function ($loading, filterFilter, componentsFactory, storageManagerFactory, templateEditorUtils) {
+    'templateEditorUtils', '$rootScope', 'plansFactory', 'currentPlanFactory',
+    function ($loading, filterFilter, componentsFactory, storageManagerFactory, templateEditorUtils,
+    $rootScope, plansFactory, currentPlanFactory) {
       return {
         restrict: 'E',
         scope: true,
@@ -20,6 +21,13 @@ angular.module('risevision.template-editor.directives')
             doSearch: function () {},
             reverse: false
           };
+
+          $scope.plansFactory = plansFactory;
+          $scope.isPlanActive = currentPlanFactory.isPlanActive();
+
+          $rootScope.$on('risevision.plan.loaded', function () {
+            $scope.isPlanActive = currentPlanFactory.isPlanActive();
+          });
 
           $scope.storageSelectorId = 'storage-selector';
           $scope.storageUploadManager = {

--- a/src/scripts/template-editor/components/directives/dtv-component-video.js
+++ b/src/scripts/template-editor/components/directives/dtv-component-video.js
@@ -5,9 +5,11 @@ angular.module('risevision.template-editor.directives')
   .constant('SUPPORTED_VIDEO_TYPES', '.mp4, .webm')
   .directive('templateComponentVideo', ['$log', '$timeout', '$loading', 'componentsFactory', 'templateEditorFactory',
     'attributeDataFactory', 'storageManagerFactory', 'templateEditorUtils', 'fileExistenceCheckService', 
-    'fileMetadataUtilsService', 'DEFAULT_VIDEO_THUMBNAIL', 'SUPPORTED_VIDEO_TYPES',
+    'fileMetadataUtilsService', '$rootScope', 'plansFactory', 'currentPlanFactory',
+    'DEFAULT_VIDEO_THUMBNAIL', 'SUPPORTED_VIDEO_TYPES',
     function ($log, $timeout, $loading, componentsFactory, templateEditorFactory, attributeDataFactory, 
       storageManagerFactory, templateEditorUtils, fileExistenceCheckService, fileMetadataUtilsService,
+      $rootScope, plansFactory, currentPlanFactory,
       DEFAULT_VIDEO_THUMBNAIL, SUPPORTED_VIDEO_TYPES) {
       return {
         restrict: 'E',
@@ -16,6 +18,14 @@ angular.module('risevision.template-editor.directives')
         link: function ($scope, element) {
           $scope.templateEditorFactory = templateEditorFactory;
           $scope.validExtensions = SUPPORTED_VIDEO_TYPES;
+
+          $scope.plansFactory = plansFactory;
+          $scope.isPlanActive = currentPlanFactory.isPlanActive();
+
+          $rootScope.$on('risevision.plan.loaded', function () {
+            $scope.isPlanActive = currentPlanFactory.isPlanActive();
+          });
+
           $scope.uploadManager = {
             onUploadStatus: function (isUploading) {
               $scope.isUploading = isUploading;

--- a/test/unit/template-editor/components/directives/dtv-component-image.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-image.spec.js
@@ -2,6 +2,7 @@
 
 describe('directive: TemplateComponentImage', function() {
   var $scope,
+    $rootScope,
     element,
     templateEditorFactory,
     componentsFactory,
@@ -11,6 +12,7 @@ describe('directive: TemplateComponentImage', function() {
     baseImageFactory,
     logoImageFactory,
     storageManagerFactory,
+    currentPlanFactory,
     sandbox = sinon.sandbox.create(),
     fileDownloader = sandbox.stub();
 
@@ -104,9 +106,21 @@ describe('directive: TemplateComponentImage', function() {
     $provide.factory('fileDownloader', function() {
       return fileDownloader;
     });
+
+    $provide.service('currentPlanFactory',function(){
+      return {
+          isPlanActive: sandbox.stub().returns(true)
+      };
+    });
+    $provide.service('plansFactory',function(){
+      return {};
+    });
+
   }));
 
-  beforeEach(inject(function($compile, $rootScope, $templateCache, $timeout, $injector){
+  beforeEach(inject(function($compile, _$rootScope_, $templateCache, $timeout, $injector){
+    $rootScope = _$rootScope_;
+
     $loading = $injector.get('$loading');
     templateEditorFactory = $injector.get('templateEditorFactory');
     componentsFactory = $injector.get('componentsFactory');
@@ -114,6 +128,7 @@ describe('directive: TemplateComponentImage', function() {
     baseImageFactory = $injector.get('baseImageFactory');
     logoImageFactory = $injector.get('logoImageFactory');
     storageManagerFactory = $injector.get('storageManagerFactory');
+    currentPlanFactory = $injector.get('currentPlanFactory');
 
     $templateCache.put('partials/template-editor/components/component-image.html', '<p>mock</p>');
     $scope = $rootScope.$new();
@@ -133,6 +148,23 @@ describe('directive: TemplateComponentImage', function() {
     expect($scope.sortItem).to.be.a('function');
     expect($scope.saveDuration).to.be.a('function');
     expect($scope.saveTransition).to.be.a('function');
+
+    expect($scope.plansFactory).to.be.ok;
+  });
+
+  it('should initialize isPlanActive', function() {
+    currentPlanFactory.isPlanActive.should.have.been.calledOnce;
+    expect($scope.isPlanActive).to.be.true;
+  });
+
+  it('should update isPlanActive on plan updates', function() {
+    currentPlanFactory.isPlanActive.returns(false);
+
+    $scope.$emit('risevision.plan.loaded');
+    $scope.$digest();
+    
+    currentPlanFactory.isPlanActive.should.have.been.calledTwice;
+    expect($scope.isPlanActive).to.be.false;
   });
 
   describe('registerDirective:', function() {

--- a/test/unit/template-editor/components/directives/dtv-component-storage-selector.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-storage-selector.spec.js
@@ -2,7 +2,7 @@
 
 describe('directive: componentStorageSelector', function() {
   var sandbox = sinon.sandbox.create(),
-      $scope, element, $loading, componentsFactory, templateEditorUtils, storageManagerFactory;
+      $scope, $rootScope, element, $loading, componentsFactory, templateEditorUtils, storageManagerFactory, currentPlanFactory;
 
   beforeEach(module('risevision.template-editor.directives'));
   beforeEach(module(function ($provide) {
@@ -32,13 +32,25 @@ describe('directive: componentStorageSelector', function() {
       };
     });
 
+    $provide.service('currentPlanFactory',function(){
+      return {
+          isPlanActive: sinon.stub().returns(true)
+      };
+    });
+    $provide.service('plansFactory',function(){
+      return {};
+    });
+
   }));
 
-  beforeEach(inject(function($injector, $compile, $rootScope, $templateCache) {
+  beforeEach(inject(function($injector, $compile, _$rootScope_, $templateCache) {
+    $rootScope = _$rootScope_;
+
     $loading = $injector.get('$loading');
     componentsFactory = $injector.get('componentsFactory');
     templateEditorUtils = $injector.get('templateEditorUtils');
     storageManagerFactory = $injector.get('storageManagerFactory');
+    currentPlanFactory = $injector.get('currentPlanFactory');
 
     $templateCache.put('partials/template-editor/components/component-storage-selector.html', '<p>mock</p>');
     $scope = $rootScope.$new();
@@ -68,6 +80,23 @@ describe('directive: componentStorageSelector', function() {
     expect($scope.sortBy).to.be.a('function');
     expect($scope.dateModifiedOrderFunction).to.be.a('function');
     expect($scope.fileNameOrderFunction).to.be.a('function');
+
+    expect($scope.plansFactory).to.be.ok;
+  });
+
+  it('should initialize isPlanActive', function() {
+    currentPlanFactory.isPlanActive.should.have.been.calledOnce;
+    expect($scope.isPlanActive).to.be.true;
+  });
+
+  it('should update isPlanActive on plan updates', function() {
+    currentPlanFactory.isPlanActive.returns(false);
+
+    $scope.$emit('risevision.plan.loaded');
+    $scope.$digest();
+    
+    currentPlanFactory.isPlanActive.should.have.been.calledTwice;
+    expect($scope.isPlanActive).to.be.false;
   });
 
   it('should init default values', function() {

--- a/test/unit/template-editor/components/directives/dtv-component-video.spec.js
+++ b/test/unit/template-editor/components/directives/dtv-component-video.spec.js
@@ -2,6 +2,7 @@
 
 describe('directive: templateComponentVideo', function() {
   var $scope,
+      $rootScope,
       element,
       templateEditorFactory,
       componentsFactory,
@@ -9,7 +10,8 @@ describe('directive: templateComponentVideo', function() {
       storageManagerFactory,
       testMetadata,
       $loading,
-      $timeout;
+      $timeout,
+      currentPlanFactory;
 
   beforeEach(module('risevision.template-editor.directives'));
   beforeEach(module(function ($provide) {
@@ -48,15 +50,28 @@ describe('directive: templateComponentVideo', function() {
         }
       };
     });
+
+    $provide.service('currentPlanFactory',function(){
+      return {
+          isPlanActive: sinon.stub().returns(true)
+      };
+    });
+    $provide.service('plansFactory',function(){
+      return {};
+    });
+
   }));
 
-  beforeEach(inject(function($compile, $rootScope, $templateCache, $injector){
+  beforeEach(inject(function($compile, _$rootScope_, $templateCache, $injector){
+    $rootScope = _$rootScope_;
+
     $timeout = $injector.get('$timeout');
     $loading = $injector.get('$loading');
     templateEditorFactory = $injector.get('templateEditorFactory');
     componentsFactory = $injector.get('componentsFactory');
     attributeDataFactory = $injector.get('attributeDataFactory');
     storageManagerFactory = $injector.get('storageManagerFactory');
+    currentPlanFactory = $injector.get('currentPlanFactory');
 
     $templateCache.put('partials/template-editor/components/component-video.html', '<p>mock</p>');
     $scope = $rootScope.$new();
@@ -70,6 +85,23 @@ describe('directive: templateComponentVideo', function() {
     expect($scope).to.be.ok;
     expect($scope.templateEditorFactory).to.be.ok;
     expect($scope.sortItem).to.be.a('function');
+
+    expect($scope.plansFactory).to.be.ok;
+  });
+
+  it('should initialize isPlanActive', function() {
+    currentPlanFactory.isPlanActive.should.have.been.calledOnce;
+    expect($scope.isPlanActive).to.be.true;
+  });
+
+  it('should update isPlanActive on plan updates', function() {
+    currentPlanFactory.isPlanActive.returns(false);
+
+    $scope.$emit('risevision.plan.loaded');
+    $scope.$digest();
+    
+    currentPlanFactory.isPlanActive.should.have.been.calledTwice;
+    expect($scope.isPlanActive).to.be.false;
   });
 
   describe('registerDirective:', function() {


### PR DESCRIPTION
## Description
Show unlock storage feature modal on upload

Check if unsubscribed, and replace the buttons
Updated Image, Video and Storage selector buttons
including Canva button

[stage-11]

## Motivation and Context
Fix for #2628 

## How Has This Been Tested?
Tested locally with all the elements. Updated test coverage.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No