### PR TITLE
Return files when metadata fails to refresh

### DIFF
--- a/src/scripts/storage/services/svc-storage.js
+++ b/src/scripts/storage/services/svc-storage.js
@@ -291,7 +291,7 @@ angular.module('risevision.storage.services')
         },
 
         refreshFileMetadata: function (fileName) {
-          return _refreshFileMetadata(fileName, 3);
+          return _refreshFileMetadata(fileName, 2);
 
           function _refreshFileMetadata(fileName, remainingAttempts) {
             console.log('Attempt #' + remainingAttempts + ' to get metadata for: ' + fileName);
@@ -307,7 +307,9 @@ angular.module('risevision.storage.services')
                 } else if (file && remainingAttempts > 0) {
                   return _refreshFileMetadata(fileName, remainingAttempts - 1);
                 } else {
-                  return $q.reject();
+                  console.log('Error refreshing metadata', file.name);
+
+                  return $q.resolve(file);
                 }
               });
           }

--- a/src/scripts/template-editor/components/services/svc-file-metadata-utils.js
+++ b/src/scripts/template-editor/components/services/svc-file-metadata-utils.js
@@ -1,11 +1,15 @@
 'use strict';
 
 angular.module('risevision.template-editor.services')
-  .service('fileMetadataUtilsService', ['templateEditorUtils',
-    function (templateEditorUtils) {
+  .service('fileMetadataUtilsService', ['templateEditorUtils', 'storageUtils',
+    function (templateEditorUtils, storageUtils) {
       var service = {};
 
       function _addFileToSet(selectedImages, defaultThumbnailUrl, file, alwaysAppend) {
+        if (!file.bucket) {
+          file.bucket = storageUtils.getBucketName();
+        }
+
         var filePath = file.bucket + '/' + file.name;
         var initialLength = selectedImages.length;
         var timeCreated = service.timeCreatedFor(file);

--- a/test/unit/storage/services/svc-storage.spec.js
+++ b/test/unit/storage/services/svc-storage.spec.js
@@ -565,21 +565,17 @@ describe('service: storage:', function() {
         });
     });
 
-    it('should fail after the third attempt', function(done) {
-      var getStub = sinon.stub(storage.files, 'get');
+    it('should return files on third failure attempt', function(done) {
+      sinon.stub(storage.files, 'get').resolves({
+        files: [{ metadata: { 'needs-thumbnail-update': 'true' } }]
+      });
 
-      getStub.onCall(0).returns(Q.resolve({
-        files: [{ metadata: { 'needs-thumbnail-update': 'true' } }]
-      }));
-      getStub.onCall(1).returns(Q.resolve({
-        files: [{ metadata: { 'needs-thumbnail-update': 'true' } }]
-      }));
-      getStub.onCall(2).returns(Q.resolve({
-        files: [{ metadata: { 'needs-thumbnail-update': 'true' } }]
-      }));
 
       storage.refreshFileMetadata('file1')
-        .catch(function(err) {
+        .then(function(result) {
+          expect(result).to.be.ok;
+          expect(storage.files.get).have.been.calledThrice;
+
           done();
         });
     });

--- a/test/unit/template-editor/components/services/svc-file-metadata-utils.spec.js
+++ b/test/unit/template-editor/components/services/svc-file-metadata-utils.spec.js
@@ -5,6 +5,14 @@ describe('service: fileMetadataUtilsService:', function() {
 
   var fileMetadataUtilsService;
 
+  beforeEach(module(function ($provide) {
+    $provide.service('storageUtils',function(){
+      return {
+        getBucketName: sinon.stub().returns('bucket-name')
+      };
+    });
+  }));
+
   beforeEach(function() {
     inject(function($injector) {
       fileMetadataUtilsService = $injector.get('fileMetadataUtilsService');
@@ -137,6 +145,31 @@ describe('service: fileMetadataUtilsService:', function() {
       expect(metadata).to.deep.equal([
         {
           file: 'x/d.txt',
+          exists: true,
+          'time-created': 200,
+          'thumbnail-url': 'http://thumbnail?_=200'
+        }
+      ]);
+    });
+
+    it('should retrieve bucket name if missing', function() {
+      var metadata = fileMetadataUtilsService.metadataWithFile([],
+        'http://default-thumbnail', [
+          {
+            name: 'd.txt',
+            metadata: {
+              thumbnail: 'http://thumbnail'
+            },
+            timeCreated: {
+              value: 200
+            }
+          }
+        ]
+      );
+
+      expect(metadata).to.deep.equal([
+        {
+          file: 'bucket-name/d.txt',
           exists: true,
           'time-created': 200,
           'thumbnail-url': 'http://thumbnail?_=200'


### PR DESCRIPTION
## Description
Return files when metadata fails to refresh

No need to reject and return the fake file list

Add bucket name if missing
in case file metadata update failed

[stage-14]

## Motivation and Context
Fix for #2669 

## How Has This Been Tested?
Tested both fixes individually to ensure correct operation. Used the corrupt PNG file from that company. Updated test coverage.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No