### PR TITLE
Retrieve and show renewal estimate for subscription

### DIFF
--- a/src/partials/billing/subscription.html
+++ b/src/partials/billing/subscription.html
@@ -44,10 +44,10 @@
           <label>Plan Amount</label>
           <h1 class="mb-4">${{subscriptionFactory.getItemSubscription().plan_amount / 100 | number:2}}</h1>
           <p><b>Renewing On:</b> {{subscriptionFactory.getItemSubscription().current_term_end * 1000 | date:'d-MMM-yyyy'}}</p>
-          <p ng-show="subscriptionFactory.getRenewalEstimate()">
+          <p ng-show="subscriptionFactory.renewalEstimate.invoice_estimate">
             <b ng-show="subscriptionFactory.isInvoiced()">Next Invoice:</b>
             <b ng-show="!subscriptionFactory.isInvoiced()">Next Payment:</b>
-            ${{subscriptionFactory.getRenewalEstimate().total / 100 | number:2}}
+            ${{subscriptionFactory.renewalEstimate.invoice_estimate.total / 100 | number:2}}
           </p>
           <p><b>Billing Frequency:</b> {{subscriptionFactory.getItemSubscription().billing_period_unit === 'month' ? 'Monthly' : subscriptionFactory.getItemSubscription().billing_period === 1 ? 'Yearly' : subscriptionFactory.getItemSubscription().billing_period + ' Years'}}</p>
 

--- a/src/partials/billing/subscription.html
+++ b/src/partials/billing/subscription.html
@@ -44,6 +44,11 @@
           <label>Plan Amount</label>
           <h1 class="mb-4">${{subscriptionFactory.getItemSubscription().plan_amount / 100 | number:2}}</h1>
           <p><b>Renewing On:</b> {{subscriptionFactory.getItemSubscription().current_term_end * 1000 | date:'d-MMM-yyyy'}}</p>
+          <p ng-show="subscriptionFactory.getRenewalEstimate()">
+            <b ng-show="subscriptionFactory.isInvoiced()">Next Invoice:</b>
+            <b ng-show="!subscriptionFactory.isInvoiced()">Next Payment:</b>
+            ${{subscriptionFactory.getRenewalEstimate().total / 100 | number:2}}
+          </p>
           <p><b>Billing Frequency:</b> {{subscriptionFactory.getItemSubscription().billing_period_unit === 'month' ? 'Monthly' : subscriptionFactory.getItemSubscription().billing_period === 1 ? 'Yearly' : subscriptionFactory.getItemSubscription().billing_period + ' Years'}}</p>
 
           <a id="switchToAnnual" class="btn btn-default btn-block mt-3" ui-sref="apps.purchase.frequency({subscriptionId: subscriptionFactory.getItemSubscription().id})" ng-show="subscriptionFactory.getItemSubscription().billing_period_unit === 'month'">Switch To Annual Billing (Save 10%)</a>

--- a/src/partials/purchase/update-subscription.html
+++ b/src/partials/purchase/update-subscription.html
@@ -116,14 +116,14 @@
               <span class="purchase-total">${{factory.getCreditTotal() | number:2}}</span>
             </span>
           </p>
-          <p id="prorated-amount-row" class="left-right-aligner mb-4" ng-if="factory.estimate.invoice_estimate.amount_due">
+          <p id="prorated-amount-row" class="left-right-aligner mb-4" ng-if="factory.estimate.invoice_estimate">
             <span class="font-weight-bold">Prorated amount, due now:</span>
             <span>
               <span class="u_margin-right text-subtle">{{factory.estimate.invoice_estimate.currency_code}}</span>
               <span class="purchase-total">${{factory.estimate.invoice_estimate.amount_due/100 | number:2}}</span>
             </span>
           </p>
-          <p id="next-invoice-row" class="left-right-aligner mb-0" ng-if="factory.estimate.next_invoice_estimate.total">
+          <p id="next-invoice-row" class="left-right-aligner mb-0" ng-if="factory.estimate.next_invoice_estimate">
             <span class="font-weight-bold">Next invoice on {{factory.estimate.subscription_estimate.next_billing_at * 1000 | date:'d-MMM-yyyy'}}:</span>
             <span>
               <span class="u_margin-right text-subtle">{{factory.estimate.next_invoice_estimate.currency_code}}</span>

--- a/src/scripts/billing/app.js
+++ b/src/scripts/billing/app.js
@@ -43,7 +43,7 @@ angular.module('risevision.apps')
             invoiceInfo: ['canAccessApps', 'subscriptionFactory', '$stateParams',
               function (canAccessApps, subscriptionFactory, $stateParams) {
                 return canAccessApps().then(function () {
-                  subscriptionFactory.getSubscription($stateParams.subscriptionId);
+                  subscriptionFactory.getSubscription($stateParams.subscriptionId, true);
                 });
               }
             ]

--- a/src/scripts/billing/services/svc-billing.js
+++ b/src/scripts/billing/services/svc-billing.js
@@ -57,6 +57,29 @@ angular.module('risevision.apps.billing.services')
 
           return deferred.promise;
         },
+        estimateSubscriptionRenewal: function (subscriptionId) {
+          var deferred = $q.defer();
+
+          var obj = {
+            subscriptionId: subscriptionId,
+            companyId: userState.getSelectedCompanyId()
+          };
+
+          $log.debug('Store integrations.subscription.estimateRenewal called with', obj);
+
+          storeAPILoader().then(function (storeApi) {
+              return storeApi.integrations.subscription.estimateRenewal(obj);
+            })
+            .then(function (resp) {
+              $log.debug('integrations.subscription.estimateRenewal resp', resp);
+              deferred.resolve(resp.result);
+            })
+            .then(null, function (e) {
+              console.error('Failed to retrieve subscription renewal estimate.', e);
+              deferred.reject(e);
+            });
+          return deferred.promise;
+        },
         estimateSubscriptionUpdate: function (displayCount, subscriptionId, planId, companyId, couponCode) {
           var deferred = $q.defer();
 

--- a/src/scripts/billing/services/svc-subscription-factory.js
+++ b/src/scripts/billing/services/svc-subscription-factory.js
@@ -23,6 +23,10 @@ angular.module('risevision.apps.billing.services')
         return factory.item && factory.item.customer || {};
       };
 
+      factory.getRenewalEstimate = function () {
+        return factory.renewalEstimate && factory.renewalEstimate.next_invoice_estimate || null;
+      };
+
       factory.isInvoiced = function () {
         if (factory.getItemSubscription().auto_collection) {
           return factory.getItemSubscription().auto_collection === 'off';
@@ -51,7 +55,7 @@ angular.module('risevision.apps.billing.services')
         }
       };
 
-      factory.getSubscription = function (subscriptionId) {
+      factory.getSubscription = function (subscriptionId, estimateRenewal) {
         if (!subscriptionId) {
           subscriptionId = currentPlanFactory.currentPlan.subscriptionId;
         }
@@ -66,6 +70,15 @@ angular.module('risevision.apps.billing.services')
             factory.item = resp.item;
 
             _updatePaymentSourceId();
+
+            if (estimateRenewal) {
+              return billing.estimateSubscriptionRenewal(subscriptionId);
+            } else {
+              return;
+            }
+          })
+          .then(function (resp) {
+            factory.renewalEstimate = resp && resp.item;
           })
           .catch(function (e) {
             _showErrorMessage(e);

--- a/src/scripts/billing/services/svc-subscription-factory.js
+++ b/src/scripts/billing/services/svc-subscription-factory.js
@@ -23,10 +23,6 @@ angular.module('risevision.apps.billing.services')
         return factory.item && factory.item.customer || {};
       };
 
-      factory.getRenewalEstimate = function () {
-        return factory.renewalEstimate && factory.renewalEstimate.next_invoice_estimate || null;
-      };
-
       factory.isInvoiced = function () {
         if (factory.getItemSubscription().auto_collection) {
           return factory.getItemSubscription().auto_collection === 'off';

--- a/test/unit/billing/app.spec.js
+++ b/test/unit/billing/app.spec.js
@@ -80,7 +80,7 @@ describe('app:', function() {
       $state.get('apps.billing.subscription').resolve.invoiceInfo[3](canAccessApps, subscriptionFactory, $stateParams);
       setTimeout(function() {
         canAccessApps.should.have.been.called.once;
-        subscriptionFactory.getSubscription.should.have.been.calledWith('subscriptionId');
+        subscriptionFactory.getSubscription.should.have.been.calledWith('subscriptionId', true);
 
         done();
       }, 10);

--- a/test/unit/billing/services/svc-billing.spec.js
+++ b/test/unit/billing/services/svc-billing.spec.js
@@ -40,6 +40,16 @@ describe('service: billing:', function() {
                   return Q.reject('API Failed');
                 }
               }),
+              estimateRenewal: sinon.spy(function() {
+                if (!failedResponse) {
+                  return Q.resolve({
+                    result: 'subscription renewal estimate'
+                  });
+                }
+                else {
+                  return Q.reject('API Failed');
+                }
+              }),
               estimate: sinon.spy(function() {
                 if (!failedResponse) {
                   return Q.resolve({
@@ -212,6 +222,7 @@ describe('service: billing:', function() {
     expect(billing).to.be.ok;
     expect(billing.getSubscriptions).to.be.a.function;
     expect(billing.getSubscription).to.be.a.function;
+    expect(billing.estimateSubscriptionRenewal).to.be.a.function;
     expect(billing.estimateSubscriptionUpdate).to.be.a.function;
     expect(billing.updateSubscription).to.be.a.function;
     expect(billing.changePoNumber).to.be.a.function;
@@ -286,6 +297,38 @@ describe('service: billing:', function() {
       failedResponse = true;
 
       billing.getSubscription('subscriptionId')
+      .then(function(subscription) {
+        done(subscription);
+      })
+      .then(null, function(error) {
+        expect(error).to.deep.equal('API Failed');
+        done();
+      });
+    });
+  });
+
+  describe('estimateSubscriptionRenewal:', function() {
+    it('should return a subscription renewal estimate', function(done) {
+      failedResponse = false;
+
+      billing.estimateSubscriptionRenewal('subscriptionId')
+      .then(function(result) {
+        storeApi.integrations.subscription.estimateRenewal.should.have.been.called;
+        storeApi.integrations.subscription.estimateRenewal.should.have.been.calledWith({
+          subscriptionId: 'subscriptionId',
+          companyId: 'testId1'
+        });
+
+        expect(result).to.be.ok;
+        expect(result).to.equal('subscription renewal estimate');
+        done();
+      });
+    });
+
+    it('should handle failure to estimate subscription renewal correctly', function(done) {
+      failedResponse = true;
+
+      billing.estimateSubscriptionRenewal('subscriptionId')
       .then(function(subscription) {
         done(subscription);
       })

--- a/test/unit/billing/services/svc-subscription-factory.spec.js
+++ b/test/unit/billing/services/svc-subscription-factory.spec.js
@@ -11,6 +11,7 @@ describe('service: subscriptionFactory:', function() {
     $provide.service('billing',function() {
       return {
         getSubscription: sinon.stub().returns(Q.resolve({item: 'subscription'})),
+        estimateSubscriptionRenewal: sinon.stub().returns(Q.resolve({item: 'subscription renewal'})),
         changePoNumber: sinon.stub().returns(Q.resolve({item: {subscription: {po_number: 'updatedPo'}}})),
         changePaymentSource: sinon.stub().returns(Q.resolve({item: {payment_source: 'paymentSource'}}))
       }
@@ -266,8 +267,29 @@ describe('service: subscriptionFactory:', function() {
 
         expect(subscriptionFactory.item).to.equal('subscription');
 
+        expect(subscriptionFactory.renewalEstimate).to.not.be.ok;
+
         done();
       }, 10);
+    });
+
+    it('should retrieve subscription estimate if flag is set', function(done) {
+      billing.getSubscription.returns(Q.resolve({
+        item: {
+          subscription: {}
+        }
+      }));
+
+      subscriptionFactory.getSubscription('subscriptionId', true)
+        .then(function() {
+          expect(subscriptionFactory.loading).to.be.false;
+
+          billing.estimateSubscriptionRenewal.should.have.been.calledWith('subscriptionId');
+
+          expect(subscriptionFactory.renewalEstimate).to.equal('subscription renewal');
+
+          done();          
+        });
     });
 
     describe('_updatePaymentSourceId:', function() {


### PR DESCRIPTION
## Description
Retrieve and show renewal estimate for subscription

Use new api for this

Show totals even if 0

[stage-12]

## Motivation and Context
Fix for #2658 

## How Has This Been Tested?
Tested locally with the updated store server version. Will update unit tests in a subsequent PR.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No