### PR TITLE
Solve Playlist performance issues

### DIFF
--- a/src/partials/template-editor/components/component-text.html
+++ b/src/partials/template-editor/components/component-text.html
@@ -1,11 +1,11 @@
 <div class="attribute-editor-component">
   <div class="attribute-editor-row">
     <label>Text:</label>
-    <input ng-hide="isMultiline" id="text-component-input" type="text" class="form-control" ng-model="value" placeholder="Enter your text" ng-change="save()">
+    <input ng-hide="isMultiline" id="text-component-input" type="text" class="form-control" ng-model="value" placeholder="Enter your text" ng-model-options="{ debounce: 1000 }" ng-change="save()">
     <p ng-show="isMultiline" class="text-sm">Hit enter to add a line break.</p>
     <div ng-show="isMultiline" class="row">
       <div class="col-xs-12">
-        ​<textarea id="text-component-input-multiline" class="form-control resize-vertical" rows="2" ng-model="value" placeholder="Enter your text" ng-change="save()"></textarea>
+        ​<textarea id="text-component-input-multiline" class="form-control resize-vertical" rows="2" ng-model="value" placeholder="Enter your text" ng-model-options="{ debounce: 1000 }" ng-change="save()"></textarea>
       </div>
     </div>
   </div>

--- a/src/scripts/template-editor/components/services/svc-playlist-component-factory.js
+++ b/src/scripts/template-editor/components/services/svc-playlist-component-factory.js
@@ -26,9 +26,11 @@ angular.module('risevision.template-editor.services')
       };
 
       factory.loadPresentationNames = function(presentations) {
-        var presentationIds = _.map(presentations, function (item) {
-          return 'id:' + item.id;
-        });
+        var presentationIds = _.uniq(
+          _.map(presentations, function (item) {
+            return 'id:' + item.id;
+          })
+        );
 
         var search = {
           filter: presentationIds.join(' OR ')

--- a/test/unit/template-editor/components/services/svc-playlist-component-factory.spec.js
+++ b/test/unit/template-editor/components/services/svc-playlist-component-factory.spec.js
@@ -151,6 +151,46 @@ describe('service: playlistComponentFactory:', function() {
       }, 10);
     });
 
+    it('should load presentation names once for repeated ids', function(done) {
+      var presentations = [
+        {
+          id: 'presentation-id-1'
+        },
+        {
+          id: 'presentation-id-2'
+        },
+        {
+          id: 'presentation-id-2'
+        },
+        {
+          id: 'presentation-id-2'
+        }
+      ];
+
+      playlistComponentFactory.loadPresentationNames(presentations);
+
+      expect(playlistComponentFactory.loading).to.be.true;
+
+      presentation.list.should.have.been.calledWith({
+        filter: 'id:presentation-id-1 OR id:presentation-id-2'
+      });
+
+      setTimeout(function() {
+        expect(presentations[0].name).to.equal('some name');
+        expect(presentations[0].revisionStatusName).to.equal('revised');
+        expect(presentations[0].removed).to.be.false;
+
+        expect(presentations[1].name).to.equal('some name 2');
+        expect(presentations[1].revisionStatusName).to.equal('published');
+        expect(presentations[1].removed).to.be.false;
+
+        expect(playlistComponentFactory.loading).to.be.false;
+
+        done();
+      }, 10);
+
+    });
+
   });
 
   describe('addTemplates:', function() {


### PR DESCRIPTION
## Description

- Debounce rise-text input to prevent overflow of attribute data updates.
- Query presentation name only once for repeated presentation ids

## Motivation and Context
Final fix for #2635
Details in https://trello.com/c/6Xc5DMob/7460-issue-2635-playlist-ui-consolidated-feedback-2

## How Has This Been Tested?
Tested locally and on [stage-1]
Sample Presentation: https://apps-stage-1.risevision.com/templates/edit/7018a90b-4794-467b-b579-67dfd70df9cb/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
