### PR TITLE
Only register Education users to playbook

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -190,6 +190,7 @@
               "src/scripts/components/userstate/services/svc-userauth.js",
               "src/scripts/components/userstate/services/svc-userstate.js",
               "src/scripts/components/userstate/services/svc-openid-connect.js",
+              "src/scripts/components/userstate/services/svc-registration-factory.js",
 
               "src/scripts/components/last-modified/dtv-last-modified.js",
               "src/scripts/components/last-modified/ftr-username.js",
@@ -754,6 +755,7 @@
                 "src/scripts/components/userstate/services/svc-userauth.js",
                 "src/scripts/components/userstate/services/svc-userstate.js",
                 "src/scripts/components/userstate/services/svc-openid-connect.js",
+                "src/scripts/components/userstate/services/svc-registration-factory.js",
 
                 "src/scripts/components/last-modified/dtv-last-modified.js",
                 "src/scripts/components/last-modified/ftr-username.js",

--- a/src/partials/components/userstate/signup.html
+++ b/src/partials/components/userstate/signup.html
@@ -3,7 +3,7 @@
 <div class="border-container mx-auto">
   <div class="panel-body">
 
-    <div rv-spinner rv-spinner-key="registration-modal" rv-spinner-start-active="0">
+    <div rv-spinner rv-spinner-key="registration-loader" rv-spinner-start-active="0">
       <h4>Help us personalize your experience.</h4>
 
       <div id="registration-modal" stop-event="touchend">
@@ -14,7 +14,7 @@
               <!-- First Name -->
               <div class="form-group" ng-class="{ 'has-error' : forms.registrationForm.firstName.$invalid && !forms.registrationForm.firstName.$pristine }">
                 <label for="firstName">First Name: *</label>
-                <input type="text" class="form-control firstName" name="firstName" id="firstName" autocomplete="fname" aria-required="true" tabindex="1" ng-model="profile.firstName" autofocus required>
+                <input type="text" class="form-control firstName" name="firstName" id="firstName" autocomplete="fname" aria-required="true" tabindex="1" ng-model="registrationFactory.profile.firstName" autofocus required>
                 <p ng-show="forms.registrationForm.firstName.$invalid && !forms.registrationForm.firstName.$pristine"
                   class="help-block validation-error-message-first-name">Enter a First Name.</p>
               </div>
@@ -22,23 +22,23 @@
               <!-- Last Name -->
               <div class="form-group" ng-class="{ 'has-error' : forms.registrationForm.lastName.$invalid && !forms.registrationForm.lastName.$pristine }">
                 <label for="lastName">Last Name: *</label>
-                <input type="text" class="form-control lastName" name="lastName" id="lastName" autocomplete="lname" aria-required="true" tabindex="1" ng-model="profile.lastName" required>
+                <input type="text" class="form-control lastName" name="lastName" id="lastName" autocomplete="lname" aria-required="true" tabindex="1" ng-model="registrationFactory.profile.lastName" required>
                 <p ng-show="forms.registrationForm.lastName.$invalid && !forms.registrationForm.lastName.$pristine"
                   class="help-block validation-error-message-last-name">Enter a Last Name.</p>
               </div>
 
               <!-- Organization -->
-              <div class="form-group" ng-class="{'has-error': forms.registrationForm.companyName.$invalid && !forms.registrationForm.companyName.$pristine}" ng-show="newUser">
+              <div class="form-group" ng-class="{'has-error': forms.registrationForm.companyName.$invalid && !forms.registrationForm.companyName.$pristine}" ng-show="registrationFactory.newUser">
                 <label for="companyName">Organization: *</label>
-                <input type="text" class="form-control companyName" name="companyName" id="companyName" tabindex="1" aria-required="true" ng-model="company.name" ng-required="newUser">
+                <input type="text" class="form-control companyName" name="companyName" id="companyName" tabindex="1" aria-required="true" ng-model="registrationFactory.company.name" ng-required="registrationFactory.newUser">
                 <p ng-show="forms.registrationForm.companyName.$invalid && !forms.registrationForm.companyName.$pristine"
                   class="help-block validation-error-message-company-name">Enter an Organization.</p>
               </div>
 
               <!-- Industry -->
-              <div class="form-group" ng-class="{'has-error': forms.registrationForm.companyIndustry.$invalid && !forms.registrationForm.companyIndustry.$pristine}" ng-show="newUser">
+              <div class="form-group" ng-class="{'has-error': forms.registrationForm.companyIndustry.$invalid && !forms.registrationForm.companyIndustry.$pristine}" ng-show="registrationFactory.newUser">
                 <label for="companyIndustry">Tell us your Industry to help us make your displays look great: *</label>
-                <select class="form-control selectpicker companyIndustry" name="companyIndustry" id="companyIndustry" tabindex="1" aria-required="true" ng-model="company.companyIndustry" ng-required="newUser">
+                <select class="form-control selectpicker companyIndustry" name="companyIndustry" id="companyIndustry" tabindex="1" aria-required="true" ng-model="registrationFactory.company.companyIndustry" ng-required="registrationFactory.newUser">
                   <option value="" ng-show="false">&lt; Select Industry &gt;</option>
                   <option class="companyIndustryOption"
                     ng-repeat="industry in DROPDOWN_INDUSTRY_FIELDS | orderBy:industry[0]" value="{{industry[1]}}">{{industry[0]}}
@@ -52,7 +52,7 @@
               <div class="form-group">
                 <div class="checkbox" ng-class="{ 'has-error' : forms.registrationForm.accepted.$invalid && !userForm.accepted.$pristine }">
                   <label for="accepted">
-                    <input type="checkbox" id="accepted" name="accepted" class="accept-terms-checkbox" ng-model="profile.accepted" tabindex="1" required />
+                    <input type="checkbox" id="accepted" name="accepted" class="accept-terms-checkbox" ng-model="registrationFactory.profile.accepted" tabindex="1" required />
                     <span>
                        I accept the
                        <a class="madero-link" href="https://help.risevision.com/hc/en-us/articles/360000924446-Terms-of-Service" target="_blank" tabindex="1">Terms of Service</a>

--- a/src/partials/components/userstate/signup.html
+++ b/src/partials/components/userstate/signup.html
@@ -3,7 +3,7 @@
 <div class="border-container mx-auto">
   <div class="panel-body">
 
-    <div rv-spinner rv-spinner-key="registration-loader" rv-spinner-start-active="0">
+    <div rv-spinner rv-spinner-key="registration-loader" rv-spinner-start-active="1">
       <h4>Help us personalize your experience.</h4>
 
       <div id="registration-modal" stop-event="touchend">

--- a/src/scripts/common-header/services/svc-account.js
+++ b/src/scripts/common-header/services/svc-account.js
@@ -77,17 +77,12 @@
 
     .factory('getAccount', ['$q', 'riseAPILoader', '$log',
       function ($q, riseAPILoader, $log) {
-        return function (email) {
+        return function () {
           $log.debug('getAccount called.');
           var deferred = $q.defer();
 
-          var criteria = {};
-          if (email) {
-            criteria.email = email;
-          }
-
           riseAPILoader().then(function (riseApi) {
-            var request = riseApi.account.get(criteria);
+            var request = riseApi.account.get();
             request.execute(function (resp) {
               $log.debug('getAccount resp', resp);
               if (resp.item) {

--- a/src/scripts/common/directives/dtv-page-title.js
+++ b/src/scripts/common/directives/dtv-page-title.js
@@ -23,9 +23,6 @@ angular.module('risevision.apps.directives')
             case 'common.auth.resetpassword':
               return 'Reset Password';
 
-            case 'common.auth.confirmaccount':
-              return 'Confirm Account';
-
             case 'common.auth.unsubscribe':
               return 'Unsubscribe';
 

--- a/src/scripts/components/userstate/app.js
+++ b/src/scripts/components/userstate/app.js
@@ -140,20 +140,14 @@
             url: '/unregistered/:state',
             controller: 'RegistrationCtrl',
             resolve: {
-              account: ['userState', 'getUserProfile', 'getAccount',
-                function (userState, getUserProfile, getAccount) {
-                  return getUserProfile(userState.getUsername())
-                    .then(null, function (resp) {
-                      if (resp && resp.message ===
-                        'User has not yet accepted the Terms of Service'
-                      ) {
-                        return getAccount();
-                      } else {
-                        return null;
-                      }
+              authenticate: ['userAuthFactory', 'registrationFactory',
+                function(userAuthFactory, registrationFactory) {
+                  return userAuthFactory.authenticate(false)
+                    .then(function () {
+                      registrationFactory.init();
                     })
                     .catch(function () {
-                      return null;
+                      // return to signin page
                     });
                 }
               ]

--- a/src/scripts/components/userstate/app.js
+++ b/src/scripts/components/userstate/app.js
@@ -140,14 +140,14 @@
             url: '/unregistered/:state',
             controller: 'RegistrationCtrl',
             resolve: {
-              authenticate: ['userAuthFactory', 'registrationFactory',
-                function(userAuthFactory, registrationFactory) {
+              authenticate: ['$state', '$stateParams', 'userAuthFactory', 'registrationFactory',
+                function($state, $stateParams, userAuthFactory, registrationFactory) {
                   return userAuthFactory.authenticate(false)
                     .then(function () {
                       registrationFactory.init();
                     })
                     .catch(function () {
-                      // return to signin page
+                      $state.go('common.auth.unauthorized', $stateParams);
                     });
                 }
               ]
@@ -206,8 +206,7 @@
         $rootScope.$on('risevision.user.authorized', function () {
           var currentState = $state.current.name;
 
-          if (currentState.indexOf('common.auth') !== -1 && currentState !== 'common.auth.unsubscribe' &&
-            currentState !== 'common.auth.confirmaccount') {
+          if (currentState.indexOf('common.auth') !== -1 && currentState !== 'common.auth.unsubscribe') {
             urlStateService.redirectToState($stateParams.state);
           }
         });

--- a/src/scripts/components/userstate/controllers/ctr-registration.js
+++ b/src/scripts/components/userstate/controllers/ctr-registration.js
@@ -1,32 +1,14 @@
 'use strict';
 
 angular.module('risevision.common.components.userstate')
-  .controller('RegistrationCtrl', [
-    '$q', '$scope', '$rootScope',
-    '$loading', 'addAccount', '$exceptionHandler',
-    'userState', 'pick', 'messageBox', 'humanReadableError',
-    'agreeToTermsAndUpdateUser', 'account', 'analyticsFactory',
-    'bigQueryLogging', 'updateCompany', 'currentPlanFactory',
-    'COMPANY_INDUSTRY_FIELDS', 'EDUCATION_INDUSTRIES', 'urlStateService', 'hubspot',
-    function ($q, $scope, $rootScope, $loading, addAccount,
-      $exceptionHandler, userState, pick, messageBox, humanReadableError,
-      agreeToTermsAndUpdateUser, account, analyticsFactory, bigQueryLogging,
-      updateCompany, currentPlanFactory, COMPANY_INDUSTRY_FIELDS, EDUCATION_INDUSTRIES, urlStateService, hubspot) {
+  .controller('RegistrationCtrl', ['$scope', '$loading', 'registrationFactory',
+    'urlStateService', 'COMPANY_INDUSTRY_FIELDS',
+    function ($scope, $loading, registrationFactory, urlStateService,
+      COMPANY_INDUSTRY_FIELDS) {
 
-      $scope.newUser = !account;
+      $scope.registrationFactory = registrationFactory;
       $scope.DROPDOWN_INDUSTRY_FIELDS = COMPANY_INDUSTRY_FIELDS;
 
-      var copyOfProfile = account ? account : userState.getCopyOfProfile() || {};
-
-      $scope.company = {};
-
-      $scope.profile = pick(copyOfProfile, 'email', 'firstName', 'lastName');
-      $scope.profile.email = $scope.profile.email || userState.getUsername();
-      $scope.registering = false;
-
-      $scope.profile.accepted =
-        angular.isDefined(copyOfProfile.termsAcceptanceDate) &&
-        copyOfProfile.termsAcceptanceDate !== null;
       $scope.save = function () {
         $scope.forms.registrationForm.accepted.$pristine = false;
         $scope.forms.registrationForm.firstName.$pristine = false;
@@ -35,74 +17,19 @@ angular.module('risevision.common.components.userstate')
         $scope.forms.registrationForm.companyIndustry.$pristine = false;
 
         if (!$scope.forms.registrationForm.$invalid) {
-          //update terms and conditions date
-          $scope.registering = true;
-          $loading.start('registration-modal');
-
-          var action;
-          if ($scope.newUser) {
-            // Automatically subscribe education users on registration
-            var mailSyncEnabled = EDUCATION_INDUSTRIES.indexOf($scope.company.companyIndustry) !== -1;
-
-            action = addAccount($scope.profile.firstName, $scope.profile.lastName, $scope.company.name, $scope
-              .company.companyIndustry, mailSyncEnabled);
-          } else {
-            // Automatically subscribe education users on registration
-            $scope.profile.mailSyncEnabled = EDUCATION_INDUSTRIES.indexOf(account.companyIndustry) !== -1;
-
-            action = agreeToTermsAndUpdateUser(userState.getUsername(), $scope.profile);
-          }
-
-          action
-            .then(function () {
-              userState.refreshProfile()
-                .finally(function () {
-                  if ($scope.newUser) {
-                    currentPlanFactory.initVolumePlanTrial();
-                  }
-
-                  var userCompany = userState.getCopyOfUserCompany();
-                  var userProfile = userState.getCopyOfProfile();
-                  analyticsFactory.track('User Registered', {
-                    'companyId': userState.getUserCompanyId(),
-                    'companyName': userState.getUserCompanyName(),
-                    'parentId': userCompany.parentId,
-                    'isNewCompany': $scope.newUser,
-                    'registeredDate': userProfile.creationDate,
-                    'invitationAcceptedDate': $scope.newUser ? null : new Date()
-                  });
-
-                  hubspot.loadAs(userState.getUsername());
-
-                  bigQueryLogging.logEvent('User Registered');
-
-                  $rootScope.$broadcast('risevision.user.authorized');
-
-                  $loading.stop('registration-modal');
-                });
-            })
-            .catch(function (err) {
-              messageBox('Error', humanReadableError(err));
-              $exceptionHandler(err, 'User registration failed.', true);
-
-              userState.refreshProfile();
-            })
-            .finally(function () {
-              $scope.registering = false;
-            });
+          registrationFactory.register();
         }
-
       };
 
       var populateIndustryFromUrl = function () {
 
         var industryName = urlStateService.getUrlParam('industry');
 
-        if ($scope.newUser && industryName) {
+        if (registrationFactory.newUser && industryName) {
 
           COMPANY_INDUSTRY_FIELDS.forEach(function (industry) {
             if (industryName === industry[0]) {
-              $scope.company.companyIndustry = industry[1];
+              registrationFactory.company.companyIndustry = industry[1];
             }
           });
         }
@@ -111,5 +38,14 @@ angular.module('risevision.common.components.userstate')
       populateIndustryFromUrl();
 
       $scope.forms = {};
+
+      $scope.$watch('registrationFactory.loading', function (loading) {
+        if (loading) {
+          $loading.start('registration-loader');
+        } else {
+          $loading.stop('registration-loader');
+        }
+      });
+
     }
   ]);

--- a/src/scripts/components/userstate/controllers/ctr-registration.js
+++ b/src/scripts/components/userstate/controllers/ctr-registration.js
@@ -7,11 +7,11 @@ angular.module('risevision.common.components.userstate')
     'userState', 'pick', 'messageBox', 'humanReadableError',
     'agreeToTermsAndUpdateUser', 'account', 'analyticsFactory',
     'bigQueryLogging', 'updateCompany', 'currentPlanFactory',
-    'COMPANY_INDUSTRY_FIELDS', 'urlStateService', 'hubspot',
+    'COMPANY_INDUSTRY_FIELDS', 'EDUCATION_INDUSTRIES', 'urlStateService', 'hubspot',
     function ($q, $scope, $rootScope, $loading, addAccount,
       $exceptionHandler, userState, pick, messageBox, humanReadableError,
       agreeToTermsAndUpdateUser, account, analyticsFactory, bigQueryLogging,
-      updateCompany, currentPlanFactory, COMPANY_INDUSTRY_FIELDS, urlStateService, hubspot) {
+      updateCompany, currentPlanFactory, COMPANY_INDUSTRY_FIELDS, EDUCATION_INDUSTRIES, urlStateService, hubspot) {
 
       $scope.newUser = !account;
       $scope.DROPDOWN_INDUSTRY_FIELDS = COMPANY_INDUSTRY_FIELDS;
@@ -27,9 +27,6 @@ angular.module('risevision.common.components.userstate')
       $scope.profile.accepted =
         angular.isDefined(copyOfProfile.termsAcceptanceDate) &&
         copyOfProfile.termsAcceptanceDate !== null;
-      // Automatically subscribe users on registration
-      $scope.profile.mailSyncEnabled = true;
-
       $scope.save = function () {
         $scope.forms.registrationForm.accepted.$pristine = false;
         $scope.forms.registrationForm.firstName.$pristine = false;
@@ -44,9 +41,15 @@ angular.module('risevision.common.components.userstate')
 
           var action;
           if ($scope.newUser) {
+            // Automatically subscribe education users on registration
+            var mailSyncEnabled = EDUCATION_INDUSTRIES.indexOf($scope.company.companyIndustry) !== -1;
+
             action = addAccount($scope.profile.firstName, $scope.profile.lastName, $scope.company.name, $scope
-              .company.companyIndustry, $scope.profile.mailSyncEnabled);
+              .company.companyIndustry, mailSyncEnabled);
           } else {
+            // Automatically subscribe education users on registration
+            $scope.profile.mailSyncEnabled = EDUCATION_INDUSTRIES.indexOf(account.companyIndustry) !== -1;
+
             action = agreeToTermsAndUpdateUser(userState.getUsername(), $scope.profile);
           }
 

--- a/src/scripts/components/userstate/services/svc-registration-factory.js
+++ b/src/scripts/components/userstate/services/svc-registration-factory.js
@@ -1,0 +1,124 @@
+(function (angular) {
+  'use strict';
+  /*jshint camelcase: false */
+
+  angular.module('risevision.common.components.userstate')
+    .factory('registrationFactory', ['$q', '$log', 
+    'userState', 'getUserProfile', 'getAccount',
+    '$rootScope', 'addAccount', '$exceptionHandler',
+    'pick', 'messageBox', 'humanReadableError',
+    'agreeToTermsAndUpdateUser', 'analyticsFactory',
+    'bigQueryLogging', 'currentPlanFactory',
+    'hubspot', 'EDUCATION_INDUSTRIES',
+      function ($q, $log, userState, getUserProfile, getAccount,
+        $rootScope, addAccount,
+        $exceptionHandler, pick, messageBox, humanReadableError,
+        agreeToTermsAndUpdateUser, analyticsFactory, bigQueryLogging,
+        currentPlanFactory, hubspot, EDUCATION_INDUSTRIES) {
+        var factory = {};
+
+        var _reset = function() {
+          factory.newUser = true;
+
+          factory.profile = {};
+          factory.company = {};
+        };
+
+        var _checkNewUser = function() {
+          return getUserProfile(userState.getUsername())
+            .catch(function (resp) {
+              if (resp && resp.message === 'User has not yet accepted the Terms of Service') {
+                factory.newUser = false;
+              } else {
+                factory.newUser = true;
+              }
+            });
+        };
+
+        var _getAccount = function() {
+          return getAccount()
+            .catch(function () {
+              return null;
+            });
+        };
+
+        factory.init = function() {
+          _reset();
+
+          factory.loading = true;
+
+          $q.all([_getAccount(), _checkNewUser()])
+            .then(function(result) {
+              var account = result[0] || {};
+
+              factory.profile = pick(account, 'email', 'firstName', 'lastName', 'mailSyncEnabled');
+              factory.profile.email = factory.profile.email || userState.getUsername();
+              factory.company.companyIndustry = account.companyIndustry;
+            })
+            .finally(function() {
+              factory.loading = false;              
+            });
+        };
+
+        var _isEducation = function (companyIndustry) {
+          return EDUCATION_INDUSTRIES.indexOf(companyIndustry) !== -1;
+        };
+
+        factory.register = function() {
+          var action;
+
+          // Automatically subscribe education users on registration or if they were already subscribed
+          factory.profile.mailSyncEnabled = factory.profile.mailSyncEnabled || _isEducation(factory.company.companyIndustry);
+
+          factory.loading = true;              
+
+          if (factory.newUser) {
+            action = addAccount(factory.profile.firstName, factory.profile.lastName, factory.company.name, factory
+              .company.companyIndustry, factory.profile.mailSyncEnabled);
+          } else {
+            action = agreeToTermsAndUpdateUser(userState.getUsername(), factory.profile);
+          }
+
+          action
+            .then(function () {
+              userState.refreshProfile()
+                .finally(function () {
+                  if (factory.newUser) {
+                    currentPlanFactory.initVolumePlanTrial();
+                  }
+
+                  var userCompany = userState.getCopyOfUserCompany();
+                  var userProfile = userState.getCopyOfProfile();
+                  analyticsFactory.track('User Registered', {
+                    'companyId': userState.getUserCompanyId(),
+                    'companyName': userState.getUserCompanyName(),
+                    'parentId': userCompany.parentId,
+                    'isNewCompany': factory.newUser,
+                    'registeredDate': userProfile.creationDate,
+                    'invitationAcceptedDate': factory.newUser ? null : new Date()
+                  });
+
+                  hubspot.loadAs(userState.getUsername());
+
+                  bigQueryLogging.logEvent('User Registered');
+
+                  $rootScope.$broadcast('risevision.user.authorized');
+
+                  factory.loading = false;              
+                });
+            })
+            .catch(function (err) {
+              messageBox('Error', humanReadableError(err));
+              $exceptionHandler(err, 'User registration failed.', true);
+
+              userState.refreshProfile();
+
+              factory.loading = false;              
+            });
+        };
+
+        return factory;
+      }
+    ]);
+
+})(angular);

--- a/test/unit/common/directives/dtv-page-title.spec.js
+++ b/test/unit/common/directives/dtv-page-title.spec.js
@@ -67,8 +67,6 @@ describe('directive: page title', function() {
     checkState('common.auth.requestpasswordreset', 'Reset Password');
     checkState('common.auth.resetpassword', 'Reset Password');
 
-    checkState('common.auth.confirmaccount', 'Confirm Account');
-
     checkState('common.auth.unsubscribe', 'Unsubscribe');
 
     // Apps auth routes:

--- a/test/unit/components/userstate/app.spec.js
+++ b/test/unit/components/userstate/app.spec.js
@@ -281,25 +281,37 @@ describe("app:", function() {
       });      
 
       describe('authenticate:', function() {
+        var $stateParams;
+
+        beforeEach(function() {
+          sinon.spy($state, 'go');
+
+          $stateParams = 'stateParams';
+        });
+
         it('should check if user is authenticated', function(done) {
-          $state.get('common.auth.unregistered').resolve.authenticate[2](userAuthFactory, registrationFactory)
+          $state.get('common.auth.unregistered').resolve.authenticate[4]($state, $stateParams, userAuthFactory, registrationFactory)
             .then(function() {
               userAuthFactory.authenticate.should.have.been.calledWith(false);
 
               registrationFactory.init.should.have.been.called;
 
+              $state.go.should.not.have.been.called;
+
               done();
             });
         });
 
-        it('should not proceed if user is not authenticated', function(done) {
+        it('should redirect user to login page if not authenticated', function(done) {
           userAuthFactory.authenticate.rejects();
 
-          $state.get('common.auth.unregistered').resolve.authenticate[2](userAuthFactory, registrationFactory)
+          $state.get('common.auth.unregistered').resolve.authenticate[4]($state, $stateParams, userAuthFactory, registrationFactory)
             .then(function() {
               userAuthFactory.authenticate.should.have.been.calledWith(false);
 
               registrationFactory.init.should.not.have.been.called;
+
+              $state.go.should.have.been.calledWith('common.auth.unauthorized', 'stateParams');
 
               done();
             });

--- a/test/unit/components/userstate/app.spec.js
+++ b/test/unit/components/userstate/app.spec.js
@@ -25,16 +25,33 @@ describe("app:", function() {
   beforeEach(function () {
     module("risevision.common.components.userstate");
 
+    module(function ($provide) {
+      $provide.service('userAuthFactory',function(){
+        return {
+          authenticate: sinon.stub().resolves()
+        };
+      });
+
+      $provide.service('registrationFactory',function(){
+        return {
+          init: sinon.stub()
+        };
+      });
+
+    });
+
     inject(function ($injector) {
       $state = $injector.get("$state");
       $rootScope = $injector.get("$rootScope");
       urlStateService = $injector.get("urlStateService");
+      userAuthFactory = $injector.get('userAuthFactory');
+      registrationFactory = $injector.get('registrationFactory');
 
       sinon.stub(urlStateService, "redirectToState");
     });
   });
 
-  var $state, $rootScope, urlStateService;
+  var $state, $rootScope, urlStateService, userAuthFactory, registrationFactory;
   var locationProvider, urlRouterProvider, urlMatcherFactoryProvider, stateProvider;
 
   describe("mappings: ", function() {
@@ -250,6 +267,47 @@ describe("app:", function() {
         joinAccount: true
       });
     });
+
+    describe('common.auth.unregistered', function() {
+      it("should exist", function() {
+        var state = $state.get('common.auth.unregistered');
+        expect(state).to.be.ok;
+        expect(state.templateUrl).to.equal('partials/components/userstate/signup.html');
+        expect(state.url).to.equal("/unregistered/:state");
+        expect(state.controller).to.equal("RegistrationCtrl");
+
+        expect(state.resolve).to.be.ok;
+        expect(state.resolve.authenticate).to.be.ok;
+      });      
+
+      describe('authenticate:', function() {
+        it('should check if user is authenticated', function(done) {
+          $state.get('common.auth.unregistered').resolve.authenticate[2](userAuthFactory, registrationFactory)
+            .then(function() {
+              userAuthFactory.authenticate.should.have.been.calledWith(false);
+
+              registrationFactory.init.should.have.been.called;
+
+              done();
+            });
+        });
+
+        it('should not proceed if user is not authenticated', function(done) {
+          userAuthFactory.authenticate.rejects();
+
+          $state.get('common.auth.unregistered').resolve.authenticate[2](userAuthFactory, registrationFactory)
+            .then(function() {
+              userAuthFactory.authenticate.should.have.been.calledWith(false);
+
+              registrationFactory.init.should.not.have.been.called;
+
+              done();
+            });
+        });
+      });
+
+    });
+
   });
 
   describe("listeners: ", function() {

--- a/test/unit/components/userstate/controllers/ctr-registration.spec.js
+++ b/test/unit/components/userstate/controllers/ctr-registration.spec.js
@@ -6,139 +6,31 @@
 describe("controller: registration", function() {
   beforeEach(module("risevision.common.components.userstate"));
   beforeEach(module(function ($provide) {
-    $provide.service("userState", function(){
+    $provide.factory('registrationFactory', function() {
       return {
-        getCopyOfProfile : function(){
-          return userProfile;
-        },
-        getUsername: function() {
-          return "e@mail.com";
-        },
-        _restoreState : function(){
-          
-        },
-        getUserCompanyId : function(){
-          return "some_company_id";
-        },
-        getUserCompanyName: function() {
-          return "company_name";
-        },
-        updateCompanySettings: sinon.stub(),
-        refreshProfile: function() {
-          var deferred = Q.defer();
-          
-          deferred.resolve({});
-          
-          return deferred.promise;
-        },
-        getCopyOfUserCompany: function() {
-          return {
-            parentId: "parentId"
-          };
-        }
+        register: sinon.stub()
       };
     });
 
-    $provide.service("updateCompany",function(){
-      return function(companyId, company){
-        updateCompanyCalled = company.name;
-
-        return Q.resolve("companyResult");
-      };
-    });
-    
-    var registrationService = function(calledFrom){
-      return function() {
-        newUser = calledFrom === "addAccount";
-        var deferred = Q.defer();
-        
-        if(registerUser){
-          deferred.resolve("registered");
-        }else{
-          deferred.reject("ERROR");
-        }
-        return deferred.promise;
-      };
-    };
-    
-    $provide.service("addAccount", function(){
-      return registrationService("addAccount");
-    });
-    $provide.service("agreeToTermsAndUpdateUser", function() {
-      return registrationService("agreeToTerms");
-    });
-
-    $provide.service("currentPlanFactory", function() {
-      return currentPlanFactory = {
-        initVolumePlanTrial: sinon.spy()
-      };
-    });
-
-    $provide.service("analyticsFactory", function() { 
+    $provide.service('$loading',function(){
       return {
-        track: sinon.stub(),
-        load: function() {}
-      };
-    });
-
-    $provide.service("$exceptionHandler",function(){
-      return sinon.spy();
-    });
-
-    $provide.service("bigQueryLogging", function() { 
-      return {
-        logEvent: function(name) {
-          bqCalled = name;
-        }
-      };
-    });
-
-    $provide.factory("customLoader", function ($q) {
-      return function () {
-        return Q.resolve({});
-      };
-    });
-
-    $provide.factory("messageBox", function() {
-      return function() {};
-    });
-
-    $provide.factory("hubspot", function() {
-      return {
-        loadAs: sinon.stub()
-      };
+        start : sinon.spy(),
+        stop : sinon.spy()
+      }
     });
 
     $provide.value('COMPANY_INDUSTRY_FIELDS', []);
   }));
-  var $scope, userProfile, userState, newUser;
-  var registerUser, account, analyticsFactory, bqCalled,
-    updateCompanyCalled, currentPlanFactory, hubspot;
+  var $scope, $loading, registrationFactory;
   
   beforeEach(function() {
-    registerUser = true;
-    bqCalled = undefined;
-    userProfile = {
-      id : "RV_user_id",
-      firstName : "first",
-      lastName : "last",
-      telephone : "telephone",
-      creationDate: "creationDate"
-    };
-    
     inject(function($injector,$rootScope, $controller){
       $scope = $rootScope.$new();
-      analyticsFactory = $injector.get("analyticsFactory");
-      userState = $injector.get("userState");
-      hubspot = $injector.get('hubspot');
+      $loading = $injector.get('$loading');
+      registrationFactory = $injector.get("registrationFactory");
+
       $controller("RegistrationCtrl", {
-        $scope : $scope,
-        $cookies: $injector.get("$cookies"),
-        userState : userState,
-        updateCompany: $injector.get("updateCompany"),
-        agreeToTermsAndUpdateUser:$injector.get("agreeToTermsAndUpdateUser"),
-        addAccount:$injector.get("addAccount"),
-        account: account
+        $scope: $scope
       });
       $scope.$digest();
       $scope.forms = {
@@ -156,16 +48,7 @@ describe("controller: registration", function() {
   
   it("should initialize",function(){
     expect($scope).to.be.ok;
-    expect($scope.profile).to.be.ok;
-    
-    expect($scope.profile).to.deep.equal({
-      email: "e@mail.com",
-      firstName: "first",
-      lastName: "last",
-      accepted: false
-    });
-
-    expect($scope.registering).to.be.false;
+    expect($scope.registrationFactory).to.be.ok;
 
     expect($scope.save).to.exist;
   });
@@ -174,120 +57,35 @@ describe("controller: registration", function() {
     it("should not save if form is invalid", function() {
       $scope.forms.registrationForm.$invalid = true;
       $scope.save();
-      expect($scope.registering).to.be.false;        
+
+      registrationFactory.register.should.not.have.been.called;
     });
 
-    it("should use username as email",function(){
-      expect($scope.profile.email).to.be.equal("e@mail.com");
-    });
-    
-    it("should register user and close the modal",function(done){
+    it("should register user",function(){
       $scope.forms.registrationForm.$invalid = false;
       $scope.save();
-      expect($scope.registering).to.be.true;
-      
-      var profileSpy = sinon.spy(userState, "refreshProfile");
-      setTimeout(function() {
-        expect(newUser).to.be.true;
-        currentPlanFactory.initVolumePlanTrial.should.have.been.called;
-        expect(analyticsFactory.track).to.have.been.calledWith("User Registered",{
-          companyId: "some_company_id",
-          companyName: "company_name",
-          parentId: "parentId",
-          isNewCompany: true,
-          registeredDate: "creationDate",
-          invitationAcceptedDate: null
-        });
-        expect(bqCalled).to.equal("User Registered");
-        hubspot.loadAs.should.have.been.calledWith('e@mail.com');
-        expect($scope.registering).to.be.false;
 
-        expect(profileSpy.called).to.be.true;
-
-        done();
-      },10);
+      registrationFactory.register.should.have.been.called;
     });
 
-    it("should handle failure to create user",function(done){
-      registerUser = false;
-      $scope.forms.registrationForm.$invalid = false;
-      $scope.save();
-      
-      var profileSpy = sinon.spy(userState, "refreshProfile");
-      setTimeout(function(){
-        expect(newUser).to.be.true;
-        currentPlanFactory.initVolumePlanTrial.should.not.have.been.called;
-        expect(analyticsFactory.track).to.not.have.been.called;
-        expect(bqCalled).to.not.be.ok;
-        hubspot.loadAs.should.not.have.been.called;
-        expect($scope.registering).to.be.false;
-
-        expect(profileSpy.called).to.be.true;
-
-        done();
-      },10);
-    });
-  
   });
-    
-  describe("save existing user: ", function() {
-    beforeEach(function() {
-      account = userProfile;
+
+  describe('$loading: ', function() {
+    it('should stop spinner', function() {
+      $loading.stop.should.have.been.calledWith('registration-loader');
     });
     
-    it("should not save if form is invalid", function() {
-      $scope.forms.registrationForm.$invalid = true;
-      $scope.save();
-      expect($scope.registering).to.be.false;        
-    });
-    
-    it("should register user and close the modal",function(done){
-      $scope.forms.registrationForm.$invalid = false;
-      $scope.save();
-      expect($scope.registering).to.be.true;
-      
-      var profileSpy = sinon.spy(userState, "refreshProfile");
+    it('should start spinner', function(done) {
+      registrationFactory.loading = true;
+      $scope.$digest();
       setTimeout(function() {
-        expect(newUser).to.be.false;
-        currentPlanFactory.initVolumePlanTrial.should.not.have.been.called;
-        expect(analyticsFactory.track).to.have.been.calledWithMatch("User Registered",{
-          companyId: "some_company_id",
-          companyName: "company_name",
-          parentId: "parentId",
-          isNewCompany: false,
-          registeredDate: "creationDate"
-        });
-        expect(analyticsFactory.track.getCall(0).args[1].invitationAcceptedDate).to.be.a('date');
-        expect(bqCalled).to.equal("User Registered");
-        hubspot.loadAs.should.have.been.calledWith('e@mail.com');
-        expect($scope.registering).to.be.false;
-
-        expect(profileSpy.called).to.be.true;
-
+        $loading.start.should.have.been.calledWith('registration-loader');
+        
         done();
-      },10);
+      }, 10);
     });
-    
-    it("should handle failure to create user",function(done){
-      registerUser = false;
-      $scope.forms.registrationForm.$invalid = false;
-      $scope.save();
-      
-      var profileSpy = sinon.spy(userState, "refreshProfile");
-      setTimeout(function(){
-        expect(newUser).to.be.false;
-        expect(analyticsFactory.track).to.not.have.been.called;
-        expect(bqCalled).to.not.be.ok;
-        hubspot.loadAs.should.not.have.been.called;
-        expect($scope.registering).to.be.false;
-
-        expect(profileSpy.called).to.be.true;
-
-        done();
-      },10);
-    });
-      
   });
+
 
 });
   

--- a/test/unit/components/userstate/controllers/ctr-registration.spec.js
+++ b/test/unit/components/userstate/controllers/ctr-registration.spec.js
@@ -162,8 +162,7 @@ describe("controller: registration", function() {
       email: "e@mail.com",
       firstName: "first",
       lastName: "last",
-      accepted: false,
-      mailSyncEnabled: true
+      accepted: false
     });
 
     expect($scope.registering).to.be.false;

--- a/test/unit/components/userstate/services/svc-registration-factory.spec.js
+++ b/test/unit/components/userstate/services/svc-registration-factory.spec.js
@@ -1,0 +1,392 @@
+'use strict';
+describe('service: registrationFactory:', function() {
+  beforeEach(module('risevision.common.components.userstate'));
+
+  beforeEach(module(function ($provide) {
+    $provide.service("$q", function() {return Q;});
+
+    $provide.service('userState', function(){
+      return {
+        getCopyOfProfile: function() {
+          return {
+            creationDate: 'creationDate'
+          };
+        },
+        getUsername: function() {
+          return 'e@mail.com';
+        },
+        _restoreState : function(){
+          
+        },
+        getUserCompanyId : function(){
+          return 'some_company_id';
+        },
+        getUserCompanyName: function() {
+          return 'company_name';
+        },
+        updateCompanySettings: sinon.stub(),
+        refreshProfile: sinon.stub().resolves(),
+        getCopyOfUserCompany: function() {
+          return {
+            parentId: 'parentId'
+          };
+        }
+      };
+    });
+
+    $provide.service('getUserProfile', function(){
+      return sinon.stub().rejects();
+    });
+
+    $provide.service('getAccount', function(){
+      return sinon.stub().resolves();
+    });
+    
+    $provide.service('addAccount', function(){
+      return sinon.stub().resolves('registered');
+    });
+
+    $provide.service('agreeToTermsAndUpdateUser', function() {
+      return sinon.stub().resolves('registered');
+    });
+
+    $provide.service('currentPlanFactory', function() {
+      return currentPlanFactory = {
+        initVolumePlanTrial: sinon.spy()
+      };
+    });
+
+    $provide.service('analyticsFactory', function() { 
+      return {
+        track: sinon.stub(),
+        load: function() {}
+      };
+    });
+
+    $provide.service('$exceptionHandler',function(){
+      return sinon.spy();
+    });
+
+    $provide.service('bigQueryLogging', function() { 
+      return {
+        logEvent: sinon.spy()
+      };
+    });
+
+    $provide.factory('customLoader', function ($q) {
+      return function () {
+        return Q.resolve({});
+      };
+    });
+
+    $provide.factory('messageBox', function() {
+      return function() {};
+    });
+
+    $provide.factory('hubspot', function() {
+      return {
+        loadAs: sinon.stub()
+      };
+    });
+
+  }));
+  
+  var registrationFactory, userState, getUserProfile, getAccount, addAccount, agreeToTermsAndUpdateUser;
+  var analyticsFactory, bigQueryLogging,
+    updateCompanyCalled, currentPlanFactory, hubspot;
+
+  beforeEach(function(){
+    inject(function($injector){
+      userState = $injector.get('userState');
+      analyticsFactory = $injector.get("analyticsFactory");
+      bigQueryLogging = $injector.get('bigQueryLogging');
+      hubspot = $injector.get('hubspot');
+      getUserProfile = $injector.get('getUserProfile');
+      getAccount = $injector.get('getAccount');
+      addAccount = $injector.get('addAccount');
+      agreeToTermsAndUpdateUser = $injector.get('agreeToTermsAndUpdateUser');
+      registrationFactory = $injector.get('registrationFactory');
+    });
+  });
+
+  it('should initialize',function(){
+    expect(registrationFactory).to.be.ok;
+    expect(registrationFactory.init).to.be.a('function');
+    expect(registrationFactory.register).to.be.a('function');
+  });
+  
+  describe('init:', function() {
+    it('should load data and start spinner',function(){
+      registrationFactory.init();
+
+      expect(registrationFactory.loading).to.be.true;
+
+      getUserProfile.should.have.been.calledWith('e@mail.com');
+      getAccount.should.have.been.called;
+    });
+
+    it('should reset old values',function(){
+      registrationFactory.newUser = 'oldvalue';
+      registrationFactory.profile = 'oldprofile';
+      registrationFactory.company = 'oldcompany';
+
+      registrationFactory.init();
+
+      expect(registrationFactory.newUser).to.be.true;
+      expect(registrationFactory.profile).to.deep.equal({});
+      expect(registrationFactory.company).to.deep.equal({});
+
+    });
+
+    describe('_checkNewUser:', function() {
+      it('should handle rejection with a random error',function(done){
+        registrationFactory.init();
+
+        registrationFactory.newUser = 'oldvalue';
+
+        setTimeout(function() {
+          expect(registrationFactory.newUser).to.be.true;
+
+          done();
+        });
+      });
+
+      it('should detect terms acceptance error',function(done){
+        getUserProfile.rejects({
+          message: 'User has not yet accepted the Terms of Service'
+        });
+        
+        registrationFactory.init();
+
+        setTimeout(function() {
+          expect(registrationFactory.newUser).to.be.false;
+
+          done();
+        });
+      });
+
+      it('should use default value if function resolves (should never happen)',function(done){
+        getUserProfile.resolves();
+
+        registrationFactory.init();
+
+        registrationFactory.newUser = 'oldvalue';
+
+        setTimeout(function() {
+          expect(registrationFactory.newUser).to.equal('oldvalue');
+
+          done();
+        });
+      });
+
+    });
+
+    it('should update profile and company objects',function(done){
+      getAccount.resolves({
+        email : "RV_user_id",
+        firstName : "first",
+        lastName : "last",
+        mailSyncEnabled: true,
+        telephone : "telephone",
+        companyIndustry: 'EDUCATION'
+      });
+
+      registrationFactory.init();
+
+      setTimeout(function() {
+        expect(registrationFactory.profile).to.deep.equal({
+          email : "RV_user_id",
+          firstName : "first",
+          lastName : "last",
+          mailSyncEnabled: true
+        });
+
+        expect(registrationFactory.company).to.deep.equal({
+          companyIndustry: 'EDUCATION'
+        });
+
+        expect(registrationFactory.loading).to.be.false;
+
+        done();
+      });
+    });
+
+    it('should use username as email',function(done){
+      registrationFactory.init();
+
+      setTimeout(function() {
+        expect(registrationFactory.profile).to.deep.equal({
+          email : "e@mail.com"
+        });
+
+        expect(registrationFactory.company).to.deep.equal({
+          companyIndustry: undefined
+        });
+
+        done();
+      });
+    });
+
+    it('should handle failure to getAccount',function(done){
+      getAccount.rejects();
+
+      registrationFactory.init();
+
+      setTimeout(function() {
+        expect(registrationFactory.profile).to.deep.equal({
+          email : "e@mail.com"
+        });
+
+        expect(registrationFactory.company).to.deep.equal({
+          companyIndustry: undefined
+        });
+
+        done();
+      });
+    });
+
+  });
+
+  describe('save:', function() {
+    beforeEach(function() {
+      registrationFactory.profile = {};
+      registrationFactory.company = {};
+    });
+    
+    describe('mailSyncEnabled', function() {
+      it('should enable for education', function() {
+        registrationFactory.company.companyIndustry = 'PRIMARY_SECONDARY_EDUCATION';
+        registrationFactory.register();
+        
+        expect(registrationFactory.profile.mailSyncEnabled).to.be.true;
+      });
+
+      it('should disable for non education', function() {
+        registrationFactory.company.companyIndustry = 'MISC';
+        registrationFactory.register();
+        
+        expect(registrationFactory.profile.mailSyncEnabled).to.be.false;
+      });
+
+      it('should not override existing subscription', function() {
+        registrationFactory.profile.mailSyncEnabled = true;
+        registrationFactory.company.companyIndustry = 'MISC';
+        registrationFactory.register();
+        
+        expect(registrationFactory.profile.mailSyncEnabled).to.be.true;
+      });
+    });
+
+    describe('new user: ', function() {      
+      beforeEach(function() {
+        registrationFactory.newUser = true;
+      });
+
+      it('should register user and close the modal', function(done){
+        registrationFactory.register();
+        expect(registrationFactory.loading).to.be.true;
+        
+        setTimeout(function() {
+          addAccount.should.have.been.called;
+          agreeToTermsAndUpdateUser.should.not.have.been.called;
+          
+          currentPlanFactory.initVolumePlanTrial.should.have.been.called;
+          expect(analyticsFactory.track).to.have.been.calledWith('User Registered',{
+            companyId: 'some_company_id',
+            companyName: 'company_name',
+            parentId: 'parentId',
+            isNewCompany: true,
+            registeredDate: 'creationDate',
+            invitationAcceptedDate: null
+          });
+          bigQueryLogging.logEvent.should.have.been.calledWith('User Registered');
+          hubspot.loadAs.should.have.been.calledWith('e@mail.com');
+
+          userState.refreshProfile.should.have.been.called;
+
+          expect(registrationFactory.loading).to.be.false;
+
+          done();
+        },10);
+      });
+
+      it('should handle failure to create user', function(done){
+        addAccount.rejects('error');
+        registrationFactory.register();
+        
+        setTimeout(function(){
+          addAccount.should.have.been.called;
+          agreeToTermsAndUpdateUser.should.not.have.been.called;
+
+          currentPlanFactory.initVolumePlanTrial.should.not.have.been.called;
+          expect(analyticsFactory.track).to.not.have.been.called;
+          bigQueryLogging.logEvent.should.not.have.been.called;
+          hubspot.loadAs.should.not.have.been.called;
+
+          userState.refreshProfile.should.have.been.called;
+
+          expect(registrationFactory.loading).to.be.false;
+
+          done();
+        },10);
+      });
+    });
+      
+    describe('existing user:', function() {
+      beforeEach(function() {
+        registrationFactory.newUser = false;
+      });
+      
+      it('should register user and close the modal', function(done){
+        registrationFactory.register();
+        expect(registrationFactory.loading).to.be.true;
+        
+        setTimeout(function() {
+          addAccount.should.not.have.been.called;
+          agreeToTermsAndUpdateUser.should.have.been.called;
+
+          currentPlanFactory.initVolumePlanTrial.should.not.have.been.called;
+          expect(analyticsFactory.track).to.have.been.calledWithMatch('User Registered',{
+            companyId: 'some_company_id',
+            companyName: 'company_name',
+            parentId: 'parentId',
+            isNewCompany: false,
+            registeredDate: 'creationDate'
+          });
+          expect(analyticsFactory.track.getCall(0).args[1].invitationAcceptedDate).to.be.a('date');
+          bigQueryLogging.logEvent.should.have.been.calledWith('User Registered');
+          hubspot.loadAs.should.have.been.calledWith('e@mail.com');
+
+          userState.refreshProfile.should.have.been.called;
+
+          expect(registrationFactory.loading).to.be.false;
+
+          done();
+        },10);
+      });
+      
+      it('should handle failure to create user', function(done){
+        agreeToTermsAndUpdateUser.rejects('error');
+        registrationFactory.register();
+        
+        setTimeout(function(){
+          addAccount.should.not.have.been.called;
+          agreeToTermsAndUpdateUser.should.have.been.called;
+
+          expect(analyticsFactory.track).to.not.have.been.called;
+          bigQueryLogging.logEvent.should.not.have.been.called;
+          hubspot.loadAs.should.not.have.been.called;
+          expect(registrationFactory.loading).to.be.false;
+
+          userState.refreshProfile.should.have.been.called;
+
+          expect(registrationFactory.loading).to.be.false;
+
+          done();
+        },10);
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
## Description
Only register Education users to playbook

Check company industry from the form for new users

Retrieve industry via the get account api for existing
Remove the username parameter from the
account.get api

[stage-2]

## Motivation and Context
Only automatically subscribe education customers to the playbook on registration

## How Has This Been Tested?
Tested locally with the updated core version. Will update unit tests in a subsequent PR.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No