### PR TITLE
Keep existing playbook subscription

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -190,6 +190,7 @@
               "src/scripts/components/userstate/services/svc-userauth.js",
               "src/scripts/components/userstate/services/svc-userstate.js",
               "src/scripts/components/userstate/services/svc-openid-connect.js",
+              "src/scripts/components/userstate/services/svc-registration-factory.js",
 
               "src/scripts/components/last-modified/dtv-last-modified.js",
               "src/scripts/components/last-modified/ftr-username.js",
@@ -754,6 +755,7 @@
                 "src/scripts/components/userstate/services/svc-userauth.js",
                 "src/scripts/components/userstate/services/svc-userstate.js",
                 "src/scripts/components/userstate/services/svc-openid-connect.js",
+                "src/scripts/components/userstate/services/svc-registration-factory.js",
 
                 "src/scripts/components/last-modified/dtv-last-modified.js",
                 "src/scripts/components/last-modified/ftr-username.js",

--- a/src/partials/components/userstate/signup.html
+++ b/src/partials/components/userstate/signup.html
@@ -3,7 +3,7 @@
 <div class="border-container mx-auto">
   <div class="panel-body">
 
-    <div rv-spinner rv-spinner-key="registration-modal" rv-spinner-start-active="0">
+    <div rv-spinner rv-spinner-key="registration-loader" rv-spinner-start-active="0">
       <h4>Help us personalize your experience.</h4>
 
       <div id="registration-modal" stop-event="touchend">
@@ -14,7 +14,7 @@
               <!-- First Name -->
               <div class="form-group" ng-class="{ 'has-error' : forms.registrationForm.firstName.$invalid && !forms.registrationForm.firstName.$pristine }">
                 <label for="firstName">First Name: *</label>
-                <input type="text" class="form-control firstName" name="firstName" id="firstName" autocomplete="fname" aria-required="true" tabindex="1" ng-model="profile.firstName" autofocus required>
+                <input type="text" class="form-control firstName" name="firstName" id="firstName" autocomplete="fname" aria-required="true" tabindex="1" ng-model="registrationFactory.profile.firstName" autofocus required>
                 <p ng-show="forms.registrationForm.firstName.$invalid && !forms.registrationForm.firstName.$pristine"
                   class="help-block validation-error-message-first-name">Enter a First Name.</p>
               </div>
@@ -22,23 +22,23 @@
               <!-- Last Name -->
               <div class="form-group" ng-class="{ 'has-error' : forms.registrationForm.lastName.$invalid && !forms.registrationForm.lastName.$pristine }">
                 <label for="lastName">Last Name: *</label>
-                <input type="text" class="form-control lastName" name="lastName" id="lastName" autocomplete="lname" aria-required="true" tabindex="1" ng-model="profile.lastName" required>
+                <input type="text" class="form-control lastName" name="lastName" id="lastName" autocomplete="lname" aria-required="true" tabindex="1" ng-model="registrationFactory.profile.lastName" required>
                 <p ng-show="forms.registrationForm.lastName.$invalid && !forms.registrationForm.lastName.$pristine"
                   class="help-block validation-error-message-last-name">Enter a Last Name.</p>
               </div>
 
               <!-- Organization -->
-              <div class="form-group" ng-class="{'has-error': forms.registrationForm.companyName.$invalid && !forms.registrationForm.companyName.$pristine}" ng-show="newUser">
+              <div class="form-group" ng-class="{'has-error': forms.registrationForm.companyName.$invalid && !forms.registrationForm.companyName.$pristine}" ng-show="registrationFactory.newUser">
                 <label for="companyName">Organization: *</label>
-                <input type="text" class="form-control companyName" name="companyName" id="companyName" tabindex="1" aria-required="true" ng-model="company.name" ng-required="newUser">
+                <input type="text" class="form-control companyName" name="companyName" id="companyName" tabindex="1" aria-required="true" ng-model="registrationFactory.company.name" ng-required="registrationFactory.newUser">
                 <p ng-show="forms.registrationForm.companyName.$invalid && !forms.registrationForm.companyName.$pristine"
                   class="help-block validation-error-message-company-name">Enter an Organization.</p>
               </div>
 
               <!-- Industry -->
-              <div class="form-group" ng-class="{'has-error': forms.registrationForm.companyIndustry.$invalid && !forms.registrationForm.companyIndustry.$pristine}" ng-show="newUser">
+              <div class="form-group" ng-class="{'has-error': forms.registrationForm.companyIndustry.$invalid && !forms.registrationForm.companyIndustry.$pristine}" ng-show="registrationFactory.newUser">
                 <label for="companyIndustry">Tell us your Industry to help us make your displays look great: *</label>
-                <select class="form-control selectpicker companyIndustry" name="companyIndustry" id="companyIndustry" tabindex="1" aria-required="true" ng-model="company.companyIndustry" ng-required="newUser">
+                <select class="form-control selectpicker companyIndustry" name="companyIndustry" id="companyIndustry" tabindex="1" aria-required="true" ng-model="registrationFactory.company.companyIndustry" ng-required="registrationFactory.newUser">
                   <option value="" ng-show="false">&lt; Select Industry &gt;</option>
                   <option class="companyIndustryOption"
                     ng-repeat="industry in DROPDOWN_INDUSTRY_FIELDS | orderBy:industry[0]" value="{{industry[1]}}">{{industry[0]}}
@@ -52,7 +52,7 @@
               <div class="form-group">
                 <div class="checkbox" ng-class="{ 'has-error' : forms.registrationForm.accepted.$invalid && !userForm.accepted.$pristine }">
                   <label for="accepted">
-                    <input type="checkbox" id="accepted" name="accepted" class="accept-terms-checkbox" ng-model="profile.accepted" tabindex="1" required />
+                    <input type="checkbox" id="accepted" name="accepted" class="accept-terms-checkbox" ng-model="registrationFactory.profile.accepted" tabindex="1" required />
                     <span>
                        I accept the
                        <a class="madero-link" href="https://help.risevision.com/hc/en-us/articles/360000924446-Terms-of-Service" target="_blank" tabindex="1">Terms of Service</a>

--- a/src/scripts/components/userstate/app.js
+++ b/src/scripts/components/userstate/app.js
@@ -140,23 +140,14 @@
             url: '/unregistered/:state',
             controller: 'RegistrationCtrl',
             resolve: {
-              newUser: ['userState', 'getUserProfile',
-                function(userState, getUserProfile) {
-                  return getUserProfile(userState.getUsername())
-                    .catch(function (resp) {
-                      if (resp && resp.message === 'User has not yet accepted the Terms of Service') {
-                        return false;
-                      } else {
-                        return true;
-                      }
-                    });
-                }
-              ],
-              account: ['getAccount',
-                function (getAccount) {
-                  return getAccount()
+              authenticate: ['userAuthFactory', 'registrationFactory',
+                function(userAuthFactory, registrationFactory) {
+                  return userAuthFactory.authenticate(false)
+                    .then(function () {
+                      registrationFactory.init();
+                    })
                     .catch(function () {
-                      return null;
+                      // return to signin page
                     });
                 }
               ]

--- a/src/scripts/components/userstate/app.js
+++ b/src/scripts/components/userstate/app.js
@@ -140,18 +140,21 @@
             url: '/unregistered/:state',
             controller: 'RegistrationCtrl',
             resolve: {
-              account: ['userState', 'getUserProfile', 'getAccount',
-                function (userState, getUserProfile, getAccount) {
+              newUser: ['userState', 'getUserProfile',
+                function(userState, getUserProfile) {
                   return getUserProfile(userState.getUsername())
-                    .then(null, function (resp) {
-                      if (resp && resp.message ===
-                        'User has not yet accepted the Terms of Service'
-                      ) {
-                        return getAccount();
+                    .catch(function (resp) {
+                      if (resp && resp.message === 'User has not yet accepted the Terms of Service') {
+                        return false;
                       } else {
-                        return null;
+                        return true;
                       }
-                    })
+                    });
+                }
+              ],
+              account: ['getAccount',
+                function (getAccount) {
+                  return getAccount()
                     .catch(function () {
                       return null;
                     });

--- a/src/scripts/components/userstate/controllers/ctr-registration.js
+++ b/src/scripts/components/userstate/controllers/ctr-registration.js
@@ -1,28 +1,13 @@
 'use strict';
 
 angular.module('risevision.common.components.userstate')
-  .controller('RegistrationCtrl', [
-    '$scope', '$rootScope',
-    '$loading', 'addAccount', '$exceptionHandler',
-    'userState', 'pick', 'messageBox', 'humanReadableError',
-    'agreeToTermsAndUpdateUser', 'newUser', 'account', 'analyticsFactory',
-    'bigQueryLogging', 'currentPlanFactory',
-    'COMPANY_INDUSTRY_FIELDS', 'EDUCATION_INDUSTRIES', 'urlStateService', 'hubspot',
-    function ($scope, $rootScope, $loading, addAccount,
-      $exceptionHandler, userState, pick, messageBox, humanReadableError,
-      agreeToTermsAndUpdateUser, newUser, account, analyticsFactory, bigQueryLogging,
-      currentPlanFactory, COMPANY_INDUSTRY_FIELDS, EDUCATION_INDUSTRIES, urlStateService, hubspot) {
+  .controller('RegistrationCtrl', ['$scope', '$loading', 'registrationFactory',
+    'urlStateService', 'COMPANY_INDUSTRY_FIELDS',
+    function ($scope, $loading, registrationFactory, urlStateService,
+      COMPANY_INDUSTRY_FIELDS) {
 
-      $scope.newUser = newUser;
+      $scope.registrationFactory = registrationFactory;
       $scope.DROPDOWN_INDUSTRY_FIELDS = COMPANY_INDUSTRY_FIELDS;
-
-      var copyOfProfile = account || {};
-
-      $scope.company = {};
-
-      $scope.profile = pick(copyOfProfile, 'email', 'firstName', 'lastName', 'mailSyncEnabled');
-      $scope.profile.email = $scope.profile.email || userState.getUsername();
-      $scope.registering = false;
 
       $scope.save = function () {
         $scope.forms.registrationForm.accepted.$pristine = false;
@@ -32,78 +17,19 @@ angular.module('risevision.common.components.userstate')
         $scope.forms.registrationForm.companyIndustry.$pristine = false;
 
         if (!$scope.forms.registrationForm.$invalid) {
-          //update terms and conditions date
-          $scope.registering = true;
-          $loading.start('registration-modal');
-
-          var action;
-          if ($scope.newUser) {
-            // Automatically subscribe education users on registration or if they were already subscribed
-            $scope.profile.mailSyncEnabled = $scope.profile.mailSyncEnabled || isEducation($scope.company.companyIndustry);
-
-            action = addAccount($scope.profile.firstName, $scope.profile.lastName, $scope.company.name, $scope
-              .company.companyIndustry, $scope.profile.mailSyncEnabled);
-          } else {
-            // Automatically subscribe education users on registration or if they were already subscribed
-            $scope.profile.mailSyncEnabled = $scope.profile.mailSyncEnabled || isEducation(copyOfProfile.companyIndustry);
-
-            action = agreeToTermsAndUpdateUser(userState.getUsername(), $scope.profile);
-          }
-
-          action
-            .then(function () {
-              userState.refreshProfile()
-                .finally(function () {
-                  if ($scope.newUser) {
-                    currentPlanFactory.initVolumePlanTrial();
-                  }
-
-                  var userCompany = userState.getCopyOfUserCompany();
-                  var userProfile = userState.getCopyOfProfile();
-                  analyticsFactory.track('User Registered', {
-                    'companyId': userState.getUserCompanyId(),
-                    'companyName': userState.getUserCompanyName(),
-                    'parentId': userCompany.parentId,
-                    'isNewCompany': $scope.newUser,
-                    'registeredDate': userProfile.creationDate,
-                    'invitationAcceptedDate': $scope.newUser ? null : new Date()
-                  });
-
-                  hubspot.loadAs(userState.getUsername());
-
-                  bigQueryLogging.logEvent('User Registered');
-
-                  $rootScope.$broadcast('risevision.user.authorized');
-
-                  $loading.stop('registration-modal');
-                });
-            })
-            .catch(function (err) {
-              messageBox('Error', humanReadableError(err));
-              $exceptionHandler(err, 'User registration failed.', true);
-
-              userState.refreshProfile();
-            })
-            .finally(function () {
-              $scope.registering = false;
-            });
+          registrationFactory.register();
         }
-
-      };
-
-      var isEducation = function (companyIndustry) {
-        return EDUCATION_INDUSTRIES.indexOf(companyIndustry) !== -1;
       };
 
       var populateIndustryFromUrl = function () {
 
         var industryName = urlStateService.getUrlParam('industry');
 
-        if ($scope.newUser && industryName) {
+        if (registrationFactory.newUser && industryName) {
 
           COMPANY_INDUSTRY_FIELDS.forEach(function (industry) {
             if (industryName === industry[0]) {
-              $scope.company.companyIndustry = industry[1];
+              registrationFactory.company.companyIndustry = industry[1];
             }
           });
         }
@@ -112,5 +38,14 @@ angular.module('risevision.common.components.userstate')
       populateIndustryFromUrl();
 
       $scope.forms = {};
+
+      $scope.$watch('registrationFactory.loading', function (loading) {
+        if (loading) {
+          $loading.start('registration-loader');
+        } else {
+          $loading.stop('registration-loader');
+        }
+      });
+
     }
   ]);

--- a/src/scripts/components/userstate/services/svc-registration-factory.js
+++ b/src/scripts/components/userstate/services/svc-registration-factory.js
@@ -1,0 +1,124 @@
+(function (angular) {
+  'use strict';
+  /*jshint camelcase: false */
+
+  angular.module('risevision.common.components.userstate')
+    .factory('registrationFactory', ['$q', '$log', 
+    'userState', 'getUserProfile', 'getAccount',
+    '$rootScope', 'addAccount', '$exceptionHandler',
+    'pick', 'messageBox', 'humanReadableError',
+    'agreeToTermsAndUpdateUser', 'analyticsFactory',
+    'bigQueryLogging', 'currentPlanFactory',
+    'hubspot', 'EDUCATION_INDUSTRIES',
+      function ($q, $log, userState, getUserProfile, getAccount,
+        $rootScope, addAccount,
+        $exceptionHandler, pick, messageBox, humanReadableError,
+        agreeToTermsAndUpdateUser, analyticsFactory, bigQueryLogging,
+        currentPlanFactory, hubspot, EDUCATION_INDUSTRIES) {
+        var factory = {};
+
+        var _reset = function() {
+          factory.newUser = true;
+
+          factory.profile = {};
+          factory.company = {};
+        };
+
+        var _checkNewUser = function() {
+          return getUserProfile(userState.getUsername())
+            .catch(function (resp) {
+              if (resp && resp.message === 'User has not yet accepted the Terms of Service') {
+                factory.newUser = false;
+              } else {
+                factory.newUser = true;
+              }
+            });
+        };
+
+        var _getAccount = function() {
+          return getAccount()
+            .catch(function () {
+              return null;
+            });
+        };
+
+        factory.init = function() {
+          _reset();
+
+          factory.loading = true;
+
+          $q.all([_getAccount(), _checkNewUser()])
+            .then(function(result) {
+              var account = result[0] || {};
+
+              factory.profile = pick(account, 'email', 'firstName', 'lastName', 'mailSyncEnabled');
+              factory.profile.email = factory.profile.email || userState.getUsername();
+              factory.company.companyIndustry = account.companyIndustry;
+            })
+            .finally(function() {
+              factory.loading = false;              
+            });
+        };
+
+        var _isEducation = function (companyIndustry) {
+          return EDUCATION_INDUSTRIES.indexOf(companyIndustry) !== -1;
+        };
+
+        factory.register = function() {
+          var action;
+
+          // Automatically subscribe education users on registration or if they were already subscribed
+          factory.profile.mailSyncEnabled = factory.profile.mailSyncEnabled || _isEducation(factory.company.companyIndustry);
+
+          factory.loading = true;              
+
+          if (factory.newUser) {
+            action = addAccount(factory.profile.firstName, factory.profile.lastName, factory.company.name, factory
+              .company.companyIndustry, factory.profile.mailSyncEnabled);
+          } else {
+            action = agreeToTermsAndUpdateUser(userState.getUsername(), factory.profile);
+          }
+
+          action
+            .then(function () {
+              userState.refreshProfile()
+                .finally(function () {
+                  if (factory.newUser) {
+                    currentPlanFactory.initVolumePlanTrial();
+                  }
+
+                  var userCompany = userState.getCopyOfUserCompany();
+                  var userProfile = userState.getCopyOfProfile();
+                  analyticsFactory.track('User Registered', {
+                    'companyId': userState.getUserCompanyId(),
+                    'companyName': userState.getUserCompanyName(),
+                    'parentId': userCompany.parentId,
+                    'isNewCompany': factory.newUser,
+                    'registeredDate': userProfile.creationDate,
+                    'invitationAcceptedDate': factory.newUser ? null : new Date()
+                  });
+
+                  hubspot.loadAs(userState.getUsername());
+
+                  bigQueryLogging.logEvent('User Registered');
+
+                  $rootScope.$broadcast('risevision.user.authorized');
+
+                  factory.loading = false;              
+                });
+            })
+            .catch(function (err) {
+              messageBox('Error', humanReadableError(err));
+              $exceptionHandler(err, 'User registration failed.', true);
+
+              userState.refreshProfile();
+
+              factory.loading = false;              
+            });
+        };
+
+        return factory;
+      }
+    ]);
+
+})(angular);

--- a/test/unit/components/userstate/controllers/ctr-registration.spec.js
+++ b/test/unit/components/userstate/controllers/ctr-registration.spec.js
@@ -6,140 +6,31 @@
 describe("controller: registration", function() {
   beforeEach(module("risevision.common.components.userstate"));
   beforeEach(module(function ($provide) {
-    $provide.service("userState", function(){
+    $provide.factory('registrationFactory', function() {
       return {
-        getCopyOfProfile: function() {
-          return {
-            creationDate: 'creationDate'
-          };
-        },
-        getUsername: function() {
-          return "e@mail.com";
-        },
-        _restoreState : function(){
-          
-        },
-        getUserCompanyId : function(){
-          return "some_company_id";
-        },
-        getUserCompanyName: function() {
-          return "company_name";
-        },
-        updateCompanySettings: sinon.stub(),
-        refreshProfile: function() {
-          var deferred = Q.defer();
-          
-          deferred.resolve({});
-          
-          return deferred.promise;
-        },
-        getCopyOfUserCompany: function() {
-          return {
-            parentId: "parentId"
-          };
-        }
+        register: sinon.stub()
       };
     });
 
-    $provide.service("updateCompany",function(){
-      return function(companyId, company){
-        updateCompanyCalled = company.name;
-
-        return Q.resolve("companyResult");
-      };
-    });
-    
-    var registrationService = function(calledFrom){
-      return function() {
-        newUser = calledFrom === "addAccount";
-        var deferred = Q.defer();
-        
-        if(registerUser){
-          deferred.resolve("registered");
-        }else{
-          deferred.reject("ERROR");
-        }
-        return deferred.promise;
-      };
-    };
-    
-    $provide.service("addAccount", function(){
-      return registrationService("addAccount");
-    });
-    $provide.service("agreeToTermsAndUpdateUser", function() {
-      return registrationService("agreeToTerms");
-    });
-
-    $provide.service("currentPlanFactory", function() {
-      return currentPlanFactory = {
-        initVolumePlanTrial: sinon.spy()
-      };
-    });
-
-    $provide.service("analyticsFactory", function() { 
+    $provide.service('$loading',function(){
       return {
-        track: sinon.stub(),
-        load: function() {}
-      };
-    });
-
-    $provide.service("$exceptionHandler",function(){
-      return sinon.spy();
-    });
-
-    $provide.service("bigQueryLogging", function() { 
-      return {
-        logEvent: function(name) {
-          bqCalled = name;
-        }
-      };
-    });
-
-    $provide.factory("customLoader", function ($q) {
-      return function () {
-        return Q.resolve({});
-      };
-    });
-
-    $provide.factory("messageBox", function() {
-      return function() {};
-    });
-
-    $provide.factory("hubspot", function() {
-      return {
-        loadAs: sinon.stub()
-      };
-    });
-
-    $provide.factory('account', function() {
-      return account;
+        start : sinon.spy(),
+        stop : sinon.spy()
+      }
     });
 
     $provide.value('COMPANY_INDUSTRY_FIELDS', []);
   }));
-  var $scope, userState, newUser;
-  var registerUser, account, analyticsFactory, bqCalled,
-    updateCompanyCalled, currentPlanFactory, hubspot;
+  var $scope, $loading, registrationFactory;
   
   beforeEach(function() {
-    registerUser = true;
-    bqCalled = undefined;
-    account = {
-      id : "RV_user_id",
-      firstName : "first",
-      lastName : "last",
-      telephone : "telephone"
-    };
-    
     inject(function($injector,$rootScope, $controller){
       $scope = $rootScope.$new();
-      analyticsFactory = $injector.get("analyticsFactory");
-      userState = $injector.get("userState");
-      hubspot = $injector.get('hubspot');
+      $loading = $injector.get('$loading');
+      registrationFactory = $injector.get("registrationFactory");
+
       $controller("RegistrationCtrl", {
-        $scope: $scope,
-        account: account,
-        newUser: true
+        $scope: $scope
       });
       $scope.$digest();
       $scope.forms = {
@@ -157,15 +48,7 @@ describe("controller: registration", function() {
   
   it("should initialize",function(){
     expect($scope).to.be.ok;
-    expect($scope.profile).to.be.ok;
-    
-    expect($scope.profile).to.deep.equal({
-      email: "e@mail.com",
-      firstName: "first",
-      lastName: "last"
-    });
-
-    expect($scope.registering).to.be.false;
+    expect($scope.registrationFactory).to.be.ok;
 
     expect($scope.save).to.exist;
   });
@@ -174,193 +57,35 @@ describe("controller: registration", function() {
     it("should not save if form is invalid", function() {
       $scope.forms.registrationForm.$invalid = true;
       $scope.save();
-      expect($scope.registering).to.be.false;        
+
+      registrationFactory.register.should.not.have.been.called;
     });
 
-    it("should use username as email",function(){
-      expect($scope.profile.email).to.be.equal("e@mail.com");
-    });
-    
-    it("should register user and close the modal",function(done){
+    it("should register user",function(){
       $scope.forms.registrationForm.$invalid = false;
       $scope.save();
-      expect($scope.registering).to.be.true;
-      
-      var profileSpy = sinon.spy(userState, "refreshProfile");
-      setTimeout(function() {
-        expect(newUser).to.be.true;
-        currentPlanFactory.initVolumePlanTrial.should.have.been.called;
-        expect(analyticsFactory.track).to.have.been.calledWith("User Registered",{
-          companyId: "some_company_id",
-          companyName: "company_name",
-          parentId: "parentId",
-          isNewCompany: true,
-          registeredDate: "creationDate",
-          invitationAcceptedDate: null
-        });
-        expect(bqCalled).to.equal("User Registered");
-        hubspot.loadAs.should.have.been.calledWith('e@mail.com');
-        expect($scope.registering).to.be.false;
 
-        expect(profileSpy.called).to.be.true;
-
-        done();
-      },10);
-    });
-
-    it("should handle failure to create user",function(done){
-      registerUser = false;
-      $scope.forms.registrationForm.$invalid = false;
-      $scope.save();
-      
-      var profileSpy = sinon.spy(userState, "refreshProfile");
-      setTimeout(function(){
-        expect(newUser).to.be.true;
-        currentPlanFactory.initVolumePlanTrial.should.not.have.been.called;
-        expect(analyticsFactory.track).to.not.have.been.called;
-        expect(bqCalled).to.not.be.ok;
-        hubspot.loadAs.should.not.have.been.called;
-        expect($scope.registering).to.be.false;
-
-        expect(profileSpy.called).to.be.true;
-
-        done();
-      },10);
-    });
-
-    describe('mailSyncEnabled', function() {
-      it('should enable for education', function() {
-        $scope.forms.registrationForm.$invalid = false;
-        $scope.company.companyIndustry = 'PRIMARY_SECONDARY_EDUCATION';
-        $scope.save();
-        
-        expect($scope.profile.mailSyncEnabled).to.be.true;
-      });
-
-      it('should disable for non education', function() {
-        $scope.forms.registrationForm.$invalid = false;
-        $scope.company.companyIndustry = 'MISC';
-        $scope.save();
-        
-        expect($scope.profile.mailSyncEnabled).to.be.false;
-      });
-
-      it('should not override existing subscription', function() {
-        $scope.forms.registrationForm.$invalid = false;
-        $scope.profile.mailSyncEnabled = true
-        $scope.company.companyIndustry = 'MISC';
-        $scope.save();
-        
-        expect($scope.profile.mailSyncEnabled).to.be.true;
-      });
+      registrationFactory.register.should.have.been.called;
     });
 
   });
-    
-  describe("save existing user: ", function() {
-    beforeEach(function() {
-      inject(function($controller){
-        $controller("RegistrationCtrl", {
-          $scope: $scope,
-          account: account,
-          newUser: false
-        });
-        $scope.$digest();
-        $scope.forms = {
-          registrationForm: {
-            accepted: {},
-            firstName: {},
-            lastName: {},
-            companyName: {},
-            companyIndustry: {},
-            email: {}
-          }
-        };
-      });
 
+  describe('$loading: ', function() {
+    it('should stop spinner', function() {
+      $loading.stop.should.have.been.calledWith('registration-loader');
     });
     
-    it("should not save if form is invalid", function() {
-      $scope.forms.registrationForm.$invalid = true;
-      $scope.save();
-      expect($scope.registering).to.be.false;        
-    });
-    
-    it("should register user and close the modal",function(done){
-      $scope.forms.registrationForm.$invalid = false;
-      $scope.save();
-      expect($scope.registering).to.be.true;
-      
-      var profileSpy = sinon.spy(userState, "refreshProfile");
+    it('should start spinner', function(done) {
+      registrationFactory.loading = true;
+      $scope.$digest();
       setTimeout(function() {
-        expect(newUser).to.be.false;
-        currentPlanFactory.initVolumePlanTrial.should.not.have.been.called;
-        expect(analyticsFactory.track).to.have.been.calledWithMatch("User Registered",{
-          companyId: "some_company_id",
-          companyName: "company_name",
-          parentId: "parentId",
-          isNewCompany: false,
-          registeredDate: "creationDate"
-        });
-        expect(analyticsFactory.track.getCall(0).args[1].invitationAcceptedDate).to.be.a('date');
-        expect(bqCalled).to.equal("User Registered");
-        hubspot.loadAs.should.have.been.calledWith('e@mail.com');
-        expect($scope.registering).to.be.false;
-
-        expect(profileSpy.called).to.be.true;
-
+        $loading.start.should.have.been.calledWith('registration-loader');
+        
         done();
-      },10);
+      }, 10);
     });
-    
-    it("should handle failure to create user",function(done){
-      registerUser = false;
-      $scope.forms.registrationForm.$invalid = false;
-      $scope.save();
-      
-      var profileSpy = sinon.spy(userState, "refreshProfile");
-      setTimeout(function(){
-        expect(newUser).to.be.false;
-        expect(analyticsFactory.track).to.not.have.been.called;
-        expect(bqCalled).to.not.be.ok;
-        hubspot.loadAs.should.not.have.been.called;
-        expect($scope.registering).to.be.false;
-
-        expect(profileSpy.called).to.be.true;
-
-        done();
-      },10);
-    });
-
-    describe('mailSyncEnabled', function() {
-      it('should enable for education', function() {
-        $scope.forms.registrationForm.$invalid = false;
-        account.companyIndustry = 'PRIMARY_SECONDARY_EDUCATION';
-        $scope.save();
-        
-        expect($scope.profile.mailSyncEnabled).to.be.true;
-      });
-
-      it('should disable for non education', function() {
-        $scope.forms.registrationForm.$invalid = false;
-        account.companyIndustry = 'MISC';
-        $scope.save();
-        
-        expect($scope.profile.mailSyncEnabled).to.be.false;
-      });
-
-      it('should not override existing subscription', function() {
-        $scope.forms.registrationForm.$invalid = false;
-        $scope.profile.mailSyncEnabled = true
-        account.companyIndustry = 'MISC';
-        $scope.save();
-        
-        expect($scope.profile.mailSyncEnabled).to.be.true;
-      });
-
-    });
-
   });
+
 
 });
   

--- a/test/unit/components/userstate/services/svc-registration-factory.spec.js
+++ b/test/unit/components/userstate/services/svc-registration-factory.spec.js
@@ -1,0 +1,392 @@
+'use strict';
+describe('service: registrationFactory:', function() {
+  beforeEach(module('risevision.common.components.userstate'));
+
+  beforeEach(module(function ($provide) {
+    $provide.service("$q", function() {return Q;});
+
+    $provide.service('userState', function(){
+      return {
+        getCopyOfProfile: function() {
+          return {
+            creationDate: 'creationDate'
+          };
+        },
+        getUsername: function() {
+          return 'e@mail.com';
+        },
+        _restoreState : function(){
+          
+        },
+        getUserCompanyId : function(){
+          return 'some_company_id';
+        },
+        getUserCompanyName: function() {
+          return 'company_name';
+        },
+        updateCompanySettings: sinon.stub(),
+        refreshProfile: sinon.stub().resolves(),
+        getCopyOfUserCompany: function() {
+          return {
+            parentId: 'parentId'
+          };
+        }
+      };
+    });
+
+    $provide.service('getUserProfile', function(){
+      return sinon.stub().rejects();
+    });
+
+    $provide.service('getAccount', function(){
+      return sinon.stub().resolves();
+    });
+    
+    $provide.service('addAccount', function(){
+      return sinon.stub().resolves('registered');
+    });
+
+    $provide.service('agreeToTermsAndUpdateUser', function() {
+      return sinon.stub().resolves('registered');
+    });
+
+    $provide.service('currentPlanFactory', function() {
+      return currentPlanFactory = {
+        initVolumePlanTrial: sinon.spy()
+      };
+    });
+
+    $provide.service('analyticsFactory', function() { 
+      return {
+        track: sinon.stub(),
+        load: function() {}
+      };
+    });
+
+    $provide.service('$exceptionHandler',function(){
+      return sinon.spy();
+    });
+
+    $provide.service('bigQueryLogging', function() { 
+      return {
+        logEvent: sinon.spy()
+      };
+    });
+
+    $provide.factory('customLoader', function ($q) {
+      return function () {
+        return Q.resolve({});
+      };
+    });
+
+    $provide.factory('messageBox', function() {
+      return function() {};
+    });
+
+    $provide.factory('hubspot', function() {
+      return {
+        loadAs: sinon.stub()
+      };
+    });
+
+  }));
+  
+  var registrationFactory, userState, getUserProfile, getAccount, addAccount, agreeToTermsAndUpdateUser;
+  var analyticsFactory, bigQueryLogging,
+    updateCompanyCalled, currentPlanFactory, hubspot;
+
+  beforeEach(function(){
+    inject(function($injector){
+      userState = $injector.get('userState');
+      analyticsFactory = $injector.get("analyticsFactory");
+      bigQueryLogging = $injector.get('bigQueryLogging');
+      hubspot = $injector.get('hubspot');
+      getUserProfile = $injector.get('getUserProfile');
+      getAccount = $injector.get('getAccount');
+      addAccount = $injector.get('addAccount');
+      agreeToTermsAndUpdateUser = $injector.get('agreeToTermsAndUpdateUser');
+      registrationFactory = $injector.get('registrationFactory');
+    });
+  });
+
+  it('should initialize',function(){
+    expect(registrationFactory).to.be.ok;
+    expect(registrationFactory.init).to.be.a('function');
+    expect(registrationFactory.register).to.be.a('function');
+  });
+  
+  describe('init:', function() {
+    it('should load data and start spinner',function(){
+      registrationFactory.init();
+
+      expect(registrationFactory.loading).to.be.true;
+
+      getUserProfile.should.have.been.calledWith('e@mail.com');
+      getAccount.should.have.been.called;
+    });
+
+    it('should reset old values',function(){
+      registrationFactory.newUser = 'oldvalue';
+      registrationFactory.profile = 'oldprofile';
+      registrationFactory.company = 'oldcompany';
+
+      registrationFactory.init();
+
+      expect(registrationFactory.newUser).to.be.true;
+      expect(registrationFactory.profile).to.deep.equal({});
+      expect(registrationFactory.company).to.deep.equal({});
+
+    });
+
+    describe('_checkNewUser:', function() {
+      it('should handle rejection with a random error',function(done){
+        registrationFactory.init();
+
+        registrationFactory.newUser = 'oldvalue';
+
+        setTimeout(function() {
+          expect(registrationFactory.newUser).to.be.true;
+
+          done();
+        });
+      });
+
+      it('should detect terms acceptance error',function(done){
+        getUserProfile.rejects({
+          message: 'User has not yet accepted the Terms of Service'
+        });
+        
+        registrationFactory.init();
+
+        setTimeout(function() {
+          expect(registrationFactory.newUser).to.be.false;
+
+          done();
+        });
+      });
+
+      it('should use default value if function resolves (should never happen)',function(done){
+        getUserProfile.resolves();
+
+        registrationFactory.init();
+
+        registrationFactory.newUser = 'oldvalue';
+
+        setTimeout(function() {
+          expect(registrationFactory.newUser).to.equal('oldvalue');
+
+          done();
+        });
+      });
+
+    });
+
+    it('should update profile and company objects',function(done){
+      getAccount.resolves({
+        email : "RV_user_id",
+        firstName : "first",
+        lastName : "last",
+        mailSyncEnabled: true,
+        telephone : "telephone",
+        companyIndustry: 'EDUCATION'
+      });
+
+      registrationFactory.init();
+
+      setTimeout(function() {
+        expect(registrationFactory.profile).to.deep.equal({
+          email : "RV_user_id",
+          firstName : "first",
+          lastName : "last",
+          mailSyncEnabled: true
+        });
+
+        expect(registrationFactory.company).to.deep.equal({
+          companyIndustry: 'EDUCATION'
+        });
+
+        expect(registrationFactory.loading).to.be.false;
+
+        done();
+      });
+    });
+
+    it('should use username as email',function(done){
+      registrationFactory.init();
+
+      setTimeout(function() {
+        expect(registrationFactory.profile).to.deep.equal({
+          email : "e@mail.com"
+        });
+
+        expect(registrationFactory.company).to.deep.equal({
+          companyIndustry: undefined
+        });
+
+        done();
+      });
+    });
+
+    it('should handle failure to getAccount',function(done){
+      getAccount.rejects();
+
+      registrationFactory.init();
+
+      setTimeout(function() {
+        expect(registrationFactory.profile).to.deep.equal({
+          email : "e@mail.com"
+        });
+
+        expect(registrationFactory.company).to.deep.equal({
+          companyIndustry: undefined
+        });
+
+        done();
+      });
+    });
+
+  });
+
+  describe('save:', function() {
+    beforeEach(function() {
+      registrationFactory.profile = {};
+      registrationFactory.company = {};
+    });
+    
+    describe('mailSyncEnabled', function() {
+      it('should enable for education', function() {
+        registrationFactory.company.companyIndustry = 'PRIMARY_SECONDARY_EDUCATION';
+        registrationFactory.register();
+        
+        expect(registrationFactory.profile.mailSyncEnabled).to.be.true;
+      });
+
+      it('should disable for non education', function() {
+        registrationFactory.company.companyIndustry = 'MISC';
+        registrationFactory.register();
+        
+        expect(registrationFactory.profile.mailSyncEnabled).to.be.false;
+      });
+
+      it('should not override existing subscription', function() {
+        registrationFactory.profile.mailSyncEnabled = true;
+        registrationFactory.company.companyIndustry = 'MISC';
+        registrationFactory.register();
+        
+        expect(registrationFactory.profile.mailSyncEnabled).to.be.true;
+      });
+    });
+
+    describe('new user: ', function() {      
+      beforeEach(function() {
+        registrationFactory.newUser = true;
+      });
+
+      it('should register user and close the modal', function(done){
+        registrationFactory.register();
+        expect(registrationFactory.loading).to.be.true;
+        
+        setTimeout(function() {
+          addAccount.should.have.been.called;
+          agreeToTermsAndUpdateUser.should.not.have.been.called;
+          
+          currentPlanFactory.initVolumePlanTrial.should.have.been.called;
+          expect(analyticsFactory.track).to.have.been.calledWith('User Registered',{
+            companyId: 'some_company_id',
+            companyName: 'company_name',
+            parentId: 'parentId',
+            isNewCompany: true,
+            registeredDate: 'creationDate',
+            invitationAcceptedDate: null
+          });
+          bigQueryLogging.logEvent.should.have.been.calledWith('User Registered');
+          hubspot.loadAs.should.have.been.calledWith('e@mail.com');
+
+          userState.refreshProfile.should.have.been.called;
+
+          expect(registrationFactory.loading).to.be.false;
+
+          done();
+        },10);
+      });
+
+      it('should handle failure to create user', function(done){
+        addAccount.rejects('error');
+        registrationFactory.register();
+        
+        setTimeout(function(){
+          addAccount.should.have.been.called;
+          agreeToTermsAndUpdateUser.should.not.have.been.called;
+
+          currentPlanFactory.initVolumePlanTrial.should.not.have.been.called;
+          expect(analyticsFactory.track).to.not.have.been.called;
+          bigQueryLogging.logEvent.should.not.have.been.called;
+          hubspot.loadAs.should.not.have.been.called;
+
+          userState.refreshProfile.should.have.been.called;
+
+          expect(registrationFactory.loading).to.be.false;
+
+          done();
+        },10);
+      });
+    });
+      
+    describe('existing user:', function() {
+      beforeEach(function() {
+        registrationFactory.newUser = false;
+      });
+      
+      it('should register user and close the modal', function(done){
+        registrationFactory.register();
+        expect(registrationFactory.loading).to.be.true;
+        
+        setTimeout(function() {
+          addAccount.should.not.have.been.called;
+          agreeToTermsAndUpdateUser.should.have.been.called;
+
+          currentPlanFactory.initVolumePlanTrial.should.not.have.been.called;
+          expect(analyticsFactory.track).to.have.been.calledWithMatch('User Registered',{
+            companyId: 'some_company_id',
+            companyName: 'company_name',
+            parentId: 'parentId',
+            isNewCompany: false,
+            registeredDate: 'creationDate'
+          });
+          expect(analyticsFactory.track.getCall(0).args[1].invitationAcceptedDate).to.be.a('date');
+          bigQueryLogging.logEvent.should.have.been.calledWith('User Registered');
+          hubspot.loadAs.should.have.been.calledWith('e@mail.com');
+
+          userState.refreshProfile.should.have.been.called;
+
+          expect(registrationFactory.loading).to.be.false;
+
+          done();
+        },10);
+      });
+      
+      it('should handle failure to create user', function(done){
+        agreeToTermsAndUpdateUser.rejects('error');
+        registrationFactory.register();
+        
+        setTimeout(function(){
+          addAccount.should.not.have.been.called;
+          agreeToTermsAndUpdateUser.should.have.been.called;
+
+          expect(analyticsFactory.track).to.not.have.been.called;
+          bigQueryLogging.logEvent.should.not.have.been.called;
+          hubspot.loadAs.should.not.have.been.called;
+          expect(registrationFactory.loading).to.be.false;
+
+          userState.refreshProfile.should.have.been.called;
+
+          expect(registrationFactory.loading).to.be.false;
+
+          done();
+        },10);
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
## Description
Keep existing playbook subscription

Call account.get api for new users to check subscription
Split out logic for determining new vs existing account

Clean out dependencies, remove support for user profile
as it is not present

[stage-19]

## Motivation and Context
Intermediary PR for #2687 

## How Has This Been Tested?
Tested locally. Updated unit test coverage.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No