### PR TITLE
Redirect to login page if not authenticated

### DIFF
--- a/src/partials/components/userstate/signup.html
+++ b/src/partials/components/userstate/signup.html
@@ -3,7 +3,7 @@
 <div class="border-container mx-auto">
   <div class="panel-body">
 
-    <div rv-spinner rv-spinner-key="registration-loader" rv-spinner-start-active="0">
+    <div rv-spinner rv-spinner-key="registration-loader" rv-spinner-start-active="1">
       <h4>Help us personalize your experience.</h4>
 
       <div id="registration-modal" stop-event="touchend">

--- a/src/scripts/common/directives/dtv-page-title.js
+++ b/src/scripts/common/directives/dtv-page-title.js
@@ -23,9 +23,6 @@ angular.module('risevision.apps.directives')
             case 'common.auth.resetpassword':
               return 'Reset Password';
 
-            case 'common.auth.confirmaccount':
-              return 'Confirm Account';
-
             case 'common.auth.unsubscribe':
               return 'Unsubscribe';
 

--- a/src/scripts/components/userstate/app.js
+++ b/src/scripts/components/userstate/app.js
@@ -140,14 +140,14 @@
             url: '/unregistered/:state',
             controller: 'RegistrationCtrl',
             resolve: {
-              authenticate: ['userAuthFactory', 'registrationFactory',
-                function(userAuthFactory, registrationFactory) {
+              authenticate: ['$state', '$stateParams', 'userAuthFactory', 'registrationFactory',
+                function($state, $stateParams, userAuthFactory, registrationFactory) {
                   return userAuthFactory.authenticate(false)
                     .then(function () {
                       registrationFactory.init();
                     })
                     .catch(function () {
-                      // return to signin page
+                      $state.go('common.auth.unauthorized', $stateParams);
                     });
                 }
               ]
@@ -206,8 +206,7 @@
         $rootScope.$on('risevision.user.authorized', function () {
           var currentState = $state.current.name;
 
-          if (currentState.indexOf('common.auth') !== -1 && currentState !== 'common.auth.unsubscribe' &&
-            currentState !== 'common.auth.confirmaccount') {
+          if (currentState.indexOf('common.auth') !== -1 && currentState !== 'common.auth.unsubscribe') {
             urlStateService.redirectToState($stateParams.state);
           }
         });

--- a/test/unit/common/directives/dtv-page-title.spec.js
+++ b/test/unit/common/directives/dtv-page-title.spec.js
@@ -67,8 +67,6 @@ describe('directive: page title', function() {
     checkState('common.auth.requestpasswordreset', 'Reset Password');
     checkState('common.auth.resetpassword', 'Reset Password');
 
-    checkState('common.auth.confirmaccount', 'Confirm Account');
-
     checkState('common.auth.unsubscribe', 'Unsubscribe');
 
     // Apps auth routes:

--- a/test/unit/components/userstate/app.spec.js
+++ b/test/unit/components/userstate/app.spec.js
@@ -281,25 +281,37 @@ describe("app:", function() {
       });      
 
       describe('authenticate:', function() {
+        var $stateParams;
+
+        beforeEach(function() {
+          sinon.spy($state, 'go');
+
+          $stateParams = 'stateParams';
+        });
+
         it('should check if user is authenticated', function(done) {
-          $state.get('common.auth.unregistered').resolve.authenticate[2](userAuthFactory, registrationFactory)
+          $state.get('common.auth.unregistered').resolve.authenticate[4]($state, $stateParams, userAuthFactory, registrationFactory)
             .then(function() {
               userAuthFactory.authenticate.should.have.been.calledWith(false);
 
               registrationFactory.init.should.have.been.called;
 
+              $state.go.should.not.have.been.called;
+
               done();
             });
         });
 
-        it('should not proceed if user is not authenticated', function(done) {
+        it('should redirect user to login page if not authenticated', function(done) {
           userAuthFactory.authenticate.rejects();
 
-          $state.get('common.auth.unregistered').resolve.authenticate[2](userAuthFactory, registrationFactory)
+          $state.get('common.auth.unregistered').resolve.authenticate[4]($state, $stateParams, userAuthFactory, registrationFactory)
             .then(function() {
               userAuthFactory.authenticate.should.have.been.calledWith(false);
 
               registrationFactory.init.should.not.have.been.called;
+
+              $state.go.should.have.been.calledWith('common.auth.unauthorized', 'stateParams');
 
               done();
             });


### PR DESCRIPTION
## Description
Redirect to login page if not authenticated

If the user is not authenticated they cant register
But chances are their credentials are in the system

Fix spinner not showing
Remove references to deprecated state

[stage-19]

## Motivation and Context
Unauthenticated users can't register.

## How Has This Been Tested?
Tested locally. Ensured the state variable is preserved. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No