### PR TITLE
Use new 14.17.1-browsers image for docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
 
 defaults: &defaults
   docker: 
-    - image: jenkinsrise/apps-node:10.23.2-browsers
+    - image: jenkinsrise/apps-node:14.17.1-browsers
       auth:
         username: $DOCKERHUB_USERNAME
         password: $DOCKERHUB_PASSWORD

--- a/package-lock.json
+++ b/package-lock.json
@@ -3629,12 +3629,6 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
-    "casperjs": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/casperjs/-/casperjs-1.1.4.tgz",
-      "integrity": "sha1-6wH07YWsUgqPTZMrTap00+d7x0Y=",
-      "dev": true
-    },
     "chai": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
@@ -18841,7 +18835,6 @@
       "requires": {
         "@kollavarsham/gulp-coveralls": "~0.3.4",
         "async": "^0.9.0",
-        "casperjs": "^1.1.4",
         "chai": "^4.2.0",
         "chai-as-promised": "^7.1.1",
         "event-stream": "^4.0.1",


### PR DESCRIPTION
## Description
Use new 14.17.1-browsers image for docker

Update package-lock

[stage-11]

## Motivation and Context
Update docker node version in preparation for angular 12

## How Has This Been Tested?
Build passes. Tested staging.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No