### PR TITLE
Remove link to node_modules; fix assert reference

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -575,8 +575,7 @@
             "buildOptimizer": false,
             "sourceMap": true,
             "optimization": false,
-            "namedChunks": true,
-            "preserveSymlinks": true
+            "namedChunks": true
           },
           "configurations": {
             "deployment": {
@@ -818,8 +817,8 @@
                 "src/scripts/storage/services/svc-upload-overwrite-warning.js",
                 "src/scripts/storage/services/svc-pending-operations-factory.js",
                 "src/scripts/storage/services/svc-encoding.js",
-                "src/node_modules/tus-js-client/dist/tus.min.js",
-                "src/node_modules/compressorjs/dist/compressor.min.js",
+                "node_modules/tus-js-client/dist/tus.min.js",
+                "node_modules/compressorjs/dist/compressor.min.js",
 
                 "src/scripts/storage/filters/ftr-filters.js",
                 "src/scripts/storage/directives/dtv-storage-file-select.js",

--- a/src/app/purchase/services/stripe-loader.service.spec.ts
+++ b/src/app/purchase/services/stripe-loader.service.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import { TestBed } from '@angular/core/testing';
 
 import { StripeLoaderService } from './stripe-loader.service';
-import { fail } from 'assert';
+import { assert } from 'sinon';
 import { UserState } from 'src/app/ajs-upgraded-providers';
 
 describe('StripeLoaderService', () => {
@@ -44,7 +44,7 @@ describe('StripeLoaderService', () => {
   it("should not resolve if Stripe object is not present", function(done) {
     stripeLoader.load()
     .then(function() {
-      fail("failed");
+      assert.fail("failed");
     });
 
     clock.tick(100);

--- a/src/node_modules
+++ b/src/node_modules
@@ -1,1 +1,0 @@
-../node_modules


### PR DESCRIPTION
## Description
Remove link to node_modules

No longer needed/used
Fixes need for symlinks

Fix assert reference

[stage-12]


## Motivation and Context
Fix Angular 12 build.

## How Has This Been Tested?
Tested locally. Tests pass. Tested staging.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No