### PR TITLE
Deprecate APPS_ENV to use the production boolean

### DIFF
--- a/src/environments/environment.beta.ts
+++ b/src/environments/environment.beta.ts
@@ -3,7 +3,6 @@ export const environment = {
   BLUEPRINT_URL: 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/blueprint.json',
   canvaApiKey: '_Ow6FgJpQ3S_k0Mgyo1UX2nM',
   // AngularJS config
-  APPS_ENV: 'PROD',
   CORE_URL: 'https://rvaserver2.appspot.com/_ah/api',
   STORE_SERVER_URL: 'https://store-dot-rvaserver2.appspot.com/',
   STORE_ENDPOINT_URL: 'https://store-dot-rvaserver2.appspot.com/_ah/api',

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -3,7 +3,6 @@ export const environment = {
   BLUEPRINT_URL: 'https://widgets.risevision.com/stable/templates/PRODUCT_CODE/blueprint.json',
   canvaApiKey: '_Ow6FgJpQ3S_k0Mgyo1UX2nM',
   // AngularJS config
-  APPS_ENV: 'PROD',
   CORE_URL: 'https://rvaserver2.appspot.com/_ah/api',
   STORE_SERVER_URL: 'https://store-dot-rvaserver2.appspot.com/',
   STORE_ENDPOINT_URL: 'https://store-dot-rvaserver2.appspot.com/_ah/api',

--- a/src/environments/environment.stage.ts
+++ b/src/environments/environment.stage.ts
@@ -3,7 +3,6 @@ export const environment = {
   BLUEPRINT_URL: 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/blueprint.json',
   canvaApiKey: 'EwLWFws4Qjpa-n_2ZJgBMQbz',
   // AngularJS config
-  APPS_ENV: 'TEST',
   CORE_URL: 'https://rvacore-test.appspot.com/_ah/api',
   STORE_ENDPOINT_URL: 'https://store-dot-rvacore-test.appspot.com/_ah/api',
   STORE_SERVER_URL: 'https://store-dot-rvacore-test.appspot.com/',

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -3,7 +3,6 @@ export const environment = {
   BLUEPRINT_URL: 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/blueprint.json',
   canvaApiKey: 'EwLWFws4Qjpa-n_2ZJgBMQbz',
   // AngularJS config
-  APPS_ENV: 'TEST',
   CORE_URL: 'https://rvacore-test.appspot.com/_ah/api',
   STORE_ENDPOINT_URL: 'https://store-dot-rvacore-test.appspot.com/_ah/api',
   STORE_SERVER_URL: 'https://store-dot-rvacore-test.appspot.com/',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -7,7 +7,6 @@ export const environment = {
   BLUEPRINT_URL: 'https://widgets.risevision.com/staging/templates/PRODUCT_CODE/blueprint.json',
   canvaApiKey: 'EwLWFws4Qjpa-n_2ZJgBMQbz',
   // AngularJS config
-  APPS_ENV: 'TEST',
   CORE_URL: 'https://rvacore-test.appspot.com/_ah/api',
   STORE_ENDPOINT_URL: 'https://store-dot-rvacore-test.appspot.com/_ah/api',
   STORE_SERVER_URL: 'https://store-dot-rvacore-test.appspot.com/',

--- a/src/scripts/editor/services/svc-widget-utils.js
+++ b/src/scripts/editor/services/svc-widget-utils.js
@@ -184,12 +184,16 @@ angular.module('risevision.editor.services')
         }
       };
 
+      var _getEnv = function() {
+        return environment.production ? 'PROD' : 'TEST';
+      };
+
       factory.getWidgetId = function (type) {
         if (!type) {
           return null;
         }
         if (WIDGETS_INFO[type.toUpperCase()]) {
-          return WIDGETS_INFO[type.toUpperCase()].ids[environment.APPS_ENV];
+          return WIDGETS_INFO[type.toUpperCase()].ids[_getEnv()];
         }
         return null;
       };
@@ -211,7 +215,7 @@ angular.module('risevision.editor.services')
 
       factory.getProfessionalWidgets = function () {
         return _.filter(PROFESSIONAL_WIDGETS, function (item) {
-          return !item.env || item.env === environment.APPS_ENV;
+          return !item.env || item.env === _getEnv();
         });
       };
 

--- a/src/scripts/template-editor/components/services/svc-file-existence-check.js
+++ b/src/scripts/template-editor/components/services/svc-file-existence-check.js
@@ -18,7 +18,7 @@ angular.module('risevision.template-editor.services')
       }
 
       function _isDefaultImageOnTestAppsEnvironment(fileName) {
-        if (environment.APPS_ENV !== 'TEST') {
+        if (environment.production) {
           return false;
         }
 

--- a/test/unit/config/test.js
+++ b/test/unit/config/test.js
@@ -15,7 +15,7 @@
   angular.module('risevision.common.config')
     // Mock Angular environment variable
     .value('environment', {
-      APPS_ENV: 'TEST',
+      production: false,
       TAG_MANAGER_CONTAINER_ID: null,
       TAG_MANAGER_AUTH: null,
       TAG_MANAGER_ENV: null,


### PR DESCRIPTION
## Description
Deprecate APPS_ENV to use the production boolean

[stage-12]

## Motivation and Context
Angular migration.

## How Has This Been Tested?
Tested locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No