### PR TITLE
Use a function to match google auth result hash

### DIFF
--- a/src/scripts/components/userstate/app.js
+++ b/src/scripts/components/userstate/app.js
@@ -57,28 +57,24 @@
                 });
             }
           ])
-          .when('/', ['$location', '$state', 'userAuthFactory', 'openidConnect',
-            function ($location, $state, userAuthFactory, openidConnect) {
-              var hash = $location.hash();
-
-              if (hash && hash.match(/.*(id_token|access_token)=.*/)) {
-                console.log('Google Auth result received');
-
-                openidConnect.signinRedirectCallback()
-                  .then(function (user) {
-                    return userAuthFactory.authenticate(true);
-                  })
-                  .then(function () {
-                    window.location.hash = '';
-                  })
-                  .catch(function (e) {
-                    return $state.go('common.auth.unauthorized', {
-                      authError: e
-                    });
+          .when(function(url) {
+            return url.hash && url.hash.match(/.*(id_token|access_token)=.*/);
+          }, ['$state', 'userAuthFactory', 'openidConnect',
+            function ($state, userAuthFactory, openidConnect) {
+              console.log('Google Auth result received');
+        
+              openidConnect.signinRedirectCallback()
+                .then(function (user) {
+                  return userAuthFactory.authenticate(true);
+                })
+                .then(function () {
+                  window.location.hash = '';
+                })
+                .catch(function (e) {
+                  return $state.go('common.auth.unauthorized', {
+                    authError: e
                   });
-              } else {
-                return $state.go('apps.home');
-              }
+                });
             }
           ])
           .otherwise('/');

--- a/src/scripts/components/userstate/controllers/ctr-login.js
+++ b/src/scripts/components/userstate/controllers/ctr-login.js
@@ -20,7 +20,7 @@ angular.module('risevision.common.components.userstate')
 
       var _processErrorCode = function (e, actionName) {
         var error = getError(e);
-        var messageTitle = $filter('translate')('apps-common.errors.messagePrefix');
+        var messageTitle = 'Something went wrong.';
         var message = error.message ? error.message :
           'Please try again or <a target="_blank" href="mailto:support@risevision.com">reach out to our Support team</a> if the problem persists.';
 

--- a/test/unit/components/userstate/controllers/ctr-login.spec.js
+++ b/test/unit/components/userstate/controllers/ctr-login.spec.js
@@ -189,7 +189,7 @@ describe("controller: Log In", function() {
           $loading.stopGlobal.should.have.been.calledWith("auth-buttons-login");
           uiFlowManager.invalidateStatus.should.have.been.calledWith("endStatus");
 
-          expect($scope.errors.messageTitle).to.equal('translated apps-common.errors.messagePrefix');
+          expect($scope.errors.messageTitle).to.equal('Something went wrong.');
           expect($scope.errors.message).to.equal('Please try again or <a target="_blank" href="mailto:support@risevision.com">reach out to our Support team</a> if the problem persists.');
           expect($scope.errors.genericError).to.be.falsey;
           expect($scope.errors.userAccountLockoutError).to.be.falsey;
@@ -283,7 +283,7 @@ describe("controller: Log In", function() {
           $loading.stopGlobal.should.have.been.calledWith("auth-buttons-login");
           uiFlowManager.invalidateStatus.should.have.been.calledWith("endStatus");
 
-          expect($scope.errors.messageTitle).to.equal('translated apps-common.errors.messagePrefix');
+          expect($scope.errors.messageTitle).to.equal('Something went wrong.');
           expect($scope.errors.message).to.equal('Please try again or <a target="_blank" href="mailto:support@risevision.com">reach out to our Support team</a> if the problem persists.');
           expect($scope.errors.genericError).to.be.falsey;
           expect($scope.messages.isGoogleAccount).to.be.falsey;
@@ -305,7 +305,7 @@ describe("controller: Log In", function() {
           $loading.stopGlobal.should.have.been.calledWith("auth-buttons-login");
           uiFlowManager.invalidateStatus.should.have.been.calledWith("endStatus");
 
-          expect($scope.errors.messageTitle).to.equal('translated apps-common.errors.messagePrefix');
+          expect($scope.errors.messageTitle).to.equal('Something went wrong.');
           expect($scope.errors.message).to.equal('Please try again or <a target="_blank" href="mailto:support@risevision.com">reach out to our Support team</a> if the problem persists.');
           expect($scope.errors.genericError).to.be.falsey;
           expect($scope.errors.userAccountLockoutError).to.be.falsey;
@@ -326,7 +326,7 @@ describe("controller: Log In", function() {
           $loading.stopGlobal.should.have.been.calledWith("auth-buttons-login");
           uiFlowManager.invalidateStatus.should.have.been.calledWith("endStatus");
 
-          expect($scope.errors.messageTitle).to.equal('translated apps-common.errors.messagePrefix');
+          expect($scope.errors.messageTitle).to.equal('Something went wrong.');
           expect($scope.errors.message).to.equal('Please try again or <a target="_blank" href="mailto:support@risevision.com">reach out to our Support team</a> if the problem persists.');
           expect($scope.errors.genericError).to.be.falsey;
           expect($scope.messages.isGoogleAccount).to.be.falsey;
@@ -346,7 +346,7 @@ describe("controller: Log In", function() {
           $loading.stopGlobal.should.have.been.calledWith("auth-buttons-login");
           uiFlowManager.invalidateStatus.should.have.been.calledWith("endStatus");
 
-          expect($scope.errors.messageTitle).to.equal('translated apps-common.errors.messagePrefix');
+          expect($scope.errors.messageTitle).to.equal('Something went wrong.');
           expect($scope.errors.message).to.equal('Server error');
           expect($scope.errors.genericError).to.be.falsey;
           expect($scope.messages.isGoogleAccount).to.be.falsey;
@@ -366,7 +366,7 @@ describe("controller: Log In", function() {
           $loading.stopGlobal.should.have.been.calledWith("auth-buttons-login");
           uiFlowManager.invalidateStatus.should.have.been.calledWith("endStatus");
 
-          expect($scope.errors.messageTitle).to.equal('translated apps-common.errors.messagePrefix');
+          expect($scope.errors.messageTitle).to.equal('Something went wrong.');
           expect($scope.errors.message).to.equal('translated apps-common.errors.checkConnection');
           expect($scope.errors.genericError).to.be.falsey;
           expect($scope.messages.isGoogleAccount).to.be.falsey;
@@ -435,7 +435,7 @@ describe("controller: Log In", function() {
         $loading.stopGlobal.should.have.been.calledWith("auth-buttons-login");
         uiFlowManager.invalidateStatus.should.have.been.calledWith("endStatus");
 
-        expect($scope.errors.messageTitle).to.equal('translated apps-common.errors.messagePrefix');
+        expect($scope.errors.messageTitle).to.equal('Something went wrong.');
 
         done();
       },10);
@@ -456,7 +456,7 @@ describe("controller: Log In", function() {
         $loading.stopGlobal.should.have.been.calledWith("auth-buttons-login");
         uiFlowManager.invalidateStatus.should.have.been.calledWith("endStatus");
 
-        expect($scope.errors.messageTitle).to.equal('translated apps-common.errors.messagePrefix');
+        expect($scope.errors.messageTitle).to.equal('Something went wrong.');
 
         done();
       },10);

--- a/test/unit/purchase/app.spec.js
+++ b/test/unit/purchase/app.spec.js
@@ -124,7 +124,8 @@ describe('app:', function() {
           'Ok', 'madero-style centered-modal', 'partials/template-editor/message-box.html', 'sm'
         );
 
-        expect($state.go).to.have.been.calledWith('apps.home');
+        // $state.current.name exists; should not redirect to home
+        expect($state.go).to.not.have.been.calledWith('apps.home');
         expect($state.go).to.not.have.been.calledWith('apps.purchase.licenses.add');
         done();
       },10);
@@ -145,7 +146,8 @@ describe('app:', function() {
           'Ok', 'madero-style centered-modal', 'partials/template-editor/message-box.html', 'sm'
         );
 
-        expect($state.go).to.have.been.calledWith('apps.home');
+        // $state.current.name exists; should not redirect to home
+        expect($state.go).to.not.have.been.calledWith('apps.home');
         expect($state.go).to.not.have.been.calledWith('apps.purchase.licenses.add');
         done();
       },10);


### PR DESCRIPTION
## Description
Use a function to match google auth result hash

Removes the need for home redirect
Revert unit test fixes for apps.home

Fix i18n string that may not have been resolved

[stage-2]

## Motivation and Context
Simplify matcher function.

## How Has This Been Tested?
Tested locally. 
## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No