### PR TITLE
Use redirectTo for redirects

### DIFF
--- a/src/scripts/app.module.ajs.js
+++ b/src/scripts/app.module.ajs.js
@@ -80,14 +80,7 @@ angular.module('risevision.apps', [
 
         .state('apps.home', {
           url: '/',
-          controller: ['$location', '$state', 'canAccessApps',
-            function ($location, $state, canAccessApps) {
-              return canAccessApps().then(function () {
-                $location.replace();
-                $state.go('apps.editor.home');
-              });
-            }
-          ]
+          redirectTo: 'apps.editor.home'
         })
 
         .state('apps.users', {
@@ -157,8 +150,8 @@ angular.module('risevision.apps', [
       }
     }
   ])
-  .run(['$rootScope', '$state', '$stateParams', '$exceptionHandler',
-    function ($rootScope, $state, $stateParams, $exceptionHandler) {
+  .run(['$rootScope', '$state', '$exceptionHandler',
+    function ($rootScope, $state, $exceptionHandler) {
 
       $rootScope.$on('risevision.user.signedOut', function () {
         $state.go('common.auth.unauthorized');
@@ -186,14 +179,14 @@ angular.module('risevision.apps', [
           $state.current.name === 'apps.storage.home' ||
           $state.current.name === 'apps.home') {
 
-          $state.go($state.current, $stateParams, {
+          $state.go($state.current, $state.params, {
             reload: true
           });
         } else if (($state.current.name.indexOf('apps.purchase') !== -1 ||
             $state.current.name.indexOf('apps.billing') !== -1) &&
           $state.current.forceAuth !== false) {
 
-          $state.go('apps.billing.home', $stateParams, {
+          $state.go('apps.billing.home', $state.params, {
             reload: true
           });
         }

--- a/src/scripts/components/userstate/app.js
+++ b/src/scripts/components/userstate/app.js
@@ -57,28 +57,24 @@
                 });
             }
           ])
-          .when('/', ['$location', '$state', 'userAuthFactory', 'openidConnect',
-            function ($location, $state, userAuthFactory, openidConnect) {
-              var hash = $location.hash();
-
-              if (hash && hash.match(/.*(id_token|access_token)=.*/)) {
-                console.log('Google Auth result received');
-
-                openidConnect.signinRedirectCallback()
-                  .then(function (user) {
-                    return userAuthFactory.authenticate(true);
-                  })
-                  .then(function () {
-                    window.location.hash = '';
-                  })
-                  .catch(function (e) {
-                    return $state.go('common.auth.unauthorized', {
-                      authError: e
-                    });
+          .when(function(url) {
+            return url.hash && url.hash.match(/.*(id_token|access_token)=.*/);
+          }, ['$state', 'userAuthFactory', 'openidConnect',
+            function ($state, userAuthFactory, openidConnect) {
+              console.log('Google Auth result received');
+        
+              openidConnect.signinRedirectCallback()
+                .then(function (user) {
+                  return userAuthFactory.authenticate(true);
+                })
+                .then(function () {
+                  window.location.hash = '';
+                })
+                .catch(function (e) {
+                  return $state.go('common.auth.unauthorized', {
+                    authError: e
                   });
-              } else {
-                return $state.go('apps.home');
-              }
+                });
             }
           ])
           .otherwise('/');

--- a/src/scripts/components/userstate/controllers/ctr-login.js
+++ b/src/scripts/components/userstate/controllers/ctr-login.js
@@ -20,7 +20,7 @@ angular.module('risevision.common.components.userstate')
 
       var _processErrorCode = function (e, actionName) {
         var error = getError(e);
-        var messageTitle = $filter('translate')('apps-common.errors.messagePrefix');
+        var messageTitle = 'Something went wrong.';
         var message = error.message ? error.message :
           'Please try again or <a target="_blank" href="mailto:support@risevision.com">reach out to our Support team</a> if the problem persists.';
 

--- a/src/scripts/components/userstate/services/svc-access.js
+++ b/src/scripts/components/userstate/services/svc-access.js
@@ -1,17 +1,13 @@
 'use strict';
 
 angular.module('risevision.common.components.userstate')
-  .factory('canAccessApps', ['$q', '$state', '$location',
+  .factory('canAccessApps', ['$q', '$state',
     'userState', 'userAuthFactory', 'urlStateService',
-    function ($q, $state, $location, userState, userAuthFactory,
-      urlStateService) {
+    function ($q, $state, userState, userAuthFactory, urlStateService) {
       return function (signup, allowReturn) {
-        var deferred = $q.defer();
-        userAuthFactory.authenticate(false)
+        return userAuthFactory.authenticate(false)
           .then(function () {
-            if (userState.isRiseVisionUser()) {
-              deferred.resolve();
-            } else {
+            if (!userState.isRiseVisionUser()) {
               return $q.reject();
             }
           })
@@ -32,19 +28,13 @@ angular.module('risevision.common.components.userstate')
               $state.go(newState, {
                 state: urlStateService.get()
               }, {
-                reload: true
+                reload: true,
+                location: allowReturn ? true : 'replace'
               });
 
-              if (!allowReturn) {
-                $location.replace();
-              }
-
-              deferred.reject();
-            } else {
-              deferred.resolve();
+              return $q.reject();
             }
           });
-        return deferred.promise;
       };
     }
   ]);

--- a/src/scripts/displays/app.js
+++ b/src/scripts/displays/app.js
@@ -14,14 +14,7 @@ angular.module('risevision.apps')
 
         .state('apps.displays.home', {
           url: '/displays',
-          controller: ['canAccessApps', '$state', '$location',
-            function (canAccessApps, $state, $location) {
-              canAccessApps().then(function () {
-                $location.replace();
-                $state.go('apps.displays.list');
-              });
-            }
-          ]
+          redirectTo: 'apps.displays.list'
         })
 
         .state('apps.displays.list', {

--- a/src/scripts/editor/app.js
+++ b/src/scripts/editor/app.js
@@ -14,14 +14,7 @@ angular.module('risevision.apps')
 
         .state('apps.editor.home', {
           url: '/editor',
-          controller: ['canAccessApps', '$state', '$location',
-            function (canAccessApps, $state, $location) {
-              canAccessApps().then(function () {
-                $location.replace();
-                $state.go('apps.editor.list');
-              });
-            }
-          ]
+          redirectTo: 'apps.editor.list'
         })
 
         .state('apps.editor.list', {

--- a/src/scripts/editor/controllers/ctr-workspace.js
+++ b/src/scripts/editor/controllers/ctr-workspace.js
@@ -82,9 +82,8 @@ angular.module('risevision.editor.controllers')
       });
 
       var _bypass = false;
-      $scope.$on('$stateChangeStart', function (event, toState, toParams) {
+      $scope.$on('$stateChangeStart', function (event, toState, toParams, fromState, fromParams) {
         if (_bypass) {
-          _bypass = false;
           return;
         }
         if ($scope.hasUnsavedChanges && $scope.hasContentEditorRole() && (toState.name !==

--- a/src/scripts/purchase/app.js
+++ b/src/scripts/purchase/app.js
@@ -17,11 +17,7 @@ angular.module('risevision.apps')
 
         .state('apps.purchase.plans', {
           url: '/plans',
-          controller: ['$state',
-            function ($state) {
-              $state.go('apps.purchase.home');
-            }
-          ]
+          redirectTo: 'apps.purchase.home'
         })
 
         .state('apps.purchase.home', {

--- a/src/scripts/schedules/app.js
+++ b/src/scripts/schedules/app.js
@@ -14,14 +14,7 @@ angular.module('risevision.apps')
 
         .state('apps.schedules.home', {
           url: '/schedules',
-          controller: ['canAccessApps', '$state', '$location',
-            function (canAccessApps, $state, $location) {
-              canAccessApps().then(function () {
-                $location.replace();
-                $state.go('apps.schedules.list');
-              });
-            }
-          ]
+          redirectTo: 'apps.schedules.list'
         })
 
         .state('apps.schedules.list', {

--- a/test/unit/app.spec.js
+++ b/test/unit/app.spec.js
@@ -160,52 +160,11 @@ describe('app:', function() {
 
   });
 
-  describe('state apps.home:',function(){
-    it('should register state',function(){
-      var state = $state.get('apps.home');
-      expect(state).to.be.ok;
-      expect(state.url).to.equal('/');
-      expect(state.controller).to.be.ok;
-    });
-
-    it('should redirect to editor',function(done){
-      var $location = {
-        replace: sinon.spy()
-      };
-
-      sinon.spy($state,'go');
-      
-      $state.get('apps.home').controller[3]($location, $state, canAccessApps);
-
-      setTimeout(function() {
-        canAccessApps.should.have.been.called;
-
-        $location.replace.should.have.been.called;
-        $state.go.should.have.been.calledWith('apps.editor.home');
-
-        done();
-      }, 10);
-    });
-
-    it('should not redirect if user is not logged in',function(done){
-      canAccessApps.returns(Q.reject());
-
-      var $location = {
-        replace: sinon.spy()
-      };
-
-      sinon.spy($state,'go');
-      
-      $state.get('apps.home').controller[3]($location, $state, canAccessApps);
-
-      setTimeout(function() {
-        $location.replace.should.not.have.been.called;
-        $state.go.should.not.have.been.called;
-
-        done();
-      }, 10);
-    });
-
+  it('state apps.home:',function(){
+    var state = $state.get('apps.home');
+    expect(state).to.be.ok;
+    expect(state.url).to.equal('/');
+    expect(state.redirectTo).to.equal('apps.editor.home');
   });
 
   describe('state common.auth.signup:',function(){

--- a/test/unit/components/userstate/controllers/ctr-login.spec.js
+++ b/test/unit/components/userstate/controllers/ctr-login.spec.js
@@ -189,7 +189,7 @@ describe("controller: Log In", function() {
           $loading.stopGlobal.should.have.been.calledWith("auth-buttons-login");
           uiFlowManager.invalidateStatus.should.have.been.calledWith("endStatus");
 
-          expect($scope.errors.messageTitle).to.equal('translated apps-common.errors.messagePrefix');
+          expect($scope.errors.messageTitle).to.equal('Something went wrong.');
           expect($scope.errors.message).to.equal('Please try again or <a target="_blank" href="mailto:support@risevision.com">reach out to our Support team</a> if the problem persists.');
           expect($scope.errors.genericError).to.be.falsey;
           expect($scope.errors.userAccountLockoutError).to.be.falsey;
@@ -283,7 +283,7 @@ describe("controller: Log In", function() {
           $loading.stopGlobal.should.have.been.calledWith("auth-buttons-login");
           uiFlowManager.invalidateStatus.should.have.been.calledWith("endStatus");
 
-          expect($scope.errors.messageTitle).to.equal('translated apps-common.errors.messagePrefix');
+          expect($scope.errors.messageTitle).to.equal('Something went wrong.');
           expect($scope.errors.message).to.equal('Please try again or <a target="_blank" href="mailto:support@risevision.com">reach out to our Support team</a> if the problem persists.');
           expect($scope.errors.genericError).to.be.falsey;
           expect($scope.messages.isGoogleAccount).to.be.falsey;
@@ -305,7 +305,7 @@ describe("controller: Log In", function() {
           $loading.stopGlobal.should.have.been.calledWith("auth-buttons-login");
           uiFlowManager.invalidateStatus.should.have.been.calledWith("endStatus");
 
-          expect($scope.errors.messageTitle).to.equal('translated apps-common.errors.messagePrefix');
+          expect($scope.errors.messageTitle).to.equal('Something went wrong.');
           expect($scope.errors.message).to.equal('Please try again or <a target="_blank" href="mailto:support@risevision.com">reach out to our Support team</a> if the problem persists.');
           expect($scope.errors.genericError).to.be.falsey;
           expect($scope.errors.userAccountLockoutError).to.be.falsey;
@@ -326,7 +326,7 @@ describe("controller: Log In", function() {
           $loading.stopGlobal.should.have.been.calledWith("auth-buttons-login");
           uiFlowManager.invalidateStatus.should.have.been.calledWith("endStatus");
 
-          expect($scope.errors.messageTitle).to.equal('translated apps-common.errors.messagePrefix');
+          expect($scope.errors.messageTitle).to.equal('Something went wrong.');
           expect($scope.errors.message).to.equal('Please try again or <a target="_blank" href="mailto:support@risevision.com">reach out to our Support team</a> if the problem persists.');
           expect($scope.errors.genericError).to.be.falsey;
           expect($scope.messages.isGoogleAccount).to.be.falsey;
@@ -346,7 +346,7 @@ describe("controller: Log In", function() {
           $loading.stopGlobal.should.have.been.calledWith("auth-buttons-login");
           uiFlowManager.invalidateStatus.should.have.been.calledWith("endStatus");
 
-          expect($scope.errors.messageTitle).to.equal('translated apps-common.errors.messagePrefix');
+          expect($scope.errors.messageTitle).to.equal('Something went wrong.');
           expect($scope.errors.message).to.equal('Server error');
           expect($scope.errors.genericError).to.be.falsey;
           expect($scope.messages.isGoogleAccount).to.be.falsey;
@@ -366,7 +366,7 @@ describe("controller: Log In", function() {
           $loading.stopGlobal.should.have.been.calledWith("auth-buttons-login");
           uiFlowManager.invalidateStatus.should.have.been.calledWith("endStatus");
 
-          expect($scope.errors.messageTitle).to.equal('translated apps-common.errors.messagePrefix');
+          expect($scope.errors.messageTitle).to.equal('Something went wrong.');
           expect($scope.errors.message).to.equal('translated apps-common.errors.checkConnection');
           expect($scope.errors.genericError).to.be.falsey;
           expect($scope.messages.isGoogleAccount).to.be.falsey;
@@ -435,7 +435,7 @@ describe("controller: Log In", function() {
         $loading.stopGlobal.should.have.been.calledWith("auth-buttons-login");
         uiFlowManager.invalidateStatus.should.have.been.calledWith("endStatus");
 
-        expect($scope.errors.messageTitle).to.equal('translated apps-common.errors.messagePrefix');
+        expect($scope.errors.messageTitle).to.equal('Something went wrong.');
 
         done();
       },10);
@@ -456,7 +456,7 @@ describe("controller: Log In", function() {
         $loading.stopGlobal.should.have.been.calledWith("auth-buttons-login");
         uiFlowManager.invalidateStatus.should.have.been.calledWith("endStatus");
 
-        expect($scope.errors.messageTitle).to.equal('translated apps-common.errors.messagePrefix');
+        expect($scope.errors.messageTitle).to.equal('Something went wrong.');
 
         done();
       },10);

--- a/test/unit/components/userstate/services/svc-access.spec.js
+++ b/test/unit/components/userstate/services/svc-access.spec.js
@@ -40,18 +40,6 @@ describe("service: access:", function() {
         })
       };
     });
-    $provide.service("$location", function() {
-      return $location = {
-        replace: sinon.spy(),
-        path: sinon.spy(),
-        search: sinon.spy(),
-        hash: sinon.spy(),
-        port: sinon.spy(),
-        protocol: sinon.spy(),
-        host: sinon.spy(),
-        url: sinon.spy()
-      };
-    });
     $provide.service("urlStateService", function() {
       return {
         get: function() {
@@ -61,7 +49,7 @@ describe("service: access:", function() {
     });
   }));
   
-  var canAccessApps, $location, $state, stateAvailable, authenticate, isRiseVisionUser, isLoggedIn;
+  var canAccessApps, $state, stateAvailable, authenticate, isRiseVisionUser, isLoggedIn;
   beforeEach(function(){
     isRiseVisionUser = true;
     authenticate = true;
@@ -101,10 +89,9 @@ describe("service: access:", function() {
       $state.go.should.have.been.calledWith("common.auth.unregistered", {
         state: "newState"
       }, {
-        reload: true
+        reload: true,
+        location: 'replace'
       });
-
-      $location.replace.should.have.been.called;
 
       done();
     });  
@@ -123,10 +110,9 @@ describe("service: access:", function() {
       $state.go.should.have.been.calledWith("common.auth.unregistered", {
         state: "newState"
       }, {
-        reload: true
+        reload: true,
+        location: true
       });
-
-      $location.replace.should.not.have.been.called;
 
       done();
     });  
@@ -141,8 +127,6 @@ describe("service: access:", function() {
     canAccessApps()
     .then(function() {
       $state.go.should.not.have.been.called;
-
-      $location.replace.should.not.have.been.called;
 
       done();
     })
@@ -164,10 +148,9 @@ describe("service: access:", function() {
       $state.go.should.have.been.calledWith("common.auth.unauthorized", {
         state: "newState"
       }, {
-        reload: true
+        reload: true,
+        location: 'replace'
       });
-
-      $location.replace.should.have.been.called;
 
       done();
     });
@@ -186,10 +169,9 @@ describe("service: access:", function() {
       $state.go.should.have.been.calledWith("common.auth.unauthorized", {
         state: "newState"
       }, {
-        reload: true
+        reload: true,
+        location: 'replace'
       });
-
-      $location.replace.should.have.been.called;
 
       done();
     });
@@ -208,10 +190,9 @@ describe("service: access:", function() {
       $state.go.should.have.been.calledWith("common.auth.createaccount", {
         state: "newState"
       }, {
-        reload: true
+        reload: true,
+        location: 'replace'
       });
-
-      $location.replace.should.have.been.called;
 
       done();
     });

--- a/test/unit/purchase/app.spec.js
+++ b/test/unit/purchase/app.spec.js
@@ -41,25 +41,12 @@ describe('app:', function() {
 
   var $state, canAccessApps, currentPlanFactory, userState, $rootScope, messageBoxStub, $location;
 
-  describe('state apps.purchase.plans:',function(){
-    it('should register state',function(){
-      var state = $state.get('apps.purchase.plans');
-      expect(state).to.be.ok;
-      expect(state.url).to.equal('/plans');
-      expect(state.controller).to.be.ok;
-    });
-
-    it('should navigate the purchase page',function(done){
-      $state.get('apps.purchase.plans').controller[1]($state);
-      setTimeout(function() {
-        $state.go.should.have.been.calledWith('apps.purchase.home');
-
-        done();
-      }, 10);
-    });
-
+  it('state apps.purchase.plans:',function(){
+    var state = $state.get('apps.purchase.plans');
+    expect(state).to.be.ok;
+    expect(state.url).to.equal('/plans');
+    expect(state.redirectTo).to.equal('apps.purchase.home');
   });
-
 
   describe('state apps.purchase.home:', function(){
     it('should register state',function(){
@@ -124,8 +111,7 @@ describe('app:', function() {
           'Ok', 'madero-style centered-modal', 'partials/template-editor/message-box.html', 'sm'
         );
 
-        // $state.current.name exists; should not redirect to home
-        expect($state.go).to.not.have.been.calledWith('apps.home');
+        expect($state.go).to.have.been.calledWith('apps.home');
         expect($state.go).to.not.have.been.calledWith('apps.purchase.licenses.add');
         done();
       },10);
@@ -146,8 +132,7 @@ describe('app:', function() {
           'Ok', 'madero-style centered-modal', 'partials/template-editor/message-box.html', 'sm'
         );
 
-        // $state.current.name exists; should not redirect to home
-        expect($state.go).to.not.have.been.calledWith('apps.home');
+        expect($state.go).to.have.been.calledWith('apps.home');
         expect($state.go).to.not.have.been.calledWith('apps.purchase.licenses.add');
         done();
       },10);

--- a/test/unit/purchase/app.spec.js
+++ b/test/unit/purchase/app.spec.js
@@ -124,7 +124,8 @@ describe('app:', function() {
           'Ok', 'madero-style centered-modal', 'partials/template-editor/message-box.html', 'sm'
         );
 
-        expect($state.go).to.have.been.calledWith('apps.home');
+        // $state.current.name exists; should not redirect to home
+        expect($state.go).to.not.have.been.calledWith('apps.home');
         expect($state.go).to.not.have.been.calledWith('apps.purchase.licenses.add');
         done();
       },10);
@@ -145,7 +146,8 @@ describe('app:', function() {
           'Ok', 'madero-style centered-modal', 'partials/template-editor/message-box.html', 'sm'
         );
 
-        expect($state.go).to.have.been.calledWith('apps.home');
+        // $state.current.name exists; should not redirect to home
+        expect($state.go).to.not.have.been.calledWith('apps.home');
         expect($state.go).to.not.have.been.calledWith('apps.purchase.licenses.add');
         done();
       },10);


### PR DESCRIPTION
## Description
Use redirectTo for redirects

Use state.params as they are more reliable

Remove bypass reset; route redirect calls handler twice

[stage-11]

## Motivation and Context
Simplify ui-router implementation. Prevent issues caused by the multiple redirects.

## How Has This Been Tested?
Tested locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No