### PR TITLE
Add internal watch for spinner

### DIFF
--- a/src/partials/billing/add-payment-source.html
+++ b/src/partials/billing/add-payment-source.html
@@ -4,7 +4,7 @@
     <h1 class="app-header-title">Add Payment Method</h1>
   </div>
 
-  <div rv-spinner rv-spinner-key="payment-source-loader" rv-spinner-start-active="1"></div>
+  <div rv-spinner rv-spinner-key="payment-source-loader"></div>
 
   <div id="errorBox" ng-show="subscriptionFactory.apiError" class="madero-style alert alert-danger text-center u_margin-md-top" role="alert">
     <strong>{{subscriptionFactory.apiError}}</strong>

--- a/src/partials/billing/app-billing.html
+++ b/src/partials/billing/app-billing.html
@@ -4,7 +4,7 @@
     <h1 class="app-header-title">Account & Billing</h1>
   </div>
 
-  <div rv-spinner rv-spinner-key="billing-loader" rv-spinner-start-active="1">
+  <div rv-spinner rv-spinner-key="billing-loader">
 
     <div class="form-group mt-5 mb-3">
       <label>Billing Settings</label>

--- a/src/partials/billing/invoice.html
+++ b/src/partials/billing/invoice.html
@@ -18,7 +18,7 @@
     </div>
   </div>
 
-  <div rv-spinner rv-spinner-key="invoice-loader"></div>
+  <div rv-spinner rv-spinner-key="invoice-loader" rv-show-spinner="invoiceFactory.loading"></div>
 
   <div id="errorBox" ng-show="invoiceFactory.apiError" class="madero-style alert alert-danger" role="alert">
     <strong>{{invoiceFactory.apiError}}</strong>

--- a/src/partials/billing/invoice.html
+++ b/src/partials/billing/invoice.html
@@ -18,7 +18,7 @@
     </div>
   </div>
 
-  <div rv-spinner rv-spinner-key="invoice-loader" rv-spinner-start-active="1"></div>
+  <div rv-spinner rv-spinner-key="invoice-loader"></div>
 
   <div id="errorBox" ng-show="invoiceFactory.apiError" class="madero-style alert alert-danger" role="alert">
     <strong>{{invoiceFactory.apiError}}</strong>

--- a/src/partials/billing/subscription.html
+++ b/src/partials/billing/subscription.html
@@ -4,7 +4,7 @@
     <h1 class="app-header-title">Subscription</h1>
   </div>
 
-  <div rv-spinner rv-spinner-key="subscription-loader" rv-spinner-start-active="1">
+  <div rv-spinner rv-spinner-key="subscription-loader">
 
   <div id="errorBox" ng-show="subscriptionFactory.apiError" class="madero-style alert alert-danger" role="alert">
     <strong>{{subscriptionFactory.apiError}}</strong>

--- a/src/partials/billing/unpaid-invoices.html
+++ b/src/partials/billing/unpaid-invoices.html
@@ -15,7 +15,7 @@
     <h4>Unpaid Invoices</h4>
   </div>
 
-  <div rv-spinner rv-spinner-key="unpaid-invoice-loader"></div>
+  <div rv-spinner rv-spinner-key="unpaid-invoice-loader" rv-show-spinner="unpaidInvoices.loadingItems"></div>
   <div id="errorBox" ng-show="unpaidInvoices.apiError" class="madero-style alert alert-danger" role="alert">
     <p><strong>{{unpaidInvoices.errorMessage}}</strong></p>
     {{unpaidInvoices.apiError}}

--- a/src/partials/billing/unpaid-invoices.html
+++ b/src/partials/billing/unpaid-invoices.html
@@ -15,7 +15,7 @@
     <h4>Unpaid Invoices</h4>
   </div>
 
-  <div rv-spinner rv-spinner-key="unpaid-invoice-loader" rv-spinner-start-active="1"></div>
+  <div rv-spinner rv-spinner-key="unpaid-invoice-loader"></div>
   <div id="errorBox" ng-show="unpaidInvoices.apiError" class="madero-style alert alert-danger" role="alert">
     <p><strong>{{unpaidInvoices.errorMessage}}</strong></p>
     {{unpaidInvoices.apiError}}

--- a/src/partials/common-header/company-selector-modal.html
+++ b/src/partials/common-header/company-selector-modal.html
@@ -21,7 +21,6 @@
 		<div class="panel panel-default scrollable-list u_margin-sm-top"
 		  scrolling-list="companies.load()"
 		  rv-spinner rv-spinner-key="company-selector-modal-list"
-			rv-spinner-start-active="1"
 		>
 			<div class="list-group-item"  ng-repeat="company in companies.items.list" ng-click="setCompany(company)">
 				<p class="list-group-item-text"><strong>{{company.name}}</strong><br/><small class="text-muted">{{company | fullAddress}}</small>

--- a/src/partials/common-header/company-selector-modal.html
+++ b/src/partials/common-header/company-selector-modal.html
@@ -20,8 +20,7 @@
 		<!-- List of Companies -->
 		<div class="panel panel-default scrollable-list u_margin-sm-top"
 		  scrolling-list="companies.load()"
-		  rv-spinner rv-spinner-key="company-selector-modal-list"
-		>
+		  rv-spinner rv-spinner-key="company-selector-modal-list" rv-show-spinner="companies.loadingItems">
 			<div class="list-group-item"  ng-repeat="company in companies.items.list" ng-click="setCompany(company)">
 				<p class="list-group-item-text"><strong>{{company.name}}</strong><br/><small class="text-muted">{{company | fullAddress}}</small>
 				</p>

--- a/src/partials/common-header/company-settings-modal.html
+++ b/src/partials/common-header/company-settings-modal.html
@@ -1,6 +1,5 @@
 <div rv-spinner
-  rv-spinner-key="company-settings-modal"
-  rv-spinner-start-active="1">
+  rv-spinner-key="company-settings-modal">
 
 <div class="modal-header">
   <button type="button" class="close" data-dismiss="modal" aria-hidden="true" ng-click="closeModal()">

--- a/src/partials/common-header/company-users-modal.html
+++ b/src/partials/common-header/company-users-modal.html
@@ -17,8 +17,7 @@
   <div class="panel panel-default scrollable-list company-users-list u_margin-sm-top"
     scrolling-list="users.load()"
     rv-spinner
-    rv-spinner-key="company-users-list"
-    rv-spinner-start-active="1">
+    rv-spinner-key="company-users-list">
     <div class="list-group-item company-users-list-item"
       ng-repeat="user in users.items.list | orderBy:sort.field:sort.descending | filter:userSearchString" ng-click="editUser(user.username)">
       <p class="list-group-item-text"><strong>{{user.firstName}} {{user.lastName}}</strong> <small class="text-muted">{{user.email}}</small></p>

--- a/src/partials/common-header/move-company-modal.html
+++ b/src/partials/common-header/move-company-modal.html
@@ -1,6 +1,5 @@
 <div rv-spinner
-  rv-spinner-key="move-company-modal"
-  rv-spinner-start-active="1">
+  rv-spinner-key="move-company-modal">
 <div class="modal-header">
   <button type="button" class="close" data-dismiss="modal" aria-hidden="true" ng-click="closeModal()">
     <i class="fa fa-times"></i>

--- a/src/partials/common-header/subcompany-modal.html
+++ b/src/partials/common-header/subcompany-modal.html
@@ -1,6 +1,5 @@
 <div rv-spinner
-  rv-spinner-key="add-subcompany-modal"
-  rv-spinner-start-active="1">
+  rv-spinner-key="add-subcompany-modal">
 <div class="modal-header">
   <button type="button" class="close" ng-click="closeModal()" aria-hidden="true">
     <i class="fa fa-times"></i>

--- a/src/partials/common-header/user-settings-modal.html
+++ b/src/partials/common-header/user-settings-modal.html
@@ -1,6 +1,5 @@
 <div rv-spinner="spinnerOptions"
-rv-spinner-key="user-settings-modal"
-rv-spinner-start-active="1">
+rv-spinner-key="user-settings-modal">
   <div class="modal-header">
     <button type="button" class="close" data-dismiss="modal" aria-hidden="true" ng-click="closeModal()">
       <i class="fa fa-times"></i>

--- a/src/partials/components/distribution-selector/distribution-list.html
+++ b/src/partials/components/distribution-selector/distribution-list.html
@@ -3,9 +3,7 @@
   <div class="panel u_margin-sm-top">
     <div class="scrollable-list"
          scrolling-list="displays.load()"
-         rv-spinner rv-spinner-key="display-list-loader"
-         rv-spinner-start-active="1"
-      >
+         rv-spinner rv-spinner-key="display-list-loader">
 
       <div class="text-center u_margin-lg-top" ng-if="!loadingDisplays && displays.items.list.length === 0">
         <h4 class="text-muted u_margin-md-bottom u_margin-md-top">No Displays Available</h4> 

--- a/src/partials/components/store-products/store-content-modal.html
+++ b/src/partials/components/store-products/store-content-modal.html
@@ -13,8 +13,7 @@
 
     <section id="productList" class="product-grid" 
         scrolling-list="factory.load()"
-        rv-spinner rv-spinner-key="product-list-loader"
-        rv-spinner-start-active="1">
+        rv-spinner rv-spinner-key="product-list-loader">
 
       <div class="professional-content panel panel-default">
         <div class="panel-body">

--- a/src/partials/components/userstate/signup.html
+++ b/src/partials/components/userstate/signup.html
@@ -3,7 +3,7 @@
 <div class="border-container mx-auto">
   <div class="panel-body">
 
-    <div rv-spinner rv-spinner-key="registration-loader" rv-spinner-start-active="1">
+    <div rv-spinner rv-spinner-key="registration-loader">
       <h4>Help us personalize your experience.</h4>
 
       <div id="registration-modal" stop-event="touchend">

--- a/src/partials/displays/display-add.html
+++ b/src/partials/displays/display-add.html
@@ -11,7 +11,7 @@
     </div>
   </div>
 
-  <div rv-spinner rv-spinner-key="display-loader" rv-spinner-start-active="0"></div>
+  <div rv-spinner rv-spinner-key="display-loader"></div>
 
   <div>
     <form id="displayAdd" role="form" name="displayDetails" ng-submit="save()" novalidate>

--- a/src/partials/displays/display-control-modal.html
+++ b/src/partials/displays/display-control-modal.html
@@ -21,7 +21,7 @@
 
     <button id="saveButton" type="submit" class="btn btn-primary"
             ng-click="saveConfiguration()" ng-disabled="displayDetails.$invalid" require-role="da"
-            rv-spinner rv-spinner-key="saving-display-control">
+            rv-spinner rv-spinner-key="saving-display-control" rv-show-spinner="loading">
       {{ factory.savingDisplay ? ('common.saving' | translate) : ('common.save' | translate)}}
       <i class="fa fa-check icon-right"></i>
     </button>

--- a/src/partials/displays/display-control-modal.html
+++ b/src/partials/displays/display-control-modal.html
@@ -21,7 +21,7 @@
 
     <button id="saveButton" type="submit" class="btn btn-primary"
             ng-click="saveConfiguration()" ng-disabled="displayDetails.$invalid" require-role="da"
-            rv-spinner rv-spinner-key="saving-display-control" rv-spinner-start-active="0">
+            rv-spinner rv-spinner-key="saving-display-control">
       {{ factory.savingDisplay ? ('common.saving' | translate) : ('common.save' | translate)}}
       <i class="fa fa-check icon-right"></i>
     </button>

--- a/src/partials/displays/display-details.html
+++ b/src/partials/displays/display-details.html
@@ -17,7 +17,7 @@
     </div>
   </div>
 
-  <div rv-spinner rv-spinner-key="display-loader" rv-spinner-start-active="1"></div>
+  <div rv-spinner rv-spinner-key="display-loader"></div>
 
   <!-- body -->
   <div>

--- a/src/partials/displays/display-email.html
+++ b/src/partials/displays/display-email.html
@@ -1,4 +1,4 @@
-<div id="emailedInstructions" rv-spinner rv-spinner-key="display-email" rv-spinner-start-active="1">
+<div id="emailedInstructions" rv-spinner rv-spinner-key="display-email">
   <p>
     These instructions have been sent via email. Send to another address?
   </p>

--- a/src/partials/displays/displays-list.html
+++ b/src/partials/displays/displays-list.html
@@ -36,7 +36,7 @@
     <batch-operations list-object="displays"></batch-operations>
 
     <div class="scrollable-list horizontal-scroll border-container u_margin-md-top u_margin-md-bottom"
-      scrolling-list="displays.load()" rv-spinner rv-spinner-key="displays-list-loader" rv-spinner-start-active="1">
+      scrolling-list="displays.load()" rv-spinner rv-spinner-key="displays-list-loader" rv-show-spinner="displays.loadingItems">
 
       <table id="displaysListTable" class="table">
         <thead class="table-header">

--- a/src/partials/editor/presentation-list.html
+++ b/src/partials/editor/presentation-list.html
@@ -30,7 +30,7 @@
     <batch-operations list-object="presentations"></batch-operations>
 
     <div class="scrollable-list horizontal-scroll border-container u_margin-md-top u_margin-md-bottom"
-      scrolling-list="presentations.load()" rv-spinner rv-spinner-key="presentation-list-loader" rv-spinner-start-active="1">
+      scrolling-list="presentations.load()" rv-spinner rv-spinner-key="presentation-list-loader">
 
       <table id="presentationListTable" class="table">
         <thead class="table-header">

--- a/src/partials/editor/presentation-multi-selector-list.html
+++ b/src/partials/editor/presentation-multi-selector-list.html
@@ -3,9 +3,7 @@
   <div class="panel u_margin-sm-top">
     <div class="scrollable-list" 
       scrolling-list="presentations.load()"
-      rv-spinner rv-spinner-key="presentation-list-loader"
-      rv-spinner-start-active="1"
-      >
+      rv-spinner rv-spinner-key="presentation-list-loader">
       <table id="presentationListTable" class="table table--hover table--selector table--multiple-selector animated fadeIn">
         <thead class="table-header">
           <tr class="table-header__row">

--- a/src/partials/editor/presentation-selector-list.html
+++ b/src/partials/editor/presentation-selector-list.html
@@ -3,9 +3,7 @@
   <div class="panel u_margin-sm-top">
     <div class="scrollable-list" 
       scrolling-list="presentations.load()"
-      rv-spinner rv-spinner-key="presentation-list-loader"
-      rv-spinner-start-active="1"
-      >
+      rv-spinner rv-spinner-key="presentation-list-loader">
       <table id="presentationListTable" class="table table--hover">
         <thead class="table-header">
           <tr class="table-header__row">

--- a/src/partials/editor/shared-templates-modal.html
+++ b/src/partials/editor/shared-templates-modal.html
@@ -11,9 +11,7 @@
   <div class="panel u_margin-sm-top">
     <div class="scrollable-list" 
       scrolling-list="factory.load()"
-      rv-spinner rv-spinner-key="template-list-loader"
-      rv-spinner-start-active="1"
-      >
+      rv-spinner rv-spinner-key="template-list-loader">
       <table class="table table--hover" id="templatesTable">
         <thead class="table-header">
           <tr class="table-header__row u_clickable" ng-click="factory.sortBy('name')">

--- a/src/partials/editor/store-templates-modal.html
+++ b/src/partials/editor/store-templates-modal.html
@@ -30,8 +30,7 @@
 
     <section id="productList" class="product-grid" 
         scrolling-list="factory.load()"
-        rv-spinner rv-spinner-key="product-list-loader"
-        rv-spinner-start-active="1">
+        rv-spinner rv-spinner-key="product-list-loader">
 
       <div class="professional-content panel panel-default">
         <div class="panel-body">

--- a/src/partials/editor/widget-modal.html
+++ b/src/partials/editor/widget-modal.html
@@ -1,3 +1,3 @@
-<div id="widget-modal" rv-spinner rv-spinner-key="widget-modal-loader" rv-spinner-start-active="1">
+<div id="widget-modal" rv-spinner rv-spinner-key="widget-modal-loader">
   <iframe id="widget-modal-frame" name="widget-modal-frame" class="modal-dialog" scrolling="no" marginwidth="0" ng-src="{{ widgetUrl }}"></iframe>
 </div>

--- a/src/partials/purchase/app-purchase.html
+++ b/src/partials/purchase/app-purchase.html
@@ -4,7 +4,7 @@
     <h1 class="app-header-title">Subscribe</h1>
   </div>
 
-  <div rv-spinner rv-spinner-key="purchase-loader" rv-spinner-start-active="1"></div>
+  <div rv-spinner rv-spinner-key="purchase-loader"></div>
 
   <plan-picker ng-show="currentStep === 0"></plan-picker>
   <billing-address ng-show="currentStep === 1"></billing-address>

--- a/src/partials/purchase/update-subscription.html
+++ b/src/partials/purchase/update-subscription.html
@@ -8,7 +8,7 @@
 
   </div>
 
-  <div rv-spinner rv-spinner-key="update-subscription-loader" rv-spinner-start-active="1"></div>
+  <div rv-spinner rv-spinner-key="update-subscription-loader"></div>
 
   <div ng-show="factory.apiError" class="madero-style alert alert-danger text-center u_margin-md-top" role="alert">
     <strong>{{factory.apiError}}</strong>

--- a/src/partials/schedules/add-to-schedule-modal.html
+++ b/src/partials/schedules/add-to-schedule-modal.html
@@ -1,4 +1,4 @@
-<form rv-spinner rv-spinner-key="add-to-schedule-spinner" rv-spinner-start-active="0">
+<form rv-spinner rv-spinner-key="add-to-schedule-spinner">
   <div class="modal-header">
     <button type="button" class="close" ng-click="dismiss()" data-dismiss="modal" aria-hidden="true">
       <streamline-icon name="close" width="12" height="12"></streamline-icon>

--- a/src/partials/schedules/playlist-item.html
+++ b/src/partials/schedules/playlist-item.html
@@ -6,7 +6,7 @@
     <h3 class="modal-title">{{isNew ? 'common.add' : 'common.edit' | translate}} {{'schedules-app.playlist.item.title' | translate}}</h3>
   </div>
 
-  <div class="modal-body" stop-event="touchend" rv-spinner rv-spinner-key="playlist-item-modal-loader" rv-spinner-start-active="1">
+  <div class="modal-body" stop-event="touchend" rv-spinner rv-spinner-key="playlist-item-modal-loader">
     <form role="form" name="playlistItemFields" ng-enter="save()" novalidate>
       <div class="form-group" ng-if="playlistItem.type !== 'presentation'">
         <label class="control-label" translate>schedules-app.playlist.item.name</label>

--- a/src/partials/schedules/preview-selector-tooltip.html
+++ b/src/partials/schedules/preview-selector-tooltip.html
@@ -8,9 +8,7 @@
   <div class="scrollable-list mt-3 mb-3"
     scrolling-list="schedules.load()"
     rv-spinner
-    rv-spinner-key="preview-selector-spinner"
-    rv-spinner-start-active="1"
-  >
+    rv-spinner-key="preview-selector-spinner">
     <div class="flex-row" ng-repeat="schedule in schedules.items.list">
       <div class="row-entry mb-3">
         <a class="madero-link mr-auto u_text-ellipsis" href="" ng-click="select(schedule)">

--- a/src/partials/schedules/schedule-add.html
+++ b/src/partials/schedules/schedule-add.html
@@ -4,7 +4,7 @@
     <h1 class="app-header-title" id="title" translate>schedules-app.title</h1>
   </div>
 
-  <div rv-spinner rv-spinner-key="schedule-loader" rv-spinner-start-active="0"></div>
+  <div rv-spinner rv-spinner-key="schedule-loader"></div>
 
   <div>
     <form id="scheduleAdd" role="form" name="scheduleDetails" ng-submit="save()" novalidate>

--- a/src/partials/schedules/schedule-details.html
+++ b/src/partials/schedules/schedule-details.html
@@ -10,7 +10,7 @@
     </div>
   </div>
 
-  <div rv-spinner rv-spinner-key="schedule-loader" rv-spinner-start-active="0"></div>
+  <div rv-spinner rv-spinner-key="schedule-loader"></div>
 
   <div>
     <form role="form" name="scheduleDetails" ng-submit="save()" novalidate>

--- a/src/partials/schedules/schedule-selector-tooltip.html
+++ b/src/partials/schedules/schedule-selector-tooltip.html
@@ -8,9 +8,7 @@
   <div class="scrollable-list mt-3 mb-3"
     scrolling-list="factory.unselectedSchedules.load()"
     rv-spinner
-    rv-spinner-key="selected-schedules-spinner"
-    rv-spinner-start-active="0"
-  >
+    rv-spinner-key="selected-schedules-spinner">
     <div class="flex-row" ng-repeat="schedule in factory.selectedSchedules | filter:factory.search.query track by $index">
       <div class="row-entry">
         <madero-checkbox ng-click="factory.selectItem(schedule, true)" ng-value="factory.isSelected(schedule, true)"></madero-checkbox>

--- a/src/partials/schedules/schedules-list.html
+++ b/src/partials/schedules/schedules-list.html
@@ -23,7 +23,7 @@
     <batch-operations list-object="schedules"></batch-operations>
 
     <div class="scrollable-list horizontal-scroll border-container u_margin-md-top u_margin-md-bottom"
-      scrolling-list="schedules.load()" rv-spinner rv-spinner-key="schedules-list-loader" rv-spinner-start-active="1">
+      scrolling-list="schedules.load()" rv-spinner rv-spinner-key="schedules-list-loader">
 
       <table id="schedulesListTable" class="table">
         <thead class="table-header">

--- a/src/partials/storage/files-list.html
+++ b/src/partials/storage/files-list.html
@@ -1,8 +1,7 @@
 <div class="u_margin-sm-top">
 
   <div class="panel panel-default grid-selector" 
-  rv-spinner rv-spinner-key="storage-selector-loader"
-  rv-spinner-start-active="1" >
+  rv-spinner rv-spinner-key="storage-selector-loader">
     <ng-include src="'partials/storage/list-view.html'" ng-if="isListView"></ng-include>
     <ng-include src="'partials/storage/grid-view.html'" ng-if="!isListView"></ng-include>
     <empty-state ng-show="!filesFactory.loadingItems && isEmptyState()"></empty-state>

--- a/src/partials/template-editor/components/component-financial.html
+++ b/src/partials/template-editor/components/component-financial.html
@@ -2,8 +2,7 @@
 <div class="instrument-list te-scrollable-container"
     ng-class="{ 'instrument-list-show': enteringInstrumentSelector, 'instrument-list-cover': enteringSymbolSelector, 'instrument-list-uncover': exitingSymbolSelector }"
     ng-show="showInstrumentList || enteringInstrumentSelector || exitingSymbolSelector"
-    rv-spinner rv-spinner-key="template-editor-loader"
-    rv-spinner-start-active="1">
+    rv-spinner rv-spinner-key="template-editor-loader">
   <div class="row instrument-row" ng-repeat="instr in instruments track by $index">
     <div class="col-xs-10 pl-0">
       <div class="instrument-name instrument-name-ellipsis">{{ instr.name | uppercase }}</div>

--- a/src/partials/template-editor/components/component-rss.html
+++ b/src/partials/template-editor/components/component-rss.html
@@ -1,4 +1,4 @@
-<div class="attribute-editor-component" rv-spinner rv-spinner-key="rss-editor-loader" rv-spinner-start-active="1">
+<div class="attribute-editor-component" rv-spinner rv-spinner-key="rss-editor-loader">
   <div class="attribute-editor-row">
     <div class="form-group has-feedback" ng-class="{ 'has-error': validationResult && validationResult !== 'VALID', 'has-success': validationResult === 'VALID' && feed !== '' }">
       <label class="control-label" for="te-rss-feed">Enter the link to your RSS feed:</label>

--- a/src/partials/template-editor/components/component-schedules.html
+++ b/src/partials/template-editor/components/component-schedules.html
@@ -1,4 +1,4 @@
-<div class="attribute-editor-component" rv-spinner rv-spinner-key="schedules-component-spinner" rv-spinner-start-active="0">
+<div class="attribute-editor-component" rv-spinner rv-spinner-key="schedules-component-spinner">
   <div class="attribute-editor-row">
     <label class="text-sm mb-3">Which schedule(s) should this presentation show on?</label>
 

--- a/src/partials/template-editor/components/component-slides.html
+++ b/src/partials/template-editor/components/component-slides.html
@@ -1,4 +1,4 @@
-<div class="attribute-editor-component" rv-spinner rv-spinner-key="slides-editor-loader" rv-spinner-start-active="1">
+<div class="attribute-editor-component" rv-spinner rv-spinner-key="slides-editor-loader">
   <div class="attribute-editor-row">
     <!-- Use the <form> tag in order to handle "debounce" option correctly for the <input ng-model="src">.
          That way the model value is processed immeditly on Form submit and saveSrc() is called only once. -->

--- a/src/partials/template-editor/components/component-storage-selector.html
+++ b/src/partials/template-editor/components/component-storage-selector.html
@@ -8,9 +8,7 @@
   <div class="storage-selector-component te-scrollable-container"
     ng-class="{ 'no-files': !hasRegularFileItems() }"
     rv-spinner
-    rv-spinner-key="component-storage-selector-spinner"
-    rv-spinner-start-active="1"
-  >
+    rv-spinner-key="component-storage-selector-spinner">
 
     <div class="file-component-list" ng-show="folderItems.length > 0 && !isUploading" ng-if="storageManagerFactory.isListView">
       <div class="pl-0 file-component-list-header" ng-hide="filteredItems.length === 0">

--- a/src/partials/template-editor/components/component-twitter.html
+++ b/src/partials/template-editor/components/component-twitter.html
@@ -1,4 +1,4 @@
-<div class="attribute-editor-component" rv-spinner rv-spinner-key="twitter-editor-loader" rv-spinner-start-active="1">
+<div class="attribute-editor-component" rv-spinner rv-spinner-key="twitter-editor-loader">
   <div class="attribute-editor-row" ng-show="connectionFailure">
     <p class="text-error">
       <span>We're having trouble connecting to your Twitter account.</span>

--- a/src/partials/template-editor/components/component-video/video-list.html
+++ b/src/partials/template-editor/components/component-video/video-list.html
@@ -23,7 +23,6 @@
 
 <div class="video-component-list file-component-list te-scrollable-container"
      rv-spinner rv-spinner-key="video-file-loader"
-     rv-spinner-start-active="1"
      ng-class="{ 'not-empty': selectedFiles.length > 0 }"
 >
   <div rv-sortable on-sort="sortItem(evt)" append-to=".component-container" class="sortable-list">

--- a/src/scripts/billing/controllers/ctr-invoice.js
+++ b/src/scripts/billing/controllers/ctr-invoice.js
@@ -1,17 +1,9 @@
 'use strict';
 
 angular.module('risevision.apps.billing.controllers')
-  .controller('InvoiceCtrl', ['$scope', '$loading', 'invoiceFactory',
-    function ($scope, $loading, invoiceFactory) {
+  .controller('InvoiceCtrl', ['$scope', 'invoiceFactory',
+    function ($scope, invoiceFactory) {
       $scope.invoiceFactory = invoiceFactory;
-
-      $scope.$watch('invoiceFactory.loading', function (newValue) {
-        if (newValue) {
-          $loading.start('invoice-loader');
-        } else {
-          $loading.stop('invoice-loader');
-        }
-      });
 
       $scope.completeCardPayment = function () {
         if (!$scope.form.paymentMethodsForm.$valid) {

--- a/src/scripts/billing/controllers/ctr-unpaid-invoices.js
+++ b/src/scripts/billing/controllers/ctr-unpaid-invoices.js
@@ -1,9 +1,9 @@
 'use strict';
 
 angular.module('risevision.apps.billing.controllers')
-  .controller('UnpaidInvoicesCtrl', ['$scope', '$loading', '$stateParams',
+  .controller('UnpaidInvoicesCtrl', ['$scope', '$stateParams',
     'billing', 'invoiceFactory', 'ScrollingListService',
-    function ($scope, $loading, $stateParams, billing, invoiceFactory, ScrollingListService) {
+    function ($scope, $stateParams, billing, invoiceFactory, ScrollingListService) {
 
       $scope.invoiceFactory = invoiceFactory;
 
@@ -11,14 +11,6 @@ angular.module('risevision.apps.billing.controllers')
         companyId: $stateParams.cid,
         token: $stateParams.token,
         name: 'Unpaid Invoices'
-      });
-
-      $scope.$watch('unpaidInvoices.loadingItems', function (newValue) {
-        if (newValue) {
-          $loading.start('unpaid-invoice-loader');
-        } else {
-          $loading.stop('unpaid-invoice-loader');
-        }
       });
 
     }

--- a/src/scripts/common-header/controllers/ctr-subcompany-selector-modal.js
+++ b/src/scripts/common-header/controllers/ctr-subcompany-selector-modal.js
@@ -1,9 +1,9 @@
 'use strict';
 
 angular.module('risevision.common.header')
-  .controller('companySelectorCtr', ['$scope', '$loading', '$modalInstance',
+  .controller('companySelectorCtr', ['$scope', '$modalInstance',
     'companyService', 'companyId', 'ScrollingListService',
-    function ($scope, $loading, $modalInstance, companyService,
+    function ($scope, $modalInstance, companyService,
       companyId, ScrollingListService) {
 
       $scope.search = {
@@ -18,14 +18,6 @@ angular.module('risevision.common.header')
       $scope.filterConfig = {
         placeholder: 'Search Companies'
       };
-
-      $scope.$watch('companies.loadingItems', function (loading) {
-        if (loading) {
-          $loading.start('company-selector-modal-list');
-        } else {
-          $loading.stop('company-selector-modal-list');
-        }
-      });
 
       $scope.closeModal = function () {
         $modalInstance.dismiss('cancel');

--- a/src/scripts/components/loading/dtv-loading.js
+++ b/src/scripts/components/loading/dtv-loading.js
@@ -10,38 +10,44 @@ angular.module('risevision.common.components.loading')
           rvSpinnerOptions: '=rvSpinner',
           rvShowSpinner: '=?rvShowSpinner'
         },
-        link: function postLink(scope, $element, iAttrs) {
-          scope.active = true;
+        link: function postLink($scope, $element) {
+          $scope.active = true;
           var tpl =
             '<div ng-show="active" class="spinner-backdrop fade {{backdropClass}}"' +
             ' ng-class="{in: active}" us-spinner="rvSpinnerOptions"' +
             ' spinner-key="{{rvSpinnerKey}}" spinner-start-active="1"></div>';
 
-          $element.prepend($compile(tpl)(scope));
+          $element.prepend($compile(tpl)($scope));
 
-          if (angular.isDefined(scope.rvShowSpinner)) {
-            scope.$watch('rvShowSpinner', function (loading) {
+          var _startSpinner = function() {
+            usSpinnerService.spin($scope.rvSpinnerKey);
+            $scope.active = true;
+          };
+
+          var _stopSpinner = function() {
+            usSpinnerService.stop($scope.rvSpinnerKey);
+            $scope.active = false;
+          };
+
+          if (angular.isDefined($scope.rvShowSpinner)) {
+            $scope.$watch('rvShowSpinner', function (loading) {
               if (loading) {
-                usSpinnerService.spin(scope.rvSpinnerKey);
-                scope.active = true;
+                _startSpinner();
               } else {
-                usSpinnerService.stop(scope.rvSpinnerKey);
-                scope.active = false;
+                _stopSpinner();
               }
             });            
           }
 
-          scope.$on('rv-spinner:start', function (event, key) {
-            if (key === scope.rvSpinnerKey) {
-              usSpinnerService.spin(key);
-              scope.active = true;
+          $scope.$on('rv-spinner:start', function (event, key) {
+            if (key === $scope.rvSpinnerKey) {
+              _startSpinner();
             }
           });
 
-          scope.$on('rv-spinner:stop', function (event, key) {
-            if (key === scope.rvSpinnerKey) {
-              usSpinnerService.stop(key);
-              scope.active = false;
+          $scope.$on('rv-spinner:stop', function (event, key) {
+            if (key === $scope.rvSpinnerKey) {
+              _stopSpinner();
             }
           });
         }

--- a/src/scripts/components/loading/dtv-loading.js
+++ b/src/scripts/components/loading/dtv-loading.js
@@ -7,25 +7,29 @@ angular.module('risevision.common.components.loading')
         scope: {
           backdropClass: '@rvSpinnerBackdropClass',
           rvSpinnerKey: '@rvSpinnerKey',
-          rvSpinnerStartActive: '=?rvSpinnerStartActive',
-          rvSpinnerOptions: '=rvSpinner'
+          rvSpinnerOptions: '=rvSpinner',
+          rvShowSpinner: '=?rvShowSpinner'
         },
         link: function postLink(scope, $element, iAttrs) {
-          scope.active = angular.isDefined(iAttrs.rvSpinnerStartActive) &&
-            iAttrs.rvSpinnerStartActive === '1';
+          scope.active = true;
           var tpl =
             '<div ng-show="active" class="spinner-backdrop fade {{backdropClass}}"' +
             ' ng-class="{in: active}" us-spinner="rvSpinnerOptions"' +
-            ' spinner-key="{{rvSpinnerKey}}"';
-
-          if (iAttrs.rvSpinnerStartActive && iAttrs.rvSpinnerStartActive ===
-            '1') {
-            tpl += ' spinner-start-active="1"></div>';
-          } else {
-            tpl += '></div>';
-          }
+            ' spinner-key="{{rvSpinnerKey}}" spinner-start-active="1"></div>';
 
           $element.prepend($compile(tpl)(scope));
+
+          if (angular.isDefined(scope.rvShowSpinner)) {
+            scope.$watch('rvShowSpinner', function (loading) {
+              if (loading) {
+                usSpinnerService.spin(scope.rvSpinnerKey);
+                scope.active = true;
+              } else {
+                usSpinnerService.stop(scope.rvSpinnerKey);
+                scope.active = false;
+              }
+            });            
+          }
 
           scope.$on('rv-spinner:start', function (event, key) {
             if (key === scope.rvSpinnerKey) {

--- a/src/scripts/displays/controllers/ctr-display-control-modal.js
+++ b/src/scripts/displays/controllers/ctr-display-control-modal.js
@@ -1,11 +1,13 @@
 'use strict';
 angular.module('risevision.displays.controllers')
   .controller('DisplayControlModalCtrl', ['$scope', '$modalInstance',
-    'displayControlFactory', '$loading',
-    function ($scope, $modalInstance, displayControlFactory, $loading) {
+    'displayControlFactory',
+    function ($scope, $modalInstance, displayControlFactory) {
       $scope.formData = {};
 
       var _loadConfiguration = function () {
+        $scope.loading = true;
+
         displayControlFactory.getConfiguration()
           .then(function (config) {
             $scope.formData.displayControlContents = config;
@@ -13,13 +15,16 @@ angular.module('risevision.displays.controllers')
           .catch(function (err) {
             console.log('Failed to load config; showing default', err);
             $scope.resetForm();
+          })
+          .finally(function () {
+            $scope.loading = false;
           });
       };
 
       _loadConfiguration();
 
       $scope.saveConfiguration = function () {
-        $loading.start('saving-display-control');
+        $scope.loading = true;
 
         displayControlFactory.updateConfiguration($scope.formData.displayControlContents)
           .then(function () {
@@ -29,7 +34,7 @@ angular.module('risevision.displays.controllers')
             console.log('Failed to save configuration file', err);
           })
           .finally(function () {
-            $loading.stop('saving-display-control');
+            $scope.loading = false;
           });
       };
 

--- a/src/scripts/displays/controllers/ctr-displays-list.js
+++ b/src/scripts/displays/controllers/ctr-displays-list.js
@@ -2,9 +2,9 @@
 
 angular.module('risevision.displays.controllers')
   .controller('displaysList', ['$scope', '$rootScope', '$q', 'userState', 'display',
-    'ScrollingListService', '$loading', '$filter', 'displayFactory', 'playerLicenseFactory',
+    'ScrollingListService', '$filter', 'displayFactory', 'playerLicenseFactory',
     '$modal', 'displaySummaryFactory', 'DisplayListOperations',
-    function ($scope, $rootScope, $q, userState, display, ScrollingListService, $loading,
+    function ($scope, $rootScope, $q, userState, display, ScrollingListService,
       $filter, displayFactory, playerLicenseFactory, $modal, displaySummaryFactory,
       DisplayListOperations) {
       $scope.search = {
@@ -28,14 +28,6 @@ angular.module('risevision.displays.controllers')
         placeholder: $filter('translate')(
           'displays-app.list.filter.placeholder')
       };
-
-      $scope.$watch('displays.loadingItems', function (loading) {
-        if (loading) {
-          $loading.start('displays-list-loader');
-        } else {
-          $loading.stop('displays-list-loader');
-        }
-      });
 
       $scope.$on('displayCreated', function () {
         // use doSearch because it clears the list

--- a/test/unit/billing/controllers/ctr-invoice.spec.js
+++ b/test/unit/billing/controllers/ctr-invoice.spec.js
@@ -1,18 +1,11 @@
 'use strict';
 describe('controller: InvoiceCtrl', function () {
   var sandbox = sinon.sandbox.create();
-  var $scope, $loading, invoiceFactory;
+  var $scope, invoiceFactory;
 
   beforeEach(module('risevision.apps.billing.controllers'));
 
   beforeEach(module(function ($provide) {
-    $provide.service('$loading', function () {
-      return {
-        start: sandbox.stub(),
-        stop: sandbox.stub()
-      };
-    });
-
     $provide.value('invoiceFactory', {
       payInvoice: sandbox.spy(),
       invoice: {}
@@ -22,7 +15,6 @@ describe('controller: InvoiceCtrl', function () {
 
   beforeEach(inject(function($injector, $rootScope, $controller) {
     $scope = $rootScope.$new();
-    $loading = $injector.get('$loading');
     invoiceFactory = $injector.get('invoiceFactory');
 
     $scope.form = {
@@ -45,22 +37,6 @@ describe('controller: InvoiceCtrl', function () {
     expect($scope.invoiceFactory).to.be.ok;
 
     expect($scope.completeCardPayment).to.be.a('function');
-  });
-  
-  describe('$loading: ', function() {
-    it('should stop spinner', function() {
-      $loading.stop.should.have.been.calledWith('invoice-loader');
-    });
-
-    it('should start spinner', function(done) {
-      $scope.invoiceFactory.loading = true;
-      $scope.$digest();
-      setTimeout(function() {
-        $loading.start.should.have.been.calledWith('invoice-loader');
-
-        done();
-      }, 10);
-    });
   });
 
   describe('completeCardPayment:', function() {

--- a/test/unit/billing/controllers/ctr-unpaid-invoices.spec.js
+++ b/test/unit/billing/controllers/ctr-unpaid-invoices.spec.js
@@ -2,17 +2,11 @@
 
 describe('controller: UnpaidInvoicesCtrl', function () {
   var sandbox = sinon.sandbox.create();
-  var $scope, $loading, $stateParams, ScrollingListService, listServiceInstance;
+  var $scope, $stateParams, ScrollingListService, listServiceInstance;
 
   beforeEach(module('risevision.apps.billing.controllers'));
 
   beforeEach(module(function ($provide) {
-    $provide.service('$loading', function () {
-      return {
-        start: sandbox.stub(),
-        stop: sandbox.stub()
-      };
-    });
     $provide.service('ScrollingListService', function () {
       return sinon.stub().returns(listServiceInstance);
     });
@@ -31,7 +25,6 @@ describe('controller: UnpaidInvoicesCtrl', function () {
 
   beforeEach(inject(function($injector, $rootScope, $controller) {
     $scope = $rootScope.$new();
-    $loading = $injector.get('$loading');
     ScrollingListService = $injector.get('ScrollingListService');
 
     $controller('UnpaidInvoicesCtrl', {
@@ -56,22 +49,6 @@ describe('controller: UnpaidInvoicesCtrl', function () {
       name: 'Unpaid Invoices',
       companyId: 'companyId',
       token: 'token'
-    });
-  });
-
-  describe('$loading: ', function() {
-    it('should stop spinner', function() {
-      $loading.stop.should.have.been.calledWith('unpaid-invoice-loader');
-    });
-
-    it('should start spinner', function(done) {
-      $scope.unpaidInvoices.loadingItems = true;
-      $scope.$digest();
-      setTimeout(function() {
-        $loading.start.should.have.been.calledWith('unpaid-invoice-loader');
-
-        done();
-      }, 10);
     });
   });
 

--- a/test/unit/components/loading/dtv-loading.spec.js
+++ b/test/unit/components/loading/dtv-loading.spec.js
@@ -1,0 +1,96 @@
+'use strict';
+describe('directive: loading', function() {
+  beforeEach(module('risevision.common.components.loading'));
+  beforeEach(module(function ($provide) {
+    $provide.service('usSpinnerService',function(){
+      return {
+        spin: sinon.spy(),
+        stop: sinon.spy()
+      };
+    });
+  }));
+
+  var elm, $scope, usSpinnerService;
+
+  beforeEach(inject(function($injector, $compile, $rootScope, $templateCache){
+    usSpinnerService = $injector.get('usSpinnerService');
+
+    $rootScope.loadingItems = true;
+
+    var tpl = '<div rv-spinner rv-spinner-key="list-loader" rv-show-spinner="loadingItems"></div>';
+
+    elm = $compile(tpl)($rootScope.$new());
+    $rootScope.$digest();
+    
+    $scope = elm.isolateScope();
+  }));
+
+  it('should compile html', function() {
+    expect(elm.html()).to.contain('us-spinner="rvSpinnerOptions" spinner-key="list-loader" spinner-start-active="1"');
+
+    expect($scope.rvSpinnerKey).to.equal('list-loader');
+    expect($scope.rvShowSpinner).to.be.true;
+  });
+
+  describe('rvShowSpinner:', function() {
+    it('should start spinner', function() {
+      usSpinnerService.spin.should.have.been.calledWith('list-loader');
+      expect($scope.active).to.be.true;
+    });
+    
+    it('should stop spinner', function() {
+      $scope.rvShowSpinner = false;
+      $scope.$digest();
+
+      usSpinnerService.stop.should.have.been.calledWith('list-loader');
+      expect($scope.active).to.be.false;
+    });
+  });
+
+  describe('rv-spinner:start', function() {
+    beforeEach(function() {
+      $scope.rvShowSpinner = false;
+      $scope.$digest();
+      usSpinnerService.spin.reset();
+    });
+
+    it('should start spinner', function() {
+      $scope.$emit('rv-spinner:start', 'list-loader');
+
+      $scope.$digest();
+
+      usSpinnerService.spin.should.have.been.calledWith('list-loader');
+      expect($scope.active).to.be.true;
+    });
+    
+    it('should check spinner key', function() {
+      $scope.$emit('rv-spinner:start', 'another-loader');
+
+      $scope.$digest();
+
+      usSpinnerService.spin.should.not.have.been.called;
+      expect($scope.active).to.be.false;
+    });
+  });
+
+  describe('rv-spinner:stop', function() {
+    it('should stop spinner', function() {
+      $scope.$emit('rv-spinner:stop', 'list-loader');
+
+      $scope.$digest();
+
+      usSpinnerService.stop.should.have.been.calledWith('list-loader');
+      expect($scope.active).to.be.false;
+    });
+    
+    it('should check spinner key', function() {
+      $scope.$emit('rv-spinner:stop', 'another-loader');
+
+      $scope.$digest();
+
+      usSpinnerService.stop.should.not.have.been.called;
+      expect($scope.active).to.be.true;
+    });
+  });
+
+});

--- a/test/unit/displays/controllers/ctr-display-control-modal.spec.js
+++ b/test/unit/displays/controllers/ctr-display-control-modal.spec.js
@@ -29,14 +29,8 @@ describe('controller: display control modal', function() {
         }
       }
     });
-    $provide.service('$loading', function() {
-      return {
-        start: sandbox.stub(),
-        stop: sandbox.stub()
-      };
-    });
   }));
-  var $scope, $modalInstance, displayControlFactory, $loading, $controller;
+  var $scope, $modalInstance, displayControlFactory, $controller;
   beforeEach(function() {   
     sandbox = sinon.sandbox.create();
 
@@ -49,14 +43,12 @@ describe('controller: display control modal', function() {
       $modalInstance = $injector.get('$modalInstance');
       sinon.spy($modalInstance, 'dismiss');
       sinon.spy($modalInstance, 'close');
-      $loading = $injector.get('$loading');
 
       $controller = _$controller_;
       $controller('DisplayControlModalCtrl', {
         $scope : $scope,
         displayControlFactory: displayControlFactory,
-        $modalInstance: $modalInstance,
-        $loading: $loading
+        $modalInstance: $modalInstance
       });
 
       $scope.$digest();
@@ -81,14 +73,17 @@ describe('controller: display control modal', function() {
     $controller('DisplayControlModalCtrl', {
       $scope : $scope,
       displayControlFactory: displayControlFactory,
-      $modalInstance: $modalInstance,
-      $loading: $loading
+      $modalInstance: $modalInstance
     });
+
+    expect($scope.loading).to.be.true;
 
     setTimeout(function() {
       expect(displayControlFactory.getConfiguration).to.have.been.called;
       expect(displayControlFactory.getDefaultConfiguration).to.not.have.been.called;
       expect($scope.formData.displayControlContents).to.be.equal('loaded contents');
+      expect($scope.loading).to.be.false;
+
       done();
     }, 0);
   });
@@ -99,14 +94,17 @@ describe('controller: display control modal', function() {
     $controller('DisplayControlModalCtrl', {
       $scope : $scope,
       displayControlFactory: displayControlFactory,
-      $modalInstance: $modalInstance,
-      $loading: $loading
+      $modalInstance: $modalInstance
     });
+
+    expect($scope.loading).to.be.true;
 
     setTimeout(function() {
       expect(displayControlFactory.getConfiguration).to.have.been.called;
       expect(displayControlFactory.getDefaultConfiguration).to.have.been.called;
       expect($scope.formData.displayControlContents).to.be.equal('default contents');
+      expect($scope.loading).to.be.false;
+
       done();
     }, 0);
   });
@@ -123,10 +121,11 @@ describe('controller: display control modal', function() {
       $scope.formData.displayControlContents = 'contents';
       $scope.saveConfiguration();
 
+      expect($scope.loading).to.be.true;
+
       setTimeout(function() {
         displayControlFactory.updateConfiguration.should.have.been.calledWith('contents');
-        $loading.start.should.have.been.called;
-        $loading.stop.should.have.been.called;
+        expect($scope.loading).to.be.false;
         $modalInstance.close.should.have.been.called;
         done();
       }, 10);
@@ -137,10 +136,11 @@ describe('controller: display control modal', function() {
       $scope.formData.displayControlContents = 'contents';
       $scope.saveConfiguration();
 
+      expect($scope.loading).to.be.true;
+
       setTimeout(function() {
         displayControlFactory.updateConfiguration.should.have.been.calledWith('contents');
-        $loading.start.should.have.been.called;
-        $loading.stop.should.have.been.called;
+        expect($scope.loading).to.be.false;
         $modalInstance.close.should.not.have.been.called;
         done();
       }, 10);

--- a/test/unit/displays/controllers/ctr-displays-list.spec.js
+++ b/test/unit/displays/controllers/ctr-displays-list.spec.js
@@ -30,13 +30,6 @@ describe('controller: displays list', function() {
       };
     });
 
-    $provide.service('$loading',function(){
-      return {
-        start : sinon.spy(),
-        stop : sinon.spy()
-      }
-    });
-    
     $provide.value('translateFilter', function(){
       return function(key){
         return key;
@@ -64,19 +57,17 @@ describe('controller: displays list', function() {
       };
     });
   }));
-  var $scope, $loading, $filter, $window, displaySummaryFactory, ScrollingListService;
+  var $scope, $filter, $window, displaySummaryFactory, ScrollingListService;
   beforeEach(function(){
     inject(function($injector,$rootScope, $controller){
       $scope = $rootScope.$new();
       $scope.listLimit = 5;
       $filter = $injector.get('$filter');
-      $loading = $injector.get('$loading');
       displaySummaryFactory = $injector.get('displaySummaryFactory');
       ScrollingListService = $injector.get('ScrollingListService');
       $window = $injector.get('$window');
       $controller('displaysList', {
         $scope : $scope,
-        $loading: $loading,
         $filter: $filter,
         $window: $window
       });
@@ -115,22 +106,6 @@ describe('controller: displays list', function() {
     expect($scope.search.count).to.equal(5);
 
     displaySummaryFactory.loadSummary.should.have.been.caled;
-  });
-
-  describe('$loading: ', function() {
-    it('should stop spinner', function() {
-      $loading.stop.should.have.been.calledWith('displays-list-loader');
-    });
-    
-    it('should start spinner', function(done) {
-      $scope.displays.loadingItems = true;
-      $scope.$digest();
-      setTimeout(function() {
-        $loading.start.should.have.been.calledWith('displays-list-loader');
-        
-        done();
-      }, 10);
-    });
   });
   
   it('should reload list when a Display is created', function() {


### PR DESCRIPTION
## Description
Add internal watch for spinner

It can be controlled by a variable

Remove rv-spinner-start-active property
and make it default for all spinners

[stage-19]

## Motivation and Context
Remove need for `$watch` to trigger spinner.

## How Has This Been Tested?
Tested locally with the display list spinner and all the spinners that didn't have that setting enabled.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No