### PR TITLE
Update private repos references to fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,11 +91,11 @@
     "lcov-result-merger": "^3.1.0",
     "protractor": "~7.0.0",
     "rimraf": "^2.5.4",
-    "rv-common-e2e": "git://github.com/Rise-Vision/rv-common-e2e.git",
+    "rv-common-e2e": "git@github.com:Rise-Vision/rv-common-e2e.git",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
     "typescript": "~4.2.4",
-    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
+    "widget-tester": "git@github.com:Rise-Vision/widget-tester.git"
   },
   "repository": {
     "type": "git",
@@ -106,4 +106,3 @@
   },
   "homepage": "http://apps.risevision.com"
 }
-

--- a/package.json
+++ b/package.json
@@ -106,3 +106,4 @@
   },
   "homepage": "http://apps.risevision.com"
 }
+


### PR DESCRIPTION
## Description
Update private repos references to fix build
It also required adding a user key to circle ci

Source: https://discuss.circleci.com/t/cant-install-npm-package-from-private-github-repo/37481/2

## Motivation and Context
Repos were changed to private

## How Has This Been Tested?
Build passes. Also tested running npm install locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
