### PR TITLE
Persist redirect state when switching auth routes

### DIFF
--- a/src/scripts/components/userstate/app.js
+++ b/src/scripts/components/userstate/app.js
@@ -200,11 +200,11 @@
               toState.name === 'common.auth.createaccount') && !toParams.state) {
 
             if (fromParams.state) {
-              toParams.state = fromParams.state;
+              $state.params.state = fromParams.state;
 
               event.preventDefault();
 
-              $state.go(toState.name, toParams);
+              $state.go(toState.name, $state.params);
             }
           }
         });

--- a/src/scripts/components/userstate/services/svc-access.js
+++ b/src/scripts/components/userstate/services/svc-access.js
@@ -32,7 +32,7 @@ angular.module('risevision.common.components.userstate')
                 location: allowReturn ? true : 'replace'
               });
 
-              return $q.reject();
+              return $q.reject('unauthenticated');
             }
           });
       };

--- a/test/unit/components/userstate/app.spec.js
+++ b/test/unit/components/userstate/app.spec.js
@@ -392,6 +392,8 @@ describe("app:", function() {
       });
 
       it("should redirect and use existing state variable", function() {
+        $state.params.param = 'existingParam';
+
         $rootScope.$broadcast("$stateChangeStart", {
           name: "common.auth.unauthorized"
         }, {}, null, {
@@ -399,6 +401,7 @@ describe("app:", function() {
         });
 
         $state.go.should.have.been.calledWith("common.auth.unauthorized", {
+          param: 'existingParam',
           state: "existingState"
         });
       });

--- a/test/unit/components/userstate/services/svc-access.spec.js
+++ b/test/unit/components/userstate/services/svc-access.spec.js
@@ -85,7 +85,9 @@ describe("service: access:", function() {
     .then(function() {
       done("authenticated");
     })
-    .then(null, function() {
+    .then(null, function(result) {
+      expect(result).to.equal('unauthenticated');
+
       $state.go.should.have.been.calledWith("common.auth.unregistered", {
         state: "newState"
       }, {


### PR DESCRIPTION
## Description
Persist redirect state when switching auth routes

Previous method was throwing an error
Updated to use $state.params

Return unauthenticated error on canAccessApps
Should update ui-router error logging

[stage-18]

## Motivation and Context
Fixes issue where an error is thrown when switching from the Sign In to Sign Up page and vice versa.
Adds a logging message for unauthenticated redirects.

## How Has This Been Tested?
Tested locally. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No