### PR TITLE
Fix delete functionality, unload handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2103,6 +2103,12 @@
       "integrity": "sha512-Z6DoceYb/1xSg5+e+ZlPZ9v0N16ZvZ+wYMraFue4HYrE4ttONKtsvruIRf6t9TBR0YvSOfi1hUU0fJfBLCDYow==",
       "dev": true
     },
+    "@types/angular": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.8.2.tgz",
+      "integrity": "sha512-V0Hgx2Q3wFNcrrmx8zVepdasDuwnK4lqQFe0Zr9Ll3DoTJIuhKOpyfHC6KuVDBXJGgTkMKtELbvDe9crIkSGzg==",
+      "dev": true
+    },
     "@types/chai": {
       "version": "4.2.18",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.18.tgz",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "pretest-e2e": "npm run ng-build",
     "test-e2e": "gulp test:e2e",
     "test-e2e-ci": "gulp test:e2e",
-    "ng": "ng",
     "ng-update": "ng update @angular/cli@^12 @angular/core@^12"
   },
   "private": true,
@@ -50,6 +49,7 @@
     "@angular-devkit/build-angular": "~12.0.5",
     "@angular/cli": "~12.0.5",
     "@angular/compiler-cli": "~12.0.5",
+    "@types/angular": "^1.8.2",
     "@types/chai": "~4.2.17",
     "@types/chai-as-promised": "~7.1.3",
     "@types/jasmine": "~3.6.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule } from '@angular/core';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { HttpClientModule } from '@angular/common/http';
+import { SharedModule } from './shared/shared.module';
 import { CommonHeaderModule } from './common-header/common-header.module';
 import { EditorModule } from './editor/editor.module';
 import { $stateProvider, $transitionsProvider, addressServiceProvider, analyticsFactoryProvider, billingProvider, canvaTypePickerProvider, confirmModalProvider, contactServiceProvider, plansServiceProvider, processErrorCodeProvider, purchaseFlowTrackerProvider, storeServiceProvider, subscriptionFactoryProvider, templateEditorFactoryProvider, templateEditorUtilsProvider, componentsFactoryProvider, autoSaveServiceProvider, presentationUtilsProvider, userAuthFactoryProvider, userStateProvider } from './ajs-upgraded-providers';
@@ -12,7 +13,6 @@ import { environment } from 'src/environments/environment';
 import * as angular from 'angular';
 import { ComponentsModule } from './components/components.module';
 import { ModalModule } from 'ngx-bootstrap/modal';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 
 @NgModule({
   imports: [
@@ -23,8 +23,9 @@ import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 
     ModalModule.forRoot(),
 
-    ComponentsModule,
+    SharedModule,
     CommonHeaderModule,
+    ComponentsModule,
     EditorModule,
     PurchaseModule,
     TemplateEditorModule

--- a/src/app/common-header/directives/common-header-height.directive.spec.ts
+++ b/src/app/common-header/directives/common-header-height.directive.spec.ts
@@ -1,8 +1,10 @@
+import {expect} from 'chai';
+
 import { CommonHeaderHeightDirective } from './common-header-height.directive';
 
 describe('CommonHeaderHeightDirective', () => {
   it('should create an instance', () => {
     const directive = new CommonHeaderHeightDirective();
-    expect(directive).toBeTruthy();
+    expect(directive).to.be.ok;
   });
 });

--- a/src/app/shared/services/broadcaster.service.spec.ts
+++ b/src/app/shared/services/broadcaster.service.spec.ts
@@ -1,3 +1,5 @@
+import {expect} from 'chai';
+
 import { TestBed } from '@angular/core/testing';
 
 import { BroadcasterService } from './broadcaster.service';
@@ -11,6 +13,6 @@ describe('BroadcasterService', () => {
   });
 
   it('should be created', () => {
-    expect(service).toBeTruthy();
+    expect(service).to.be.ok;
   });
 });

--- a/src/app/shared/services/broadcaster.service.ts
+++ b/src/app/shared/services/broadcaster.service.ts
@@ -24,5 +24,5 @@ export class BroadcasterService extends EventEmitter {
   }
 }
 
-angular.module('risevision.template-editor.services')
+angular.module('risevision.apps.services')
   .factory('broadcaster', downgradeInjectable(BroadcasterService));

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { BroadcasterService } from './services/broadcaster.service';
+
+
+@NgModule({
+  declarations: [
+  ],
+  imports: [
+    CommonModule
+  ]
+})
+export class SharedModule {
+  //workaround for including downgraded components into build files
+  //https://github.com/angular/angular/issues/35314#issuecomment-584821399
+  static entryComponents = [  ]
+  static providers = [ BroadcasterService ]
+}

--- a/src/app/storage-selector.module.ts
+++ b/src/app/storage-selector.module.ts
@@ -2,12 +2,16 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { environment } from 'src/environments/environment';
+import { SharedModule } from './shared/shared.module';
+
 import * as angular from 'angular';
 
 @NgModule({
   imports: [
     BrowserModule,
-    UpgradeModule
+    UpgradeModule,
+
+    SharedModule
   ],
   declarations: [
   ],

--- a/src/app/template-editor/components/template-attribute-editor/template-attribute-editor.component.spec.ts
+++ b/src/app/template-editor/components/template-attribute-editor/template-attribute-editor.component.spec.ts
@@ -1,3 +1,5 @@
+import {expect} from 'chai';
+
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TemplateAttributeEditorComponent } from './template-attribute-editor.component';
@@ -20,6 +22,6 @@ describe('TemplateAttributeEditorComponent', () => {
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(component).to.be.ok;
   });
 });

--- a/src/app/template-editor/components/template-editor-footer/template-editor-footer.component.spec.ts
+++ b/src/app/template-editor/components/template-editor-footer/template-editor-footer.component.spec.ts
@@ -1,3 +1,5 @@
+import {expect} from 'chai';
+
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TemplateEditorFooterComponent } from './template-editor-footer.component';
@@ -20,6 +22,6 @@ describe('TemplateEditorFooterComponent', () => {
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(component).to.be.ok;
   });
 });

--- a/src/app/template-editor/components/template-editor-preview-holder/template-editor-preview-holder.component.spec.ts
+++ b/src/app/template-editor/components/template-editor-preview-holder/template-editor-preview-holder.component.spec.ts
@@ -1,3 +1,5 @@
+import {expect} from 'chai';
+
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TemplateEditorPreviewHolderComponent } from './template-editor-preview-holder.component';
@@ -20,6 +22,6 @@ describe('TemplateEditorPreviewHolderComponent', () => {
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(component).to.be.ok;
   });
 });

--- a/src/app/template-editor/components/template-editor-toolbar/template-editor-toolbar.component.spec.ts
+++ b/src/app/template-editor/components/template-editor-toolbar/template-editor-toolbar.component.spec.ts
@@ -1,3 +1,5 @@
+import {expect} from 'chai';
+
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TemplateEditorToolbarComponent } from './template-editor-toolbar.component';
@@ -20,6 +22,6 @@ describe('TemplateEditorToolbarComponent', () => {
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(component).to.be.ok;
   });
 });

--- a/src/app/template-editor/components/template-editor/template-editor.component.spec.ts
+++ b/src/app/template-editor/components/template-editor/template-editor.component.spec.ts
@@ -1,3 +1,5 @@
+import {expect} from 'chai';
+
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TemplateEditorComponent } from './template-editor.component';
@@ -20,6 +22,6 @@ describe('TemplateEditorComponent', () => {
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(component).to.be.ok;
   });
 });

--- a/src/app/template-editor/components/template-editor/template-editor.component.ts
+++ b/src/app/template-editor/components/template-editor/template-editor.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener } from '@angular/core';
+import { Component, HostListener, DoCheck, OnDestroy } from '@angular/core';
 
 import * as _ from 'lodash';
 import * as angular from 'angular';
@@ -11,7 +11,7 @@ import { BroadcasterService } from '../../services/broadcaster.service';
   templateUrl: './template-editor.component.html',
   styleUrls: ['./template-editor.component.scss']
 })
-export class TemplateEditorComponent {
+export class TemplateEditorComponent implements DoCheck, OnDestroy {
   private subscription: any;
   private _oldPresentation: any;
 

--- a/src/app/template-editor/components/template-editor/template-editor.component.ts
+++ b/src/app/template-editor/components/template-editor/template-editor.component.ts
@@ -18,16 +18,6 @@ export class TemplateEditorComponent implements DoCheck, OnDestroy {
   private autoSaveService: any;
   private _bypassUnsaved = false;
 
-  @HostListener('window:beforeunload')
-  checkUnsaved(e: Event) {
-    if (this.templateEditorFactory.isUnsaved()) {
-      // Cancel the event
-      e.preventDefault(); // If you prevent default behavior in Mozilla Firefox prompt will always be shown
-      // Chrome requires returnValue to be set
-      e.returnValue = true;
-    }
-  }
-
   constructor(
     private $state: AjsState,
     private $transitions: AjsTransitions,
@@ -62,6 +52,15 @@ export class TemplateEditorComponent implements DoCheck, OnDestroy {
           });  
       }
     });
+
+    window.onbeforeunload = (e: Event) => {
+      if (that.templateEditorFactory.isUnsaved()) {
+        // Cancel the event
+        e.preventDefault(); // If you prevent default behavior in Mozilla Firefox prompt will always be shown
+        // Chrome requires returnValue to be set
+        e.returnValue = true;
+      }
+    };
 
     this.subscription = this.broadcaster.subscribe({
       next: (event: String) => {
@@ -120,6 +119,8 @@ export class TemplateEditorComponent implements DoCheck, OnDestroy {
 
   ngOnDestroy(): void {
     this.subscription.unsubscribe();
+
+    window.onbeforeunload = undefined;
   }
 
   considerChromeBarHeight() {

--- a/src/app/template-editor/components/template-editor/template-editor.component.ts
+++ b/src/app/template-editor/components/template-editor/template-editor.component.ts
@@ -1,10 +1,10 @@
-import { Component, HostListener, DoCheck, OnDestroy } from '@angular/core';
+import { Component, DoCheck, OnDestroy } from '@angular/core';
 
 import * as _ from 'lodash';
 import * as angular from 'angular';
 import { downgradeComponent } from '@angular/upgrade/static';
 import { AjsState, AjsTransitions, ComponentsFactory, TemplateEditorFactory, AutoSaveService, PresentationUtils } from 'src/app/ajs-upgraded-providers';
-import { BroadcasterService } from '../../services/broadcaster.service';
+import { BroadcasterService } from 'src/app/shared/services/broadcaster.service';
 
 @Component({
   selector: 'app-template-editor',

--- a/src/app/template-editor/services/canva-api.service.ts
+++ b/src/app/template-editor/services/canva-api.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { AnalyticsFactory, CanvaTypePicker } from 'src/app/ajs-upgraded-providers';
-import { environment } from './../../../environments/environment';
+import { environment } from 'src/environments/environment';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/template-editor/template-editor.module.ts
+++ b/src/app/template-editor/template-editor.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CommonHeaderModule } from '../common-header/common-header.module';
 import { CanvaButtonComponent } from './components/canva-button/canva-button.component';
-import { BroadcasterService } from './services/broadcaster.service';
 import { AttributeDataService } from './services/attribute-data.service';
 import { BlueprintService } from './services/blueprint.service';
 import { TemplateEditorFooterComponent } from './components/template-editor-footer/template-editor-footer.component';
@@ -34,5 +33,5 @@ export class TemplateEditorModule {
   //workaround for including downgraded components into build files
   //https://github.com/angular/angular/issues/35314#issuecomment-584821399
   static entryComponents = [ CanvaButtonComponent, TemplateEditorComponent, StreamlineIconComponent ]
-  static providers = [ BroadcasterService, AttributeDataService, BlueprintService ]
+  static providers = [ AttributeDataService, BlueprintService ]
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -27,9 +27,11 @@ declare global {
 }
 export {};
 
+angular.module('risevision.apps.services',[])
 angular.module('risevision.editor.directives',[])
 angular.module('risevision.apps.purchase',[])
 angular.module('risevision.template-editor.directives',[])
+angular.module('risevision.template-editor.controllers',[])
 angular.module('risevision.template-editor.services',[])
 
 // First, initialize the Angular testing environment.

--- a/test/unit/ng-providers.js
+++ b/test/unit/ng-providers.js
@@ -6,4 +6,13 @@ beforeEach(module(function ($provide) {
         confirmDanger: sinon.stub().resolves()
       };
     });
+
+    $provide.service('broadcaster',function() {
+      return {
+        emit: sinon.stub(),
+        emitWithParams: sinon.stub(),
+        subscribe: sinon.stub()
+      };
+    });
+
   }));

--- a/test/unit/template-editor/app.spec.js
+++ b/test/unit/template-editor/app.spec.js
@@ -58,7 +58,7 @@ describe('app:', function() {
       var state = $state.get('apps.editor.templates.edit');
       expect(state).to.be.ok;
       expect(state.url).to.equal('/edit/:presentationId/:productId');
-      expect(state.controller).to.be.ok;
+      expect(state.component).to.equal('ngTemplateEditor');
       expect(state.params).to.be.ok;
     });
 

--- a/test/unit/template-editor/services/svc-template-editor-factory.spec.js
+++ b/test/unit/template-editor/services/svc-template-editor-factory.spec.js
@@ -29,7 +29,8 @@ describe('service: templateEditorFactory:', function() {
       return {
         getUsername: function() {
           return 'testusername';
-        },
+        }, 
+        hasRole: sandbox.stub().returns(true),
         _restoreState: function() {}
       };
     });
@@ -84,12 +85,13 @@ describe('service: templateEditorFactory:', function() {
 
   }));
 
-  var $state, templateEditorFactory, templateEditorUtils, blueprintFactory, presentation, processErrorCode,
+  var $state, userState, templateEditorFactory, templateEditorUtils, blueprintFactory, presentation, processErrorCode,
     HTML_PRESENTATION_TYPE, storeProduct, createFirstSchedule, scheduleFactory, brandingFactory, scheduleSelectorFactory;
 
   beforeEach(function() {
     inject(function($injector) {
       $state = $injector.get('$state');
+      userState = $injector.get('userState');
       templateEditorFactory = $injector.get('templateEditorFactory');
 
       presentation = $injector.get('presentation');
@@ -118,6 +120,14 @@ describe('service: templateEditorFactory:', function() {
 
     expect(templateEditorFactory.getPresentation).to.be.a('function');
     expect(templateEditorFactory.addPresentation).to.be.a('function');
+  });
+
+  describe('hasContentEditorRole:', function() {
+    it('should check role and return result', function() {
+      expect(templateEditorFactory.hasContentEditorRole()).to.be.true;
+
+      userState.hasRole.should.have.been.calledWith('ce');
+    });
   });
 
   describe('addFromProduct:', function() {


### PR DESCRIPTION
## Description
Fix delete functionality, unload handler

No longer block redirect if changes are not needed

Fix beforeunload handler, return string functionality
is deprecated

Remove broadcaster subscription on unload

[stage-18]

## Motivation and Context
Fixes error when Presentation is deleted

Fix onbeforeunload handler as per https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload

## How Has This Been Tested?
Tested locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No