### PR TITLE
Handle spinner variable after directive initialization

### DIFF
--- a/src/partials/template-editor/components/component-financial.html
+++ b/src/partials/template-editor/components/component-financial.html
@@ -2,7 +2,7 @@
 <div class="instrument-list te-scrollable-container"
     ng-class="{ 'instrument-list-show': enteringInstrumentSelector, 'instrument-list-cover': enteringSymbolSelector, 'instrument-list-uncover': exitingSymbolSelector }"
     ng-show="showInstrumentList || enteringInstrumentSelector || exitingSymbolSelector"
-    rv-spinner rv-spinner-key="template-editor-loader"  rv-show-spinner="templateEditorFactory.loadingPresentation">
+    rv-spinner rv-spinner-key="template-editor-loader" rv-show-spinner="templateEditorFactory.loadingPresentation">
   <div class="row instrument-row" ng-repeat="instr in instruments track by $index">
     <div class="col-xs-10 pl-0">
       <div class="instrument-name instrument-name-ellipsis">{{ instr.name | uppercase }}</div>

--- a/src/scripts/components/loading/dtv-loading.js
+++ b/src/scripts/components/loading/dtv-loading.js
@@ -29,15 +29,17 @@ angular.module('risevision.common.components.loading')
             $scope.active = false;
           };
 
-          if (angular.isDefined($scope.rvShowSpinner)) {
-            $scope.$watch('rvShowSpinner', function (loading) {
-              if (loading) {
-                _startSpinner();
-              } else {
-                _stopSpinner();
-              }
-            });            
-          }
+          $scope.$watch('rvShowSpinner', function (loading) {
+            if (!angular.isDefined($scope.rvShowSpinner)) {
+              return;
+            }
+
+            if (loading) {
+              _startSpinner();
+            } else {
+              _stopSpinner();
+            }
+          });            
 
           $scope.$on('rv-spinner:start', function (event, key) {
             if (key === $scope.rvSpinnerKey) {

--- a/test/unit/components/loading/dtv-loading.spec.js
+++ b/test/unit/components/loading/dtv-loading.spec.js
@@ -15,7 +15,7 @@ describe('directive: loading', function() {
   beforeEach(inject(function($injector, $compile, $rootScope, $templateCache){
     usSpinnerService = $injector.get('usSpinnerService');
 
-    $rootScope.loadingItems = true;
+    $rootScope.loadingItems = undefined;
 
     var tpl = '<div rv-spinner rv-spinner-key="list-loader" rv-show-spinner="loadingItems"></div>';
 
@@ -29,11 +29,20 @@ describe('directive: loading', function() {
     expect(elm.html()).to.contain('us-spinner="rvSpinnerOptions" spinner-key="list-loader" spinner-start-active="1"');
 
     expect($scope.rvSpinnerKey).to.equal('list-loader');
-    expect($scope.rvShowSpinner).to.be.true;
+    expect($scope.rvShowSpinner).to.be.undefined;
   });
 
   describe('rvShowSpinner:', function() {
-    it('should start spinner', function() {
+    it('should not start or stop spinner if undefined', function() {
+      usSpinnerService.spin.should.not.have.been.called;
+      usSpinnerService.stop.should.not.have.been.called;
+      expect($scope.active).to.be.true;
+    });
+
+    it('should start spinner if true', function() {
+      $scope.rvShowSpinner = true;
+      $scope.$digest();
+
       usSpinnerService.spin.should.have.been.calledWith('list-loader');
       expect($scope.active).to.be.true;
     });


### PR DESCRIPTION
## Description
Handle spinner variable after directive initialization

Always start the watch
Check for undefined inside the handler

[stage-19]

## Motivation and Context
Fix issue with financial component spinner not hiding.

## How Has This Been Tested?
Tested locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No