### PR TITLE
Migrate componentsFactory

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -466,7 +466,6 @@
               "src/scripts/template-editor/app.js",
               "src/scripts/template-editor/services/svc-template-editor-factory.js",
               "src/scripts/template-editor/services/svc-template-editor-utils.js",
-              "src/scripts/template-editor/services/svc-components-factory.js",
 
               "src/scripts/template-editor/components/services/svc-storage-manager-factory.js",
               "src/scripts/template-editor/components/services/svc-playlist-component-factory.js",

--- a/angular.json
+++ b/angular.json
@@ -464,7 +464,6 @@
               "src/scripts/editor/directives/dtv-presentation-name.js",
 
               "src/scripts/template-editor/app.js",
-              "src/scripts/template-editor/services/svc-template-editor-factory.js",
               "src/scripts/template-editor/services/svc-template-editor-utils.js",
 
               "src/scripts/template-editor/components/services/svc-storage-manager-factory.js",

--- a/src/app/ajs-upgraded-providers.spec.ts
+++ b/src/app/ajs-upgraded-providers.spec.ts
@@ -12,10 +12,9 @@ import {
   ProcessErrorCode, processErrorCodeProvider, 
   StoreService, storeServiceProvider,
   SubscriptionFactory, subscriptionFactoryProvider,
-  TemplateEditorFactory, templateEditorFactoryProvider,
   PresentationUtils, presentationUtilsProvider,
   UserAuthFactory, userAuthFactoryProvider,
-  UserState, userStateProvider, purchaseFlowTrackerProvider, PurchaseFlowTracker, contactServiceProvider, ContactService
+  UserState, userStateProvider, purchaseFlowTrackerProvider, PurchaseFlowTracker, contactServiceProvider, ContactService, PresentationService, presentationServiceProvider, createFirstScheduleServiceProvider, CreateFirstScheduleService, brandingFactoryProvider, BrandingFactory, scheduleFactoryProvider, ScheduleFactory, PresentationTracker, presentationTrackerProvider, ScheduleSelectorFactory, scheduleSelectorFactoryProvider
 } from './ajs-upgraded-providers';
 
 describe('ajs-upgraded-providers', () => {
@@ -42,11 +41,6 @@ describe('ajs-upgraded-providers', () => {
   it('analyticsFactory:', () => {
     testRegisterProvider(analyticsFactoryProvider, AnalyticsFactory);
     testAngularJsService(analyticsFactoryProvider, 'analyticsFactory');
-  });
-
-  it('templateEditorFactory:', () => {
-    testRegisterProvider(templateEditorFactoryProvider, TemplateEditorFactory);
-    testAngularJsService(templateEditorFactoryProvider, 'templateEditorFactory');
   });
 
   it('presentationUtils:', () => {
@@ -119,5 +113,34 @@ describe('ajs-upgraded-providers', () => {
     testAngularJsService(contactServiceProvider, 'contactService');
   });
 
+  it('presentation:', () => {
+    testRegisterProvider(presentationServiceProvider, PresentationService);
+    testAngularJsService(presentationServiceProvider, 'presentation');
+  });
+
+  it('createFirstSchedule:', () => {
+    testRegisterProvider(createFirstScheduleServiceProvider, CreateFirstScheduleService);
+    testAngularJsService(createFirstScheduleServiceProvider, 'createFirstSchedule');
+  });
+
+  it('brandingFactory:', () => {
+    testRegisterProvider(brandingFactoryProvider, BrandingFactory);
+    testAngularJsService(brandingFactoryProvider, 'brandingFactory');
+  });
+
+  it('scheduleFactory:', () => {
+    testRegisterProvider(scheduleFactoryProvider, ScheduleFactory);
+    testAngularJsService(scheduleFactoryProvider, 'scheduleFactory');
+  });
+
+  it('presentationTracker:', () => {
+    testRegisterProvider(presentationTrackerProvider, PresentationTracker);
+    testAngularJsService(presentationTrackerProvider, 'presentationTracker');
+  });
+
+  it('scheduleSelectorFactory:', () => {
+    testRegisterProvider(scheduleSelectorFactoryProvider, ScheduleSelectorFactory);
+    testAngularJsService(scheduleSelectorFactoryProvider, 'scheduleSelectorFactory');
+  });  
   
 });

--- a/src/app/ajs-upgraded-providers.spec.ts
+++ b/src/app/ajs-upgraded-providers.spec.ts
@@ -13,7 +13,6 @@ import {
   StoreService, storeServiceProvider,
   SubscriptionFactory, subscriptionFactoryProvider,
   TemplateEditorFactory, templateEditorFactoryProvider,
-  ComponentsFactory, componentsFactoryProvider,
   PresentationUtils, presentationUtilsProvider,
   UserAuthFactory, userAuthFactoryProvider,
   UserState, userStateProvider, purchaseFlowTrackerProvider, PurchaseFlowTracker, contactServiceProvider, ContactService
@@ -48,11 +47,6 @@ describe('ajs-upgraded-providers', () => {
   it('templateEditorFactory:', () => {
     testRegisterProvider(templateEditorFactoryProvider, TemplateEditorFactory);
     testAngularJsService(templateEditorFactoryProvider, 'templateEditorFactory');
-  });
-
-  it('componentsFactory:', () => {
-    testRegisterProvider(componentsFactoryProvider, ComponentsFactory);
-    testAngularJsService(componentsFactoryProvider, 'componentsFactory');
   });
 
   it('presentationUtils:', () => {

--- a/src/app/ajs-upgraded-providers.ts
+++ b/src/app/ajs-upgraded-providers.ts
@@ -127,6 +127,17 @@ export const purchaseFlowTrackerProvider = {
   deps: ['$injector']
 };
 
+export abstract class PresentationTracker extends Function {
+}
+export const presentationTrackerProvider = {
+  provide: PresentationTracker,
+  useFactory: function ($injector: any) {
+    return $injector.get('presentationTracker');
+  },
+  deps: ['$injector']
+};
+
+
 
 // components/plans
 export abstract class PlansService {
@@ -177,18 +188,7 @@ export const userAuthFactoryProvider = {
 };
 
 
-// template-editor/services
-export abstract class TemplateEditorFactory {
-  [key: string]: any;
-}
-export const templateEditorFactoryProvider = {
-  provide: TemplateEditorFactory,
-  useFactory: function ($injector: any) {
-    return $injector.get('templateEditorFactory');
-  },
-  deps: ['$injector']
-};
-
+// editor/services
 export abstract class PresentationUtils {
   [key: string]: any;
 }
@@ -196,6 +196,64 @@ export const presentationUtilsProvider = {
   provide: PresentationUtils,
   useFactory: function ($injector: any) {
     return $injector.get('presentationUtils');
+  },
+  deps: ['$injector']
+};
+
+export abstract class PresentationService {
+  [key: string]: any;
+}
+export const presentationServiceProvider = {
+  provide: PresentationService,
+  useFactory: function ($injector: any) {
+    return $injector.get('presentation');
+  },
+  deps: ['$injector']
+};
+
+
+// template-editor/components/services
+export abstract class BrandingFactory {
+  [key: string]: any;
+}
+export const brandingFactoryProvider = {
+  provide: BrandingFactory,
+  useFactory: function ($injector: any) {
+    return $injector.get('brandingFactory');
+  },
+  deps: ['$injector']
+};
+
+
+//schedules/services
+export abstract class CreateFirstScheduleService extends Function {
+}
+export const createFirstScheduleServiceProvider = {
+  provide: CreateFirstScheduleService,
+  useFactory: function ($injector: any) {
+    return $injector.get('createFirstSchedule');
+  },
+  deps: ['$injector']
+};
+
+export abstract class ScheduleFactory {
+  [key: string]: any;
+}
+export const scheduleFactoryProvider = {
+  provide: ScheduleFactory,
+  useFactory: function ($injector: any) {
+    return $injector.get('scheduleFactory');
+  },
+  deps: ['$injector']
+};
+
+export abstract class ScheduleSelectorFactory {
+  [key: string]: any;
+}
+export const scheduleSelectorFactoryProvider = {
+  provide: ScheduleSelectorFactory,
+  useFactory: function ($injector: any) {
+    return $injector.get('scheduleSelectorFactory');
   },
   deps: ['$injector']
 };

--- a/src/app/ajs-upgraded-providers.ts
+++ b/src/app/ajs-upgraded-providers.ts
@@ -189,17 +189,6 @@ export const templateEditorFactoryProvider = {
   deps: ['$injector']
 };
 
-export abstract class ComponentsFactory {
-  [key: string]: any;
-}
-export const componentsFactoryProvider = {
-  provide: ComponentsFactory,
-  useFactory: function ($injector: any) {
-    return $injector.get('componentsFactory');
-  },
-  deps: ['$injector']
-};
-
 export abstract class PresentationUtils {
   [key: string]: any;
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,7 +6,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { SharedModule } from './shared/shared.module';
 import { CommonHeaderModule } from './common-header/common-header.module';
 import { EditorModule } from './editor/editor.module';
-import { $stateProvider, $transitionsProvider, addressServiceProvider, analyticsFactoryProvider, billingProvider, canvaTypePickerProvider, confirmModalProvider, contactServiceProvider, plansServiceProvider, processErrorCodeProvider, purchaseFlowTrackerProvider, storeServiceProvider, subscriptionFactoryProvider, templateEditorFactoryProvider, componentsFactoryProvider, presentationUtilsProvider, userAuthFactoryProvider, userStateProvider } from './ajs-upgraded-providers';
+import { $stateProvider, $transitionsProvider, addressServiceProvider, analyticsFactoryProvider, billingProvider, canvaTypePickerProvider, confirmModalProvider, contactServiceProvider, plansServiceProvider, processErrorCodeProvider, purchaseFlowTrackerProvider, storeServiceProvider, subscriptionFactoryProvider, templateEditorFactoryProvider, presentationUtilsProvider, userAuthFactoryProvider, userStateProvider } from './ajs-upgraded-providers';
 import { TemplateEditorModule } from './template-editor/template-editor.module';
 import { PurchaseModule } from './purchase/purchase.module';
 import { environment } from 'src/environments/environment';
@@ -49,7 +49,6 @@ import { ModalModule } from 'ngx-bootstrap/modal';
     storeServiceProvider,
     subscriptionFactoryProvider,
     templateEditorFactoryProvider,
-    componentsFactoryProvider,
     presentationUtilsProvider,
     userAuthFactoryProvider,
     userStateProvider

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,7 +6,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { SharedModule } from './shared/shared.module';
 import { CommonHeaderModule } from './common-header/common-header.module';
 import { EditorModule } from './editor/editor.module';
-import { $stateProvider, $transitionsProvider, addressServiceProvider, analyticsFactoryProvider, billingProvider, canvaTypePickerProvider, confirmModalProvider, contactServiceProvider, plansServiceProvider, processErrorCodeProvider, purchaseFlowTrackerProvider, storeServiceProvider, subscriptionFactoryProvider, templateEditorFactoryProvider, presentationUtilsProvider, userAuthFactoryProvider, userStateProvider } from './ajs-upgraded-providers';
+import { $stateProvider, $transitionsProvider, addressServiceProvider, analyticsFactoryProvider, billingProvider, canvaTypePickerProvider, confirmModalProvider, contactServiceProvider, plansServiceProvider, processErrorCodeProvider, purchaseFlowTrackerProvider, storeServiceProvider, subscriptionFactoryProvider, presentationUtilsProvider, userAuthFactoryProvider, userStateProvider, presentationServiceProvider, createFirstScheduleServiceProvider, brandingFactoryProvider, scheduleFactoryProvider, presentationTrackerProvider, scheduleSelectorFactoryProvider } from './ajs-upgraded-providers';
 import { TemplateEditorModule } from './template-editor/template-editor.module';
 import { PurchaseModule } from './purchase/purchase.module';
 import { environment } from 'src/environments/environment';
@@ -39,16 +39,21 @@ import { ModalModule } from 'ngx-bootstrap/modal';
     $transitionsProvider,
     addressServiceProvider,
     analyticsFactoryProvider,
+    brandingFactoryProvider,
     contactServiceProvider,
+    createFirstScheduleServiceProvider,
     billingProvider,
     canvaTypePickerProvider,
     confirmModalProvider,
     plansServiceProvider,
+    presentationServiceProvider,
+    presentationTrackerProvider,
     processErrorCodeProvider,
     purchaseFlowTrackerProvider,
+    scheduleFactoryProvider,
+    scheduleSelectorFactoryProvider,
     storeServiceProvider,
     subscriptionFactoryProvider,
-    templateEditorFactoryProvider,
     presentationUtilsProvider,
     userAuthFactoryProvider,
     userStateProvider

--- a/src/app/shared/services/promise-utils.service.spec.ts
+++ b/src/app/shared/services/promise-utils.service.spec.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { TestBed } from '@angular/core/testing';
+
+import { PromiseUtilsService } from './promise-utils.service';
+
+describe('PromiseUtilsService', () => {
+  let service: PromiseUtilsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PromiseUtilsService);
+  });
+
+  it('should be created', () => {
+    expect(service).to.exist;
+  });
+
+  describe('generateDeferredPromise', () => {
+    it('generate a deferred promise', () => {
+      let deferred = service.generateDeferredPromise();
+      expect(deferred.reject).to.be.a('function');
+      expect(deferred.resolve).to.be.a('function');
+      expect(deferred.promise).to.be.instanceOf(Promise);
+    });
+  })
+});

--- a/src/app/shared/services/promise-utils.service.ts
+++ b/src/app/shared/services/promise-utils.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PromiseUtilsService {
+
+  constructor() { }
+
+  generateDeferredPromise() {
+    let resolve;
+    let reject;
+    let p = new Promise((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise: p, reject, resolve };
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BroadcasterService } from './services/broadcaster.service';
+import { PromiseUtilsService } from './services/promise-utils.service';
 
 
 @NgModule({
@@ -14,5 +15,5 @@ export class SharedModule {
   //workaround for including downgraded components into build files
   //https://github.com/angular/angular/issues/35314#issuecomment-584821399
   static entryComponents = [  ]
-  static providers = [ BroadcasterService ]
+  static providers = [ BroadcasterService, PromiseUtilsService ]
 }

--- a/src/app/template-editor/components/template-editor/template-editor.component.spec.ts
+++ b/src/app/template-editor/components/template-editor/template-editor.component.spec.ts
@@ -1,12 +1,13 @@
 import {expect} from 'chai';
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { AjsState, AjsTransitions, TemplateEditorFactory, PresentationUtils } from 'src/app/ajs-upgraded-providers';
+import { AjsState, AjsTransitions, PresentationUtils } from 'src/app/ajs-upgraded-providers';
 import { BroadcasterService } from 'src/app/shared/services/broadcaster.service';
 
 import { TemplateEditorComponent } from './template-editor.component';
 import { AutoSaveService } from '../../services/auto-save.service';
 import { ComponentsService } from '../../services/components.service';
+import { TemplateEditorService } from '../../services/template-editor.service';
 
 describe('TemplateEditorComponent', () => {
   let sandbox = sinon.sandbox.create();
@@ -60,7 +61,7 @@ describe('TemplateEditorComponent', () => {
         {provide: AjsTransitions, useValue: mockAjsTransitions},
         {provide: BroadcasterService, useValue: mockBroadcasterService},
         {provide: ComponentsService, useValue: componentsFactory},
-        {provide: TemplateEditorFactory, useValue: templateEditorFactory},
+        {provide: TemplateEditorService, useValue: templateEditorFactory},
         {provide: AutoSaveService, useValue: autoSaveService},
         {provide: PresentationUtils, useValue: presentationUtils}
       ]

--- a/src/app/template-editor/components/template-editor/template-editor.component.spec.ts
+++ b/src/app/template-editor/components/template-editor/template-editor.component.spec.ts
@@ -1,11 +1,12 @@
 import {expect} from 'chai';
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { AjsState, AjsTransitions, ComponentsFactory, TemplateEditorFactory, PresentationUtils } from 'src/app/ajs-upgraded-providers';
+import { AjsState, AjsTransitions, TemplateEditorFactory, PresentationUtils } from 'src/app/ajs-upgraded-providers';
 import { BroadcasterService } from 'src/app/shared/services/broadcaster.service';
 
 import { TemplateEditorComponent } from './template-editor.component';
 import { AutoSaveService } from '../../services/auto-save.service';
+import { ComponentsService } from '../../services/components.service';
 
 describe('TemplateEditorComponent', () => {
   let sandbox = sinon.sandbox.create();
@@ -58,7 +59,7 @@ describe('TemplateEditorComponent', () => {
         {provide: AjsState, useValue: mockAjsState},
         {provide: AjsTransitions, useValue: mockAjsTransitions},
         {provide: BroadcasterService, useValue: mockBroadcasterService},
-        {provide: ComponentsFactory, useValue: componentsFactory},
+        {provide: ComponentsService, useValue: componentsFactory},
         {provide: TemplateEditorFactory, useValue: templateEditorFactory},
         {provide: AutoSaveService, useValue: autoSaveService},
         {provide: PresentationUtils, useValue: presentationUtils}

--- a/src/app/template-editor/components/template-editor/template-editor.component.ts
+++ b/src/app/template-editor/components/template-editor/template-editor.component.ts
@@ -3,9 +3,10 @@ import { Component, DoCheck, OnDestroy } from '@angular/core';
 import * as _ from 'lodash';
 import * as angular from 'angular';
 import { downgradeComponent } from '@angular/upgrade/static';
-import { AjsState, AjsTransitions, ComponentsFactory, TemplateEditorFactory, PresentationUtils } from 'src/app/ajs-upgraded-providers';
+import { AjsState, AjsTransitions, TemplateEditorFactory, PresentationUtils } from 'src/app/ajs-upgraded-providers';
 import { BroadcasterService } from 'src/app/shared/services/broadcaster.service';
 import { AutoSaveService } from '../../services/auto-save.service';
+import { ComponentsService } from '../../services/components.service';
 
 
 export function AutoSaveServiceFactory(templateEditorFactory: TemplateEditorFactory) {
@@ -29,7 +30,7 @@ export class TemplateEditorComponent implements DoCheck, OnDestroy {
     private $state: AjsState,
     private $transitions: AjsTransitions,
     private broadcaster: BroadcasterService,
-    public componentsFactory: ComponentsFactory,
+    public componentsFactory: ComponentsService,
     private templateEditorFactory: TemplateEditorFactory,
     private autoSaveService: AutoSaveService,
     private presentationUtils: PresentationUtils) {

--- a/src/app/template-editor/components/template-editor/template-editor.component.ts
+++ b/src/app/template-editor/components/template-editor/template-editor.component.ts
@@ -3,21 +3,22 @@ import { Component, DoCheck, OnDestroy } from '@angular/core';
 import * as _ from 'lodash';
 import * as angular from 'angular';
 import { downgradeComponent } from '@angular/upgrade/static';
-import { AjsState, AjsTransitions, TemplateEditorFactory, PresentationUtils } from 'src/app/ajs-upgraded-providers';
+import { AjsState, AjsTransitions, PresentationUtils } from 'src/app/ajs-upgraded-providers';
 import { BroadcasterService } from 'src/app/shared/services/broadcaster.service';
 import { AutoSaveService } from '../../services/auto-save.service';
 import { ComponentsService } from '../../services/components.service';
+import { TemplateEditorService } from '../../services/template-editor.service';
 
 
-export function AutoSaveServiceFactory(templateEditorFactory: TemplateEditorFactory) {
-  return new AutoSaveService(templateEditorFactory.save);
+export function AutoSaveServiceFactory(templateEditorFactory: TemplateEditorService) {
+  return new AutoSaveService(templateEditorFactory.save.bind(templateEditorFactory));
 }
 @Component({
   selector: 'app-template-editor',
   templateUrl: './template-editor.component.html',
   styleUrls: ['./template-editor.component.scss'],
   providers: [
-    {provide: AutoSaveService, useFactory: AutoSaveServiceFactory, deps: [TemplateEditorFactory] }
+    {provide: AutoSaveService, useFactory: AutoSaveServiceFactory, deps: [TemplateEditorService] }
   ]
 })
 export class TemplateEditorComponent implements DoCheck, OnDestroy {
@@ -31,7 +32,7 @@ export class TemplateEditorComponent implements DoCheck, OnDestroy {
     private $transitions: AjsTransitions,
     private broadcaster: BroadcasterService,
     public componentsFactory: ComponentsService,
-    private templateEditorFactory: TemplateEditorFactory,
+    private templateEditorFactory: TemplateEditorService,
     private autoSaveService: AutoSaveService,
     private presentationUtils: PresentationUtils) {
 

--- a/src/app/template-editor/services/attribute-data.service.spec.ts
+++ b/src/app/template-editor/services/attribute-data.service.spec.ts
@@ -1,10 +1,10 @@
 import {expect} from 'chai';
 
 import { TestBed } from '@angular/core/testing';
-import { TemplateEditorFactory } from 'src/app/ajs-upgraded-providers';
 
 import { AttributeDataService } from './attribute-data.service';
 import { BlueprintService } from './blueprint.service';
+import { TemplateEditorService } from './template-editor.service';
 
 describe('AttributeDataService', () => {
   let sandbox = sinon.sandbox.create();
@@ -25,7 +25,7 @@ describe('AttributeDataService', () => {
     TestBed.configureTestingModule({
       providers: [
         {provide: BlueprintService, useValue: blueprintFactory},
-        {provide: TemplateEditorFactory, useValue: templateEditorFactory}        
+        {provide: TemplateEditorService, useValue: templateEditorFactory}        
       ]
     });
     attributeDataFactory = TestBed.inject(AttributeDataService);

--- a/src/app/template-editor/services/attribute-data.service.ts
+++ b/src/app/template-editor/services/attribute-data.service.ts
@@ -1,16 +1,16 @@
 import { Injectable } from '@angular/core';
-import { TemplateEditorFactory } from 'src/app/ajs-upgraded-providers';
 import * as angular from 'angular';
 import * as _ from 'lodash';
 import { downgradeInjectable } from '@angular/upgrade/static';
 import { BlueprintService } from './blueprint.service';
+import { TemplateEditorService } from './template-editor.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AttributeDataService {
 
-  constructor(private blueprintFactory: BlueprintService, private templateEditorFactory: TemplateEditorFactory) {}
+  constructor(private blueprintFactory: BlueprintService, private templateEditorFactory: TemplateEditorService) {}
 
   getBlueprintData(componentId, attributeKey?) {
     return this.blueprintFactory.getBlueprintData(componentId, attributeKey);

--- a/src/app/template-editor/services/components.service.spec.ts
+++ b/src/app/template-editor/services/components.service.spec.ts
@@ -471,10 +471,6 @@ describe('ComponentsService', () => {
       directive.element.show.should.have.been.called;
       directive.show.should.have.been.called;
 
-      expect(componentsFactory.showAttributeList).to.be.true;
-
-      clock.tick(500);
-
       expect(componentsFactory.showAttributeList).to.be.false;
     });    
   });
@@ -648,9 +644,6 @@ describe('ComponentsService', () => {
       directive.element.show.should.have.been.called;
       directive.show.should.have.been.called;
 
-      expect(componentsFactory.showAttributeList).to.be.true;
-
-      clock.tick(500);
       expect(componentsFactory.showAttributeList).to.be.false;
     });
 
@@ -694,9 +687,6 @@ describe('ComponentsService', () => {
       directive.element.show.should.have.been.called;
       directive.show.should.have.been.called;
 
-      expect(componentsFactory.showAttributeList).to.be.true;
-
-      clock.tick(500);
       expect(componentsFactory.showAttributeList).to.be.false;
     });
   });
@@ -719,16 +709,12 @@ describe('ComponentsService', () => {
 
       componentsFactory.registerDirective(directive);
       componentsFactory.editComponent(component);
-      clock.tick(500);
 
       componentsFactory.backToList();
 
       expect(componentsFactory.selected).to.be.null;
       directive.element.hide.should.have.been.calledTwice;
 
-      expect(componentsFactory.showAttributeList).to.be.false;
-
-      clock.tick(500);
       expect(componentsFactory.showAttributeList).to.be.true;
     });
   });
@@ -752,7 +738,6 @@ describe('ComponentsService', () => {
       componentsFactory.highlightComponent = sandbox.stub();
       componentsFactory.registerDirective(directive);
       componentsFactory.editComponent(component);
-      clock.tick(500);
 
       componentsFactory.onBackButton();
 
@@ -760,9 +745,6 @@ describe('ComponentsService', () => {
       directive.element.hide.should.have.been.calledTwice;
       componentsFactory.highlightComponent.should.have.been.calledOnce;
 
-      expect(componentsFactory.showAttributeList).to.be.false;
-
-      clock.tick(500);
       expect(componentsFactory.showAttributeList).to.be.true;
     });
 
@@ -785,7 +767,6 @@ describe('ComponentsService', () => {
       componentsFactory.highlightComponent = sandbox.stub();
       componentsFactory.registerDirective(directive);
       componentsFactory.editComponent(component);
-      clock.tick(500);
 
       componentsFactory.onBackButton();
 
@@ -793,9 +774,6 @@ describe('ComponentsService', () => {
       directive.element.hide.should.have.been.calledTwice;
       componentsFactory.highlightComponent.should.have.been.calledOnce;
 
-      expect(componentsFactory.showAttributeList).to.be.false;
-
-      clock.tick(500);
       expect(componentsFactory.showAttributeList).to.be.true;
     });
 
@@ -818,8 +796,6 @@ describe('ComponentsService', () => {
       componentsFactory.highlightComponent = sandbox.stub();
       componentsFactory.registerDirective(directive);
       componentsFactory.editComponent(component);
-      clock.tick(500);
-
       componentsFactory.onBackButton();
 
       expect(componentsFactory.selected).to.not.be.null;
@@ -848,7 +824,6 @@ describe('ComponentsService', () => {
 
       componentsFactory.registerDirective(directive);
       componentsFactory.editComponent(component);
-      clock.tick(500);
 
       var visible = componentsFactory.isHeaderBottomRuleVisible(component);
 
@@ -874,7 +849,6 @@ describe('ComponentsService', () => {
 
       componentsFactory.registerDirective(directive);
       componentsFactory.editComponent(component);
-      clock.tick(500);
 
       var visible = componentsFactory.isHeaderBottomRuleVisible(component);
 
@@ -900,7 +874,6 @@ describe('ComponentsService', () => {
 
       componentsFactory.registerDirective(directive);
       componentsFactory.editComponent(component);
-      clock.tick(500);
 
       var visible = componentsFactory.isHeaderBottomRuleVisible(component);
 

--- a/src/app/template-editor/services/components.service.spec.ts
+++ b/src/app/template-editor/services/components.service.spec.ts
@@ -1,0 +1,1121 @@
+import { expect } from 'chai';
+import { TestBed } from '@angular/core/testing';
+
+import { ComponentsService } from './components.service';
+import { TemplateEditorUtilsService } from './template-editor-utils.service';
+import { BlueprintService } from './blueprint.service';
+
+describe('ComponentsService', () => {
+  let componentsFactory: ComponentsService;
+
+  var sandbox = sinon.sandbox.create();
+  var COMPONENTS_MAP, COMPONENTS_ARRAY, PLAYLIST_COMPONENTS;
+  var blueprintFactory,
+    templateEditorUtils,
+    clock;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+    COMPONENTS_MAP = ComponentsService.COMPONENTS_MAP;
+    COMPONENTS_ARRAY = ComponentsService.COMPONENTS_ARRAY;
+    PLAYLIST_COMPONENTS = ComponentsService.PLAYLIST_COMPONENTS;
+    var elementStub = {
+      hide: sandbox.stub(),
+      show: sandbox.stub(),
+      addClass: sandbox.stub(),
+      removeClass: sandbox.stub()
+    };    
+    templateEditorUtils = {
+      elementStub: elementStub,
+      findElement: sandbox.stub().returns(elementStub)
+    };
+    blueprintFactory = {};
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: TemplateEditorUtilsService, useValue: templateEditorUtils},
+        {provide: BlueprintService, useValue: blueprintFactory}
+      ]
+    });
+    componentsFactory = TestBed.inject(ComponentsService);
+  });
+
+  afterEach(function() {
+    clock.restore();
+    sandbox.restore();
+  });
+
+  it('should be created', () => {
+    expect(componentsFactory).to.exist;
+  });
+
+  describe('COMPONENTS_MAP', function() {
+    it('should exist', function() {
+      expect(COMPONENTS_MAP).to.be.an('object');
+    });
+
+    it('rise-branding-colors', function() {
+      var directive = COMPONENTS_MAP['rise-branding-colors'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-branding-colors');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('palette');
+      expect(directive.title).to.equal('Color Settings');
+      expect(directive.panel).to.equal('.branding-colors-container');
+    });
+
+    it('rise-branding', function() {
+      var directive = COMPONENTS_MAP['rise-branding'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-branding');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('ratingStar');
+      expect(directive.title).to.equal('Brand Settings');
+      expect(directive.panel).to.equal('.branding-component-container');
+    });
+
+    it('rise-override-brand-colors', function() {
+      var directive = COMPONENTS_MAP['rise-override-brand-colors'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-override-brand-colors');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.exist;
+    });
+
+    it('rise-data-counter', function() {
+      var directive = COMPONENTS_MAP['rise-data-counter'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-data-counter');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.exist;
+    });
+
+    it('rise-data-financial', function() {
+      var directive = COMPONENTS_MAP['rise-data-financial'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-data-financial');
+      expect(directive.icon).to.equal('financial');
+      expect(directive.iconType).to.equal('streamline');
+    });
+
+    it('rise-html', function() {
+      var directive = COMPONENTS_MAP['rise-html'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-html');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('html');
+    });
+
+    it('rise-image', function() {
+      var directive = COMPONENTS_MAP['rise-image'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-image');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('image');
+      expect(directive.panel).to.equal('.image-component-container');
+    });
+
+    it('rise-image-logo', function() {
+      var directive = COMPONENTS_MAP['rise-image-logo'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-image-logo');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('circleStar');
+      expect(directive.title).to.equal('Logo Settings');
+      expect(directive.panel).to.equal('.image-component-container');
+    });
+
+    it('rise-playlist', function() {
+      var directive = COMPONENTS_MAP['rise-playlist'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal("rise-playlist");
+      expect(directive.iconType).to.equal("streamline");
+      expect(directive.icon).to.exist;
+      expect(directive.panel).to.equal(".rise-playlist-container");
+    });
+
+    it('rise-playlist-item', function() {
+      var directive = COMPONENTS_MAP['rise-playlist-item'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal("rise-playlist-item");
+      expect(directive.iconType).to.equal("streamline");
+      expect(directive.icon).to.exist;
+      expect(directive.panel).to.equal(".playlist-item-container");
+    });
+
+    it('rise-presentation-selector', function() {
+      var directive = COMPONENTS_MAP['rise-presentation-selector'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal("rise-presentation-selector");
+      expect(directive.iconType).to.equal("streamline");
+      expect(directive.icon).to.exist;
+      expect(directive.panel).to.equal(".presentation-selector-container");
+    });
+
+    it('rise-data-rss', function() {
+      var directive = COMPONENTS_MAP['rise-data-rss'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-data-rss');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('rss');
+    });
+
+    it('rise-schedules', function() {
+      var directive = COMPONENTS_MAP['rise-schedules'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-schedules');
+      expect(directive.title).to.equal('Schedules');
+    });
+
+    it('rise-slides', function() {
+      var directive = COMPONENTS_MAP['rise-slides'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-slides');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('slides');
+    });
+
+    it('rise-storage-selector', function() {
+      var directive = COMPONENTS_MAP['rise-storage-selector'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-storage-selector');
+      expect(directive.iconType).to.equal('riseSvg');
+      expect(directive.icon).to.equal('riseStorage');
+      expect(directive.panel).to.equal('.storage-selector-container');
+      expect(directive.title).to.equal('Rise Storage');
+    });
+
+    it('rise-text', function() {
+      var directive = COMPONENTS_MAP['rise-text'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-text');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.exist;
+    });
+
+    it('rise-time-date', function() {
+      var directive = COMPONENTS_MAP['rise-time-date'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-time-date');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.exist;
+    });
+
+    it('rise-data-twitter', function() {
+      var directive = COMPONENTS_MAP['rise-data-twitter'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-data-twitter');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.exist;
+    });
+
+    it('rise-video', function() {
+      var directive = COMPONENTS_MAP['rise-video'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-video');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('video');
+      expect(directive.panel).to.equal('.video-component-container');
+    });
+
+    it('rise-data-weather', function() {
+      var directive = COMPONENTS_MAP['rise-data-weather'];
+
+      expect(directive).to.be.ok;
+      expect(directive.type).to.equal('rise-data-weather');
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('sun');
+    });
+  });
+
+  it('COMPONENTS_ARRAY', function() {
+    expect(COMPONENTS_ARRAY).to.have.length(20);
+
+    for (var i = 0; i < COMPONENTS_ARRAY.length; i++) {
+      expect(COMPONENTS_ARRAY[i].type).to.be.ok;
+      expect(COMPONENTS_ARRAY[i].title).to.be.ok;
+    }
+  });
+
+  it('PLAYLIST_COMPONENTS', function() {
+    expect(PLAYLIST_COMPONENTS).to.have.length(5);
+  });
+
+
+  it('should initialize', function() {
+    expect(componentsFactory).to.be.ok;
+
+    expect(componentsFactory.selected).to.be.null;
+    expect(componentsFactory.showAttributeList).to.be.true;
+    expect(componentsFactory.directives).to.deep.equal({});
+    expect(componentsFactory.pages).to.deep.equal([]);
+  });
+
+  it('should define functions', function() {
+    expect(componentsFactory.registerDirective).to.be.a('function');
+    expect(componentsFactory.editComponent).to.be.a('function');
+    expect(componentsFactory.onBackButton).to.be.a('function');
+    expect(componentsFactory.backToList).to.be.a('function');
+    expect(componentsFactory.getComponentIcon).to.be.a('function');
+    expect(componentsFactory.getComponentName).to.be.a('function');
+  });
+
+  it('reset:', function() {
+    componentsFactory.selected = 'selected';
+    componentsFactory.showAttributeList = false;
+    componentsFactory.directives = {
+      first: {}
+    };
+    componentsFactory.pages = ['page'];
+
+    componentsFactory.reset();
+
+    expect(componentsFactory.selected).to.be.null;
+    expect(componentsFactory.showAttributeList).to.be.true;
+    expect(componentsFactory.directives).to.deep.equal({});
+    expect(componentsFactory.pages).to.deep.equal([]);
+  });
+
+  describe('registerDirective:', function() {
+    it('Registers a component', function() {
+      var component = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: sandbox.stub()
+        },
+        show: function() {}
+      };
+
+      componentsFactory.registerDirective(component);
+
+      expect(componentsFactory.directives["rise-test"]).to.be.ok;
+      expect(componentsFactory.directives["rise-test"].type).to.equal("rise-test");
+
+      component.element.hide.should.have.been.called;
+    });
+
+    it('Runs the open presentation handler', function() {
+      var component = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: function() {},
+          show: function() {}
+        },
+        onPresentationOpen: sandbox.stub()
+      };
+
+      componentsFactory.registerDirective(component);
+
+      component.onPresentationOpen.should.to.have.been.called;
+    });
+
+    it('should populate directive properties', function() {
+      var directive :any = {
+        type: 'rise-text',
+        element: {
+          hide: function() {},
+          show: function() {}
+        }
+      };
+
+      componentsFactory.registerDirective(directive);
+
+      expect(directive.iconType).to.equal('streamline');
+      expect(directive.icon).to.equal('text');
+      expect(directive.title).to.equal('Text');
+    });
+
+    describe('panel:', function() {
+      it('should set default panel', function() {
+        var component = {
+          type: 'rise-test',
+          icon: 'fa-test',
+          element: {
+            hide: sandbox.stub()
+          }
+        };
+
+        componentsFactory.registerDirective(component);
+
+        expect(componentsFactory.directives["rise-test"]).to.be.ok;
+        expect(componentsFactory.directives["rise-test"].panel).to.equal('.attribute-editor-component');
+      });
+
+      it('should not override directive panel', function() {
+        var component = {
+          type: 'rise-test',
+          icon: 'fa-test',
+          panel: '.component-panel',
+          element: {
+            hide: sandbox.stub()
+          }
+        };
+
+        componentsFactory.registerDirective(component);
+
+        expect(componentsFactory.directives["rise-test"]).to.be.ok;
+        expect(componentsFactory.directives["rise-test"].panel).to.equal('.component-panel');
+      });
+
+      it('should not override default directive panel', function() {
+        var component = {
+          type: 'rise-video',
+          element: {
+            hide: sandbox.stub()
+          }
+        };
+
+        componentsFactory.registerDirective(component);
+
+        expect(componentsFactory.directives["rise-video"]).to.be.ok;
+        expect(componentsFactory.directives["rise-video"].panel).to.equal('.video-component-container');
+      });
+
+    });
+  });
+
+  describe('editComponent:', function() {
+    describe('_getDirective:', function() {
+      beforeEach(function() {
+        sandbox.stub(componentsFactory, 'showNextPage');
+      });
+
+      it('should handle missing component', function() {
+        componentsFactory.editComponent();
+
+        expect(componentsFactory.selected).to.not.be.ok;
+      });
+
+      it('should use component directive', function() {
+        var component = {
+          directive: {
+            type: 'rise-text',
+            show: sandbox.stub()
+          }
+        };
+
+        componentsFactory.editComponent(component);
+
+        expect(componentsFactory.selected).to.equal(component);
+
+        component.directive.show.should.have.been.called;
+
+        componentsFactory.showNextPage.should.have.been.calledWith(component);
+      });
+
+      it('should get directive from registered list', function() {
+        var directive = {
+          type: 'rise-text',
+          element: {
+            hide: function() {},
+          },
+          show: sandbox.stub()
+        };
+
+        var component = {
+          type: 'rise-text'
+        }
+
+        componentsFactory.registerDirective(directive);
+        componentsFactory.editComponent(component);
+
+        expect(componentsFactory.selected).to.equal(component);
+
+        directive.show.should.have.been.called;
+
+        componentsFactory.showNextPage.should.have.been.calledWith(component);
+      });
+
+    });
+
+    it('Edits a component', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: function() {},
+          show: sandbox.stub()
+        },
+        show: sandbox.stub()
+      };
+
+      var component = {
+        type: 'rise-test'
+      }
+
+      componentsFactory.registerDirective(directive);
+      componentsFactory.editComponent(component);
+
+      expect(componentsFactory.selected).to.deep.equal(component);
+
+      directive.element.show.should.have.been.called;
+      directive.show.should.have.been.called;
+
+      expect(componentsFactory.showAttributeList).to.be.true;
+
+      clock.tick(500);
+
+      expect(componentsFactory.showAttributeList).to.be.false;
+    });    
+  });
+  
+  describe('getComponentIcon:', function() {
+    it('should return empty if null', function() {
+      expect(componentsFactory.getComponentIcon()).to.equal('');
+    });
+
+    it('should return empty if directive is not found', function() {
+      var component = {};
+
+      expect(componentsFactory.getComponentIcon(component)).to.equal('');
+    });
+
+    it('should return directive icon', function() {
+      var component = {
+        directive: {
+          icon: 'sampleIcon'
+        }
+      };
+
+      expect(componentsFactory.getComponentIcon(component)).to.equal('sampleIcon');
+    });
+
+  });
+
+  describe('getComponentIconType:', function() {
+    it('should return empty if null', function() {
+      expect(componentsFactory.getComponentIconType()).to.equal('');
+    });
+
+    it('should return empty if directive is not found', function() {
+      var component = {};
+
+      expect(componentsFactory.getComponentIconType(component)).to.equal('');
+    });
+
+    it('should return directive icontype', function() {
+      var component = {
+        directive: {
+          iconType: 'iconType'
+        }
+      };
+
+      expect(componentsFactory.getComponentIconType(component)).to.equal('iconType');
+    });
+
+  });
+
+  describe('getComponentTitle:', function() {
+    it('should return empty if null', function() {
+      expect(componentsFactory.getComponentTitle()).to.equal('');
+    });
+
+    it('should return empty if directive is not found', function() {
+      var component = {};
+
+      expect(componentsFactory.getComponentTitle(component)).to.equal('');
+    });
+
+    it('should return panel title', function() {
+      componentsFactory.panelTitle = 'panelTitle';
+      var component = {
+        label: 'directiveLabel',
+        directive: {
+          title: 'directiveTitle'
+        }
+      };
+
+      expect(componentsFactory.getComponentTitle(component)).to.equal('panelTitle');
+    });
+
+    it('should return component label', function() {
+      var component = {
+        label: 'directiveLabel',
+        directive: {
+          title: 'directiveTitle'
+        }
+      };
+
+      expect(componentsFactory.getComponentTitle(component)).to.equal('directiveLabel');
+    });
+
+    it('should return directive title if label is missing', function() {
+      var component = {
+        directive: {
+          title: 'directiveTitle'
+        }
+      };
+
+      expect(componentsFactory.getComponentTitle(component)).to.equal('directiveTitle');
+    });
+
+  });
+
+  describe('getComponentName:', function() {
+    var directive, component;
+
+    beforeEach(function() {
+      directive = {
+        type: 'rise-test',
+        title: 'directiveTitle',
+        element: {
+          hide: function() {}
+        }
+      };
+
+      component = {
+        type: 'rise-test',
+        id: 'componentId'
+      };
+
+      componentsFactory.registerDirective(directive);
+    });
+
+    it('should check getName function on the directive', function() {
+      directive.getName = sandbox.stub().returns('componentName');
+
+      expect(componentsFactory.getComponentName(component)).to.equal('componentName');
+
+      directive.getName.should.have.been.calledWith('componentId');
+    });
+
+    it('should return title if getName returns blank', function() {
+      directive.getName = sandbox.stub().returns('');
+
+      expect(componentsFactory.getComponentName(component)).to.equal('directiveTitle');
+
+      directive.getName.should.have.been.calledWith('componentId');
+    });
+
+    it('should return title if getName doesnt exist', function() {
+      expect(componentsFactory.getComponentName(component)).to.equal('directiveTitle');
+    });
+
+    it('should return blank if directive is not found', function() {
+      expect(componentsFactory.getComponentName({
+        type: 'rise-test-2'
+      })).to.equal('');
+    });
+
+  });
+
+  describe('editHighlightedComponent:', function() {
+    it('Edits a highlighted component', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: function() {},
+          show: sandbox.stub()
+        },
+        show: sandbox.stub()
+      };
+
+      var component = {
+        id: 'test',
+        type: 'rise-test'
+      }
+
+      blueprintFactory.blueprintData = {
+        components: [component]
+      };
+
+      componentsFactory.registerDirective(directive);
+      componentsFactory.editHighlightedComponent(component.id);
+
+      expect(componentsFactory.selected).to.deep.equal(component);
+
+      directive.element.show.should.have.been.called;
+      directive.show.should.have.been.called;
+
+      expect(componentsFactory.showAttributeList).to.be.true;
+
+      clock.tick(500);
+      expect(componentsFactory.showAttributeList).to.be.false;
+    });
+
+    it('Resets selected pages when editing a highlighted component', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: function() {},
+          show: sandbox.stub()
+        },
+        show: sandbox.stub()
+      };
+
+      var component = {
+        id: 'test',
+        type: 'rise-test'
+      }
+      
+      componentsFactory.registerDirective(directive);
+
+      blueprintFactory.blueprintData = {
+        components: [component]
+      };
+
+      componentsFactory.selected = component;
+      componentsFactory.pages = [{}, {}, {}];
+      componentsFactory.setPanelIcon('previous-icon', 'streamline');
+      componentsFactory.setPanelTitle('Previous Title');
+      
+      componentsFactory.editHighlightedComponent(component.id);
+
+      expect(componentsFactory.selected).to.deep.equal(component);
+
+      expect(componentsFactory.pages).to.have.length(1);
+      expect(componentsFactory.pages[0]).to.equal(component);
+      expect(componentsFactory.panelIcon).to.be.null;
+      expect(componentsFactory.panelIconType).to.be.null;
+      expect(componentsFactory.panelTitle).to.be.null;
+
+      directive.element.show.should.have.been.called;
+      directive.show.should.have.been.called;
+
+      expect(componentsFactory.showAttributeList).to.be.true;
+
+      clock.tick(500);
+      expect(componentsFactory.showAttributeList).to.be.false;
+    });
+  });
+
+  describe('backToList:', function() {
+    it('Goes back to list', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: sandbox.stub(),
+          show: function() {}
+        },
+        show: function() {}
+      };
+
+      var component = {
+        type: 'rise-test'
+      }
+
+      componentsFactory.registerDirective(directive);
+      componentsFactory.editComponent(component);
+      clock.tick(500);
+
+      componentsFactory.backToList();
+
+      expect(componentsFactory.selected).to.be.null;
+      directive.element.hide.should.have.been.calledTwice;
+
+      expect(componentsFactory.showAttributeList).to.be.false;
+
+      clock.tick(500);
+      expect(componentsFactory.showAttributeList).to.be.true;
+    });
+  });
+
+  describe('onBackButton:', function() {
+    it('Goes back to list if there is no back handler', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: sandbox.stub(),
+          show: function() {}
+        },
+        show: function() {}
+      };
+
+      var component = {
+        type: 'rise-test'
+      }
+
+      componentsFactory.highlightComponent = sandbox.stub();
+      componentsFactory.registerDirective(directive);
+      componentsFactory.editComponent(component);
+      clock.tick(500);
+
+      componentsFactory.onBackButton();
+
+      expect(componentsFactory.selected).to.be.null;
+      directive.element.hide.should.have.been.calledTwice;
+      componentsFactory.highlightComponent.should.have.been.calledOnce;
+
+      expect(componentsFactory.showAttributeList).to.be.false;
+
+      clock.tick(500);
+      expect(componentsFactory.showAttributeList).to.be.true;
+    });
+
+    it('Goes back to list if back handler returns false', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: sandbox.stub(),
+          show: function() {}
+        },
+        show: function() {},
+        onBackHandler: function() { return false; }
+      };
+
+      var component = {
+        type: 'rise-test'
+      }
+
+      componentsFactory.highlightComponent = sandbox.stub();
+      componentsFactory.registerDirective(directive);
+      componentsFactory.editComponent(component);
+      clock.tick(500);
+
+      componentsFactory.onBackButton();
+
+      expect(componentsFactory.selected).to.be.null;
+      directive.element.hide.should.have.been.calledTwice;
+      componentsFactory.highlightComponent.should.have.been.calledOnce;
+
+      expect(componentsFactory.showAttributeList).to.be.false;
+
+      clock.tick(500);
+      expect(componentsFactory.showAttributeList).to.be.true;
+    });
+
+    it('Does not go back to list if back handler returns true', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: sandbox.stub(),
+          show: function() {}
+        },
+        show: function() {},
+        onBackHandler: function() { return true; }
+      };
+
+      var component = {
+        type: 'rise-test'
+      }
+
+      componentsFactory.highlightComponent = sandbox.stub();
+      componentsFactory.registerDirective(directive);
+      componentsFactory.editComponent(component);
+      clock.tick(500);
+
+      componentsFactory.onBackButton();
+
+      expect(componentsFactory.selected).to.not.be.null;
+      directive.element.hide.should.have.been.calledOnce;
+      componentsFactory.highlightComponent.should.to.have.been.calledOnce;
+      expect(componentsFactory.showAttributeList).to.be.false;
+    });
+  });
+
+  describe('isHeaderBottomRuleVisible:', function() {
+    it('Shows header bottom rule if isHeaderBottomRuleVisible is not defined for directive', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: sandbox.stub(),
+          show: function() {}
+        },
+        show: function() {},
+        onBackHandler: function() { return true; }
+      };
+
+      var component = {
+        type: 'rise-test'
+      }
+
+      componentsFactory.registerDirective(directive);
+      componentsFactory.editComponent(component);
+      clock.tick(500);
+
+      var visible = componentsFactory.isHeaderBottomRuleVisible(component);
+
+      expect(visible).to.be.true;
+    });
+
+    it('Shows header bottom rule if isHeaderBottomRuleVisible allows it', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: sandbox.stub(),
+          show: function() {}
+        },
+        show: function() {},
+        isHeaderBottomRuleVisible: function() { return true; },
+        onBackHandler: function() { return true; }
+      };
+
+      var component = {
+        type: 'rise-test'
+      }
+
+      componentsFactory.registerDirective(directive);
+      componentsFactory.editComponent(component);
+      clock.tick(500);
+
+      var visible = componentsFactory.isHeaderBottomRuleVisible(component);
+
+      expect(visible).to.be.true;
+    });
+
+    it('Does not show header bottom rule if isHeaderBottomRuleVisible not allows it', function() {
+      var directive = {
+        type: 'rise-test',
+        icon: 'fa-test',
+        element: {
+          hide: sandbox.stub(),
+          show: function() {}
+        },
+        show: function() {},
+        isHeaderBottomRuleVisible: function() { return false; },
+        onBackHandler: function() { return true; }
+      };
+
+      var component = {
+        type: 'rise-test'
+      }
+
+      componentsFactory.registerDirective(directive);
+      componentsFactory.editComponent(component);
+      clock.tick(500);
+
+      var visible = componentsFactory.isHeaderBottomRuleVisible(component);
+
+      expect(visible).to.be.false;
+    });    
+  });
+
+  describe('showNextPage:', function () {
+    it('should show a new page', function () {
+      expect(componentsFactory.pages).to.have.length(0);
+
+      componentsFactory.showNextPage('selector1');
+
+      expect(componentsFactory.pages).to.have.length(1);
+      expect(componentsFactory.pages[0]).to.equal('selector1');
+    });
+
+    it('should show a second page', function () {
+      componentsFactory.showNextPage('selector1');
+      componentsFactory.showNextPage('selector2');
+
+      expect(componentsFactory.pages).to.deep.equal(['selector1', 'selector2']);
+    });
+
+    describe('_swapToLeft:', function() {
+      var directive1, directive2;
+      var component1, component2;
+
+      beforeEach(function() {
+        directive1 = {
+          type: 'rise-test-1',
+          panel: 'panel1',
+          element: {
+            hide: sandbox.stub(),
+            show: sandbox.stub()
+          },
+          show: sandbox.stub()
+        };
+        directive2 = {
+          type: 'rise-test-2',
+          panel: 'panel2',
+          element: {
+            hide: sandbox.stub(),
+            show: sandbox.stub()
+          },
+          show: sandbox.stub()
+        };
+
+        component1 = {
+          type: 'rise-test-1'
+        };
+        component2 = {
+          type: 'rise-test-2'
+        };
+
+        componentsFactory.registerDirective(directive1);
+        componentsFactory.registerDirective(directive2);
+
+        directive1.element.hide.reset();
+        directive2.element.hide.reset();
+      });
+
+      it('should swap left', function() {
+        componentsFactory.pages.push(component1);
+        componentsFactory.selected = component2;
+
+        componentsFactory.showNextPage(component2);
+
+        directive1.element.hide.should.have.been.called;
+        templateEditorUtils.findElement.should.have.been.calledWith('panel1', directive1.element);
+
+        directive2.element.show.should.have.been.called;
+        templateEditorUtils.findElement.should.have.been.calledWith('panel2', directive2.element);
+
+        templateEditorUtils.elementStub.removeClass.should.have.been.calledWith('attribute-editor-show-from-right');
+        templateEditorUtils.elementStub.removeClass.should.have.been.calledWith('attribute-editor-show-from-left');
+
+        templateEditorUtils.elementStub.addClass.should.have.been.calledWith('attribute-editor-show-from-right');
+
+        clock.tick();
+
+        templateEditorUtils.elementStub.hide.should.have.been.called;
+        templateEditorUtils.elementStub.show.should.have.been.called;
+      });
+      
+      it('should not hide the element if its the same', function() {
+        directive2.element = directive1.element;
+        componentsFactory.selected = component2;
+
+        componentsFactory.pages.push(component1);
+
+        componentsFactory.showNextPage(component2);
+
+        directive1.element.hide.should.not.have.been.called;
+        directive1.element.show.should.have.been.called;
+      });
+
+      it('should handle missing page', function() {
+        componentsFactory.showNextPage(component2);
+
+        directive2.element.show.should.have.been.called;
+        templateEditorUtils.findElement.should.have.been.calledWith('panel2', directive2.element);
+
+        templateEditorUtils.elementStub.addClass.should.have.been.calledWith('attribute-editor-show-from-right');
+
+        clock.tick();
+        templateEditorUtils.elementStub.show.should.have.been.called;
+      });
+
+    });
+
+  });
+
+  describe('showPreviousPage:', function () {
+    beforeEach(function() {
+      sandbox.stub(componentsFactory, 'backToList');
+    });
+
+    it('should hide the first page', function () {
+      componentsFactory.showNextPage('selector1');
+
+      componentsFactory.showPreviousPage();
+
+      componentsFactory.backToList.should.have.been.called;
+
+      expect(componentsFactory.pages).to.have.length(0);
+    });
+
+    it('should hide the second page', function () {
+      componentsFactory.showNextPage('selector1');
+      componentsFactory.showNextPage('selector2');
+
+      componentsFactory.showPreviousPage();
+
+      componentsFactory.backToList.should.not.have.been.called;
+
+      expect(componentsFactory.selected).to.equal('selector1');
+
+      expect(componentsFactory.pages).to.deep.equal(['selector1']);
+    });
+
+    describe('_swapToRight:', function() {
+      var directive1, directive2;
+      var component1, component2;
+
+      beforeEach(function() {
+        directive1 = {
+          type: 'rise-test-1',
+          panel: 'panel1',
+          element: {
+            hide: sandbox.stub(),
+            show: sandbox.stub()
+          },
+          show: sandbox.stub()
+        };
+        directive2 = {
+          type: 'rise-test-2',
+          panel: 'panel2',
+          element: {
+            hide: sandbox.stub(),
+            show: sandbox.stub()
+          },
+          show: sandbox.stub()
+        };
+
+        component1 = {
+          type: 'rise-test-1'
+        };
+        component2 = {
+          type: 'rise-test-2'
+        };
+
+        componentsFactory.registerDirective(directive1);
+        componentsFactory.registerDirective(directive2);
+
+        directive1.element.hide.reset();
+        directive2.element.hide.reset();
+      });
+
+      it('should swap right', function() {
+        componentsFactory.pages.push(component1);
+        componentsFactory.pages.push(component2);
+
+        componentsFactory.showPreviousPage();
+
+        directive1.element.show.should.have.been.called;
+        templateEditorUtils.findElement.should.have.been.calledWith('panel1', directive1.element);
+
+        directive2.element.hide.should.have.been.called;
+        templateEditorUtils.findElement.should.have.been.calledWith('panel2', directive2.element);
+
+        templateEditorUtils.elementStub.removeClass.should.have.been.calledWith('attribute-editor-show-from-right');
+        templateEditorUtils.elementStub.removeClass.should.have.been.calledWith('attribute-editor-show-from-left');
+
+        templateEditorUtils.elementStub.addClass.should.have.been.calledWith('attribute-editor-show-from-left');
+
+        clock.tick();
+
+        templateEditorUtils.elementStub.hide.should.have.been.called;
+        templateEditorUtils.elementStub.show.should.have.been.called;
+      });
+
+      it('should not hide the element if its the same', function() {
+        directive2.element = directive1.element;
+
+        componentsFactory.pages.push(component1);
+        componentsFactory.pages.push(component2);
+
+        componentsFactory.showPreviousPage();
+
+        directive1.element.hide.should.not.have.been.called;
+        directive1.element.show.should.have.been.called;
+      });
+
+    });
+
+  });
+});

--- a/src/app/template-editor/services/components.service.ts
+++ b/src/app/template-editor/services/components.service.ts
@@ -1,0 +1,436 @@
+import { Injectable } from '@angular/core';
+import * as _ from 'lodash';
+import * as angular from 'angular';
+import { downgradeInjectable } from '@angular/upgrade/static';
+import { TemplateEditorUtilsService } from './template-editor-utils.service';
+import { BlueprintService } from './blueprint.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ComponentsService {
+  static readonly HTML_TEMPLATE_DOMAIN = 'https://widgets.risevision.com';
+
+  static readonly COMPONENTS_MAP = {
+    'rise-branding-colors': {
+      type: 'rise-branding-colors',
+      iconType: 'streamline',
+      icon: 'palette',
+      panel: '.branding-colors-container',
+      title: 'Color Settings',
+    },
+    'rise-branding': {
+      type: 'rise-branding',
+      iconType: 'streamline',
+      icon: 'ratingStar',
+      panel: '.branding-component-container',
+      title: 'Brand Settings',
+    },
+    'rise-override-brand-colors': {
+      type: 'rise-override-brand-colors',
+      iconType: 'streamline',
+      icon: 'palette',
+      title: 'Override Brand Colors',
+    },
+    'rise-data-counter': {
+      type: 'rise-data-counter',
+      iconType: 'streamline',
+      icon: 'hourglass',
+      title: 'Counter'
+    },
+    'rise-data-financial': {
+      type: 'rise-data-financial',
+      iconType: 'streamline',
+      icon: 'financial',
+      title: 'Financial'
+    },
+    'rise-html': {
+      type: 'rise-html',
+      iconType: 'streamline',
+      icon: 'html',
+      title: 'HTML Embed',
+      visual: true
+    },
+    'rise-image': {
+      type: 'rise-image',
+      icon: 'image',
+      iconType: 'streamline',
+      panel: '.image-component-container',
+      title: 'Image',
+      playUntilDone: true,
+      visual: true
+    },
+    'rise-image-logo': {
+      type: 'rise-image-logo',
+      icon: 'circleStar',
+      iconType: 'streamline',
+      panel: '.image-component-container',
+      title: 'Logo Settings'
+    },
+    'rise-playlist': {
+      type: 'rise-playlist',
+      iconType: 'streamline',
+      icon: 'playlist',
+      panel: '.rise-playlist-container',
+      title: 'Playlist'
+    },
+    'rise-playlist-item': {
+      type: 'rise-playlist-item',
+      iconType: 'streamline',
+      icon: 'embedded-template',
+      panel: '.playlist-item-container',
+      title: 'Playlist Item'
+    },
+    'rise-presentation-selector': {
+      type: 'rise-presentation-selector',
+      iconType: 'streamline',
+      icon: 'embedded-template',
+      panel: '.presentation-selector-container',
+      title: 'Select Presentations'
+    },
+    'rise-data-rss': {
+      type: 'rise-data-rss',
+      iconType: 'streamline',
+      icon: 'rss',
+      title: 'RSS'
+    },
+    'rise-schedules': {
+      type: 'rise-schedules',
+      title: 'Schedules'
+    },
+    'rise-slides': {
+      type: 'rise-slides',
+      iconType: 'streamline',
+      icon: 'slides',
+      title: 'Google Slides',
+      visual: true,
+      defaultAttributes: {
+        src: ''
+      }
+    },
+    'rise-storage-selector': {
+      type: 'rise-storage-selector',
+      iconType: 'riseSvg',
+      icon: 'riseStorage',
+      panel: '.storage-selector-container',
+      title: 'Rise Storage',
+    },
+    'rise-text': {
+      type: 'rise-text',
+      iconType: 'streamline',
+      icon: 'text',
+      title: 'Text',
+      visual: true,
+      defaultAttributes: {
+        fontsize: 100,
+        multiline: true,
+        verticalalign: 'middle',
+        horizontalalign: 'center',
+        textalign: 'center'
+      }
+    },
+    'rise-time-date': {
+      type: 'rise-time-date',
+      iconType: 'streamline',
+      icon: 'time',
+      title: 'Time and Date'
+    },
+    'rise-data-twitter': {
+      type: 'rise-data-twitter',
+      iconType: 'streamline',
+      icon: 'twitter',
+      title: 'Twitter'
+    },
+    'rise-video': {
+      type: 'rise-video',
+      iconType: 'streamline',
+      icon: 'video',
+      panel: '.video-component-container',
+      title: 'Video',
+      playUntilDone: true,
+      visual: true
+    },
+    'rise-data-weather': {
+      type: 'rise-data-weather',
+      iconType: 'streamline',
+      icon: 'sun',
+      title: 'Weather'
+    }
+  }
+
+  static get COMPONENTS_ARRAY() {
+    return _.values(ComponentsService.COMPONENTS_MAP);
+  }
+
+  static get PLAYLIST_COMPONENTS() {
+    return _.filter(ComponentsService.COMPONENTS_ARRAY, {
+      visual: true
+    });
+  }
+
+  selected = null;
+  showAttributeList = true;
+  directives = {};
+  pages = [];
+
+  panelIcon;
+  panelIconType;
+  panelTitle;
+
+  constructor(private templateEditorUtils: TemplateEditorUtilsService,
+    private blueprintFactory: BlueprintService) {
+      this.reset();
+    }
+
+
+    reset() {
+      this.selected = null;
+      this.showAttributeList = true;
+      this.directives = {};
+      this.pages = [];
+    };
+
+    registerDirective(directive) {
+      directive.element.hide();
+      this.directives[directive.type] = directive;
+
+      _.defaults(directive, ComponentsService.COMPONENTS_MAP[directive.type], {
+        panel: '.attribute-editor-component'
+      });
+
+      if (directive.onPresentationOpen) {
+        directive.onPresentationOpen();
+      }
+    };
+
+    _getDirective(component) {
+      if (!component) {
+        return null;
+      } else if (component.directive) {
+        return component.directive;
+      } else if (this.directives[component.type]) {
+        return this.directives[component.type];
+      } else {
+        return null;
+      }
+    };
+
+    _getSelectedDirective() {
+      var component = this.selected;
+
+      return this._getDirective(component);
+    };
+
+    editComponent(component?) {
+      var directive = this._getDirective(component);
+
+      this.selected = component;
+
+      this.showNextPage(component);
+
+      if (directive && directive.show) {
+        directive.show();
+      }
+
+      this._showAttributeList(false, 300);
+    };
+
+    onBackButton() {
+      this.highlightComponent(null);
+
+      var directive = this._getSelectedDirective();
+
+      if (!directive || !directive.onBackHandler || !directive.onBackHandler()) {
+        this.showPreviousPage();
+      }
+    };
+
+    // Private
+    backToList() {
+      var directive = this._getSelectedDirective();
+
+      if (directive && directive.element) {
+        directive.element.hide();              
+      }
+
+      this.resetPanelHeader();
+
+      this.selected = null;
+      this.pages = [];
+
+      this._showAttributeList(true, 0);
+    };
+
+    getComponentIcon(component?) {
+      var directive = this._getDirective(component);
+
+      return directive ? directive.icon : '';
+    };
+
+    getComponentIconType(component?) {
+      var directive = this._getDirective(component);
+
+      return directive ? directive.iconType : '';
+    };
+
+    getComponentTitle(component?) {
+      var directive = this._getDirective(component);
+
+      if (this.panelTitle) {
+        return this.panelTitle;
+      } else if (component && component.label) {
+        return component.label;
+      } else if (directive && directive.title) {
+        return directive.title;
+      } else {
+        return '';
+      }
+    };
+
+    getComponentName(component) {
+      var directive = this._getDirective(component);
+
+      if (directive && directive.getName) {
+        return directive.getName(component.id) || directive.title;
+      } else if (directive) {
+        return directive.title;
+      } else {
+        return '';
+      }
+    };
+
+    highlightComponent(componentId) {
+      var message = {
+        type: 'highlightComponent',
+        value: componentId
+      };
+      var iframe = window.document.getElementById('template-editor-preview') as HTMLIFrameElement;
+      iframe.contentWindow.postMessage(JSON.stringify(message), ComponentsService.HTML_TEMPLATE_DOMAIN);
+    };
+
+    isHeaderBottomRuleVisible(component) {
+      var directive = this._getDirective(component);
+
+      return directive && directive.isHeaderBottomRuleVisible ?
+        directive.isHeaderBottomRuleVisible() : true;
+    };
+
+    getCurrentPage() {
+      return this.pages.length > 0 ? this.pages[this.pages.length - 1] : null;
+    };
+
+    showNextPage(newPage) {
+      var currentPage = this.getCurrentPage();
+
+      this.pages.push(newPage);
+      this._swapToLeft(currentPage, newPage);
+    };
+
+    showPreviousPage() {
+      var currentPage = this.pages.length > 0 ? this.pages.pop() : null;
+      var previousPage = this.getCurrentPage();
+
+      if (!previousPage) {
+        this.backToList();
+      } else {
+        this.selected = previousPage;
+
+        this._swapToRight(currentPage, previousPage);
+      }
+    };
+
+    resetPanelHeader() {
+      this.setPanelIcon(null, null);
+      this.setPanelTitle(null);
+    };
+
+    setPanelIcon(panelIcon, panelIconType) {
+      this.panelIcon = panelIcon;
+      this.panelIconType = panelIconType;
+    };
+
+    setPanelTitle(panelTitle) {
+      this.panelTitle = panelTitle;
+    };
+
+    editHighlightedComponent(componentId) {
+      var component = _.find(this.blueprintFactory.blueprintData.components, (element) => {
+        return element.id === componentId;
+      });
+      if (component) {
+        if (this.selected) {
+          this.backToList();
+        }
+        this.editComponent(component);
+      }
+    };
+
+    _showAttributeList(value, delay) {
+      setTimeout( () => {
+        this.showAttributeList = value;
+      }, !isNaN(delay) ? delay : 500);
+    }
+
+    _removeAnimationClasses(element) {
+      element.removeClass('attribute-editor-show-from-right');
+      element.removeClass('attribute-editor-show-from-left');
+    }
+
+    _showElement(component, direction, delay?) {
+      var directive = this._getDirective(component);
+      var element = directive && directive.panel && this.templateEditorUtils.findElement(directive.panel, directive.element);
+
+      if (directive && directive.element) {
+        directive.element.show();
+      }
+
+      if (!element) {
+        return;
+      }
+
+      this._removeAnimationClasses(element);
+      element.addClass('attribute-editor-show-from-' + direction);
+
+      setTimeout( () => {
+        element.show();
+      }, delay || 0);
+    }
+
+    _hideElement(component, delay?) {
+      var directive = this._getDirective(component);
+      var selectedDirective = this._getSelectedDirective();
+
+      var element = directive && directive.panel && this.templateEditorUtils.findElement(directive.panel, directive.element);
+
+      if (directive && directive.element && directive.element !== selectedDirective.element) {
+        directive.element.hide();
+      }
+
+      if (!element) {
+        return;
+      }
+
+      setTimeout( () => {
+        element.hide();
+      }, delay || 0);
+    }
+
+    _swapToLeft(swappedOutSelector, swappedInSelector) {
+      this._showElement(swappedInSelector, 'right');
+      this._hideElement(swappedOutSelector);
+    }
+
+    _swapToRight(swappedOutSelector, swappedInSelector) {
+      this._showElement(swappedInSelector, 'left');
+      this._hideElement(swappedOutSelector);
+    }
+
+}
+
+
+angular.module('risevision.template-editor.services')
+  .factory('componentsFactory', downgradeInjectable(ComponentsService))
+  .factory('PLAYLIST_COMPONENTS', [() => {
+      return ComponentsService.PLAYLIST_COMPONENTS;
+    }
+  ]);

--- a/src/app/template-editor/services/components.service.ts
+++ b/src/app/template-editor/services/components.service.ts
@@ -4,12 +4,12 @@ import * as angular from 'angular';
 import { downgradeInjectable } from '@angular/upgrade/static';
 import { TemplateEditorUtilsService } from './template-editor-utils.service';
 import { BlueprintService } from './blueprint.service';
+import { TemplateEditorService } from './template-editor.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ComponentsService {
-  static readonly HTML_TEMPLATE_DOMAIN = 'https://widgets.risevision.com';
 
   static readonly COMPONENTS_MAP = {
     'rise-branding-colors': {
@@ -232,7 +232,7 @@ export class ComponentsService {
         directive.show();
       }
 
-      this._showAttributeList(false, 300);
+      this._showAttributeList(false);
     };
 
     onBackButton() {
@@ -258,7 +258,7 @@ export class ComponentsService {
       this.selected = null;
       this.pages = [];
 
-      this._showAttributeList(true, 0);
+      this._showAttributeList(true);
     };
 
     getComponentIcon(component?) {
@@ -305,7 +305,7 @@ export class ComponentsService {
         value: componentId
       };
       var iframe = window.document.getElementById('template-editor-preview') as HTMLIFrameElement;
-      iframe.contentWindow.postMessage(JSON.stringify(message), ComponentsService.HTML_TEMPLATE_DOMAIN);
+      iframe.contentWindow.postMessage(JSON.stringify(message), TemplateEditorService.HTML_TEMPLATE_DOMAIN);
     };
 
     isHeaderBottomRuleVisible(component) {
@@ -365,10 +365,8 @@ export class ComponentsService {
       }
     };
 
-    _showAttributeList(value, delay) {
-      setTimeout( () => {
+    _showAttributeList(value) {
         this.showAttributeList = value;
-      }, !isNaN(delay) ? delay : 500);
     }
 
     _removeAnimationClasses(element) {

--- a/src/app/template-editor/services/template-editor.service.spec.ts
+++ b/src/app/template-editor/services/template-editor.service.spec.ts
@@ -1,0 +1,916 @@
+import { expect } from 'chai';
+import { TestBed } from '@angular/core/testing';
+
+import { TemplateEditorService } from './template-editor.service';
+import { PromiseUtilsService } from 'src/app/shared/services/promise-utils.service';
+import { AjsState, BrandingFactory, CreateFirstScheduleService, PresentationService, PresentationTracker, ProcessErrorCode, ScheduleFactory, ScheduleSelectorFactory, UserState } from 'src/app/ajs-upgraded-providers';
+import { BroadcasterService } from 'src/app/shared/services/broadcaster.service';
+import * as Q from 'q';
+import { BlueprintService } from './blueprint.service';
+import { TemplateEditorUtilsService } from './template-editor-utils.service';
+import { assert } from 'sinon';
+
+describe('TemplateEditorService', () => {
+  let templateEditorFactory: TemplateEditorService;
+
+  var sandbox = sinon.sandbox.create();
+  var presentationTracker = sandbox.spy();
+  var $state, userState, templateEditorUtils, blueprintFactory, presentation, processErrorCode, broadcasterService,
+  createFirstSchedule, scheduleFactory, brandingFactory, scheduleSelectorFactory;
+
+
+  beforeEach(() => {
+    presentation =  {
+      add : sinon.stub().resolves(),
+      update : function() {},
+      get: function() {},
+      delete: function () {},
+      publish: function () {}
+    };
+    
+    $state = {
+      go: sandbox.stub().resolves()
+    };
+    
+    userState = {
+      getUsername: function() {
+        return 'testusername';
+      }, 
+      hasRole: sandbox.stub().returns(true),
+      _restoreState: function() {}
+    };
+    
+    processErrorCode = sandbox.spy(function() { return 'error'; });
+
+    templateEditorUtils = {      
+      showMessageWindow: sandbox.stub()
+    };
+    
+    blueprintFactory = {
+      blueprintData: {},
+      getBlueprintCached: function() {
+        return Promise.resolve(blueprintFactory.blueprintData);
+      }
+    };
+    
+    scheduleFactory = {
+      hasSchedules: sandbox.stub().returns(true)
+    };
+
+    brandingFactory = {
+      isRevised: sandbox.stub().returns(false),
+      publishBranding: sandbox.stub(),
+      saveBranding: sandbox.stub()
+    };
+
+    broadcasterService = {
+      emit: sandbox.stub()
+    };
+    
+    createFirstSchedule = sandbox.stub();
+
+    scheduleSelectorFactory = {
+      checkAssignedToSchedules: sandbox.stub().resolves(),
+      loadSelectedSchedules: sandbox.stub().resolves()
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: AjsState, useValue: $state},
+        {provide: BroadcasterService, useValue: broadcasterService},
+        {provide: PresentationService, useValue: presentation },
+        {provide: ProcessErrorCode, useValue: processErrorCode},
+        {provide: UserState, useValue: userState},
+        {provide: CreateFirstScheduleService, useValue: createFirstSchedule},
+        {provide: TemplateEditorUtilsService, useValue: templateEditorUtils },
+        {provide: BrandingFactory, useValue: brandingFactory},
+        {provide: BlueprintService, useValue: blueprintFactory},
+        {provide: ScheduleFactory, useValue: scheduleFactory},
+        {provide: PresentationTracker, useValue: presentationTracker},
+        {provide: ScheduleSelectorFactory, useValue: scheduleSelectorFactory},
+        {provide: PromiseUtilsService, useValue: new PromiseUtilsService()} 
+      ]
+    });
+    templateEditorFactory = TestBed.inject(TemplateEditorService);
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  it('should initialize', function() {
+    expect(templateEditorFactory).to.be.ok;
+
+    expect(templateEditorFactory.presentation).to.be.a('object');
+    expect(templateEditorFactory.loadingPresentation).to.be.false;
+    expect(templateEditorFactory.savingPresentation).to.be.false;
+    expect(templateEditorFactory.apiError).to.not.be.ok;
+
+    expect(templateEditorFactory.getPresentation).to.be.a('function');
+    expect(templateEditorFactory.addPresentation).to.be.a('function');
+  });
+
+  describe('hasContentEditorRole:', function() {
+    it('should check role and return result', function() {
+      expect(templateEditorFactory.hasContentEditorRole()).to.be.true;
+
+      userState.hasRole.should.have.been.calledWith('ce');
+    });
+  });
+
+  describe('addFromProduct:', function() {
+    it('should create a new presentation', function(done) {
+      blueprintFactory.blueprintData.components = [
+        {
+          type: 'rise-image',
+          id: 'rise-image-01',
+          attributes: {}
+        }
+      ];
+
+      templateEditorFactory.addFromProduct({ productCode: 'test-id', name: 'Test HTML Template' }).then(function () {
+        presentation.add.should.have.been.called;
+
+        expect(templateEditorFactory.presentation.id).to.be.undefined;
+        expect(templateEditorFactory.presentation.productCode).to.equal('test-id');
+        expect(templateEditorFactory.presentation.name).to.equal('Copy of Test HTML Template');
+        expect(templateEditorFactory.presentation.presentationType).to.equal(TemplateEditorService.HTML_PRESENTATION_TYPE);
+        presentationTracker.should.have.been.calledWith('HTML Template Copied', 'test-id', 'Test HTML Template');
+
+        done();
+      });
+    });
+
+    it('should handle failure to create a new presentation', function(done) {
+      sandbox.stub(blueprintFactory, 'getBlueprintCached').returns(Q.reject('error'));
+
+      templateEditorFactory.addFromProduct({})
+        .then(done)
+        .catch(function (err) {
+          console.log(err)
+
+          expect(err).to.equal('error');
+
+          done();
+        });
+    });
+  });
+
+  describe('isUnsaved: ', function() {
+    it('should return false if neither factory hasUnsavedChanges', function() {
+      expect(templateEditorFactory.isUnsaved()).to.be.false;
+    });
+
+    it('should return true if this factory hasUnsavedChanges', function() {
+      templateEditorFactory.hasUnsavedChanges = true;
+
+      expect(templateEditorFactory.isUnsaved()).to.be.true;
+    });
+
+    it('should return true if branding hasUnsavedChanges', function() {
+      brandingFactory.hasUnsavedChanges = true;
+
+      expect(templateEditorFactory.isUnsaved()).to.be.true;
+    });
+
+    it('should return true if both factories have UnsavedChanges', function() {
+      templateEditorFactory.hasUnsavedChanges = true;
+      brandingFactory.hasUnsavedChanges = true;
+
+      expect(templateEditorFactory.isUnsaved()).to.be.true;
+    });
+  });
+
+  describe('save: ', function() {
+    beforeEach(function() {
+      presentation.add.returns(Q.resolve({
+        item: {
+          name: 'Test Presentation',
+          id: 'presentationId',
+          productCode: 'test-id'
+        }
+      }));
+
+      sandbox.stub(presentation, 'update').returns(Q.resolve({
+        item: {
+          name: 'Test Presentation',
+          id: 'presentationId'
+        }
+      }));
+
+      templateEditorFactory.presentation.templateAttributeData = {};
+    });
+
+    it('should wait for both promises to resolve', function(done) {
+      var addTemplateDeferred = Q.defer();
+      var saveBrandingDeferred = Q.defer();
+      presentation.add.returns(addTemplateDeferred.promise);
+      brandingFactory.saveBranding.returns(saveBrandingDeferred.promise);
+
+      templateEditorFactory.save();
+
+      presentation.add.should.have.been.called;
+      brandingFactory.saveBranding.should.have.been.called;
+
+      expect(templateEditorFactory.savingPresentation).to.be.true;
+
+      addTemplateDeferred.resolve({
+        item: {
+          name: 'Test Presentation',
+          id: 'presentationId'
+        }
+      });
+
+      setTimeout(function() {
+        expect(templateEditorFactory.savingPresentation).to.be.true;  
+
+        saveBrandingDeferred.resolve();
+        
+        setTimeout(function() {
+          expect(templateEditorFactory.savingPresentation).to.be.false;  
+
+          done();
+        });
+      });
+    });
+
+    describe('save Template: ', function() {
+      it('should add the presentation if it is new', function(done) {
+        templateEditorFactory.save()
+          .then(function() {
+            presentation.add.should.have.been.called;
+            presentation.update.should.not.have.been.called;
+
+            done();
+          })
+          .then(null, function(err) {
+            assert.fail(err);
+          })
+          .then(null, done);
+      });
+
+      it('should update the presentation if it is existing', function(done) {
+        templateEditorFactory.presentation.id = 'presentationId';
+        templateEditorFactory.hasUnsavedChanges = true;
+
+        templateEditorFactory.save()
+          .then(function() {
+            presentation.add.should.not.have.been.called;
+            presentation.update.should.have.been.called;
+
+            done();
+          })
+          .then(null, function(err) {
+            assert.fail(err);
+          })
+          .then(null, done);
+      });
+
+      it('should save the presentation', function(done) {
+        templateEditorFactory.save()
+          .then(function() {
+            presentation.add.should.have.been.called;
+
+            setTimeout(function() {
+              expect(templateEditorFactory.savingPresentation).to.be.false;
+              expect(templateEditorFactory.loadingPresentation).to.be.false;
+              expect(templateEditorFactory.errorMessage).to.not.be.ok;
+              expect(templateEditorFactory.apiError).to.not.be.ok;
+
+              done();
+            },10);
+          })
+          .then(null, function(err) {
+            assert.fail(err);
+          })
+          .then(null, done);
+
+          templateEditorUtils.showMessageWindow.should.not.have.been.called;
+          expect(templateEditorFactory.savingPresentation).to.be.true;
+          expect(templateEditorFactory.loadingPresentation).to.be.true;
+      });
+
+      it('should show an error if fails to add the presentation', function(done) {
+        presentation.add.returns(Q.reject());
+
+        templateEditorFactory.save()
+          .then(null, function(e) {
+            expect(templateEditorFactory.errorMessage).to.be.ok;
+            expect(templateEditorFactory.apiError).to.be.ok;
+            templateEditorUtils.showMessageWindow.should.have.been.called;
+
+            setTimeout(function() {
+              expect(templateEditorFactory.savingPresentation).to.be.false;
+              expect(templateEditorFactory.loadingPresentation).to.be.false;
+
+              done();
+            }, 10);
+          });
+      });
+
+      it('should show an error if fails to update the presentation', function(done) {
+        templateEditorFactory.presentation.id = 'presentationId';
+        templateEditorFactory.hasUnsavedChanges = true;
+
+        presentation.update.returns(Q.reject());
+
+        templateEditorFactory.save()
+          .then(null, function(e) {
+            expect(templateEditorFactory.errorMessage).to.be.ok;
+            expect(templateEditorFactory.apiError).to.be.ok;
+            templateEditorUtils.showMessageWindow.should.have.been.called;
+
+            setTimeout(function() {
+              expect(templateEditorFactory.savingPresentation).to.be.false;
+              expect(templateEditorFactory.loadingPresentation).to.be.false;
+
+              done();
+            }, 10);
+          });
+      });
+
+    });
+
+    describe('addPresentation:',function(){
+      it('should add the presentation',function(done){
+        templateEditorFactory.addPresentation()
+          .then(function() {
+            $state.go.should.have.been.calledWith('apps.editor.templates.edit');
+            expect(presentation.add.getCall(0).args[0].templateAttributeData).to.equal('{}');
+            expect(templateEditorFactory.presentation.templateAttributeData).to.deep.equal({});
+            presentationTracker.should.have.been.calledWith('Presentation Created', 'presentationId', 'Test Presentation', {
+              presentationType: 'HTML Template',
+              sharedTemplate: 'test-id'
+            });
+
+            done();
+          })
+          .then(null, function(err) {
+            assert.fail(err);
+          })
+          .then(null, done);
+      });
+
+    });
+
+    describe('updatePresentation:',function(){
+      it('should not update the presentation if it does not have unsaved changes',function(){
+        templateEditorFactory.updatePresentation();
+        
+        presentation.update.should.not.have.been.called;
+      });
+
+      it('should still resolve it does not have unsaved changes',function(done){
+        templateEditorFactory.updatePresentation().then(function() {
+          presentation.update.should.not.have.been.called;
+
+          done();
+        });      
+      });
+
+      it('should update the presentation if it has unsaved changes',function(){
+        templateEditorFactory.hasUnsavedChanges = true;
+        templateEditorFactory.updatePresentation();
+        
+        presentation.update.should.have.been.called;
+      });
+
+      it('should update the presentation',function(done){
+        templateEditorFactory.hasUnsavedChanges = true;
+        templateEditorFactory.updatePresentation()
+          .then(function() {
+            expect(presentation.update.getCall(0).args[1].templateAttributeData).to.equal('{}');
+            expect(templateEditorFactory.presentation.templateAttributeData).to.deep.equal({});
+            presentationTracker.should.have.been.calledWith('Presentation Updated', 'presentationId', 'Test Presentation');
+
+            done();
+          })
+          .then(null, function(err) {
+            assert.fail(err);
+          })
+          .then(null, done);
+      });
+
+    });
+
+    describe('saveBranding: ', function() {
+      it('should save the branding settings', function() {
+        templateEditorFactory.save();
+
+        brandingFactory.saveBranding.should.have.been.called;
+      });
+
+      it('should show an error if fails to save the branding', function(done) {
+        brandingFactory.saveBranding.returns(Q.reject());
+
+        templateEditorFactory.save()
+          .then(null, function(e) {
+            expect(templateEditorFactory.errorMessage).to.be.ok;
+            expect(templateEditorFactory.apiError).to.be.ok;
+            templateEditorUtils.showMessageWindow.should.have.been.called;
+
+            setTimeout(function() {
+              expect(templateEditorFactory.savingPresentation).to.be.false;
+              expect(templateEditorFactory.loadingPresentation).to.be.false;
+
+              done();
+            }, 10);
+          });
+      });
+    });    
+
+  });
+
+  describe('getPresentation:', function() {
+    it('should get the presentation', function(done) {
+      sandbox.stub(presentation, 'get').returns(Q.resolve({
+        item: {
+          name: 'Test Presentation',
+          productCode: 'test-id',
+          templateAttributeData: '{ "attribute1": "value1" }'
+        }
+      }));
+
+      blueprintFactory.blueprintData.components = [
+        {
+          type: 'rise-image',
+          id: 'rise-image-01',
+          attributes: {}
+        }
+      ];
+
+      templateEditorFactory.getPresentation('presentationId')
+      .then(function() {
+        expect(templateEditorFactory.presentation).to.exist;
+        expect(templateEditorFactory.presentation.name).to.equal('Test Presentation');
+        expect(templateEditorFactory.presentation.templateAttributeData.attribute1).to.equal('value1');
+
+        setTimeout(function() {
+          expect(templateEditorFactory.loadingPresentation).to.be.false;
+          $state.go.should.not.have.been.called;
+
+          done();
+        }, 10);
+      })
+      .then(null, function(err) {
+        assert.fail(err);
+      })
+      .then(null, done);
+    });
+
+    it('should get the presentation with invalid JSON data', function(done) {
+      sandbox.stub(presentation, 'get').returns(Q.resolve({
+        item: {
+          templateAttributeData: '\\',
+          productCode: 'test-id'
+        }
+      }));
+
+      templateEditorFactory.getPresentation('presentationId')
+      .then(function() {
+        expect(templateEditorFactory.presentation).to.exist;
+        expect(templateEditorFactory.presentation.templateAttributeData).to.exist;
+
+        setTimeout(function() {
+          done();
+        }, 10);
+      })
+      .then(null, function(err) {
+        assert.fail(err);
+      })
+      .then(null, done);
+    });
+
+    it('should handle failure to get presentation correctly', function(done) {
+      sandbox.stub(presentation, 'get').returns(Q.reject({ name: 'Test Presentation' }));
+
+      templateEditorFactory.getPresentation()
+      .then(function(result:any) {
+        assert.fail(result);
+      })
+      .then(null, function(e) {
+        expect(e).to.be.ok;
+        expect(templateEditorFactory.errorMessage).to.be.ok;
+        expect(templateEditorFactory.errorMessage).to.equal('Failed to get Presentation.');
+
+        processErrorCode.should.have.been.calledWith('Presentation', 'get', e);
+        expect(templateEditorFactory.apiError).to.be.ok;
+        templateEditorUtils.showMessageWindow.should.have.been.called;
+
+        setTimeout(function() {
+          expect(templateEditorFactory.loadingPresentation).to.be.false;
+          $state.go.should.not.have.been.called;
+
+          done();
+        }, 10);
+      })
+      .then(null, done);
+    });
+
+    it('should handle failure to load blueprint.json correctly', function(done) {
+      sandbox.stub(presentation, 'get').returns(Q.resolve({
+        item: {
+          name: 'Test Presentation',
+          productCode: 'test-id',
+          templateAttributeData: '{ "attribute1": "value1" }'
+        }
+      }));
+      sandbox.stub(blueprintFactory, 'getBlueprintCached').rejects();
+
+      templateEditorFactory.getPresentation('presentationId')
+      .then(function() {
+        assert.fail('Should not succeed');
+      })
+      .then(null, function(err) {
+        setTimeout(function() {
+          expect(templateEditorFactory.presentation).to.not.be.ok;
+
+          done();
+        });
+      });
+    });
+
+  });
+
+  describe('deletePresentation:', function() {
+    beforeEach(function () {
+      sandbox.stub(presentation, 'get').returns(Q.resolve({
+        item: {
+          id: 'presentationId',
+          name: 'Test Presentation',
+          productCode: 'test-id'
+        }
+      }));
+    });
+
+    it('should delete the presentation', function(done) {
+      sandbox.stub(presentation, 'delete').resolves();
+
+      templateEditorFactory.getPresentation('presentationId')
+        .then(templateEditorFactory.deletePresentation.bind(templateEditorFactory))
+        .then(function() {
+          templateEditorUtils.showMessageWindow.should.not.have.been.called;
+          expect(templateEditorFactory.savingPresentation).to.be.true;
+          expect(templateEditorFactory.loadingPresentation).to.be.true;
+
+          setTimeout(function() {
+            $state.go.should.have.been.calledWith('apps.editor.list');
+            expect(presentation.delete.getCall(0).args[0]).to.equal('presentationId');
+            expect(templateEditorFactory.savingPresentation).to.be.false;
+            expect(templateEditorFactory.loadingPresentation).to.be.false;
+            expect(templateEditorFactory.errorMessage).to.not.be.ok;
+            expect(templateEditorFactory.apiError).to.not.be.ok;
+            presentationTracker.should.have.been.calledWith('Presentation Deleted', 'presentationId', 'Test Presentation');
+
+            done();
+          },10);
+        })
+        .then(null, function(err) {
+          assert.fail(err);
+        })
+        .then(null, done);
+    });
+
+    it('should fail to delete the presentation', function(done) {
+      sandbox.stub(presentation, 'delete').returns(Q.reject());
+
+      templateEditorFactory.getPresentation('presentationId')
+        .then(function () {
+          return templateEditorFactory.deletePresentation();
+        })
+        .then(null, function(e) {
+          setTimeout(function() {
+            expect(presentation.delete.getCall(0).args[0]).to.equal('presentationId');
+            processErrorCode.should.have.been.calledWith('Presentation', 'delete', e);
+            templateEditorUtils.showMessageWindow.should.have.been.called;
+            $state.go.should.not.have.been.called;
+            expect(templateEditorFactory.apiError).to.be.ok;
+            expect(templateEditorFactory.savingPresentation).to.be.false;
+            expect(templateEditorFactory.loadingPresentation).to.be.false;
+
+            done();
+          }, 10);
+        });
+    });
+  });
+
+  describe('isRevised:', function() {
+    beforeEach(function() {
+      templateEditorFactory.presentation = {};
+    });
+
+    it('should default to false', function() {
+      expect(templateEditorFactory.isRevised()).to.be.false;
+    });
+
+    it('should not be revised if published', function() {
+      templateEditorFactory.presentation.revisionStatusName = 'Published';
+
+      expect(templateEditorFactory.isRevised()).to.be.false;
+    });
+
+    it('should be revised with revision status Revised', function() {
+      templateEditorFactory.presentation.revisionStatusName = 'Revised';
+
+      expect(templateEditorFactory.isRevised()).to.be.true;
+    });
+  });
+
+  describe('isPublishDisabled: ', function() {
+    beforeEach(function() {
+      templateEditorFactory.presentation.revisionStatusName = 'Published';
+      templateEditorFactory.savingPresentation = false;
+      templateEditorFactory.hasUnsavedChanges = false;
+    });
+
+    it('should return true if neither factory isRevised', function() {
+      expect(templateEditorFactory.isPublishDisabled()).to.be.true;
+    });
+
+    it('should return false if this factory hasUnsavedChanges', function() {
+      templateEditorFactory.presentation.revisionStatusName = 'Revised';
+
+      expect(templateEditorFactory.isPublishDisabled()).to.be.false;
+    });
+
+    it('should return false if branding hasUnsavedChanges', function() {
+      brandingFactory.isRevised.returns(true);
+
+      expect(templateEditorFactory.isPublishDisabled()).to.be.false;
+    });
+
+    it('should return false if both factories have UnsavedChanges', function() {
+      templateEditorFactory.presentation.revisionStatusName = 'Revised';
+      brandingFactory.isRevised.returns(true);
+
+      expect(templateEditorFactory.isPublishDisabled()).to.be.false;
+    });
+
+    it('should return true if factory hasUnsavedChanges', function() {
+      templateEditorFactory.presentation.revisionStatusName = 'Revised';
+      brandingFactory.isRevised.returns(true);
+
+      templateEditorFactory.hasUnsavedChanges = true;
+
+      expect(templateEditorFactory.isPublishDisabled()).to.be.true;
+    });
+
+    it('should return true if factory is saving', function() {
+      templateEditorFactory.presentation.revisionStatus = 'Revised';
+      brandingFactory.isRevised.returns(true);
+
+      templateEditorFactory.savingPresentation = true;
+
+      expect(templateEditorFactory.isPublishDisabled()).to.be.true;
+    });
+
+  });
+
+  describe('publish: ', function() {
+    beforeEach(function (done) {
+      createFirstSchedule.resolves();
+      sandbox.stub(presentation, 'get').returns(Q.resolve({
+        item: {
+          id: 'presentationId',
+          name: 'Test Presentation',
+          productCode: 'test-id',
+          revisionStatusName: 'Revised'
+        }
+      }));
+
+      templateEditorFactory.getPresentation('presentationId').then(function() {
+        // allow get.finally to execute so flags are reset
+        setTimeout(done);
+      });
+    });
+
+    it('should wait for both promises to resolve', function(done) {
+      var publishTemplateDeferred = Q.defer();
+      var publishBrandingDeferred = Q.defer();
+      sandbox.stub(presentation, 'publish').returns(publishTemplateDeferred.promise);
+      brandingFactory.publishBranding.returns(publishBrandingDeferred.promise);
+
+      templateEditorFactory.publish();
+      setTimeout(function() {
+        presentation.publish.should.have.been.called;
+        brandingFactory.publishBranding.should.have.been.called;
+
+        expect(templateEditorFactory.savingPresentation).to.be.true;
+
+        publishTemplateDeferred.resolve();
+
+        setTimeout(function() {
+          expect(templateEditorFactory.savingPresentation).to.be.true;  
+
+          publishBrandingDeferred.resolve();
+          
+          setTimeout(function() {
+            expect(templateEditorFactory.savingPresentation).to.be.false;  
+
+            done();
+          });
+        });
+      });
+
+    });
+
+    describe('publishTemplate: ', function() {
+      beforeEach(function() {
+        sandbox.stub(presentation, 'publish').resolves();
+      });
+      it('should not publish the presentation if it is not revised', function(done) {
+        sandbox.stub(templateEditorFactory, 'isRevised').returns(false);
+
+        templateEditorFactory.publish()
+          .then(function() {
+            presentation.publish.should.not.have.been.called;
+
+            done();
+          })
+          .then(null, function(err) {
+            assert.fail(err);
+          })
+          .then(null, done);
+      });
+
+      it('should publish the presentation', function(done) {
+        var timeBeforePublish = new Date();
+
+        templateEditorFactory.publish()
+          .then(function() {
+            templateEditorUtils.showMessageWindow.should.not.have.been.called;
+            expect(templateEditorFactory.savingPresentation).to.be.true;
+            expect(templateEditorFactory.loadingPresentation).to.be.true;
+
+            setTimeout(function() {
+              expect(templateEditorFactory.presentation.revisionStatusName).to.equal('Published');
+              expect(templateEditorFactory.presentation.changeDate).to.be.gte(timeBeforePublish);
+              expect(templateEditorFactory.presentation.changedBy).to.equal("testusername");
+              expect(templateEditorFactory.savingPresentation).to.be.false;
+              expect(templateEditorFactory.loadingPresentation).to.be.false;
+              expect(templateEditorFactory.errorMessage).to.not.be.ok;
+              expect(templateEditorFactory.apiError).to.not.be.ok;
+              presentationTracker.should.have.been.calledWith('Presentation Published', 'presentationId', 'Test Presentation');
+
+              done();
+            },10);
+          })
+          .then(null, function(err) {
+            assert.fail(err);
+          })
+          .then(null, done);
+      });
+
+      it('should show an error if fails to publish the presentation', function(done) {
+        presentation.publish.returns(Q.reject());
+
+        templateEditorFactory.publish()
+          .then(null, function(e) {
+            setTimeout(function() {
+              expect(templateEditorFactory.savingPresentation).to.be.false;
+              expect(templateEditorFactory.loadingPresentation).to.be.false;
+              expect(templateEditorFactory.errorMessage).to.be.ok;
+              expect(templateEditorFactory.apiError).to.be.ok;
+              templateEditorUtils.showMessageWindow.should.have.been.called;
+
+              done();
+            }, 10);
+          });
+      });
+
+      describe('createFirstSchedule:', function() {
+        it('should create first Schedule when publishing first presentation and show modal', function(done) {
+          templateEditorFactory.publish()
+            .then(function() {
+              setTimeout(function() {
+                createFirstSchedule.should.have.been.calledWith(templateEditorFactory.presentation);
+
+                scheduleSelectorFactory.loadSelectedSchedules.should.have.been.called;
+
+                done();
+              });
+            })
+            .then(null, function(err) {
+              assert.fail(err);
+            })
+            .then(null, done);
+        });
+
+        it('should create first Schedule and show modal even if not revised', function(done) {
+          sandbox.stub(templateEditorFactory, 'isRevised').returns(false);
+
+          templateEditorFactory.publish()
+            .then(function() {
+              setTimeout(function() {
+                createFirstSchedule.should.have.been.calledWith(templateEditorFactory.presentation);
+
+                scheduleSelectorFactory.loadSelectedSchedules.should.have.been.called;
+
+                done();
+              });
+            })
+            .then(null, function(err) {
+              assert.fail(err);
+            })
+            .then(null, done);
+        });        
+
+        it('should handle case when a first schedule exists', function(done) {
+          sandbox.stub(templateEditorFactory, 'isRevised').returns(false);
+          createFirstSchedule.returns(Q.reject('Already have Schedules'));
+
+          templateEditorFactory.publish()
+            .then(function() {
+              setTimeout(function() {
+                createFirstSchedule.should.have.been.calledWith(templateEditorFactory.presentation);
+
+                scheduleSelectorFactory.loadSelectedSchedules.should.not.have.been.called;
+
+                done();
+              });
+            })
+            .then(null, function(err) {
+              assert.fail(err);
+            })
+            .then(null, done);
+        }); 
+
+        it('should handle failure to create first schedule', function(done) {
+          sandbox.stub(templateEditorFactory, 'isRevised').returns(false);
+          createFirstSchedule.returns(Q.reject());
+
+          templateEditorFactory.publish()
+            .then(function() {
+              assert.fail('error')
+            })
+            .then(null, function(err) {
+              createFirstSchedule.should.have.been.calledWith(templateEditorFactory.presentation);
+
+              scheduleSelectorFactory.loadSelectedSchedules.should.not.have.been.called;
+
+              done();
+            });
+        }); 
+      });
+
+      describe('checkAssignedToSchedules:', function() {
+        it('should check schedule assignment on successful publish', function(done) {
+          templateEditorFactory.publish()
+            .then(function() {
+              scheduleSelectorFactory.checkAssignedToSchedules.should.have.been.called;
+
+              done();
+            })
+            .then(null, function(err) {
+              assert.fail(err);
+            })
+            .then(null, done);
+        });
+      });
+
+      it('should not check schedule assignment on publish errors', function(done) {
+        presentation.publish.returns(Q.reject());
+
+        templateEditorFactory.publish()
+          .then(null, function(e) {
+            setTimeout(function() {
+              scheduleSelectorFactory.checkAssignedToSchedules.should.not.have.been.called;
+
+              done();
+            }, 10);
+          });
+      });
+    });
+
+    describe('publishBranding: ', function() {
+      beforeEach(function() {
+        sandbox.stub(presentation, 'publish').resolves();
+      });
+
+      it('should publish the branding settings', function(done) {
+        templateEditorFactory.publish().then(function(){
+          brandingFactory.publishBranding.should.have.been.called;
+          done();
+        });
+      });
+
+      it('should show an error if fails to publish the presentation', function(done) {
+        brandingFactory.publishBranding.returns(Q.reject());
+
+        templateEditorFactory.publish()
+          .then(null, function(e) {
+            setTimeout(function() {
+              expect(templateEditorFactory.savingPresentation).to.be.false;
+              expect(templateEditorFactory.loadingPresentation).to.be.false;
+              expect(templateEditorFactory.errorMessage).to.be.ok;
+              expect(templateEditorFactory.apiError).to.be.ok;
+              templateEditorUtils.showMessageWindow.should.have.been.called;
+
+              done();
+            }, 10);
+          });
+      });
+    });    
+
+  });
+});

--- a/src/app/template-editor/services/template-editor.service.ts
+++ b/src/app/template-editor/services/template-editor.service.ts
@@ -1,0 +1,351 @@
+import { Injectable } from '@angular/core';
+import * as angular from 'angular';
+import { downgradeInjectable } from '@angular/upgrade/static';
+import { AjsState, BrandingFactory, CreateFirstScheduleService, PresentationService, PresentationTracker, ProcessErrorCode, ScheduleFactory, ScheduleSelectorFactory, UserState } from 'src/app/ajs-upgraded-providers';
+import { BroadcasterService } from 'src/app/shared/services/broadcaster.service';
+import { TemplateEditorUtilsService } from './template-editor-utils.service';
+import { BlueprintService } from './blueprint.service';
+import { PromiseUtilsService } from 'src/app/shared/services/promise-utils.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TemplateEditorService {
+
+  static readonly HTML_TEMPLATE_DOMAIN = 'https://widgets.risevision.com';
+  static readonly REVISION_STATUS_PUBLISHED = 'Published';
+  static readonly REVISION_STATUS_REVISED = 'Revised';
+  static readonly HTML_PRESENTATION_TYPE = 'HTML Template';
+
+  hasUnsavedChanges = false;
+  presentation;
+  loadingPresentation;
+  savingPresentation;
+  errorMessage;
+  apiError;
+
+  constructor(private $state: AjsState, 
+    private broadcaster: BroadcasterService,
+    private presentationService: PresentationService,
+    private processErrorCode: ProcessErrorCode,
+    private userState: UserState,
+    private createFirstSchedule: CreateFirstScheduleService,
+    private templateEditorUtils: TemplateEditorUtilsService,
+    private brandingFactory: BrandingFactory,
+    private blueprintFactory: BlueprintService,
+    private scheduleFactory: ScheduleFactory,
+    private presentationTracker: PresentationTracker,
+    private scheduleSelectorFactory: ScheduleSelectorFactory,
+    private promiseUtils: PromiseUtilsService) { 
+      this._init();
+    }
+
+    hasContentEditorRole() {
+      return this.userState.hasRole('ce');
+    };
+
+    _parseJSON(json) {
+      try {
+        return JSON.parse(json);
+      } catch (err) {
+        console.error('Invalid JSON: ' + err);
+        return null;
+      }
+    };
+
+    _setPresentation(presentation, isUpdate?) {
+
+      if (isUpdate) {
+        this.presentation.id = presentation.id;
+        this.presentation.companyId = presentation.companyId;
+        this.presentation.revisionStatus = presentation.revisionStatus;
+        this.presentation.revisionStatusName = presentation.revisionStatusName;
+        this.presentation.creationDate = presentation.creationDate;
+        this.presentation.changeDate = presentation.changeDate;
+        this.presentation.changedBy = presentation.changedBy;
+      } else {
+        presentation.templateAttributeData =
+          this._parseJSON(presentation.templateAttributeData) || {};
+
+        this.presentation = presentation;
+      }
+
+      this.broadcaster.emit('presentationUpdated');
+    };
+
+    _getPresentationForUpdate() {
+      var presentationVal = JSON.parse(JSON.stringify(this.presentation));
+
+      presentationVal.templateAttributeData =
+        JSON.stringify(presentationVal.templateAttributeData);
+
+      return presentationVal;
+    };
+
+    addFromProduct(productDetails) {
+      this._clearMessages();
+
+      this.presentation = {
+        id: undefined,
+        productCode: productDetails.productCode,
+        name: 'Copy of ' + productDetails.name,
+        presentationType: TemplateEditorService.HTML_PRESENTATION_TYPE,
+        templateAttributeData: {},
+        revisionStatusName: undefined,
+        isTemplate: false,
+        isStoreProduct: false
+      };
+
+      this.presentationTracker('HTML Template Copied', productDetails.productCode, productDetails.name);
+
+      return this.blueprintFactory.getBlueprintCached(this.presentation.productCode)
+        .then(this.save.bind(this))
+        .then(null, (e) => {
+          this._showErrorMessage('add', e);
+          return Promise.reject(e);
+        });
+    };
+
+    addPresentation() {
+      var presentationVal = this._getPresentationForUpdate();
+
+      return this.presentationService.add(presentationVal)
+        .then( (resp) => {
+          if (resp && resp.item && resp.item.id) {
+            this.broadcaster.emit('presentationCreated');
+
+            this._setPresentation(resp.item);
+
+            this.presentationTracker('Presentation Created', resp.item.id, resp.item.name, {
+              presentationType: 'HTML Template',
+              sharedTemplate: resp.item.productCode
+            });
+
+            this.$state.go('apps.editor.templates.edit', {
+              presentationId: resp.item.id,
+              productId: undefined,
+            }, {
+              location: 'replace'
+            });
+
+            return Promise.resolve(resp.item.id);
+          }
+        });
+    };
+
+    updatePresentation() {
+      if (!this.hasUnsavedChanges) {
+        //Factory has no Changes.
+        return Promise.resolve();
+      }
+
+      var presentationVal = this._getPresentationForUpdate();
+
+      return this.presentationService.update(presentationVal.id, presentationVal)
+        .then( (resp) => {
+          this.presentationTracker('Presentation Updated', resp.item.id, resp.item.name);
+
+          this._setPresentation(resp.item, true);
+
+          return Promise.resolve(resp.item.id);
+        });
+    };
+
+    isUnsaved() {
+      return !!(this.hasUnsavedChanges || this.brandingFactory.hasUnsavedChanges);
+    };
+
+    save() {
+      var deferred = this.promiseUtils.generateDeferredPromise(),
+        saveFunction;
+
+      if (this.presentation.id) {
+        saveFunction = this.updatePresentation.bind(this);
+      } else {
+        saveFunction = this.addPresentation.bind(this);
+      }
+
+      this._clearMessages();
+
+      //show spinner
+      this.loadingPresentation = true;
+      this.savingPresentation = true;
+
+      Promise.all([this.brandingFactory.saveBranding(), saveFunction()])
+        .then( () => {
+          deferred.resolve();
+        })
+        .then(null, (e) => {
+          // If adding, and there is a Presentation Id it means save was successful
+          // and the failure was to update Branding
+          this._showErrorMessage(this.presentation.id ? 'update' : 'add', e);
+
+          deferred.reject(e);
+        })
+        .finally( () => {
+          this.loadingPresentation = false;
+          this.savingPresentation = false;
+        });
+
+      return deferred.promise;
+    };
+
+    getPresentation(presentationId?) {
+      var deferred = this.promiseUtils.generateDeferredPromise();
+
+      this._clearMessages();
+
+      //show loading spinner
+      this.loadingPresentation = true;
+
+      this.presentationService.get(presentationId)
+        .then( (result) => {
+          this._setPresentation(result.item);
+
+          return this.blueprintFactory.getBlueprintCached(this.presentation.productCode);
+        })
+        .then( () => {
+          deferred.resolve();
+        })
+        .then(null, (e) => {
+          this._showErrorMessage('get', e);
+          this.presentation = null;
+          this.blueprintFactory.blueprintData = null;
+
+          deferred.reject(e);
+        })
+        .finally( () => {
+          this.loadingPresentation = false;
+        });
+
+      return deferred.promise;
+    };
+
+    deletePresentation() {
+      var deferred = this.promiseUtils.generateDeferredPromise();
+
+      this._clearMessages();
+
+      //show spinner
+      this.loadingPresentation = true;
+      this.savingPresentation = true;
+
+      this.presentationService.delete(this.presentation.id)
+        .then( () => {
+          this.presentationTracker('Presentation Deleted', this.presentation.id, this.presentation.name);
+
+          this.broadcaster.emit('presentationDeleted');
+
+          this.presentation = {};
+
+          this.$state.go('apps.editor.list');
+          deferred.resolve();
+        })
+        .then(null, (e) => {
+          this._showErrorMessage('delete', e);
+          deferred.reject(e);
+        })
+        .finally( () => {
+          this.loadingPresentation = false;
+          this.savingPresentation = false;
+        });
+
+      return deferred.promise;
+    };
+
+    isRevised() {
+      return this.presentation.revisionStatusName === TemplateEditorService.REVISION_STATUS_REVISED;
+    };
+
+    isPublishDisabled() {
+      var isNotRevised = !this.isRevised() && !this.brandingFactory.isRevised() &&
+      this.scheduleFactory.hasSchedules();
+
+      return this.savingPresentation || this.isUnsaved() || isNotRevised;
+    };
+
+    publish() {
+      return this._publish().then(this.scheduleSelectorFactory.checkAssignedToSchedules);
+    };
+
+    _publish() {
+      var deferred = this.promiseUtils.generateDeferredPromise();
+
+      this._clearMessages();
+
+      //show spinner
+      this.loadingPresentation = true;
+      this.savingPresentation = true;
+
+      Promise.all([this.brandingFactory.publishBranding(), this._publishPresentation()])
+        .then( () => {
+          deferred.resolve();
+        })
+        .then(null, (e) => {
+          this._showErrorMessage('publish', e);
+
+          deferred.reject();
+        })
+        .finally( () => {
+          this.loadingPresentation = false;
+          this.savingPresentation = false;
+        });
+
+      return deferred.promise;
+    };
+
+    _publishPresentation() {
+      if (!this.isRevised()) {
+        // template is already published
+        return this._createFirstSchedule();
+      }
+
+      return this.presentationService.publish(this.presentation.id)
+        .then( () => {
+          this.presentationTracker('Presentation Published', this.presentation.id, this.presentation.name);
+
+          this.presentation.revisionStatusName = TemplateEditorService.REVISION_STATUS_PUBLISHED;
+          this.presentation.changeDate = new Date();
+          this.presentation.changedBy = this.userState.getUsername();
+          this.broadcaster.emit('presentationPublished');
+
+          return this._createFirstSchedule();
+        });
+    };
+
+    _createFirstSchedule() {
+      return this.createFirstSchedule(this.presentation)
+        .then(this.scheduleSelectorFactory.loadSelectedSchedules)
+        .catch( (err) => {
+          return err === 'Already have Schedules' ? Promise.resolve() : Promise.reject(err);
+        });
+    };
+
+    _showErrorMessage(action, e) {
+      this.errorMessage = 'Failed to ' + action + ' Presentation.';
+      this.apiError = this.processErrorCode('Presentation', action, e);
+
+      console.error(this.errorMessage, e);
+
+      this.templateEditorUtils.showMessageWindow(this.errorMessage, this.apiError);
+    };
+
+    _clearMessages() {
+      this.loadingPresentation = false;
+      this.savingPresentation = false;
+
+      this.errorMessage = '';
+      this.apiError = '';
+    };
+
+    _init() {
+      this.presentation = {};
+
+      this._clearMessages();
+    };
+    
+}
+
+angular.module('risevision.template-editor.services')
+  .constant('HTML_TEMPLATE_DOMAIN', TemplateEditorService.HTML_TEMPLATE_DOMAIN)
+  .factory('templateEditorFactory', downgradeInjectable(TemplateEditorService));


### PR DESCRIPTION
## Description
Migrate componentsFactory
Temporarily set HTML_TEMPLATE_DOMAIN in the class to avoid another upgrade. This will be reverted in the next PR as source factory will be migrated.
Also, left the original componentsFactory file in the folder to prevent unit tests issues with our components.
It will be removed once all of them are migrated, along with TemplateEditorUtils

## Motivation and Context
Angular Migration

## How Has This Been Tested?
Locally and on [stage-1]

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
