### PR TITLE
Add shown directive equivalent to ng-show

### DIFF
--- a/src/app/shared/directives/shown.directive.spec.ts
+++ b/src/app/shared/directives/shown.directive.spec.ts
@@ -1,0 +1,10 @@
+import {expect} from 'chai';
+
+import { ShownDirective } from './shown.directive';
+
+describe('ShownDirective', () => {
+  it('should create an instance', () => {
+    const directive = new ShownDirective();
+    expect(directive).to.be.ok;
+  });
+});

--- a/src/app/shared/directives/shown.directive.ts
+++ b/src/app/shared/directives/shown.directive.ts
@@ -1,0 +1,15 @@
+import { Directive, Input, HostBinding } from '@angular/core';
+
+@Directive({
+  selector: '[shown]'
+})
+export class ShownDirective {
+
+  @Input() public shown: boolean;
+
+  @HostBinding('attr.hidden')
+  public get attrHidden(): string | null {
+    return this.shown ? null : 'hidden';
+  }
+
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,13 +1,18 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BroadcasterService } from './services/broadcaster.service';
+import { ShownDirective } from './directives/shown.directive';
 
 
 @NgModule({
   declarations: [
+    ShownDirective
   ],
   imports: [
     CommonModule
+  ],
+  exports: [
+    ShownDirective
   ]
 })
 export class SharedModule {

--- a/src/app/template-editor/components/template-editor-footer/template-editor-footer.component.html
+++ b/src/app/template-editor/components/template-editor-footer/template-editor-footer.component.html
@@ -4,13 +4,13 @@
       <last-modified [changeDate]="templateEditorFactory.presentation.changeDate" [changedBy]="templateEditorFactory.presentation.changedBy"></last-modified>
       •
       <span *ngIf="templateEditorFactory.hasContentEditorRole()">
-        <span [hidden]="templateEditorFactory.savingPresentation || !templateEditorFactory.isUnsaved()">
+        <span [shown]="!templateEditorFactory.savingPresentation && templateEditorFactory.isUnsaved()">
           Unsaved changes
         </span>
-        <span [hidden]="!templateEditorFactory.savingPresentation">
+        <span [shown]="templateEditorFactory.savingPresentation">
           Saving changes...
         </span>
-        <span [hidden]="templateEditorFactory.savingPresentation || templateEditorFactory.isUnsaved()">
+        <span [shown]="!templateEditorFactory.savingPresentation && !templateEditorFactory.isUnsaved()">
           All changes saved <streamline-icon name="checkmark" width="12" height="12"></streamline-icon>
         </span>
       </span>

--- a/src/app/template-editor/components/template-editor-toolbar/template-editor-toolbar.component.html
+++ b/src/app/template-editor/components/template-editor-toolbar/template-editor-toolbar.component.html
@@ -12,13 +12,13 @@
     <last-modified [changeDate]="templateEditorFactory.presentation.changeDate" [changedBy]="templateEditorFactory.presentation.changedBy"></last-modified>
     •
     <span id="autoSavingDesktop" *ngIf="templateEditorFactory.hasContentEditorRole()">
-      <span [hidden]="templateEditorFactory.savingPresentation || !templateEditorFactory.isUnsaved()">
+      <span [shown]="!templateEditorFactory.savingPresentation && templateEditorFactory.isUnsaved()">
         Unsaved changes
       </span>
-      <span [hidden]="!templateEditorFactory.savingPresentation">
+      <span [shown]="templateEditorFactory.savingPresentation">
         Saving changes...
       </span>
-      <span [hidden]="templateEditorFactory.savingPresentation || templateEditorFactory.isUnsaved()">
+      <span [shown]="!templateEditorFactory.savingPresentation && !templateEditorFactory.isUnsaved()">
         All changes saved <streamline-icon name="checkmark" width="12" height="12"></streamline-icon>
       </span>
     </span>

--- a/src/app/template-editor/template-editor.module.ts
+++ b/src/app/template-editor/template-editor.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CommonHeaderModule } from '../common-header/common-header.module';
 import { ComponentsModule } from '../components/components.module';
+import { SharedModule } from '../shared/shared.module';
 
 import { CanvaButtonComponent } from './components/canva-button/canva-button.component';
 import { AttributeDataService } from './services/attribute-data.service';
@@ -18,7 +19,8 @@ import { EncodeLinkPipe } from './pipes/encode-link.pipe';
   imports: [
     CommonModule,
     CommonHeaderModule,
-    ComponentsModule
+    ComponentsModule,
+    SharedModule
   ],
   declarations: [
     CanvaButtonComponent,


### PR DESCRIPTION
## Description
Add shown directive equivalent to ng-show

No longer require reverting ng-hide logic

[stage-11]

## Motivation and Context
Angular migration epic.

## How Has This Been Tested?
Tested locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No