### PR TITLE
Fix reset issue; Refactor stretchy component

### DIFF
--- a/src/app/components/stretchy-input/stretchy-input.component.html
+++ b/src/app/components/stretchy-input/stretchy-input.component.html
@@ -3,7 +3,7 @@
   <input type="text" class="input-stretchy" (keydown)="inputKeyDown($event)"
     [(ngModel)]="ngModel" (ngModelChange)="ngModelChange.emit(ngModel)" (blur)="onInputBlur()" [disabled]="!isEditingInput">
   <div>
-    <button id="editButton" [disabled]="isEditingInput" type="button" class="btn-icon pr-0" (click)="isEditingInput=true">
+    <button id="editButton" [disabled]="isEditingInput" type="button" class="btn-icon pr-0" (click)="setEditable()">
       <streamline-icon class="u_margin-left streamline-component-icon mb-1" name="pencil" width="16" height="16"></streamline-icon>
     </button>
   </div>


### PR DESCRIPTION
## Description
Fix reset issue; Refactor stretchy component

Set input value on reset
Fixes issue where ngModel doesnt update input

No longer use ngCheck
Reorganize and simplify logic

Remove onInit, model updates serve the same purpose

[stage-18]

## Motivation and Context
Fix and refactoring

## How Has This Been Tested?
Tested locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No