### PR TITLE
Use broadcaster to emit branding notification

### DIFF
--- a/src/scripts/template-editor/components/services/svc-branding-factory.js
+++ b/src/scripts/template-editor/components/services/svc-branding-factory.js
@@ -1,9 +1,9 @@
 'use strict';
 
 angular.module('risevision.template-editor.services')
-  .factory('brandingFactory', ['$rootScope', '$q', 'blueprintFactory', 'userState', 'updateCompany',
+  .factory('brandingFactory', ['$rootScope', '$q', 'broadcaster', 'blueprintFactory', 'userState', 'updateCompany',
     'fileExistenceCheckService', 'DEFAULT_IMAGE_THUMBNAIL', 'REVISION_STATUS_REVISED', 'REVISION_STATUS_PUBLISHED',
-    function ($rootScope, $q, blueprintFactory, userState, updateCompany, fileExistenceCheckService,
+    function ($rootScope, $q, broadcaster, blueprintFactory, userState, updateCompany, fileExistenceCheckService,
       DEFAULT_IMAGE_THUMBNAIL, REVISION_STATUS_REVISED, REVISION_STATUS_PUBLISHED) {
       var brandingComponent = {
         type: 'rise-branding'
@@ -96,7 +96,7 @@ angular.module('risevision.template-editor.services')
       };
 
       factory.setUnsavedChanges = function () {
-        $rootScope.$broadcast('risevision.template-editor.brandingUnsavedChanges');
+        broadcaster.emit('risevision.template-editor.brandingUnsavedChanges');
 
         this.hasUnsavedChanges = true;
       };

--- a/test/unit/template-editor/components/services/svc-branding-factory.spec.js
+++ b/test/unit/template-editor/components/services/svc-branding-factory.spec.js
@@ -9,6 +9,11 @@ describe('service: brandingFactory', function() {
   beforeEach(module(function($provide) {
     $provide.service('$q', function() {return Q;});
 
+    $provide.service('broadcaster', function() {
+      return {
+        emit: sinon.stub()
+      };
+    });
     $provide.service('blueprintFactory', function() {
       return {
         hasBranding: sinon.stub()
@@ -32,13 +37,14 @@ describe('service: brandingFactory', function() {
     });
   }));
 
-  var brandingFactory, $rootScope, userState, blueprintFactory, updateCompany, fileExistenceCheckService;
+  var brandingFactory, $rootScope, broadcaster, userState, blueprintFactory, updateCompany, fileExistenceCheckService;
 
   beforeEach(function() {
     inject(function($injector) {
       brandingFactory = $injector.get('brandingFactory');
       
       $rootScope = $injector.get('$rootScope');
+      broadcaster = $injector.get('broadcaster');
       blueprintFactory = $injector.get('blueprintFactory');
       userState = $injector.get('userState');
       updateCompany = $injector.get('updateCompany');
@@ -416,16 +422,12 @@ describe('service: brandingFactory', function() {
 
   });
 
-  it('setUnsavedChanges: ', function(done) {
-    $rootScope.$on('risevision.template-editor.brandingUnsavedChanges', function() {
-      done();
-    });
-
+  it('setUnsavedChanges: ', function() {
     brandingFactory.setUnsavedChanges();
     
     expect(brandingFactory.hasUnsavedChanges).to.be.true;
 
-    $rootScope.$digest();
+    broadcaster.emit.should.have.been.calledWith('risevision.template-editor.brandingUnsavedChanges');
   });
 
   describe('isRevised', function() {


### PR DESCRIPTION
## Description
Use broadcaster to emit branding notification

Converted component expects broadcaster event

[stage-11]

## Motivation and Context
Fixes issue where branding does not autosave on its own.

## How Has This Been Tested?
Tested locally.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No